### PR TITLE
Only fetch one commit for the latest revision

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -100,6 +100,8 @@ class Webui::PackageController < Webui::WebuiController
 
     @services = @files.any? { |file| file[:name] == '_service' }
 
+    @package.cache_revisions(@revision)
+
     respond_to do |format|
       format.html
       format.js

--- a/src/api/app/lib/backend/api/sources/package.rb
+++ b/src/api/app/lib/backend/api/sources/package.rb
@@ -33,8 +33,10 @@ module Backend
 
         # Returns the revisions (mrev) list for a package
         # @return [String]
-        def self.revisions(project_name, package_name)
-          http_get(['/source/:project/:package/_history', project_name, package_name], params: { meta: 1, deleted: 1 })
+        def self.revisions(project_name, package_name, options = {})
+          http_get(['/source/:project/:package/_history', project_name, package_name], params: options,
+                                                                                       accepted: [:meta, :rev, :deleted, :limit],
+                                                                                       defaults: { meta: 1, deleted: 1 })
         end
 
         # Returns the meta file from a package

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -1207,10 +1207,9 @@ class Package < ApplicationRecord
     {}
   end
 
-  def parse_all_history
-    answer = source_file('_history')
-
-    doc = Xmlhash.parse(answer)
+  def cache_revisions(revision = nil)
+    opts = revision ? { rev: revision } : {}
+    doc = Xmlhash.parse(Backend::Api::Sources::Package.revisions(project.name, name, opts))
     doc.elements('revision') do |s|
       Rails.cache.write(['history', self, s['rev']], s)
       Rails.cache.write(['history_md5', self, s.get('srcmd5')], s)
@@ -1231,7 +1230,7 @@ class Package < ApplicationRecord
     commit = fetch_rev_from_history_cache(rev)
     return commit if commit
 
-    parse_all_history
+    cache_revisions
     # now it has to be in cache
     fetch_rev_from_history_cache(rev)
   end

--- a/src/api/spec/cassettes/Bootstrap_Requests/for_role_addition_group/for_packages/can_be_submitted.yml
+++ b/src/api/spec/cassettes/Bootstrap_Requests/for_role_addition_group/for_packages/can_be_submitted.yml
@@ -1,12 +1,132 @@
 ---
 http_interactions:
 - request:
+    method: put
+    uri: http://backend:5352/source/home:kugelblitz/_meta?user=kugelblitz
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:kugelblitz">
+          <title/>
+          <description/>
+          <person userid="kugelblitz" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '142'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:kugelblitz">
+          <title></title>
+          <description></description>
+          <person userid="kugelblitz" role="maintainer"/>
+        </project>
+  recorded_at: Wed, 22 Feb 2023 18:05:59 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:titan/_meta?user=titan
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:titan">
+          <title/>
+          <description/>
+          <person userid="titan" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '132'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:titan">
+          <title></title>
+          <description></description>
+          <person userid="titan" role="maintainer"/>
+        </project>
+  recorded_at: Wed, 22 Feb 2023 18:06:00 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:titan/goal/_meta?user=kugelblitz
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="goal" project="home:titan">
+          <title>Gone with the Wind</title>
+          <description>Vitae omnis qui minima.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '143'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="goal" project="home:titan">
+          <title>Gone with the Wind</title>
+          <description>Vitae omnis qui minima.</description>
+        </package>
+  recorded_at: Wed, 22 Feb 2023 18:06:00 GMT
+- request:
     method: get
     uri: http://backend:5352/source/home:titan/goal
     body:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - da47b1b3-3cc2-4726-9b6b-237d8d88b3e8
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -31,8 +151,7 @@ http_interactions:
       string: |
         <directory name="goal" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-    http_version: null
-  recorded_at: Thu, 09 Apr 2020 14:28:13 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:00 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:titan/goal?expand=1
@@ -64,15 +183,84 @@ http_interactions:
       string: |
         <directory name="goal" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-    http_version: null
-  recorded_at: Thu, 09 Apr 2020 14:28:13 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:00 GMT
 - request:
     method: get
-    uri: http://backend:5352/build/home:titan/_result?package=goal&view=status
+    uri: http://backend:5352/source/home:titan/goal/_history?deleted=1&meta=1
     body:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - da47b1b3-3cc2-4726-9b6b-237d8d88b3e8
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Wed, 22 Feb 2023 18:06:00 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:titan/goal
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 44d61e41-d557-46bf-8bbb-518af6c4edb2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '79'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="goal" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:06:01 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:titan/_result?lastbuild=1&locallink=1&multibuild=1&package=goal&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 44d61e41-d557-46bf-8bbb-518af6c4edb2
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -97,6 +285,107 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-    http_version: null
-  recorded_at: Thu, 09 Apr 2020 14:28:14 GMT
-recorded_with: VCR 5.1.0
+  recorded_at: Wed, 22 Feb 2023 18:06:01 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:titan/goal
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 7c5d5f4a-a883-4f08-afa8-448825c5ba1d
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '79'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="goal" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:06:01 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:titan/_result?lastbuild=1&locallink=1&multibuild=1&package=goal&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 7c5d5f4a-a883-4f08-afa8-448825c5ba1d
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 18:06:01 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:titan/_result?package=goal&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 66397d5c-d71c-4062-9762-9858c57033e6
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 18:06:01 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Bootstrap_Requests/for_role_addition_user/for_packages/can_be_submitted.yml
+++ b/src/api/spec/cassettes/Bootstrap_Requests/for_role_addition_user/for_packages/can_be_submitted.yml
@@ -1,12 +1,132 @@
 ---
 http_interactions:
 - request:
+    method: put
+    uri: http://backend:5352/source/home:kugelblitz/_meta?user=kugelblitz
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:kugelblitz">
+          <title/>
+          <description/>
+          <person userid="kugelblitz" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '142'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:kugelblitz">
+          <title></title>
+          <description></description>
+          <person userid="kugelblitz" role="maintainer"/>
+        </project>
+  recorded_at: Wed, 22 Feb 2023 18:06:03 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:titan/_meta?user=titan
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:titan">
+          <title/>
+          <description/>
+          <person userid="titan" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '132'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:titan">
+          <title></title>
+          <description></description>
+          <person userid="titan" role="maintainer"/>
+        </project>
+  recorded_at: Wed, 22 Feb 2023 18:06:04 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:titan/goal/_meta?user=kugelblitz
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="goal" project="home:titan">
+          <title>I Know Why the Caged Bird Sings</title>
+          <description>Deserunt aut quos consequatur.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '163'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="goal" project="home:titan">
+          <title>I Know Why the Caged Bird Sings</title>
+          <description>Deserunt aut quos consequatur.</description>
+        </package>
+  recorded_at: Wed, 22 Feb 2023 18:06:04 GMT
+- request:
     method: get
     uri: http://backend:5352/source/home:titan/goal
     body:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - 34b0716d-a175-4544-9b29-8678bacf1807
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -31,8 +151,7 @@ http_interactions:
       string: |
         <directory name="goal" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-    http_version: null
-  recorded_at: Thu, 09 Apr 2020 14:27:37 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:04 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:titan/goal?expand=1
@@ -64,15 +183,84 @@ http_interactions:
       string: |
         <directory name="goal" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-    http_version: null
-  recorded_at: Thu, 09 Apr 2020 14:27:37 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:04 GMT
 - request:
     method: get
-    uri: http://backend:5352/build/home:titan/_result?package=goal&view=status
+    uri: http://backend:5352/source/home:titan/goal/_history?deleted=1&meta=1
     body:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - 34b0716d-a175-4544-9b29-8678bacf1807
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Wed, 22 Feb 2023 18:06:04 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:titan/goal
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - cd8357d1-faa6-46c0-99cb-c81da366966d
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '79'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="goal" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:06:04 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:titan/_result?lastbuild=1&locallink=1&multibuild=1&package=goal&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - cd8357d1-faa6-46c0-99cb-c81da366966d
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -97,6 +285,107 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-    http_version: null
-  recorded_at: Thu, 09 Apr 2020 14:27:38 GMT
-recorded_with: VCR 5.1.0
+  recorded_at: Wed, 22 Feb 2023 18:06:04 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:titan/goal
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - af743ffd-c59a-4d4f-ad9f-2f4b67008095
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '79'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="goal" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:06:04 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:titan/_result?lastbuild=1&locallink=1&multibuild=1&package=goal&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - af743ffd-c59a-4d4f-ad9f-2f4b67008095
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 18:06:04 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:titan/_result?package=goal&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - c5cb1a6a-6b62-405b-b73f-d5d37fd8416a
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 18:06:04 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Bootstrap_Requests_Submissions/submit_package/not_setting_a_target_package/creates_a_BsRequest_with_the_source_package_name.yml
+++ b/src/api/spec/cassettes/Bootstrap_Requests_Submissions/submit_package/not_setting_a_target_package/creates_a_BsRequest_with_the_source_package_name.yml
@@ -39,7 +39,7 @@ http_interactions:
           <description></description>
           <person userid="madam_submitter" role="maintainer"/>
         </project>
-  recorded_at: Thu, 03 Nov 2022 09:59:17 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:30 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:madam_submitter/Quebec/_meta?user=madam_submitter
@@ -47,8 +47,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="Quebec" project="home:madam_submitter">
-          <title>Let Us Now Praise Famous Men</title>
-          <description>Repudiandae facilis perferendis fugit.</description>
+          <title>All Passion Spent</title>
+          <description>Ducimus dolore iste ipsum.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -69,21 +69,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '180'
+      - '157'
     body:
       encoding: UTF-8
       string: |
         <package name="Quebec" project="home:madam_submitter">
-          <title>Let Us Now Praise Famous Men</title>
-          <description>Repudiandae facilis perferendis fugit.</description>
+          <title>All Passion Spent</title>
+          <description>Ducimus dolore iste ipsum.</description>
         </package>
-  recorded_at: Thu, 03 Nov 2022 09:59:18 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:31 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:madam_submitter/Quebec/_config
     body:
       encoding: UTF-8
-      string: Voluptas fugiat amet. Aut et nesciunt. Deleniti quidem non.
+      string: Ut et numquam. Quia quo ex. Vel facilis sint.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -103,26 +103,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="3" vrev="3">
-          <srcmd5>c2e3a2c9eb148f59d124c9296ea44806</srcmd5>
+        <revision rev="17" vrev="17">
+          <srcmd5>bf3609d23273334d72de7f3d181a1064</srcmd5>
           <version>unknown</version>
-          <time>1667469558</time>
+          <time>1677089491</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 03 Nov 2022 09:59:18 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:32 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:madam_submitter/Quebec/somefile.txt
     body:
       encoding: UTF-8
-      string: Ab doloribus molestias. Voluptatem dolores cupiditate. Blanditiis dolorem
-        saepe.
+      string: Illo consectetur dolorum. Culpa vero mollitia. Hic ex neque.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -142,19 +141,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="4" vrev="4">
-          <srcmd5>eb25e0f36b43d6e581b6c59b994fc4ee</srcmd5>
+        <revision rev="18" vrev="18">
+          <srcmd5>2c4855eb11e5d1a9f88cd6a6cc40c834</srcmd5>
           <version>unknown</version>
-          <time>1667469558</time>
+          <time>1677089492</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 03 Nov 2022 09:59:18 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:32 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:madam_submitter/Quebec
@@ -163,7 +162,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - a36187f9-6a0e-4b53-b8d6-de46cdbef027
+      - 01b68c4b-7ca5-4ff5-9aa8-1a818e0026f4
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -182,18 +181,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '291'
+      - '293'
     body:
       encoding: UTF-8
       string: |
-        <directory name="Quebec" rev="4" vrev="4" srcmd5="eb25e0f36b43d6e581b6c59b994fc4ee">
-          <entry name="_config" md5="8a08252eba8aa2db93ab84d2e04a6082" size="59" mtime="1667469558"/>
-          <entry name="somefile.txt" md5="1dc4ccefbef53cafc49ddbb358f6efad" size="80" mtime="1667469558"/>
+        <directory name="Quebec" rev="18" vrev="18" srcmd5="2c4855eb11e5d1a9f88cd6a6cc40c834">
+          <entry name="_config" md5="3484fc323ac67bf322302ef973eab044" size="45" mtime="1677089491"/>
+          <entry name="somefile.txt" md5="184eb5a084171569eedf81c48c965679" size="60" mtime="1677089492"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:59:19 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:32 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:madam_submitter/Quebec?expand=1&rev=4
+    uri: http://backend:5352/source/home:madam_submitter/Quebec?expand=1&rev=18
     body:
       encoding: US-ASCII
       string: ''
@@ -216,60 +215,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '291'
+      - '293'
     body:
       encoding: UTF-8
       string: |
-        <directory name="Quebec" rev="4" vrev="4" srcmd5="eb25e0f36b43d6e581b6c59b994fc4ee">
-          <entry name="_config" md5="8a08252eba8aa2db93ab84d2e04a6082" size="59" mtime="1667469558"/>
-          <entry name="somefile.txt" md5="1dc4ccefbef53cafc49ddbb358f6efad" size="80" mtime="1667469558"/>
+        <directory name="Quebec" rev="18" vrev="18" srcmd5="2c4855eb11e5d1a9f88cd6a6cc40c834">
+          <entry name="_config" md5="3484fc323ac67bf322302ef973eab044" size="45" mtime="1677089491"/>
+          <entry name="somefile.txt" md5="184eb5a084171569eedf81c48c965679" size="60" mtime="1677089492"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:59:19 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:32 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:madam_submitter/Quebec
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Request-Id:
-      - a36187f9-6a0e-4b53-b8d6-de46cdbef027
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '291'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="Quebec" rev="4" vrev="4" srcmd5="eb25e0f36b43d6e581b6c59b994fc4ee">
-          <entry name="_config" md5="8a08252eba8aa2db93ab84d2e04a6082" size="59" mtime="1667469558"/>
-          <entry name="somefile.txt" md5="1dc4ccefbef53cafc49ddbb358f6efad" size="80" mtime="1667469558"/>
-        </directory>
-  recorded_at: Thu, 03 Nov 2022 09:59:19 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:madam_submitter/Quebec
+    uri: http://backend:5352/source/home:madam_submitter/Quebec/_history?deleted=1&meta=1&rev=18
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - a36187f9-6a0e-4b53-b8d6-de46cdbef027
+      - 01b68c4b-7ca5-4ff5-9aa8-1a818e0026f4
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -288,71 +251,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '291'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="Quebec" rev="4" vrev="4" srcmd5="eb25e0f36b43d6e581b6c59b994fc4ee">
-          <entry name="_config" md5="8a08252eba8aa2db93ab84d2e04a6082" size="59" mtime="1667469558"/>
-          <entry name="somefile.txt" md5="1dc4ccefbef53cafc49ddbb358f6efad" size="80" mtime="1667469558"/>
-        </directory>
-  recorded_at: Thu, 03 Nov 2022 09:59:19 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:madam_submitter/Quebec/_history
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '759'
+      - '31'
     body:
       encoding: UTF-8
       string: |
         <revisionlist>
-          <revision rev="1" vrev="1">
-            <srcmd5>675f87f995b3d007d0257b45ed4a7c19</srcmd5>
-            <version>unknown</version>
-            <time>1667469538</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="2" vrev="2">
-            <srcmd5>ddd3491d11bfccb6d4a5ded8d29c8e0f</srcmd5>
-            <version>unknown</version>
-            <time>1667469538</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="3" vrev="3">
-            <srcmd5>c2e3a2c9eb148f59d124c9296ea44806</srcmd5>
-            <version>unknown</version>
-            <time>1667469558</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="4" vrev="4">
-            <srcmd5>eb25e0f36b43d6e581b6c59b994fc4ee</srcmd5>
-            <version>unknown</version>
-            <time>1667469558</time>
-            <user>unknown</user>
-          </revision>
         </revisionlist>
-  recorded_at: Thu, 03 Nov 2022 09:59:19 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:32 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:madam_submitter/Quebec
@@ -361,7 +266,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - a70c4094-661c-4670-9268-6400ae22b024
+      - 01b68c4b-7ca5-4ff5-9aa8-1a818e0026f4
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -380,15 +285,121 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '291'
+      - '293'
     body:
       encoding: UTF-8
       string: |
-        <directory name="Quebec" rev="4" vrev="4" srcmd5="eb25e0f36b43d6e581b6c59b994fc4ee">
-          <entry name="_config" md5="8a08252eba8aa2db93ab84d2e04a6082" size="59" mtime="1667469558"/>
-          <entry name="somefile.txt" md5="1dc4ccefbef53cafc49ddbb358f6efad" size="80" mtime="1667469558"/>
+        <directory name="Quebec" rev="18" vrev="18" srcmd5="2c4855eb11e5d1a9f88cd6a6cc40c834">
+          <entry name="_config" md5="3484fc323ac67bf322302ef973eab044" size="45" mtime="1677089491"/>
+          <entry name="somefile.txt" md5="184eb5a084171569eedf81c48c965679" size="60" mtime="1677089492"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:59:19 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:32 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:madam_submitter/Quebec
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 01b68c4b-7ca5-4ff5-9aa8-1a818e0026f4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '293'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="Quebec" rev="18" vrev="18" srcmd5="2c4855eb11e5d1a9f88cd6a6cc40c834">
+          <entry name="_config" md5="3484fc323ac67bf322302ef973eab044" size="45" mtime="1677089491"/>
+          <entry name="somefile.txt" md5="184eb5a084171569eedf81c48c965679" size="60" mtime="1677089492"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:11:32 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:madam_submitter/Quebec/_history?deleted=1&meta=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 01b68c4b-7ca5-4ff5-9aa8-1a818e0026f4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Wed, 22 Feb 2023 18:11:32 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:madam_submitter/Quebec
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 6a552ebe-adf0-4903-9eab-9474c18b6a73
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '293'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="Quebec" rev="18" vrev="18" srcmd5="2c4855eb11e5d1a9f88cd6a6cc40c834">
+          <entry name="_config" md5="3484fc323ac67bf322302ef973eab044" size="45" mtime="1677089491"/>
+          <entry name="somefile.txt" md5="184eb5a084171569eedf81c48c965679" size="60" mtime="1677089492"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:11:32 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:madam_submitter/_result?lastbuild=1&locallink=1&multibuild=1&package=Quebec&view=status
@@ -397,7 +408,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - a70c4094-661c-4670-9268-6400ae22b024
+      - 6a552ebe-adf0-4903-9eab-9474c18b6a73
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -422,7 +433,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:59:19 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:32 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:madam_submitter/Quebec
@@ -431,7 +442,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 54e215ba-9e28-4c3f-8b3a-3c613ec4450e
+      - 6712bab2-d944-4327-9392-65b24def7605
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -450,15 +461,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '291'
+      - '293'
     body:
       encoding: UTF-8
       string: |
-        <directory name="Quebec" rev="4" vrev="4" srcmd5="eb25e0f36b43d6e581b6c59b994fc4ee">
-          <entry name="_config" md5="8a08252eba8aa2db93ab84d2e04a6082" size="59" mtime="1667469558"/>
-          <entry name="somefile.txt" md5="1dc4ccefbef53cafc49ddbb358f6efad" size="80" mtime="1667469558"/>
+        <directory name="Quebec" rev="18" vrev="18" srcmd5="2c4855eb11e5d1a9f88cd6a6cc40c834">
+          <entry name="_config" md5="3484fc323ac67bf322302ef973eab044" size="45" mtime="1677089491"/>
+          <entry name="somefile.txt" md5="184eb5a084171569eedf81c48c965679" size="60" mtime="1677089492"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:59:19 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:32 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:madam_submitter/_result?lastbuild=1&locallink=1&multibuild=1&package=Quebec&view=status
@@ -467,7 +478,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 54e215ba-9e28-4c3f-8b3a-3c613ec4450e
+      - 6712bab2-d944-4327-9392-65b24def7605
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -492,7 +503,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:59:19 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:32 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:madam_submitter/_result?package=Quebec&view=status
@@ -501,7 +512,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - a736c91a-0902-462f-b953-555edc851616
+      - 75c3d157-60f2-4fb5-bdea-572bb1843c89
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -526,7 +537,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:59:19 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:32 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:madam_submitter/Quebec?view=info
@@ -535,7 +546,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 17d500eb-339b-40fe-b875-dd31527ba22d
+      - e4bb7d69-80ca-4de5-85c9-4a79762ec3dd
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -554,14 +565,14 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '224'
+      - '226'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="Quebec" rev="4" vrev="4" srcmd5="eb25e0f36b43d6e581b6c59b994fc4ee" verifymd5="eb25e0f36b43d6e581b6c59b994fc4ee">
+        <sourceinfo package="Quebec" rev="18" vrev="18" srcmd5="2c4855eb11e5d1a9f88cd6a6cc40c834" verifymd5="2c4855eb11e5d1a9f88cd6a6cc40c834">
           <error>bad build configuration, no build type defined or detected</error>
         </sourceinfo>
-  recorded_at: Thu, 03 Nov 2022 09:59:19 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:32 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:madam_submitter/Quebec
@@ -570,7 +581,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 17d500eb-339b-40fe-b875-dd31527ba22d
+      - e4bb7d69-80ca-4de5-85c9-4a79762ec3dd
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -589,15 +600,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '291'
+      - '293'
     body:
       encoding: UTF-8
       string: |
-        <directory name="Quebec" rev="4" vrev="4" srcmd5="eb25e0f36b43d6e581b6c59b994fc4ee">
-          <entry name="_config" md5="8a08252eba8aa2db93ab84d2e04a6082" size="59" mtime="1667469558"/>
-          <entry name="somefile.txt" md5="1dc4ccefbef53cafc49ddbb358f6efad" size="80" mtime="1667469558"/>
+        <directory name="Quebec" rev="18" vrev="18" srcmd5="2c4855eb11e5d1a9f88cd6a6cc40c834">
+          <entry name="_config" md5="3484fc323ac67bf322302ef973eab044" size="45" mtime="1677089491"/>
+          <entry name="somefile.txt" md5="184eb5a084171569eedf81c48c965679" size="60" mtime="1677089492"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:59:19 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:32 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:madam_submitter/Quebec?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -625,18 +636,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '314'
+      - '315'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="b43b5cf57ee614bffe377b36fe68fd2e">
+        <sourcediff key="0dbc7081540426406f5b5ac58c084b9b">
           <old project="home:madam_submitter" package="Quebec" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:madam_submitter" package="Quebec" rev="4" srcmd5="eb25e0f36b43d6e581b6c59b994fc4ee"/>
+          <new project="home:madam_submitter" package="Quebec" rev="18" srcmd5="2c4855eb11e5d1a9f88cd6a6cc40c834"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 03 Nov 2022 09:59:19 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:32 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:mr_receiver/_meta?user=mr_receiver
@@ -676,7 +687,7 @@ http_interactions:
           <description></description>
           <person userid="mr_receiver" role="maintainer"/>
         </project>
-  recorded_at: Thu, 03 Nov 2022 09:59:19 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:32 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:madam_submitter/Quebec
@@ -685,7 +696,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 41d3dc09-d1ee-45e4-aadc-d5eee9f87805
+      - 5bd826b9-cd0a-483f-bedf-85a9fdd34ad4
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -704,15 +715,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '291'
+      - '293'
     body:
       encoding: UTF-8
       string: |
-        <directory name="Quebec" rev="4" vrev="4" srcmd5="eb25e0f36b43d6e581b6c59b994fc4ee">
-          <entry name="_config" md5="8a08252eba8aa2db93ab84d2e04a6082" size="59" mtime="1667469558"/>
-          <entry name="somefile.txt" md5="1dc4ccefbef53cafc49ddbb358f6efad" size="80" mtime="1667469558"/>
+        <directory name="Quebec" rev="18" vrev="18" srcmd5="2c4855eb11e5d1a9f88cd6a6cc40c834">
+          <entry name="_config" md5="3484fc323ac67bf322302ef973eab044" size="45" mtime="1677089491"/>
+          <entry name="somefile.txt" md5="184eb5a084171569eedf81c48c965679" size="60" mtime="1677089492"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:59:20 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:33 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:madam_submitter/Quebec
@@ -721,7 +732,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 41d3dc09-d1ee-45e4-aadc-d5eee9f87805
+      - 5bd826b9-cd0a-483f-bedf-85a9fdd34ad4
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -740,18 +751,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '291'
+      - '293'
     body:
       encoding: UTF-8
       string: |
-        <directory name="Quebec" rev="4" vrev="4" srcmd5="eb25e0f36b43d6e581b6c59b994fc4ee">
-          <entry name="_config" md5="8a08252eba8aa2db93ab84d2e04a6082" size="59" mtime="1667469558"/>
-          <entry name="somefile.txt" md5="1dc4ccefbef53cafc49ddbb358f6efad" size="80" mtime="1667469558"/>
+        <directory name="Quebec" rev="18" vrev="18" srcmd5="2c4855eb11e5d1a9f88cd6a6cc40c834">
+          <entry name="_config" md5="3484fc323ac67bf322302ef973eab044" size="45" mtime="1677089491"/>
+          <entry name="somefile.txt" md5="184eb5a084171569eedf81c48c965679" size="60" mtime="1677089492"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:59:20 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:33 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/home:madam_submitter/Quebec?cmd=diff&expand=1&nodiff=1&orev=0&rev=4
+    uri: http://backend:5352/source/home:madam_submitter/Quebec?cmd=diff&expand=1&nodiff=1&orev=0&rev=18
     body:
       encoding: UTF-8
       string: ''
@@ -759,7 +770,7 @@ http_interactions:
       Content-Type:
       - application/octet-stream
       X-Request-Id:
-      - 41d3dc09-d1ee-45e4-aadc-d5eee9f87805
+      - 5bd826b9-cd0a-483f-bedf-85a9fdd34ad4
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -798,16 +809,16 @@ http_interactions:
         ++++++ somefile.txt (new)
         --- somefile.txt
         +++ somefile.txt
-  recorded_at: Thu, 03 Nov 2022 09:59:20 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:33 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:madam_submitter/Quebec?expand=1&rev=4
+    uri: http://backend:5352/source/home:madam_submitter/Quebec?expand=1&rev=18
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - 41d3dc09-d1ee-45e4-aadc-d5eee9f87805
+      - 5bd826b9-cd0a-483f-bedf-85a9fdd34ad4
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -826,107 +837,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '291'
+      - '293'
     body:
       encoding: UTF-8
       string: |
-        <directory name="Quebec" rev="4" vrev="4" srcmd5="eb25e0f36b43d6e581b6c59b994fc4ee">
-          <entry name="_config" md5="8a08252eba8aa2db93ab84d2e04a6082" size="59" mtime="1667469558"/>
-          <entry name="somefile.txt" md5="1dc4ccefbef53cafc49ddbb358f6efad" size="80" mtime="1667469558"/>
+        <directory name="Quebec" rev="18" vrev="18" srcmd5="2c4855eb11e5d1a9f88cd6a6cc40c834">
+          <entry name="_config" md5="3484fc323ac67bf322302ef973eab044" size="45" mtime="1677089491"/>
+          <entry name="somefile.txt" md5="184eb5a084171569eedf81c48c965679" size="60" mtime="1677089492"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:59:20 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:madam_submitter/Quebec
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Request-Id:
-      - 41d3dc09-d1ee-45e4-aadc-d5eee9f87805
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '291'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="Quebec" rev="4" vrev="4" srcmd5="eb25e0f36b43d6e581b6c59b994fc4ee">
-          <entry name="_config" md5="8a08252eba8aa2db93ab84d2e04a6082" size="59" mtime="1667469558"/>
-          <entry name="somefile.txt" md5="1dc4ccefbef53cafc49ddbb358f6efad" size="80" mtime="1667469558"/>
-        </directory>
-  recorded_at: Thu, 03 Nov 2022 09:59:20 GMT
-- request:
-    method: post
-    uri: http://backend:5352/source/home:madam_submitter/Quebec?cmd=diff&expand=1&filelimit=10000&orev=0&rev=4&tarlimit=10000&view=xml&withissues=1
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      Content-Type:
-      - application/octet-stream
-      X-Request-Id:
-      - 41d3dc09-d1ee-45e4-aadc-d5eee9f87805
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '848'
-    body:
-      encoding: UTF-8
-      string: |
-        <sourcediff key="478dcf438349e223e0b09ba8d3b19215">
-          <old project="home:madam_submitter" package="Quebec" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:madam_submitter" package="Quebec" rev="4" srcmd5="eb25e0f36b43d6e581b6c59b994fc4ee"/>
-          <files>
-            <file state="added">
-              <new name="_config" md5="8a08252eba8aa2db93ab84d2e04a6082" size="59"/>
-              <diff lines="3">@@ -0,0 +1,1 @@
-        +Voluptas fugiat amet. Aut et nesciunt. Deleniti quidem non.
-        \ No newline at end of file
-        </diff>
-            </file>
-            <file state="added">
-              <new name="somefile.txt" md5="1dc4ccefbef53cafc49ddbb358f6efad" size="80"/>
-              <diff lines="3">@@ -0,0 +1,1 @@
-        +Ab doloribus molestias. Voluptatem dolores cupiditate. Blanditiis dolorem saepe.
-        \ No newline at end of file
-        </diff>
-            </file>
-          </files>
-          <issues>
-          </issues>
-        </sourcediff>
-  recorded_at: Thu, 03 Nov 2022 09:59:20 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:33 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:madam_submitter/Quebec
@@ -935,7 +854,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 447bc5bf-4247-4025-a07b-ea5a754ae726
+      - 5bd826b9-cd0a-483f-bedf-85a9fdd34ad4
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -954,18 +873,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '291'
+      - '293'
     body:
       encoding: UTF-8
       string: |
-        <directory name="Quebec" rev="4" vrev="4" srcmd5="eb25e0f36b43d6e581b6c59b994fc4ee">
-          <entry name="_config" md5="8a08252eba8aa2db93ab84d2e04a6082" size="59" mtime="1667469558"/>
-          <entry name="somefile.txt" md5="1dc4ccefbef53cafc49ddbb358f6efad" size="80" mtime="1667469558"/>
+        <directory name="Quebec" rev="18" vrev="18" srcmd5="2c4855eb11e5d1a9f88cd6a6cc40c834">
+          <entry name="_config" md5="3484fc323ac67bf322302ef973eab044" size="45" mtime="1677089491"/>
+          <entry name="somefile.txt" md5="184eb5a084171569eedf81c48c965679" size="60" mtime="1677089492"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:59:20 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:33 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/home:madam_submitter/Quebec?cacheonly=1&cmd=diff&expand=1&filelimit=10000&orev=0&rev=4&tarlimit=10000&view=xml&withissues=1
+    uri: http://backend:5352/source/home:madam_submitter/Quebec?cmd=diff&expand=1&filelimit=10000&orev=0&rev=18&tarlimit=10000&view=xml&withissues=1
     body:
       encoding: UTF-8
       string: ''
@@ -973,7 +892,99 @@ http_interactions:
       Content-Type:
       - application/octet-stream
       X-Request-Id:
-      - 447bc5bf-4247-4025-a07b-ea5a754ae726
+      - 5bd826b9-cd0a-483f-bedf-85a9fdd34ad4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '815'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="bfc8a9f8608f38c725666e93d14a94d6">
+          <old project="home:madam_submitter" package="Quebec" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="home:madam_submitter" package="Quebec" rev="18" srcmd5="2c4855eb11e5d1a9f88cd6a6cc40c834"/>
+          <files>
+            <file state="added">
+              <new name="_config" md5="3484fc323ac67bf322302ef973eab044" size="45"/>
+              <diff lines="3">@@ -0,0 +1,1 @@
+        +Ut et numquam. Quia quo ex. Vel facilis sint.
+        \ No newline at end of file
+        </diff>
+            </file>
+            <file state="added">
+              <new name="somefile.txt" md5="184eb5a084171569eedf81c48c965679" size="60"/>
+              <diff lines="3">@@ -0,0 +1,1 @@
+        +Illo consectetur dolorum. Culpa vero mollitia. Hic ex neque.
+        \ No newline at end of file
+        </diff>
+            </file>
+          </files>
+          <issues>
+          </issues>
+        </sourcediff>
+  recorded_at: Wed, 22 Feb 2023 18:11:33 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:madam_submitter/Quebec
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 3839c000-ccd3-4074-bc62-f35c6ba2e0c6
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '293'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="Quebec" rev="18" vrev="18" srcmd5="2c4855eb11e5d1a9f88cd6a6cc40c834">
+          <entry name="_config" md5="3484fc323ac67bf322302ef973eab044" size="45" mtime="1677089491"/>
+          <entry name="somefile.txt" md5="184eb5a084171569eedf81c48c965679" size="60" mtime="1677089492"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:11:33 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/home:madam_submitter/Quebec?cacheonly=1&cmd=diff&expand=1&filelimit=10000&orev=0&rev=18&tarlimit=10000&view=xml&withissues=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      X-Request-Id:
+      - 3839c000-ccd3-4074-bc62-f35c6ba2e0c6
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -988,7 +999,7 @@ http_interactions:
       Content-Type:
       - text/xml
       Content-Length:
-      - '848'
+      - '815'
       Cache-Control:
       - no-cache
       Connection:
@@ -996,21 +1007,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="478dcf438349e223e0b09ba8d3b19215">
+        <sourcediff key="bfc8a9f8608f38c725666e93d14a94d6">
           <old project="home:madam_submitter" package="Quebec" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:madam_submitter" package="Quebec" rev="4" srcmd5="eb25e0f36b43d6e581b6c59b994fc4ee"/>
+          <new project="home:madam_submitter" package="Quebec" rev="18" srcmd5="2c4855eb11e5d1a9f88cd6a6cc40c834"/>
           <files>
             <file state="added">
-              <new name="_config" md5="8a08252eba8aa2db93ab84d2e04a6082" size="59"/>
+              <new name="_config" md5="3484fc323ac67bf322302ef973eab044" size="45"/>
               <diff lines="3">@@ -0,0 +1,1 @@
-        +Voluptas fugiat amet. Aut et nesciunt. Deleniti quidem non.
+        +Ut et numquam. Quia quo ex. Vel facilis sint.
         \ No newline at end of file
         </diff>
             </file>
             <file state="added">
-              <new name="somefile.txt" md5="1dc4ccefbef53cafc49ddbb358f6efad" size="80"/>
+              <new name="somefile.txt" md5="184eb5a084171569eedf81c48c965679" size="60"/>
               <diff lines="3">@@ -0,0 +1,1 @@
-        +Ab doloribus molestias. Voluptatem dolores cupiditate. Blanditiis dolorem saepe.
+        +Illo consectetur dolorum. Culpa vero mollitia. Hic ex neque.
         \ No newline at end of file
         </diff>
             </file>
@@ -1018,7 +1029,7 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 03 Nov 2022 09:59:20 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:33 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:madam_submitter/_result?package=Quebec&view=status
@@ -1027,7 +1038,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 0b657043-2f3d-41f3-b539-039e7b700f7d
+      - 90fc7dec-b99b-41bb-994d-e46e5c7d0e75
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1052,5 +1063,5 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:59:20 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:33 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Bootstrap_Requests_Submissions/submit_package/prefill_form_for_a_branched_package/fills_in_the_submission_reasons_and_creates_a_BsRequest.yml
+++ b/src/api/spec/cassettes/Bootstrap_Requests_Submissions/submit_package/prefill_form_for_a_branched_package/fills_in_the_submission_reasons_and_creates_a_BsRequest.yml
@@ -39,7 +39,7 @@ http_interactions:
           <description></description>
           <person userid="madam_submitter" role="maintainer"/>
         </project>
-  recorded_at: Mon, 18 Oct 2021 14:48:08 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:34 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:madam_submitter/Quebec/_meta?user=madam_submitter
@@ -47,8 +47,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="Quebec" project="home:madam_submitter">
-          <title>As I Lay Dying</title>
-          <description>Est consequuntur rerum aperiam.</description>
+          <title>Death Be Not Proud</title>
+          <description>Necessitatibus mollitia voluptas dolor.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -69,21 +69,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '159'
+      - '171'
     body:
       encoding: UTF-8
       string: |
         <package name="Quebec" project="home:madam_submitter">
-          <title>As I Lay Dying</title>
-          <description>Est consequuntur rerum aperiam.</description>
+          <title>Death Be Not Proud</title>
+          <description>Necessitatibus mollitia voluptas dolor.</description>
         </package>
-  recorded_at: Mon, 18 Oct 2021 14:48:13 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:44 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:madam_submitter/Quebec/_config
     body:
       encoding: UTF-8
-      string: Aut laudantium sunt. Et est adipisci. Fugit dolores et.
+      string: Autem libero eos. Perferendis praesentium aspernatur. Ipsa modi inventore.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -103,26 +103,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="5" vrev="5">
-          <srcmd5>4ac45c25222bf25aa097b4ed0b63f9d0</srcmd5>
+        <revision rev="19" vrev="19">
+          <srcmd5>5ea83fad2c141a99219a0a897d194f70</srcmd5>
           <version>unknown</version>
-          <time>1634568493</time>
+          <time>1677089504</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Mon, 18 Oct 2021 14:48:13 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:44 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:madam_submitter/Quebec/somefile.txt
     body:
       encoding: UTF-8
-      string: Tempora laboriosam maxime. Eaque consequatur voluptatem. At voluptatibus
-        autem.
+      string: Quis quos sit. Eos non temporibus. Enim beatae blanditiis.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -142,19 +141,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="6" vrev="6">
-          <srcmd5>e0c74fad0eac27539a9e7d7283a6da34</srcmd5>
+        <revision rev="20" vrev="20">
+          <srcmd5>e414927bf2743c5efbaf4b31fdf525d2</srcmd5>
           <version>unknown</version>
-          <time>1634568493</time>
+          <time>1677089504</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Mon, 18 Oct 2021 14:48:13 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:44 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:mr_receiver/_meta?user=mr_receiver
@@ -194,7 +193,7 @@ http_interactions:
           <description></description>
           <person userid="mr_receiver" role="maintainer"/>
         </project>
-  recorded_at: Mon, 18 Oct 2021 14:48:13 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:44 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:mr_receiver/Quebec/_meta?user=madam_submitter
@@ -202,8 +201,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="Quebec" project="home:mr_receiver">
-          <title>Fame Is the Spur</title>
-          <description>Reprehenderit totam commodi dignissimos.</description>
+          <title>The Other Side of Silence</title>
+          <description>A neque velit voluptatem.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -224,21 +223,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '166'
+      - '160'
     body:
       encoding: UTF-8
       string: |
         <package name="Quebec" project="home:mr_receiver">
-          <title>Fame Is the Spur</title>
-          <description>Reprehenderit totam commodi dignissimos.</description>
+          <title>The Other Side of Silence</title>
+          <description>A neque velit voluptatem.</description>
         </package>
-  recorded_at: Mon, 18 Oct 2021 14:48:13 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:44 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:mr_receiver/Quebec/_config
     body:
       encoding: UTF-8
-      string: Aperiam facilis qui. Consequatur repellendus itaque. Quasi aut atque.
+      string: Est perferendis delectus. Ullam iste repudiandae. Debitis illo ut.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -258,25 +257,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="3" vrev="3">
-          <srcmd5>a2fdb3cf26966ae0156f3bb07fa7348a</srcmd5>
+        <revision rev="11" vrev="11">
+          <srcmd5>d277d309a099e4ab3c4156b3b182791f</srcmd5>
           <version>unknown</version>
-          <time>1634568493</time>
+          <time>1677089504</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Mon, 18 Oct 2021 14:48:13 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:44 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:mr_receiver/Quebec/somefile.txt
     body:
       encoding: UTF-8
-      string: Suscipit odit consequuntur. Autem et omnis. Animi occaecati cupiditate.
+      string: Quo autem voluptas. Libero animi in. Ratione qui et.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -296,19 +295,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="4" vrev="4">
-          <srcmd5>5218efc8527667153d25e497cdb880e7</srcmd5>
+        <revision rev="12" vrev="12">
+          <srcmd5>08207ccec2a39f1777a5dca1f3b863b9</srcmd5>
           <version>unknown</version>
-          <time>1634568493</time>
+          <time>1677089504</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Mon, 18 Oct 2021 14:48:13 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:44 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22Quebec%22%20and%20linkinfo/@project=%22home:madam_submitter%22%20and%20@project=%22home:madam_submitter%22)
@@ -336,13 +335,14 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '27'
+      - '92'
     body:
       encoding: UTF-8
       string: |
         <collection>
+          <package name="Quebec_branch" project="home:madam_submitter"/>
         </collection>
-  recorded_at: Mon, 18 Oct 2021 14:48:13 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:44 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:madam_submitter/Quebec_branch/_meta?user=madam_submitter
@@ -350,8 +350,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="Quebec_branch" project="home:madam_submitter">
-          <title>As I Lay Dying</title>
-          <description>Est consequuntur rerum aperiam.</description>
+          <title>Death Be Not Proud</title>
+          <description>Necessitatibus mollitia voluptas dolor.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -372,15 +372,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '166'
+      - '178'
     body:
       encoding: UTF-8
       string: |
         <package name="Quebec_branch" project="home:madam_submitter">
-          <title>As I Lay Dying</title>
-          <description>Est consequuntur rerum aperiam.</description>
+          <title>Death Be Not Proud</title>
+          <description>Necessitatibus mollitia voluptas dolor.</description>
         </package>
-  recorded_at: Mon, 18 Oct 2021 14:48:13 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:44 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:madam_submitter/Quebec_branch?cmd=branch&noservice=1&opackage=Quebec&oproject=home:madam_submitter&user=madam_submitter
@@ -412,15 +412,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1" vrev="1">
-          <srcmd5>bff681342dbac47bf52120585b319e83</srcmd5>
+        <revision rev="7" vrev="7">
+          <srcmd5>5cab870af101e7a08107d1f2abb76e94</srcmd5>
           <version>unknown</version>
-          <time>1634568493</time>
+          <time>1677089504</time>
           <user>madam_submitter</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Mon, 18 Oct 2021 14:48:14 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:44 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:madam_submitter/Quebec_branch/_meta?user=madam_submitter
@@ -428,8 +428,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="Quebec_branch" project="home:madam_submitter">
-          <title>As I Lay Dying</title>
-          <description>Est consequuntur rerum aperiam.</description>
+          <title>Death Be Not Proud</title>
+          <description>Necessitatibus mollitia voluptas dolor.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -450,15 +450,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '166'
+      - '178'
     body:
       encoding: UTF-8
       string: |
         <package name="Quebec_branch" project="home:madam_submitter">
-          <title>As I Lay Dying</title>
-          <description>Est consequuntur rerum aperiam.</description>
+          <title>Death Be Not Proud</title>
+          <description>Necessitatibus mollitia voluptas dolor.</description>
         </package>
-  recorded_at: Mon, 18 Oct 2021 14:48:14 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:44 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:madam_submitter/Quebec_branch
@@ -488,13 +488,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="Quebec_branch" rev="1" vrev="1" srcmd5="bff681342dbac47bf52120585b319e83">
-          <linkinfo project="home:madam_submitter" package="Quebec" srcmd5="e0c74fad0eac27539a9e7d7283a6da34" baserev="e0c74fad0eac27539a9e7d7283a6da34" xsrcmd5="6e18e2ee80fa4a000b6bcc2302b97562" lsrcmd5="bff681342dbac47bf52120585b319e83"/>
-          <entry name="_config" md5="8a94713e738c00ecaed7cb03157a71c3" size="55" mtime="1634568493"/>
-          <entry name="_link" md5="b17ccb8fdd865a64ea96f82bf79c6ffc" size="114" mtime="1634568493"/>
-          <entry name="somefile.txt" md5="e16521ba9b6163790284dbad3b87bc57" size="79" mtime="1634568493"/>
+        <directory name="Quebec_branch" rev="7" vrev="7" srcmd5="5cab870af101e7a08107d1f2abb76e94">
+          <linkinfo project="home:madam_submitter" package="Quebec" srcmd5="e414927bf2743c5efbaf4b31fdf525d2" baserev="e414927bf2743c5efbaf4b31fdf525d2" xsrcmd5="3b81a13df4e54ecc1fe05c3a8ff21345" lsrcmd5="5cab870af101e7a08107d1f2abb76e94"/>
+          <entry name="_config" md5="d9a6910d72687fa4f2487f7e6f865524" size="74" mtime="1677089504"/>
+          <entry name="_link" md5="189f2fe0ee1712f096a1c7043468a712" size="114" mtime="1677089504"/>
+          <entry name="somefile.txt" md5="17d687b5a63b461c2e1e61817934d5c7" size="58" mtime="1677089504"/>
         </directory>
-  recorded_at: Mon, 18 Oct 2021 14:48:14 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:44 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:madam_submitter/Quebec_branch?view=info
@@ -520,15 +520,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '334'
+      - '335'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="Quebec_branch" rev="1" vrev="7" srcmd5="6e18e2ee80fa4a000b6bcc2302b97562" lsrcmd5="bff681342dbac47bf52120585b319e83" verifymd5="e0c74fad0eac27539a9e7d7283a6da34">
+        <sourceinfo package="Quebec_branch" rev="7" vrev="27" srcmd5="3b81a13df4e54ecc1fe05c3a8ff21345" lsrcmd5="5cab870af101e7a08107d1f2abb76e94" verifymd5="e414927bf2743c5efbaf4b31fdf525d2">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="home:madam_submitter" package="Quebec"/>
         </sourceinfo>
-  recorded_at: Mon, 18 Oct 2021 14:48:14 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:44 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:madam_submitter/Quebec_branch
@@ -558,13 +558,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="Quebec_branch" rev="1" vrev="1" srcmd5="bff681342dbac47bf52120585b319e83">
-          <linkinfo project="home:madam_submitter" package="Quebec" srcmd5="e0c74fad0eac27539a9e7d7283a6da34" baserev="e0c74fad0eac27539a9e7d7283a6da34" xsrcmd5="6e18e2ee80fa4a000b6bcc2302b97562" lsrcmd5="bff681342dbac47bf52120585b319e83"/>
-          <entry name="_config" md5="8a94713e738c00ecaed7cb03157a71c3" size="55" mtime="1634568493"/>
-          <entry name="_link" md5="b17ccb8fdd865a64ea96f82bf79c6ffc" size="114" mtime="1634568493"/>
-          <entry name="somefile.txt" md5="e16521ba9b6163790284dbad3b87bc57" size="79" mtime="1634568493"/>
+        <directory name="Quebec_branch" rev="7" vrev="7" srcmd5="5cab870af101e7a08107d1f2abb76e94">
+          <linkinfo project="home:madam_submitter" package="Quebec" srcmd5="e414927bf2743c5efbaf4b31fdf525d2" baserev="e414927bf2743c5efbaf4b31fdf525d2" xsrcmd5="3b81a13df4e54ecc1fe05c3a8ff21345" lsrcmd5="5cab870af101e7a08107d1f2abb76e94"/>
+          <entry name="_config" md5="d9a6910d72687fa4f2487f7e6f865524" size="74" mtime="1677089504"/>
+          <entry name="_link" md5="189f2fe0ee1712f096a1c7043468a712" size="114" mtime="1677089504"/>
+          <entry name="somefile.txt" md5="17d687b5a63b461c2e1e61817934d5c7" size="58" mtime="1677089504"/>
         </directory>
-  recorded_at: Mon, 18 Oct 2021 14:48:14 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:44 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:madam_submitter/Quebec_branch?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -596,14 +596,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="2ec950b5b5ee9721a19f8911adac2954">
+        <sourcediff key="c1244000a95428f1b885116cee323b9f">
           <old project="home:madam_submitter" package="Quebec_branch" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:madam_submitter" package="Quebec_branch" rev="1" srcmd5="bff681342dbac47bf52120585b319e83"/>
+          <new project="home:madam_submitter" package="Quebec_branch" rev="7" srcmd5="5cab870af101e7a08107d1f2abb76e94"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Mon, 18 Oct 2021 14:48:14 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:44 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:madam_submitter/Quebec_branch?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -635,14 +635,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="ba60a7b9651434e18f50df41db6ff2ee">
-          <old project="home:madam_submitter" package="Quebec" rev="e0c74fad0eac27539a9e7d7283a6da34" srcmd5="e0c74fad0eac27539a9e7d7283a6da34"/>
-          <new project="home:madam_submitter" package="Quebec_branch" rev="6e18e2ee80fa4a000b6bcc2302b97562" srcmd5="6e18e2ee80fa4a000b6bcc2302b97562"/>
+        <sourcediff key="e6b64d75fc552d5840e68262fbf5e3ca">
+          <old project="home:madam_submitter" package="Quebec" rev="e414927bf2743c5efbaf4b31fdf525d2" srcmd5="e414927bf2743c5efbaf4b31fdf525d2"/>
+          <new project="home:madam_submitter" package="Quebec_branch" rev="3b81a13df4e54ecc1fe05c3a8ff21345" srcmd5="3b81a13df4e54ecc1fe05c3a8ff21345"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Mon, 18 Oct 2021 14:48:14 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:44 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:madam_submitter/_meta?user=madam_submitter
@@ -682,7 +682,7 @@ http_interactions:
           <description></description>
           <person userid="madam_submitter" role="maintainer"/>
         </project>
-  recorded_at: Mon, 18 Oct 2021 14:48:14 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:44 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:madam_submitter/Quebec_branch/new_file?user=madam_submitter
@@ -712,15 +712,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="2" vrev="2">
-          <srcmd5>484f5b39ca4c6682a003aeac924b40f3</srcmd5>
+        <revision rev="8" vrev="8">
+          <srcmd5>4b4b8e8ae3ed82710a39ff383c2e1f6c</srcmd5>
           <version>unknown</version>
-          <time>1634568494</time>
+          <time>1677089504</time>
           <user>madam_submitter</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Mon, 18 Oct 2021 14:48:14 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:44 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:madam_submitter/Quebec_branch/_meta?user=madam_submitter
@@ -728,8 +728,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="Quebec_branch" project="home:madam_submitter">
-          <title>As I Lay Dying</title>
-          <description>Est consequuntur rerum aperiam.</description>
+          <title>Death Be Not Proud</title>
+          <description>Necessitatibus mollitia voluptas dolor.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -750,15 +750,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '166'
+      - '178'
     body:
       encoding: UTF-8
       string: |
         <package name="Quebec_branch" project="home:madam_submitter">
-          <title>As I Lay Dying</title>
-          <description>Est consequuntur rerum aperiam.</description>
+          <title>Death Be Not Proud</title>
+          <description>Necessitatibus mollitia voluptas dolor.</description>
         </package>
-  recorded_at: Mon, 18 Oct 2021 14:48:14 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:44 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:madam_submitter/Quebec_branch
@@ -788,14 +788,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="Quebec_branch" rev="2" vrev="2" srcmd5="484f5b39ca4c6682a003aeac924b40f3">
-          <linkinfo project="home:madam_submitter" package="Quebec" srcmd5="e0c74fad0eac27539a9e7d7283a6da34" baserev="e0c74fad0eac27539a9e7d7283a6da34" xsrcmd5="2ee1ba7040feed5b7aa79cda85800037" lsrcmd5="484f5b39ca4c6682a003aeac924b40f3"/>
-          <entry name="_config" md5="8a94713e738c00ecaed7cb03157a71c3" size="55" mtime="1634568493"/>
-          <entry name="_link" md5="b17ccb8fdd865a64ea96f82bf79c6ffc" size="114" mtime="1634568493"/>
-          <entry name="new_file" md5="a451b9bbe42ff6529f209b4d184236fe" size="15" mtime="1634568494"/>
-          <entry name="somefile.txt" md5="e16521ba9b6163790284dbad3b87bc57" size="79" mtime="1634568493"/>
+        <directory name="Quebec_branch" rev="8" vrev="8" srcmd5="4b4b8e8ae3ed82710a39ff383c2e1f6c">
+          <linkinfo project="home:madam_submitter" package="Quebec" srcmd5="e414927bf2743c5efbaf4b31fdf525d2" baserev="e414927bf2743c5efbaf4b31fdf525d2" xsrcmd5="79420fcb8aa08dd3716c7c55f92cb1ed" lsrcmd5="4b4b8e8ae3ed82710a39ff383c2e1f6c"/>
+          <entry name="_config" md5="d9a6910d72687fa4f2487f7e6f865524" size="74" mtime="1677089504"/>
+          <entry name="_link" md5="189f2fe0ee1712f096a1c7043468a712" size="114" mtime="1677089504"/>
+          <entry name="new_file" md5="a451b9bbe42ff6529f209b4d184236fe" size="15" mtime="1677067300"/>
+          <entry name="somefile.txt" md5="17d687b5a63b461c2e1e61817934d5c7" size="58" mtime="1677089504"/>
         </directory>
-  recorded_at: Mon, 18 Oct 2021 14:48:14 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:44 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:madam_submitter/Quebec_branch?view=info
@@ -821,15 +821,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '334'
+      - '335'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="Quebec_branch" rev="2" vrev="8" srcmd5="2ee1ba7040feed5b7aa79cda85800037" lsrcmd5="484f5b39ca4c6682a003aeac924b40f3" verifymd5="47149435e84457a3a13953f9238d4894">
+        <sourceinfo package="Quebec_branch" rev="8" vrev="28" srcmd5="79420fcb8aa08dd3716c7c55f92cb1ed" lsrcmd5="4b4b8e8ae3ed82710a39ff383c2e1f6c" verifymd5="54d03615e235190bed325c762f9067c7">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="home:madam_submitter" package="Quebec"/>
         </sourceinfo>
-  recorded_at: Mon, 18 Oct 2021 14:48:14 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:44 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:madam_submitter/Quebec_branch
@@ -859,14 +859,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="Quebec_branch" rev="2" vrev="2" srcmd5="484f5b39ca4c6682a003aeac924b40f3">
-          <linkinfo project="home:madam_submitter" package="Quebec" srcmd5="e0c74fad0eac27539a9e7d7283a6da34" baserev="e0c74fad0eac27539a9e7d7283a6da34" xsrcmd5="2ee1ba7040feed5b7aa79cda85800037" lsrcmd5="484f5b39ca4c6682a003aeac924b40f3"/>
-          <entry name="_config" md5="8a94713e738c00ecaed7cb03157a71c3" size="55" mtime="1634568493"/>
-          <entry name="_link" md5="b17ccb8fdd865a64ea96f82bf79c6ffc" size="114" mtime="1634568493"/>
-          <entry name="new_file" md5="a451b9bbe42ff6529f209b4d184236fe" size="15" mtime="1634568494"/>
-          <entry name="somefile.txt" md5="e16521ba9b6163790284dbad3b87bc57" size="79" mtime="1634568493"/>
+        <directory name="Quebec_branch" rev="8" vrev="8" srcmd5="4b4b8e8ae3ed82710a39ff383c2e1f6c">
+          <linkinfo project="home:madam_submitter" package="Quebec" srcmd5="e414927bf2743c5efbaf4b31fdf525d2" baserev="e414927bf2743c5efbaf4b31fdf525d2" xsrcmd5="79420fcb8aa08dd3716c7c55f92cb1ed" lsrcmd5="4b4b8e8ae3ed82710a39ff383c2e1f6c"/>
+          <entry name="_config" md5="d9a6910d72687fa4f2487f7e6f865524" size="74" mtime="1677089504"/>
+          <entry name="_link" md5="189f2fe0ee1712f096a1c7043468a712" size="114" mtime="1677089504"/>
+          <entry name="new_file" md5="a451b9bbe42ff6529f209b4d184236fe" size="15" mtime="1677067300"/>
+          <entry name="somefile.txt" md5="17d687b5a63b461c2e1e61817934d5c7" size="58" mtime="1677089504"/>
         </directory>
-  recorded_at: Mon, 18 Oct 2021 14:48:14 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:44 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:madam_submitter/Quebec_branch?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -898,14 +898,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="9ba102a47638325efdb1314f7528c5cb">
+        <sourcediff key="410b15841c0552ec205f26376025a632">
           <old project="home:madam_submitter" package="Quebec_branch" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:madam_submitter" package="Quebec_branch" rev="2" srcmd5="484f5b39ca4c6682a003aeac924b40f3"/>
+          <new project="home:madam_submitter" package="Quebec_branch" rev="8" srcmd5="4b4b8e8ae3ed82710a39ff383c2e1f6c"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Mon, 18 Oct 2021 14:48:14 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:44 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:madam_submitter/Quebec_branch?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -937,14 +937,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="481d7958b0b99be4d0d98b61ac390d34">
-          <old project="home:madam_submitter" package="Quebec" rev="e0c74fad0eac27539a9e7d7283a6da34" srcmd5="e0c74fad0eac27539a9e7d7283a6da34"/>
-          <new project="home:madam_submitter" package="Quebec_branch" rev="2ee1ba7040feed5b7aa79cda85800037" srcmd5="2ee1ba7040feed5b7aa79cda85800037"/>
+        <sourcediff key="74b55ec960d32808681e9d165b65d8f1">
+          <old project="home:madam_submitter" package="Quebec" rev="e414927bf2743c5efbaf4b31fdf525d2" srcmd5="e414927bf2743c5efbaf4b31fdf525d2"/>
+          <new project="home:madam_submitter" package="Quebec_branch" rev="79420fcb8aa08dd3716c7c55f92cb1ed" srcmd5="79420fcb8aa08dd3716c7c55f92cb1ed"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Mon, 18 Oct 2021 14:48:14 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:44 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:madam_submitter/Quebec?view=info
@@ -953,7 +953,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - ffe0a825-f677-4c2d-8e0f-d0785dbd43c6
+      - 7d72ab24-1e82-4505-a991-c5eecf1ab635
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -972,14 +972,14 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '224'
+      - '226'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="Quebec" rev="6" vrev="6" srcmd5="e0c74fad0eac27539a9e7d7283a6da34" verifymd5="e0c74fad0eac27539a9e7d7283a6da34">
+        <sourceinfo package="Quebec" rev="20" vrev="20" srcmd5="e414927bf2743c5efbaf4b31fdf525d2" verifymd5="e414927bf2743c5efbaf4b31fdf525d2">
           <error>bad build configuration, no build type defined or detected</error>
         </sourceinfo>
-  recorded_at: Mon, 18 Oct 2021 14:48:14 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:44 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:madam_submitter/Quebec
@@ -988,7 +988,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - ffe0a825-f677-4c2d-8e0f-d0785dbd43c6
+      - 7d72ab24-1e82-4505-a991-c5eecf1ab635
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1007,15 +1007,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '291'
+      - '293'
     body:
       encoding: UTF-8
       string: |
-        <directory name="Quebec" rev="6" vrev="6" srcmd5="e0c74fad0eac27539a9e7d7283a6da34">
-          <entry name="_config" md5="8a94713e738c00ecaed7cb03157a71c3" size="55" mtime="1634568493"/>
-          <entry name="somefile.txt" md5="e16521ba9b6163790284dbad3b87bc57" size="79" mtime="1634568493"/>
+        <directory name="Quebec" rev="20" vrev="20" srcmd5="e414927bf2743c5efbaf4b31fdf525d2">
+          <entry name="_config" md5="d9a6910d72687fa4f2487f7e6f865524" size="74" mtime="1677089504"/>
+          <entry name="somefile.txt" md5="17d687b5a63b461c2e1e61817934d5c7" size="58" mtime="1677089504"/>
         </directory>
-  recorded_at: Mon, 18 Oct 2021 14:48:14 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:44 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:madam_submitter/Quebec?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -1043,18 +1043,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '314'
+      - '315'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="054449b578cf08bb0199a0c6f72b7a4e">
+        <sourcediff key="70b3a013b52203e13ea696119636edfd">
           <old project="home:madam_submitter" package="Quebec" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:madam_submitter" package="Quebec" rev="6" srcmd5="e0c74fad0eac27539a9e7d7283a6da34"/>
+          <new project="home:madam_submitter" package="Quebec" rev="20" srcmd5="e414927bf2743c5efbaf4b31fdf525d2"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Mon, 18 Oct 2021 14:48:14 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:44 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:madam_submitter/Quebec_branch
@@ -1063,7 +1063,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - ffe0a825-f677-4c2d-8e0f-d0785dbd43c6
+      - 7d72ab24-1e82-4505-a991-c5eecf1ab635
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1086,17 +1086,17 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="Quebec_branch" rev="2" vrev="2" srcmd5="484f5b39ca4c6682a003aeac924b40f3">
-          <linkinfo project="home:madam_submitter" package="Quebec" srcmd5="e0c74fad0eac27539a9e7d7283a6da34" baserev="e0c74fad0eac27539a9e7d7283a6da34" xsrcmd5="2ee1ba7040feed5b7aa79cda85800037" lsrcmd5="484f5b39ca4c6682a003aeac924b40f3"/>
-          <entry name="_config" md5="8a94713e738c00ecaed7cb03157a71c3" size="55" mtime="1634568493"/>
-          <entry name="_link" md5="b17ccb8fdd865a64ea96f82bf79c6ffc" size="114" mtime="1634568493"/>
-          <entry name="new_file" md5="a451b9bbe42ff6529f209b4d184236fe" size="15" mtime="1634568494"/>
-          <entry name="somefile.txt" md5="e16521ba9b6163790284dbad3b87bc57" size="79" mtime="1634568493"/>
+        <directory name="Quebec_branch" rev="8" vrev="8" srcmd5="4b4b8e8ae3ed82710a39ff383c2e1f6c">
+          <linkinfo project="home:madam_submitter" package="Quebec" srcmd5="e414927bf2743c5efbaf4b31fdf525d2" baserev="e414927bf2743c5efbaf4b31fdf525d2" xsrcmd5="79420fcb8aa08dd3716c7c55f92cb1ed" lsrcmd5="4b4b8e8ae3ed82710a39ff383c2e1f6c"/>
+          <entry name="_config" md5="d9a6910d72687fa4f2487f7e6f865524" size="74" mtime="1677089504"/>
+          <entry name="_link" md5="189f2fe0ee1712f096a1c7043468a712" size="114" mtime="1677089504"/>
+          <entry name="new_file" md5="a451b9bbe42ff6529f209b4d184236fe" size="15" mtime="1677067300"/>
+          <entry name="somefile.txt" md5="17d687b5a63b461c2e1e61817934d5c7" size="58" mtime="1677089504"/>
         </directory>
-  recorded_at: Mon, 18 Oct 2021 14:48:14 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:44 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:madam_submitter/Quebec_branch?expand=1&rev=2
+    uri: http://backend:5352/source/home:madam_submitter/Quebec_branch?expand=1&rev=8
     body:
       encoding: US-ASCII
       string: ''
@@ -1119,26 +1119,26 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '614'
+      - '615'
     body:
       encoding: UTF-8
       string: |
-        <directory name="Quebec_branch" rev="2ee1ba7040feed5b7aa79cda85800037" vrev="8" srcmd5="2ee1ba7040feed5b7aa79cda85800037">
-          <linkinfo project="home:madam_submitter" package="Quebec" srcmd5="e0c74fad0eac27539a9e7d7283a6da34" baserev="e0c74fad0eac27539a9e7d7283a6da34" lsrcmd5="484f5b39ca4c6682a003aeac924b40f3"/>
-          <entry name="_config" md5="8a94713e738c00ecaed7cb03157a71c3" size="55" mtime="1634568493"/>
-          <entry name="new_file" md5="a451b9bbe42ff6529f209b4d184236fe" size="15" mtime="1634568494"/>
-          <entry name="somefile.txt" md5="e16521ba9b6163790284dbad3b87bc57" size="79" mtime="1634568493"/>
+        <directory name="Quebec_branch" rev="79420fcb8aa08dd3716c7c55f92cb1ed" vrev="28" srcmd5="79420fcb8aa08dd3716c7c55f92cb1ed">
+          <linkinfo project="home:madam_submitter" package="Quebec" srcmd5="e414927bf2743c5efbaf4b31fdf525d2" baserev="e414927bf2743c5efbaf4b31fdf525d2" lsrcmd5="4b4b8e8ae3ed82710a39ff383c2e1f6c"/>
+          <entry name="_config" md5="d9a6910d72687fa4f2487f7e6f865524" size="74" mtime="1677089504"/>
+          <entry name="new_file" md5="a451b9bbe42ff6529f209b4d184236fe" size="15" mtime="1677067300"/>
+          <entry name="somefile.txt" md5="17d687b5a63b461c2e1e61817934d5c7" size="58" mtime="1677089504"/>
         </directory>
-  recorded_at: Mon, 18 Oct 2021 14:48:14 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:44 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:madam_submitter/Quebec_branch
+    uri: http://backend:5352/source/home:madam_submitter/Quebec_branch/_history?deleted=1&meta=1&rev=8
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - ffe0a825-f677-4c2d-8e0f-d0785dbd43c6
+      - 7d72ab24-1e82-4505-a991-c5eecf1ab635
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1157,110 +1157,134 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '719'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="Quebec_branch" rev="2" vrev="2" srcmd5="484f5b39ca4c6682a003aeac924b40f3">
-          <linkinfo project="home:madam_submitter" package="Quebec" srcmd5="e0c74fad0eac27539a9e7d7283a6da34" baserev="e0c74fad0eac27539a9e7d7283a6da34" xsrcmd5="2ee1ba7040feed5b7aa79cda85800037" lsrcmd5="484f5b39ca4c6682a003aeac924b40f3"/>
-          <entry name="_config" md5="8a94713e738c00ecaed7cb03157a71c3" size="55" mtime="1634568493"/>
-          <entry name="_link" md5="b17ccb8fdd865a64ea96f82bf79c6ffc" size="114" mtime="1634568493"/>
-          <entry name="new_file" md5="a451b9bbe42ff6529f209b4d184236fe" size="15" mtime="1634568494"/>
-          <entry name="somefile.txt" md5="e16521ba9b6163790284dbad3b87bc57" size="79" mtime="1634568493"/>
-        </directory>
-  recorded_at: Mon, 18 Oct 2021 14:48:14 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:madam_submitter/Quebec_branch
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Request-Id:
-      - ffe0a825-f677-4c2d-8e0f-d0785dbd43c6
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '719'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="Quebec_branch" rev="2" vrev="2" srcmd5="484f5b39ca4c6682a003aeac924b40f3">
-          <linkinfo project="home:madam_submitter" package="Quebec" srcmd5="e0c74fad0eac27539a9e7d7283a6da34" baserev="e0c74fad0eac27539a9e7d7283a6da34" xsrcmd5="2ee1ba7040feed5b7aa79cda85800037" lsrcmd5="484f5b39ca4c6682a003aeac924b40f3"/>
-          <entry name="_config" md5="8a94713e738c00ecaed7cb03157a71c3" size="55" mtime="1634568493"/>
-          <entry name="_link" md5="b17ccb8fdd865a64ea96f82bf79c6ffc" size="114" mtime="1634568493"/>
-          <entry name="new_file" md5="a451b9bbe42ff6529f209b4d184236fe" size="15" mtime="1634568494"/>
-          <entry name="somefile.txt" md5="e16521ba9b6163790284dbad3b87bc57" size="79" mtime="1634568493"/>
-        </directory>
-  recorded_at: Mon, 18 Oct 2021 14:48:14 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:madam_submitter/Quebec_branch/_history
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '411'
+      - '31'
     body:
       encoding: UTF-8
       string: |
         <revisionlist>
-          <revision rev="1" vrev="1">
-            <srcmd5>bff681342dbac47bf52120585b319e83</srcmd5>
-            <version>unknown</version>
-            <time>1634568493</time>
-            <user>madam_submitter</user>
-          </revision>
-          <revision rev="2" vrev="2">
-            <srcmd5>484f5b39ca4c6682a003aeac924b40f3</srcmd5>
-            <version>unknown</version>
-            <time>1634568494</time>
-            <user>madam_submitter</user>
-          </revision>
         </revisionlist>
-  recorded_at: Mon, 18 Oct 2021 14:48:14 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:44 GMT
 - request:
     method: get
-    uri: http://backend:5352/build/home:madam_submitter/_result?package=Quebec_branch&view=status
+    uri: http://backend:5352/source/home:madam_submitter/Quebec_branch
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - 206db302-c7bd-45ff-a5ec-ea4cbc353e59
+      - 7d72ab24-1e82-4505-a991-c5eecf1ab635
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '719'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="Quebec_branch" rev="8" vrev="8" srcmd5="4b4b8e8ae3ed82710a39ff383c2e1f6c">
+          <linkinfo project="home:madam_submitter" package="Quebec" srcmd5="e414927bf2743c5efbaf4b31fdf525d2" baserev="e414927bf2743c5efbaf4b31fdf525d2" xsrcmd5="79420fcb8aa08dd3716c7c55f92cb1ed" lsrcmd5="4b4b8e8ae3ed82710a39ff383c2e1f6c"/>
+          <entry name="_config" md5="d9a6910d72687fa4f2487f7e6f865524" size="74" mtime="1677089504"/>
+          <entry name="_link" md5="189f2fe0ee1712f096a1c7043468a712" size="114" mtime="1677089504"/>
+          <entry name="new_file" md5="a451b9bbe42ff6529f209b4d184236fe" size="15" mtime="1677067300"/>
+          <entry name="somefile.txt" md5="17d687b5a63b461c2e1e61817934d5c7" size="58" mtime="1677089504"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:11:44 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:madam_submitter/Quebec_branch
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 7d72ab24-1e82-4505-a991-c5eecf1ab635
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '719'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="Quebec_branch" rev="8" vrev="8" srcmd5="4b4b8e8ae3ed82710a39ff383c2e1f6c">
+          <linkinfo project="home:madam_submitter" package="Quebec" srcmd5="e414927bf2743c5efbaf4b31fdf525d2" baserev="e414927bf2743c5efbaf4b31fdf525d2" xsrcmd5="79420fcb8aa08dd3716c7c55f92cb1ed" lsrcmd5="4b4b8e8ae3ed82710a39ff383c2e1f6c"/>
+          <entry name="_config" md5="d9a6910d72687fa4f2487f7e6f865524" size="74" mtime="1677089504"/>
+          <entry name="_link" md5="189f2fe0ee1712f096a1c7043468a712" size="114" mtime="1677089504"/>
+          <entry name="new_file" md5="a451b9bbe42ff6529f209b4d184236fe" size="15" mtime="1677067300"/>
+          <entry name="somefile.txt" md5="17d687b5a63b461c2e1e61817934d5c7" size="58" mtime="1677089504"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:11:44 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:madam_submitter/Quebec_branch/_history?deleted=1&meta=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 7d72ab24-1e82-4505-a991-c5eecf1ab635
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Wed, 22 Feb 2023 18:11:45 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:madam_submitter/_result?lastbuild=1&locallink=1&multibuild=1&package=Quebec_branch&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 3a6fc559-4139-4944-86cf-e83eccd4d030
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1285,7 +1309,75 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Mon, 18 Oct 2021 14:48:15 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:45 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:madam_submitter/_result?lastbuild=1&locallink=1&multibuild=1&package=Quebec_branch&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 22d2075b-2d44-416c-b686-4e69f4eb512c
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 18:11:45 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:madam_submitter/_result?package=Quebec_branch&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - e4115492-c6b2-4ffd-98c5-1fa6e47bd874
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 18:11:45 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:madam_submitter/Quebec_branch
@@ -1294,7 +1386,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 877b6534-d067-4b50-9557-302a637f302e
+      - fc93b32b-27a1-4f7a-965d-65128d8edacb
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1317,14 +1409,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="Quebec_branch" rev="2" vrev="2" srcmd5="484f5b39ca4c6682a003aeac924b40f3">
-          <linkinfo project="home:madam_submitter" package="Quebec" srcmd5="e0c74fad0eac27539a9e7d7283a6da34" baserev="e0c74fad0eac27539a9e7d7283a6da34" xsrcmd5="2ee1ba7040feed5b7aa79cda85800037" lsrcmd5="484f5b39ca4c6682a003aeac924b40f3"/>
-          <entry name="_config" md5="8a94713e738c00ecaed7cb03157a71c3" size="55" mtime="1634568493"/>
-          <entry name="_link" md5="b17ccb8fdd865a64ea96f82bf79c6ffc" size="114" mtime="1634568493"/>
-          <entry name="new_file" md5="a451b9bbe42ff6529f209b4d184236fe" size="15" mtime="1634568494"/>
-          <entry name="somefile.txt" md5="e16521ba9b6163790284dbad3b87bc57" size="79" mtime="1634568493"/>
+        <directory name="Quebec_branch" rev="8" vrev="8" srcmd5="4b4b8e8ae3ed82710a39ff383c2e1f6c">
+          <linkinfo project="home:madam_submitter" package="Quebec" srcmd5="e414927bf2743c5efbaf4b31fdf525d2" baserev="e414927bf2743c5efbaf4b31fdf525d2" xsrcmd5="79420fcb8aa08dd3716c7c55f92cb1ed" lsrcmd5="4b4b8e8ae3ed82710a39ff383c2e1f6c"/>
+          <entry name="_config" md5="d9a6910d72687fa4f2487f7e6f865524" size="74" mtime="1677089504"/>
+          <entry name="_link" md5="189f2fe0ee1712f096a1c7043468a712" size="114" mtime="1677089504"/>
+          <entry name="new_file" md5="a451b9bbe42ff6529f209b4d184236fe" size="15" mtime="1677067300"/>
+          <entry name="somefile.txt" md5="17d687b5a63b461c2e1e61817934d5c7" size="58" mtime="1677089504"/>
         </directory>
-  recorded_at: Mon, 18 Oct 2021 14:48:15 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:45 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:madam_submitter/Quebec_branch
@@ -1333,7 +1425,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - c8a22245-202e-4b90-a9c7-99a0db71cc52
+      - 71448ba2-2ec9-408b-aa4c-eeccea4493be
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1356,17 +1448,17 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="Quebec_branch" rev="2" vrev="2" srcmd5="484f5b39ca4c6682a003aeac924b40f3">
-          <linkinfo project="home:madam_submitter" package="Quebec" srcmd5="e0c74fad0eac27539a9e7d7283a6da34" baserev="e0c74fad0eac27539a9e7d7283a6da34" xsrcmd5="2ee1ba7040feed5b7aa79cda85800037" lsrcmd5="484f5b39ca4c6682a003aeac924b40f3"/>
-          <entry name="_config" md5="8a94713e738c00ecaed7cb03157a71c3" size="55" mtime="1634568493"/>
-          <entry name="_link" md5="b17ccb8fdd865a64ea96f82bf79c6ffc" size="114" mtime="1634568493"/>
-          <entry name="new_file" md5="a451b9bbe42ff6529f209b4d184236fe" size="15" mtime="1634568494"/>
-          <entry name="somefile.txt" md5="e16521ba9b6163790284dbad3b87bc57" size="79" mtime="1634568493"/>
+        <directory name="Quebec_branch" rev="8" vrev="8" srcmd5="4b4b8e8ae3ed82710a39ff383c2e1f6c">
+          <linkinfo project="home:madam_submitter" package="Quebec" srcmd5="e414927bf2743c5efbaf4b31fdf525d2" baserev="e414927bf2743c5efbaf4b31fdf525d2" xsrcmd5="79420fcb8aa08dd3716c7c55f92cb1ed" lsrcmd5="4b4b8e8ae3ed82710a39ff383c2e1f6c"/>
+          <entry name="_config" md5="d9a6910d72687fa4f2487f7e6f865524" size="74" mtime="1677089504"/>
+          <entry name="_link" md5="189f2fe0ee1712f096a1c7043468a712" size="114" mtime="1677089504"/>
+          <entry name="new_file" md5="a451b9bbe42ff6529f209b4d184236fe" size="15" mtime="1677067300"/>
+          <entry name="somefile.txt" md5="17d687b5a63b461c2e1e61817934d5c7" size="58" mtime="1677089504"/>
         </directory>
-  recorded_at: Mon, 18 Oct 2021 14:48:16 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:46 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/home:madam_submitter/Quebec_branch?cmd=diff&expand=1&nodiff=1&opackage=Quebec&oproject=home:madam_submitter&rev=2
+    uri: http://backend:5352/source/home:madam_submitter/Quebec_branch?cmd=diff&expand=1&nodiff=1&opackage=Quebec&oproject=home:madam_submitter&rev=8
     body:
       encoding: UTF-8
       string: ''
@@ -1374,7 +1466,7 @@ http_interactions:
       Content-Type:
       - application/octet-stream
       X-Request-Id:
-      - c8a22245-202e-4b90-a9c7-99a0db71cc52
+      - 71448ba2-2ec9-408b-aa4c-eeccea4493be
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1408,16 +1500,16 @@ http_interactions:
         ++++++ new_file (new)
         --- new_file
         +++ new_file
-  recorded_at: Mon, 18 Oct 2021 14:48:16 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:46 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:madam_submitter/Quebec_branch?expand=1&rev=2
+    uri: http://backend:5352/source/home:madam_submitter/Quebec_branch?expand=1&rev=8
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - c8a22245-202e-4b90-a9c7-99a0db71cc52
+      - 71448ba2-2ec9-408b-aa4c-eeccea4493be
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1436,17 +1528,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '614'
+      - '615'
     body:
       encoding: UTF-8
       string: |
-        <directory name="Quebec_branch" rev="2ee1ba7040feed5b7aa79cda85800037" vrev="8" srcmd5="2ee1ba7040feed5b7aa79cda85800037">
-          <linkinfo project="home:madam_submitter" package="Quebec" srcmd5="e0c74fad0eac27539a9e7d7283a6da34" baserev="e0c74fad0eac27539a9e7d7283a6da34" lsrcmd5="484f5b39ca4c6682a003aeac924b40f3"/>
-          <entry name="_config" md5="8a94713e738c00ecaed7cb03157a71c3" size="55" mtime="1634568493"/>
-          <entry name="new_file" md5="a451b9bbe42ff6529f209b4d184236fe" size="15" mtime="1634568494"/>
-          <entry name="somefile.txt" md5="e16521ba9b6163790284dbad3b87bc57" size="79" mtime="1634568493"/>
+        <directory name="Quebec_branch" rev="79420fcb8aa08dd3716c7c55f92cb1ed" vrev="28" srcmd5="79420fcb8aa08dd3716c7c55f92cb1ed">
+          <linkinfo project="home:madam_submitter" package="Quebec" srcmd5="e414927bf2743c5efbaf4b31fdf525d2" baserev="e414927bf2743c5efbaf4b31fdf525d2" lsrcmd5="4b4b8e8ae3ed82710a39ff383c2e1f6c"/>
+          <entry name="_config" md5="d9a6910d72687fa4f2487f7e6f865524" size="74" mtime="1677089504"/>
+          <entry name="new_file" md5="a451b9bbe42ff6529f209b4d184236fe" size="15" mtime="1677067300"/>
+          <entry name="somefile.txt" md5="17d687b5a63b461c2e1e61817934d5c7" size="58" mtime="1677089504"/>
         </directory>
-  recorded_at: Mon, 18 Oct 2021 14:48:16 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:46 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:madam_submitter/Quebec_branch
@@ -1455,7 +1547,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - c8a22245-202e-4b90-a9c7-99a0db71cc52
+      - 71448ba2-2ec9-408b-aa4c-eeccea4493be
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1478,17 +1570,17 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="Quebec_branch" rev="2" vrev="2" srcmd5="484f5b39ca4c6682a003aeac924b40f3">
-          <linkinfo project="home:madam_submitter" package="Quebec" srcmd5="e0c74fad0eac27539a9e7d7283a6da34" baserev="e0c74fad0eac27539a9e7d7283a6da34" xsrcmd5="2ee1ba7040feed5b7aa79cda85800037" lsrcmd5="484f5b39ca4c6682a003aeac924b40f3"/>
-          <entry name="_config" md5="8a94713e738c00ecaed7cb03157a71c3" size="55" mtime="1634568493"/>
-          <entry name="_link" md5="b17ccb8fdd865a64ea96f82bf79c6ffc" size="114" mtime="1634568493"/>
-          <entry name="new_file" md5="a451b9bbe42ff6529f209b4d184236fe" size="15" mtime="1634568494"/>
-          <entry name="somefile.txt" md5="e16521ba9b6163790284dbad3b87bc57" size="79" mtime="1634568493"/>
+        <directory name="Quebec_branch" rev="8" vrev="8" srcmd5="4b4b8e8ae3ed82710a39ff383c2e1f6c">
+          <linkinfo project="home:madam_submitter" package="Quebec" srcmd5="e414927bf2743c5efbaf4b31fdf525d2" baserev="e414927bf2743c5efbaf4b31fdf525d2" xsrcmd5="79420fcb8aa08dd3716c7c55f92cb1ed" lsrcmd5="4b4b8e8ae3ed82710a39ff383c2e1f6c"/>
+          <entry name="_config" md5="d9a6910d72687fa4f2487f7e6f865524" size="74" mtime="1677089504"/>
+          <entry name="_link" md5="189f2fe0ee1712f096a1c7043468a712" size="114" mtime="1677089504"/>
+          <entry name="new_file" md5="a451b9bbe42ff6529f209b4d184236fe" size="15" mtime="1677067300"/>
+          <entry name="somefile.txt" md5="17d687b5a63b461c2e1e61817934d5c7" size="58" mtime="1677089504"/>
         </directory>
-  recorded_at: Mon, 18 Oct 2021 14:48:16 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:46 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/home:madam_submitter/Quebec_branch?cmd=diff&expand=1&filelimit=10000&opackage=Quebec&oproject=home:madam_submitter&rev=2&tarlimit=10000&view=xml&withissues=1
+    uri: http://backend:5352/source/home:madam_submitter/Quebec_branch?cmd=diff&expand=1&filelimit=10000&opackage=Quebec&oproject=home:madam_submitter&rev=8&tarlimit=10000&view=xml&withissues=1
     body:
       encoding: UTF-8
       string: ''
@@ -1496,7 +1588,7 @@ http_interactions:
       Content-Type:
       - application/octet-stream
       X-Request-Id:
-      - c8a22245-202e-4b90-a9c7-99a0db71cc52
+      - 71448ba2-2ec9-408b-aa4c-eeccea4493be
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1515,13 +1607,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '537'
+      - '538'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="9a70414e0ab79610c88499f265a873f6">
-          <old project="home:madam_submitter" package="Quebec" rev="6" srcmd5="e0c74fad0eac27539a9e7d7283a6da34"/>
-          <new project="home:madam_submitter" package="Quebec_branch" rev="2" srcmd5="2ee1ba7040feed5b7aa79cda85800037"/>
+        <sourcediff key="0c8acfb49e55d5a2901c597ac0d3d4db">
+          <old project="home:madam_submitter" package="Quebec" rev="20" srcmd5="e414927bf2743c5efbaf4b31fdf525d2"/>
+          <new project="home:madam_submitter" package="Quebec_branch" rev="8" srcmd5="79420fcb8aa08dd3716c7c55f92cb1ed"/>
           <files>
             <file state="added">
               <new name="new_file" md5="a451b9bbe42ff6529f209b4d184236fe" size="15"/>
@@ -1534,7 +1626,7 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Mon, 18 Oct 2021 14:48:16 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:46 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:madam_submitter/Quebec
@@ -1543,7 +1635,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - b082bf41-e1ee-4385-af92-35e5ac53f0f5
+      - fc75ee8f-4db3-40ab-a5e6-aebac430f7b1
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1562,15 +1654,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '291'
+      - '293'
     body:
       encoding: UTF-8
       string: |
-        <directory name="Quebec" rev="6" vrev="6" srcmd5="e0c74fad0eac27539a9e7d7283a6da34">
-          <entry name="_config" md5="8a94713e738c00ecaed7cb03157a71c3" size="55" mtime="1634568493"/>
-          <entry name="somefile.txt" md5="e16521ba9b6163790284dbad3b87bc57" size="79" mtime="1634568493"/>
+        <directory name="Quebec" rev="20" vrev="20" srcmd5="e414927bf2743c5efbaf4b31fdf525d2">
+          <entry name="_config" md5="d9a6910d72687fa4f2487f7e6f865524" size="74" mtime="1677089504"/>
+          <entry name="somefile.txt" md5="17d687b5a63b461c2e1e61817934d5c7" size="58" mtime="1677089504"/>
         </directory>
-  recorded_at: Mon, 18 Oct 2021 14:48:16 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:46 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:madam_submitter/Quebec_branch
@@ -1579,7 +1671,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 8c48ed50-cff8-496a-a70f-603ec004619b
+      - fda2bc08-393c-49e7-8a44-e8897557e6f8
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1602,17 +1694,17 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="Quebec_branch" rev="2" vrev="2" srcmd5="484f5b39ca4c6682a003aeac924b40f3">
-          <linkinfo project="home:madam_submitter" package="Quebec" srcmd5="e0c74fad0eac27539a9e7d7283a6da34" baserev="e0c74fad0eac27539a9e7d7283a6da34" xsrcmd5="2ee1ba7040feed5b7aa79cda85800037" lsrcmd5="484f5b39ca4c6682a003aeac924b40f3"/>
-          <entry name="_config" md5="8a94713e738c00ecaed7cb03157a71c3" size="55" mtime="1634568493"/>
-          <entry name="_link" md5="b17ccb8fdd865a64ea96f82bf79c6ffc" size="114" mtime="1634568493"/>
-          <entry name="new_file" md5="a451b9bbe42ff6529f209b4d184236fe" size="15" mtime="1634568494"/>
-          <entry name="somefile.txt" md5="e16521ba9b6163790284dbad3b87bc57" size="79" mtime="1634568493"/>
+        <directory name="Quebec_branch" rev="8" vrev="8" srcmd5="4b4b8e8ae3ed82710a39ff383c2e1f6c">
+          <linkinfo project="home:madam_submitter" package="Quebec" srcmd5="e414927bf2743c5efbaf4b31fdf525d2" baserev="e414927bf2743c5efbaf4b31fdf525d2" xsrcmd5="79420fcb8aa08dd3716c7c55f92cb1ed" lsrcmd5="4b4b8e8ae3ed82710a39ff383c2e1f6c"/>
+          <entry name="_config" md5="d9a6910d72687fa4f2487f7e6f865524" size="74" mtime="1677089504"/>
+          <entry name="_link" md5="189f2fe0ee1712f096a1c7043468a712" size="114" mtime="1677089504"/>
+          <entry name="new_file" md5="a451b9bbe42ff6529f209b4d184236fe" size="15" mtime="1677067300"/>
+          <entry name="somefile.txt" md5="17d687b5a63b461c2e1e61817934d5c7" size="58" mtime="1677089504"/>
         </directory>
-  recorded_at: Mon, 18 Oct 2021 14:48:16 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:46 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/home:madam_submitter/Quebec_branch?cacheonly=1&cmd=diff&expand=1&filelimit=10000&opackage=Quebec&oproject=home:madam_submitter&rev=2&tarlimit=10000&view=xml&withissues=1
+    uri: http://backend:5352/source/home:madam_submitter/Quebec_branch?cacheonly=1&cmd=diff&expand=1&filelimit=10000&opackage=Quebec&oproject=home:madam_submitter&rev=8&tarlimit=10000&view=xml&withissues=1
     body:
       encoding: UTF-8
       string: ''
@@ -1620,7 +1712,7 @@ http_interactions:
       Content-Type:
       - application/octet-stream
       X-Request-Id:
-      - 8c48ed50-cff8-496a-a70f-603ec004619b
+      - fda2bc08-393c-49e7-8a44-e8897557e6f8
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1635,7 +1727,7 @@ http_interactions:
       Content-Type:
       - text/xml
       Content-Length:
-      - '537'
+      - '538'
       Cache-Control:
       - no-cache
       Connection:
@@ -1643,9 +1735,9 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="9a70414e0ab79610c88499f265a873f6">
-          <old project="home:madam_submitter" package="Quebec" rev="6" srcmd5="e0c74fad0eac27539a9e7d7283a6da34"/>
-          <new project="home:madam_submitter" package="Quebec_branch" rev="2" srcmd5="2ee1ba7040feed5b7aa79cda85800037"/>
+        <sourcediff key="0c8acfb49e55d5a2901c597ac0d3d4db">
+          <old project="home:madam_submitter" package="Quebec" rev="20" srcmd5="e414927bf2743c5efbaf4b31fdf525d2"/>
+          <new project="home:madam_submitter" package="Quebec_branch" rev="8" srcmd5="79420fcb8aa08dd3716c7c55f92cb1ed"/>
           <files>
             <file state="added">
               <new name="new_file" md5="a451b9bbe42ff6529f209b4d184236fe" size="15"/>
@@ -1658,7 +1750,7 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Mon, 18 Oct 2021 14:48:16 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:46 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:madam_submitter/Quebec
@@ -1667,7 +1759,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 8c48ed50-cff8-496a-a70f-603ec004619b
+      - fda2bc08-393c-49e7-8a44-e8897557e6f8
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1686,15 +1778,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '291'
+      - '293'
     body:
       encoding: UTF-8
       string: |
-        <directory name="Quebec" rev="6" vrev="6" srcmd5="e0c74fad0eac27539a9e7d7283a6da34">
-          <entry name="_config" md5="8a94713e738c00ecaed7cb03157a71c3" size="55" mtime="1634568493"/>
-          <entry name="somefile.txt" md5="e16521ba9b6163790284dbad3b87bc57" size="79" mtime="1634568493"/>
+        <directory name="Quebec" rev="20" vrev="20" srcmd5="e414927bf2743c5efbaf4b31fdf525d2">
+          <entry name="_config" md5="d9a6910d72687fa4f2487f7e6f865524" size="74" mtime="1677089504"/>
+          <entry name="somefile.txt" md5="17d687b5a63b461c2e1e61817934d5c7" size="58" mtime="1677089504"/>
         </directory>
-  recorded_at: Mon, 18 Oct 2021 14:48:16 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:46 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:madam_submitter/_result?package=Quebec_branch&view=status
@@ -1703,7 +1795,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 8a9869cd-b816-4cc5-9e80-a06df74635f0
+      - a19b520a-e2bc-431b-bcbb-10c9b341b7a0
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1728,5 +1820,5 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Mon, 18 Oct 2021 14:48:17 GMT
-recorded_with: VCR 6.0.0
+  recorded_at: Wed, 22 Feb 2023 18:11:46 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Bootstrap_Requests_Submissions/submit_package/setting_a_target_package/creates_a_BsRequest_with_target_package_name.yml
+++ b/src/api/spec/cassettes/Bootstrap_Requests_Submissions/submit_package/setting_a_target_package/creates_a_BsRequest_with_target_package_name.yml
@@ -39,7 +39,7 @@ http_interactions:
           <description></description>
           <person userid="madam_submitter" role="maintainer"/>
         </project>
-  recorded_at: Thu, 03 Nov 2022 09:58:53 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:26 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:madam_submitter/Quebec/_meta?user=madam_submitter
@@ -47,8 +47,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="Quebec" project="home:madam_submitter">
-          <title>A Darkling Plain</title>
-          <description>Consectetur doloremque ad reiciendis.</description>
+          <title>Down to a Sunless Sea</title>
+          <description>Qui consequuntur libero ad.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -69,22 +69,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '162'
     body:
       encoding: UTF-8
       string: |
         <package name="Quebec" project="home:madam_submitter">
-          <title>A Darkling Plain</title>
-          <description>Consectetur doloremque ad reiciendis.</description>
+          <title>Down to a Sunless Sea</title>
+          <description>Qui consequuntur libero ad.</description>
         </package>
-  recorded_at: Thu, 03 Nov 2022 09:58:58 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:27 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:madam_submitter/Quebec/_config
     body:
       encoding: UTF-8
-      string: Exercitationem voluptatem necessitatibus. Autem facere dolor. Adipisci
-        est quasi.
+      string: Voluptatem fugiat ratione. Eius in officia. Laudantium asperiores temporibus.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -104,25 +103,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1" vrev="1">
-          <srcmd5>675f87f995b3d007d0257b45ed4a7c19</srcmd5>
+        <revision rev="15" vrev="15">
+          <srcmd5>79607c49fc39821e98701ed0a65cc0d0</srcmd5>
           <version>unknown</version>
-          <time>1667469538</time>
+          <time>1677089487</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 03 Nov 2022 09:58:58 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:27 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:madam_submitter/Quebec/somefile.txt
     body:
       encoding: UTF-8
-      string: Nihil in soluta. Iure dolorem aut. Cumque itaque est.
+      string: Excepturi vel blanditiis. Enim omnis eius. Modi doloribus eligendi.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -142,19 +141,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="2" vrev="2">
-          <srcmd5>ddd3491d11bfccb6d4a5ded8d29c8e0f</srcmd5>
+        <revision rev="16" vrev="16">
+          <srcmd5>1a913a143de499ea4a23395530755e09</srcmd5>
           <version>unknown</version>
-          <time>1667469538</time>
+          <time>1677089487</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 03 Nov 2022 09:58:58 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:27 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:madam_submitter/Quebec
@@ -163,7 +162,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - ca0a8250-92ef-4ccc-9eef-3485f3c38ec1
+      - bc2ff96f-0cc1-45e1-b06e-8fcd166e66f6
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -182,18 +181,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '291'
+      - '293'
     body:
       encoding: UTF-8
       string: |
-        <directory name="Quebec" rev="2" vrev="2" srcmd5="ddd3491d11bfccb6d4a5ded8d29c8e0f">
-          <entry name="_config" md5="697c34abeaacf5a27e0cefcdffb665b9" size="81" mtime="1667469538"/>
-          <entry name="somefile.txt" md5="0e2d53ce1b91d5c94cc75003fb5c4ebd" size="53" mtime="1667469538"/>
+        <directory name="Quebec" rev="16" vrev="16" srcmd5="1a913a143de499ea4a23395530755e09">
+          <entry name="_config" md5="67e4231343c0ac6c27b797a40c0026b8" size="77" mtime="1677089487"/>
+          <entry name="somefile.txt" md5="9aaa643d8969a264c279f8e0a4eec6e2" size="67" mtime="1677089487"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:58:59 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:27 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:madam_submitter/Quebec?expand=1&rev=2
+    uri: http://backend:5352/source/home:madam_submitter/Quebec?expand=1&rev=16
     body:
       encoding: US-ASCII
       string: ''
@@ -216,60 +215,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '291'
+      - '293'
     body:
       encoding: UTF-8
       string: |
-        <directory name="Quebec" rev="2" vrev="2" srcmd5="ddd3491d11bfccb6d4a5ded8d29c8e0f">
-          <entry name="_config" md5="697c34abeaacf5a27e0cefcdffb665b9" size="81" mtime="1667469538"/>
-          <entry name="somefile.txt" md5="0e2d53ce1b91d5c94cc75003fb5c4ebd" size="53" mtime="1667469538"/>
+        <directory name="Quebec" rev="16" vrev="16" srcmd5="1a913a143de499ea4a23395530755e09">
+          <entry name="_config" md5="67e4231343c0ac6c27b797a40c0026b8" size="77" mtime="1677089487"/>
+          <entry name="somefile.txt" md5="9aaa643d8969a264c279f8e0a4eec6e2" size="67" mtime="1677089487"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:58:59 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:27 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:madam_submitter/Quebec
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Request-Id:
-      - ca0a8250-92ef-4ccc-9eef-3485f3c38ec1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '291'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="Quebec" rev="2" vrev="2" srcmd5="ddd3491d11bfccb6d4a5ded8d29c8e0f">
-          <entry name="_config" md5="697c34abeaacf5a27e0cefcdffb665b9" size="81" mtime="1667469538"/>
-          <entry name="somefile.txt" md5="0e2d53ce1b91d5c94cc75003fb5c4ebd" size="53" mtime="1667469538"/>
-        </directory>
-  recorded_at: Thu, 03 Nov 2022 09:58:59 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:madam_submitter/Quebec
+    uri: http://backend:5352/source/home:madam_submitter/Quebec/_history?deleted=1&meta=1&rev=16
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - ca0a8250-92ef-4ccc-9eef-3485f3c38ec1
+      - bc2ff96f-0cc1-45e1-b06e-8fcd166e66f6
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -288,59 +251,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '291'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="Quebec" rev="2" vrev="2" srcmd5="ddd3491d11bfccb6d4a5ded8d29c8e0f">
-          <entry name="_config" md5="697c34abeaacf5a27e0cefcdffb665b9" size="81" mtime="1667469538"/>
-          <entry name="somefile.txt" md5="0e2d53ce1b91d5c94cc75003fb5c4ebd" size="53" mtime="1667469538"/>
-        </directory>
-  recorded_at: Thu, 03 Nov 2022 09:58:59 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:madam_submitter/Quebec/_history
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '395'
+      - '31'
     body:
       encoding: UTF-8
       string: |
         <revisionlist>
-          <revision rev="1" vrev="1">
-            <srcmd5>675f87f995b3d007d0257b45ed4a7c19</srcmd5>
-            <version>unknown</version>
-            <time>1667469538</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="2" vrev="2">
-            <srcmd5>ddd3491d11bfccb6d4a5ded8d29c8e0f</srcmd5>
-            <version>unknown</version>
-            <time>1667469538</time>
-            <user>unknown</user>
-          </revision>
         </revisionlist>
-  recorded_at: Thu, 03 Nov 2022 09:58:59 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:27 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:madam_submitter/Quebec
@@ -349,7 +266,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - b80106f7-f8bf-4292-93dc-c680f1f28d0d
+      - bc2ff96f-0cc1-45e1-b06e-8fcd166e66f6
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -368,15 +285,121 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '291'
+      - '293'
     body:
       encoding: UTF-8
       string: |
-        <directory name="Quebec" rev="2" vrev="2" srcmd5="ddd3491d11bfccb6d4a5ded8d29c8e0f">
-          <entry name="_config" md5="697c34abeaacf5a27e0cefcdffb665b9" size="81" mtime="1667469538"/>
-          <entry name="somefile.txt" md5="0e2d53ce1b91d5c94cc75003fb5c4ebd" size="53" mtime="1667469538"/>
+        <directory name="Quebec" rev="16" vrev="16" srcmd5="1a913a143de499ea4a23395530755e09">
+          <entry name="_config" md5="67e4231343c0ac6c27b797a40c0026b8" size="77" mtime="1677089487"/>
+          <entry name="somefile.txt" md5="9aaa643d8969a264c279f8e0a4eec6e2" size="67" mtime="1677089487"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:58:59 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:28 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:madam_submitter/Quebec
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - bc2ff96f-0cc1-45e1-b06e-8fcd166e66f6
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '293'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="Quebec" rev="16" vrev="16" srcmd5="1a913a143de499ea4a23395530755e09">
+          <entry name="_config" md5="67e4231343c0ac6c27b797a40c0026b8" size="77" mtime="1677089487"/>
+          <entry name="somefile.txt" md5="9aaa643d8969a264c279f8e0a4eec6e2" size="67" mtime="1677089487"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:11:28 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:madam_submitter/Quebec/_history?deleted=1&meta=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - bc2ff96f-0cc1-45e1-b06e-8fcd166e66f6
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Wed, 22 Feb 2023 18:11:28 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:madam_submitter/Quebec
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 9c2b3ea4-3c48-42db-ba68-0aadbf735e20
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '293'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="Quebec" rev="16" vrev="16" srcmd5="1a913a143de499ea4a23395530755e09">
+          <entry name="_config" md5="67e4231343c0ac6c27b797a40c0026b8" size="77" mtime="1677089487"/>
+          <entry name="somefile.txt" md5="9aaa643d8969a264c279f8e0a4eec6e2" size="67" mtime="1677089487"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:11:28 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:madam_submitter/_result?lastbuild=1&locallink=1&multibuild=1&package=Quebec&view=status
@@ -385,7 +408,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - b80106f7-f8bf-4292-93dc-c680f1f28d0d
+      - 9c2b3ea4-3c48-42db-ba68-0aadbf735e20
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -410,7 +433,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:58:59 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:28 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:madam_submitter/Quebec
@@ -419,7 +442,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - dcef4fbb-6ca9-4845-8fda-54c02a61082f
+      - 109773e0-cace-4765-8f5c-9c38c828c687
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -438,15 +461,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '291'
+      - '293'
     body:
       encoding: UTF-8
       string: |
-        <directory name="Quebec" rev="2" vrev="2" srcmd5="ddd3491d11bfccb6d4a5ded8d29c8e0f">
-          <entry name="_config" md5="697c34abeaacf5a27e0cefcdffb665b9" size="81" mtime="1667469538"/>
-          <entry name="somefile.txt" md5="0e2d53ce1b91d5c94cc75003fb5c4ebd" size="53" mtime="1667469538"/>
+        <directory name="Quebec" rev="16" vrev="16" srcmd5="1a913a143de499ea4a23395530755e09">
+          <entry name="_config" md5="67e4231343c0ac6c27b797a40c0026b8" size="77" mtime="1677089487"/>
+          <entry name="somefile.txt" md5="9aaa643d8969a264c279f8e0a4eec6e2" size="67" mtime="1677089487"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:58:59 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:28 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:madam_submitter/_result?lastbuild=1&locallink=1&multibuild=1&package=Quebec&view=status
@@ -455,7 +478,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - dcef4fbb-6ca9-4845-8fda-54c02a61082f
+      - 109773e0-cace-4765-8f5c-9c38c828c687
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -480,7 +503,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:58:59 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:28 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:madam_submitter/_result?package=Quebec&view=status
@@ -489,7 +512,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - '0830bb77-6cde-41a8-b0dd-486a7e3cb214'
+      - 74557b60-8c49-4e5e-82f4-973db70ab495
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -514,7 +537,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:58:59 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:28 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:madam_submitter/Quebec?view=info
@@ -523,7 +546,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - d9bb7d2c-c304-4487-9321-8c13c3a2492d
+      - 3424a369-5b17-4002-a08f-9e19513c965a
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -542,14 +565,14 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '224'
+      - '226'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="Quebec" rev="2" vrev="2" srcmd5="ddd3491d11bfccb6d4a5ded8d29c8e0f" verifymd5="ddd3491d11bfccb6d4a5ded8d29c8e0f">
+        <sourceinfo package="Quebec" rev="16" vrev="16" srcmd5="1a913a143de499ea4a23395530755e09" verifymd5="1a913a143de499ea4a23395530755e09">
           <error>bad build configuration, no build type defined or detected</error>
         </sourceinfo>
-  recorded_at: Thu, 03 Nov 2022 09:59:00 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:28 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:madam_submitter/Quebec
@@ -558,7 +581,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - d9bb7d2c-c304-4487-9321-8c13c3a2492d
+      - 3424a369-5b17-4002-a08f-9e19513c965a
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -577,15 +600,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '291'
+      - '293'
     body:
       encoding: UTF-8
       string: |
-        <directory name="Quebec" rev="2" vrev="2" srcmd5="ddd3491d11bfccb6d4a5ded8d29c8e0f">
-          <entry name="_config" md5="697c34abeaacf5a27e0cefcdffb665b9" size="81" mtime="1667469538"/>
-          <entry name="somefile.txt" md5="0e2d53ce1b91d5c94cc75003fb5c4ebd" size="53" mtime="1667469538"/>
+        <directory name="Quebec" rev="16" vrev="16" srcmd5="1a913a143de499ea4a23395530755e09">
+          <entry name="_config" md5="67e4231343c0ac6c27b797a40c0026b8" size="77" mtime="1677089487"/>
+          <entry name="somefile.txt" md5="9aaa643d8969a264c279f8e0a4eec6e2" size="67" mtime="1677089487"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:59:00 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:28 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:madam_submitter/Quebec?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -613,18 +636,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '314'
+      - '315'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="6a2f3c4ad110769f30cc57d1ae982f34">
+        <sourcediff key="10fad7d346b5c9b399c486dc1eba2b14">
           <old project="home:madam_submitter" package="Quebec" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:madam_submitter" package="Quebec" rev="2" srcmd5="ddd3491d11bfccb6d4a5ded8d29c8e0f"/>
+          <new project="home:madam_submitter" package="Quebec" rev="16" srcmd5="1a913a143de499ea4a23395530755e09"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 03 Nov 2022 09:59:00 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:28 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:mr_receiver/_meta?user=mr_receiver
@@ -664,7 +687,7 @@ http_interactions:
           <description></description>
           <person userid="mr_receiver" role="maintainer"/>
         </project>
-  recorded_at: Thu, 03 Nov 2022 09:59:00 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:28 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:mr_receiver/Quebec/_meta?user=madam_submitter
@@ -672,8 +695,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="Quebec" project="home:mr_receiver">
-          <title>The Last Temptation</title>
-          <description>Ut et ut odio.</description>
+          <title>Look Homeward, Angel</title>
+          <description>Ipsam optio dignissimos minus.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -694,21 +717,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '143'
+      - '160'
     body:
       encoding: UTF-8
       string: |
         <package name="Quebec" project="home:mr_receiver">
-          <title>The Last Temptation</title>
-          <description>Ut et ut odio.</description>
+          <title>Look Homeward, Angel</title>
+          <description>Ipsam optio dignissimos minus.</description>
         </package>
-  recorded_at: Thu, 03 Nov 2022 09:59:00 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:29 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:mr_receiver/Quebec/_config
     body:
       encoding: UTF-8
-      string: Voluptatibus et ipsam. Ipsa praesentium ut. Autem molestiae praesentium.
+      string: Vero aut quis. Illo rerum et. Eum quo earum.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -732,21 +755,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1" vrev="1">
-          <srcmd5>026be02754a4c698088212d3baea1d46</srcmd5>
+        <revision rev="9" vrev="9">
+          <srcmd5>49074aacddf6bd262cd0699a77d77bcb</srcmd5>
           <version>unknown</version>
-          <time>1667469540</time>
+          <time>1677089489</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 03 Nov 2022 09:59:00 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:29 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:mr_receiver/Quebec/somefile.txt
     body:
       encoding: UTF-8
-      string: Atque vero corrupti. Sequi animi harum. Unde ullam aspernatur.
+      string: Ab molestiae est. Sed tempore modi. Sit aspernatur quis.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -766,19 +789,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="2" vrev="2">
-          <srcmd5>084c2d00f44e4f61962ce65dc2d12103</srcmd5>
+        <revision rev="10" vrev="10">
+          <srcmd5>7e0a7d98b8428224e3c71870d418db0d</srcmd5>
           <version>unknown</version>
-          <time>1667469540</time>
+          <time>1677089489</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 03 Nov 2022 09:59:00 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:29 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:madam_submitter/Quebec
@@ -787,7 +810,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - c0946535-a27a-4cd9-8a25-7c27592c4ee3
+      - e2121707-fb44-4fdf-9a0e-021a300d07b3
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -806,18 +829,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '291'
+      - '293'
     body:
       encoding: UTF-8
       string: |
-        <directory name="Quebec" rev="2" vrev="2" srcmd5="ddd3491d11bfccb6d4a5ded8d29c8e0f">
-          <entry name="_config" md5="697c34abeaacf5a27e0cefcdffb665b9" size="81" mtime="1667469538"/>
-          <entry name="somefile.txt" md5="0e2d53ce1b91d5c94cc75003fb5c4ebd" size="53" mtime="1667469538"/>
+        <directory name="Quebec" rev="16" vrev="16" srcmd5="1a913a143de499ea4a23395530755e09">
+          <entry name="_config" md5="67e4231343c0ac6c27b797a40c0026b8" size="77" mtime="1677089487"/>
+          <entry name="somefile.txt" md5="9aaa643d8969a264c279f8e0a4eec6e2" size="67" mtime="1677089487"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:59:00 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:29 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/home:madam_submitter/Quebec?cmd=diff&expand=1&nodiff=1&opackage=Quebec&oproject=home:mr_receiver&rev=2
+    uri: http://backend:5352/source/home:madam_submitter/Quebec?cmd=diff&expand=1&nodiff=1&opackage=Quebec&oproject=home:mr_receiver&rev=16
     body:
       encoding: UTF-8
       string: ''
@@ -825,7 +848,7 @@ http_interactions:
       Content-Type:
       - application/octet-stream
       X-Request-Id:
-      - c0946535-a27a-4cd9-8a25-7c27592c4ee3
+      - e2121707-fb44-4fdf-9a0e-021a300d07b3
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -856,16 +879,16 @@ http_interactions:
         ++++++ somefile.txt
         --- somefile.txt
         +++ somefile.txt
-  recorded_at: Thu, 03 Nov 2022 09:59:00 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:29 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:madam_submitter/Quebec?expand=1&rev=2
+    uri: http://backend:5352/source/home:madam_submitter/Quebec?expand=1&rev=16
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - c0946535-a27a-4cd9-8a25-7c27592c4ee3
+      - e2121707-fb44-4fdf-9a0e-021a300d07b3
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -884,149 +907,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '291'
+      - '293'
     body:
       encoding: UTF-8
       string: |
-        <directory name="Quebec" rev="2" vrev="2" srcmd5="ddd3491d11bfccb6d4a5ded8d29c8e0f">
-          <entry name="_config" md5="697c34abeaacf5a27e0cefcdffb665b9" size="81" mtime="1667469538"/>
-          <entry name="somefile.txt" md5="0e2d53ce1b91d5c94cc75003fb5c4ebd" size="53" mtime="1667469538"/>
+        <directory name="Quebec" rev="16" vrev="16" srcmd5="1a913a143de499ea4a23395530755e09">
+          <entry name="_config" md5="67e4231343c0ac6c27b797a40c0026b8" size="77" mtime="1677089487"/>
+          <entry name="somefile.txt" md5="9aaa643d8969a264c279f8e0a4eec6e2" size="67" mtime="1677089487"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:59:00 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:madam_submitter/Quebec
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Request-Id:
-      - c0946535-a27a-4cd9-8a25-7c27592c4ee3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '291'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="Quebec" rev="2" vrev="2" srcmd5="ddd3491d11bfccb6d4a5ded8d29c8e0f">
-          <entry name="_config" md5="697c34abeaacf5a27e0cefcdffb665b9" size="81" mtime="1667469538"/>
-          <entry name="somefile.txt" md5="0e2d53ce1b91d5c94cc75003fb5c4ebd" size="53" mtime="1667469538"/>
-        </directory>
-  recorded_at: Thu, 03 Nov 2022 09:59:00 GMT
-- request:
-    method: post
-    uri: http://backend:5352/source/home:madam_submitter/Quebec?cmd=diff&expand=1&filelimit=10000&opackage=Quebec&oproject=home:mr_receiver&rev=2&tarlimit=10000&view=xml&withissues=1
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      Content-Type:
-      - application/octet-stream
-      X-Request-Id:
-      - c0946535-a27a-4cd9-8a25-7c27592c4ee3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '1196'
-    body:
-      encoding: UTF-8
-      string: |
-        <sourcediff key="4c57c9356d49e83ab300f7782dfd192f">
-          <old project="home:mr_receiver" package="Quebec" rev="2" srcmd5="084c2d00f44e4f61962ce65dc2d12103"/>
-          <new project="home:madam_submitter" package="Quebec" rev="2" srcmd5="ddd3491d11bfccb6d4a5ded8d29c8e0f"/>
-          <files>
-            <file state="changed">
-              <old name="_config" md5="c356d35d6618087a05a03812915c5bdf" size="72"/>
-              <new name="_config" md5="697c34abeaacf5a27e0cefcdffb665b9" size="81"/>
-              <diff lines="5">@@ -1,1 +1,1 @@
-        -Voluptatibus et ipsam. Ipsa praesentium ut. Autem molestiae praesentium.
-        \ No newline at end of file
-        +Exercitationem voluptatem necessitatibus. Autem facere dolor. Adipisci est quasi.
-        \ No newline at end of file
-        </diff>
-            </file>
-            <file state="changed">
-              <old name="somefile.txt" md5="ef73142d50dc2691db5dad9ce92647cd" size="62"/>
-              <new name="somefile.txt" md5="0e2d53ce1b91d5c94cc75003fb5c4ebd" size="53"/>
-              <diff lines="5">@@ -1,1 +1,1 @@
-        -Atque vero corrupti. Sequi animi harum. Unde ullam aspernatur.
-        \ No newline at end of file
-        +Nihil in soluta. Iure dolorem aut. Cumque itaque est.
-        \ No newline at end of file
-        </diff>
-            </file>
-          </files>
-          <issues>
-          </issues>
-        </sourcediff>
-  recorded_at: Thu, 03 Nov 2022 09:59:00 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:mr_receiver/Quebec
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Request-Id:
-      - b9a994e1-32d4-4bd0-8fed-8f6fa2592da2
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '291'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="Quebec" rev="2" vrev="2" srcmd5="084c2d00f44e4f61962ce65dc2d12103">
-          <entry name="_config" md5="c356d35d6618087a05a03812915c5bdf" size="72" mtime="1667469540"/>
-          <entry name="somefile.txt" md5="ef73142d50dc2691db5dad9ce92647cd" size="62" mtime="1667469540"/>
-        </directory>
-  recorded_at: Thu, 03 Nov 2022 09:59:01 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:29 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:madam_submitter/Quebec
@@ -1035,7 +924,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 29b779a3-1c15-41ef-9990-a16612baae8b
+      - e2121707-fb44-4fdf-9a0e-021a300d07b3
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1054,18 +943,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '291'
+      - '293'
     body:
       encoding: UTF-8
       string: |
-        <directory name="Quebec" rev="2" vrev="2" srcmd5="ddd3491d11bfccb6d4a5ded8d29c8e0f">
-          <entry name="_config" md5="697c34abeaacf5a27e0cefcdffb665b9" size="81" mtime="1667469538"/>
-          <entry name="somefile.txt" md5="0e2d53ce1b91d5c94cc75003fb5c4ebd" size="53" mtime="1667469538"/>
+        <directory name="Quebec" rev="16" vrev="16" srcmd5="1a913a143de499ea4a23395530755e09">
+          <entry name="_config" md5="67e4231343c0ac6c27b797a40c0026b8" size="77" mtime="1677089487"/>
+          <entry name="somefile.txt" md5="9aaa643d8969a264c279f8e0a4eec6e2" size="67" mtime="1677089487"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:59:01 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:29 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/home:madam_submitter/Quebec?cacheonly=1&cmd=diff&expand=1&filelimit=10000&opackage=Quebec&oproject=home:mr_receiver&rev=2&tarlimit=10000&view=xml&withissues=1
+    uri: http://backend:5352/source/home:madam_submitter/Quebec?cmd=diff&expand=1&filelimit=10000&opackage=Quebec&oproject=home:mr_receiver&rev=16&tarlimit=10000&view=xml&withissues=1
     body:
       encoding: UTF-8
       string: ''
@@ -1073,7 +962,7 @@ http_interactions:
       Content-Type:
       - application/octet-stream
       X-Request-Id:
-      - 29b779a3-1c15-41ef-9990-a16612baae8b
+      - e2121707-fb44-4fdf-9a0e-021a300d07b3
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1087,36 +976,36 @@ http_interactions:
     headers:
       Content-Type:
       - text/xml
-      Content-Length:
-      - '1196'
       Cache-Control:
       - no-cache
       Connection:
       - close
+      Content-Length:
+      - '1174'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="4c57c9356d49e83ab300f7782dfd192f">
-          <old project="home:mr_receiver" package="Quebec" rev="2" srcmd5="084c2d00f44e4f61962ce65dc2d12103"/>
-          <new project="home:madam_submitter" package="Quebec" rev="2" srcmd5="ddd3491d11bfccb6d4a5ded8d29c8e0f"/>
+        <sourcediff key="34d39ed001887a604da849c8cbb97fc9">
+          <old project="home:mr_receiver" package="Quebec" rev="10" srcmd5="7e0a7d98b8428224e3c71870d418db0d"/>
+          <new project="home:madam_submitter" package="Quebec" rev="16" srcmd5="1a913a143de499ea4a23395530755e09"/>
           <files>
             <file state="changed">
-              <old name="_config" md5="c356d35d6618087a05a03812915c5bdf" size="72"/>
-              <new name="_config" md5="697c34abeaacf5a27e0cefcdffb665b9" size="81"/>
+              <old name="_config" md5="3af1462ec778d041204c3cf48ee605c4" size="44"/>
+              <new name="_config" md5="67e4231343c0ac6c27b797a40c0026b8" size="77"/>
               <diff lines="5">@@ -1,1 +1,1 @@
-        -Voluptatibus et ipsam. Ipsa praesentium ut. Autem molestiae praesentium.
+        -Vero aut quis. Illo rerum et. Eum quo earum.
         \ No newline at end of file
-        +Exercitationem voluptatem necessitatibus. Autem facere dolor. Adipisci est quasi.
+        +Voluptatem fugiat ratione. Eius in officia. Laudantium asperiores temporibus.
         \ No newline at end of file
         </diff>
             </file>
             <file state="changed">
-              <old name="somefile.txt" md5="ef73142d50dc2691db5dad9ce92647cd" size="62"/>
-              <new name="somefile.txt" md5="0e2d53ce1b91d5c94cc75003fb5c4ebd" size="53"/>
+              <old name="somefile.txt" md5="bc226b6312dfaedbfd419a855b9d64f3" size="56"/>
+              <new name="somefile.txt" md5="9aaa643d8969a264c279f8e0a4eec6e2" size="67"/>
               <diff lines="5">@@ -1,1 +1,1 @@
-        -Atque vero corrupti. Sequi animi harum. Unde ullam aspernatur.
+        -Ab molestiae est. Sed tempore modi. Sit aspernatur quis.
         \ No newline at end of file
-        +Nihil in soluta. Iure dolorem aut. Cumque itaque est.
+        +Excepturi vel blanditiis. Enim omnis eius. Modi doloribus eligendi.
         \ No newline at end of file
         </diff>
             </file>
@@ -1124,7 +1013,7 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 03 Nov 2022 09:59:01 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:29 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:mr_receiver/Quebec
@@ -1133,7 +1022,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 29b779a3-1c15-41ef-9990-a16612baae8b
+      - 41cdacf9-f282-4e97-a1fb-9d44df91e78d
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1152,15 +1041,149 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '291'
+      - '293'
     body:
       encoding: UTF-8
       string: |
-        <directory name="Quebec" rev="2" vrev="2" srcmd5="084c2d00f44e4f61962ce65dc2d12103">
-          <entry name="_config" md5="c356d35d6618087a05a03812915c5bdf" size="72" mtime="1667469540"/>
-          <entry name="somefile.txt" md5="ef73142d50dc2691db5dad9ce92647cd" size="62" mtime="1667469540"/>
+        <directory name="Quebec" rev="10" vrev="10" srcmd5="7e0a7d98b8428224e3c71870d418db0d">
+          <entry name="_config" md5="3af1462ec778d041204c3cf48ee605c4" size="44" mtime="1677089489"/>
+          <entry name="somefile.txt" md5="bc226b6312dfaedbfd419a855b9d64f3" size="56" mtime="1677089489"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:59:01 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:29 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:madam_submitter/Quebec
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - c71cdea4-02bd-4591-89a1-6a296c349767
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '293'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="Quebec" rev="16" vrev="16" srcmd5="1a913a143de499ea4a23395530755e09">
+          <entry name="_config" md5="67e4231343c0ac6c27b797a40c0026b8" size="77" mtime="1677089487"/>
+          <entry name="somefile.txt" md5="9aaa643d8969a264c279f8e0a4eec6e2" size="67" mtime="1677089487"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:11:30 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/home:madam_submitter/Quebec?cacheonly=1&cmd=diff&expand=1&filelimit=10000&opackage=Quebec&oproject=home:mr_receiver&rev=16&tarlimit=10000&view=xml&withissues=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      X-Request-Id:
+      - c71cdea4-02bd-4591-89a1-6a296c349767
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '1174'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="34d39ed001887a604da849c8cbb97fc9">
+          <old project="home:mr_receiver" package="Quebec" rev="10" srcmd5="7e0a7d98b8428224e3c71870d418db0d"/>
+          <new project="home:madam_submitter" package="Quebec" rev="16" srcmd5="1a913a143de499ea4a23395530755e09"/>
+          <files>
+            <file state="changed">
+              <old name="_config" md5="3af1462ec778d041204c3cf48ee605c4" size="44"/>
+              <new name="_config" md5="67e4231343c0ac6c27b797a40c0026b8" size="77"/>
+              <diff lines="5">@@ -1,1 +1,1 @@
+        -Vero aut quis. Illo rerum et. Eum quo earum.
+        \ No newline at end of file
+        +Voluptatem fugiat ratione. Eius in officia. Laudantium asperiores temporibus.
+        \ No newline at end of file
+        </diff>
+            </file>
+            <file state="changed">
+              <old name="somefile.txt" md5="bc226b6312dfaedbfd419a855b9d64f3" size="56"/>
+              <new name="somefile.txt" md5="9aaa643d8969a264c279f8e0a4eec6e2" size="67"/>
+              <diff lines="5">@@ -1,1 +1,1 @@
+        -Ab molestiae est. Sed tempore modi. Sit aspernatur quis.
+        \ No newline at end of file
+        +Excepturi vel blanditiis. Enim omnis eius. Modi doloribus eligendi.
+        \ No newline at end of file
+        </diff>
+            </file>
+          </files>
+          <issues>
+          </issues>
+        </sourcediff>
+  recorded_at: Wed, 22 Feb 2023 18:11:30 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:mr_receiver/Quebec
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - c71cdea4-02bd-4591-89a1-6a296c349767
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '293'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="Quebec" rev="10" vrev="10" srcmd5="7e0a7d98b8428224e3c71870d418db0d">
+          <entry name="_config" md5="3af1462ec778d041204c3cf48ee605c4" size="44" mtime="1677089489"/>
+          <entry name="somefile.txt" md5="bc226b6312dfaedbfd419a855b9d64f3" size="56" mtime="1677089489"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:11:30 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:madam_submitter/_result?package=Quebec&view=status
@@ -1169,7 +1192,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 84ecb4a4-eda1-4680-b905-2c7708a80281
+      - b52b2053-d264-4e5a-b8c7-29a0de5c0175
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1194,5 +1217,5 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:59:01 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:30 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Bootstrap_Requests_Submissions/submit_package/supersede_a_request/creates_a_BsRequest_and_supersede_only_the_selected_request_s_.yml
+++ b/src/api/spec/cassettes/Bootstrap_Requests_Submissions/submit_package/supersede_a_request/creates_a_BsRequest_and_supersede_only_the_selected_request_s_.yml
@@ -39,16 +39,16 @@ http_interactions:
           <description></description>
           <person userid="madam_submitter" role="maintainer"/>
         </project>
-  recorded_at: Mon, 18 Oct 2021 14:49:13 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:24 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:madam_submitter/Quebec/_meta?user=user_1
+    uri: http://backend:5352/source/home:madam_submitter/Quebec/_meta?user=user_47
     body:
       encoding: UTF-8
       string: |
         <package name="Quebec" project="home:madam_submitter">
-          <title>The Far-Distant Oxus</title>
-          <description>Nisi veniam qui voluptatibus.</description>
+          <title>For Whom the Bell Tolls</title>
+          <description>Tenetur mollitia ipsam illum.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -69,21 +69,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '163'
+      - '166'
     body:
       encoding: UTF-8
       string: |
         <package name="Quebec" project="home:madam_submitter">
-          <title>The Far-Distant Oxus</title>
-          <description>Nisi veniam qui voluptatibus.</description>
+          <title>For Whom the Bell Tolls</title>
+          <description>Tenetur mollitia ipsam illum.</description>
         </package>
-  recorded_at: Mon, 18 Oct 2021 14:49:13 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:25 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:madam_submitter/Quebec/_config
     body:
       encoding: UTF-8
-      string: Eos vel aut. Enim saepe eaque. Est voluptas molestias.
+      string: Non sed eos. Ut exercitationem animi. Voluptates voluptatibus dolores.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -103,25 +103,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="7" vrev="7">
-          <srcmd5>4808c559b68d4cbc7690b6ffb66005ab</srcmd5>
+        <revision rev="13" vrev="13">
+          <srcmd5>a2a5e2131d260ddd980ee55250e217c7</srcmd5>
           <version>unknown</version>
-          <time>1634568553</time>
+          <time>1677089185</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Mon, 18 Oct 2021 14:49:13 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:25 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:madam_submitter/Quebec/somefile.txt
     body:
       encoding: UTF-8
-      string: Est recusandae quo. Occaecati esse minima. Porro maxime odit.
+      string: Nobis sunt quis. Aliquid qui nihil. Quas consequatur culpa.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -141,19 +141,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="8" vrev="8">
-          <srcmd5>bf6b7a77608fc277589f5a103d9049f0</srcmd5>
+        <revision rev="14" vrev="14">
+          <srcmd5>3a5362068f781c4226a3446b2c93fad2</srcmd5>
           <version>unknown</version>
-          <time>1634568553</time>
+          <time>1677089185</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Mon, 18 Oct 2021 14:49:13 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:25 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:mr_receiver/_meta?user=mr_receiver
@@ -193,16 +193,16 @@ http_interactions:
           <description></description>
           <person userid="mr_receiver" role="maintainer"/>
         </project>
-  recorded_at: Mon, 18 Oct 2021 14:49:13 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:25 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:mr_receiver/Quebec/_meta?user=user_2
+    uri: http://backend:5352/source/home:mr_receiver/Quebec/_meta?user=user_48
     body:
       encoding: UTF-8
       string: |
         <package name="Quebec" project="home:mr_receiver">
-          <title>All Passion Spent</title>
-          <description>Laudantium quia in atque.</description>
+          <title>The Wings of the Dove</title>
+          <description>Totam voluptas modi odit.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -223,21 +223,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '152'
+      - '156'
     body:
       encoding: UTF-8
       string: |
         <package name="Quebec" project="home:mr_receiver">
-          <title>All Passion Spent</title>
-          <description>Laudantium quia in atque.</description>
+          <title>The Wings of the Dove</title>
+          <description>Totam voluptas modi odit.</description>
         </package>
-  recorded_at: Mon, 18 Oct 2021 14:49:13 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:25 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:mr_receiver/Quebec/_config
     body:
       encoding: UTF-8
-      string: Non est et. Debitis inventore necessitatibus. Deleniti beatae officiis.
+      string: Ducimus nemo eos. Dolores nobis delectus. Est placeat dolorum.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -261,21 +261,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="5" vrev="5">
-          <srcmd5>79daff6634902bf73c4065efbe154a57</srcmd5>
+        <revision rev="7" vrev="7">
+          <srcmd5>511b1d407a7a1617ff65253ca5e018bd</srcmd5>
           <version>unknown</version>
-          <time>1634568553</time>
+          <time>1677089185</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Mon, 18 Oct 2021 14:49:14 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:25 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:mr_receiver/Quebec/somefile.txt
     body:
       encoding: UTF-8
-      string: Qui ut rerum. Magnam deleniti veritatis. Aperiam quo voluptatem.
+      string: Et qui consequuntur. Inventore cumque libero. Sed consequuntur rerum.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -299,15 +299,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="6" vrev="6">
-          <srcmd5>c3cb98b2a4cedd388f9a25627e48a090</srcmd5>
+        <revision rev="8" vrev="8">
+          <srcmd5>3b55a3048dffa708bf156227ce3cc8fb</srcmd5>
           <version>unknown</version>
-          <time>1634568554</time>
+          <time>1677089185</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Mon, 18 Oct 2021 14:49:14 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:25 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:madam_submitter/Quebec
@@ -333,15 +333,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '291'
+      - '293'
     body:
       encoding: UTF-8
       string: |
-        <directory name="Quebec" rev="8" vrev="8" srcmd5="bf6b7a77608fc277589f5a103d9049f0">
-          <entry name="_config" md5="ac7cbfcdb3cc1481949164825042cbbc" size="54" mtime="1634568553"/>
-          <entry name="somefile.txt" md5="9b68d21636271f84b8322522f8242105" size="61" mtime="1634568553"/>
+        <directory name="Quebec" rev="14" vrev="14" srcmd5="3a5362068f781c4226a3446b2c93fad2">
+          <entry name="_config" md5="1327892009efd20f0a58b7186d4b2735" size="70" mtime="1677089185"/>
+          <entry name="somefile.txt" md5="26e30a5a49db1d3fbd85dcc61e02f0b4" size="59" mtime="1677089185"/>
         </directory>
-  recorded_at: Mon, 18 Oct 2021 14:49:14 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:25 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:madam_submitter/Quebec?cmd=diff&expand=1&filelimit=10000&opackage=Quebec&oproject=home:mr_receiver&tarlimit=10000&view=xml&withissues=1
@@ -369,31 +369,31 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '1178'
+      - '1189'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="86ce2f67c48b3397bb33333dac73f33f">
-          <old project="home:mr_receiver" package="Quebec" rev="6" srcmd5="c3cb98b2a4cedd388f9a25627e48a090"/>
-          <new project="home:madam_submitter" package="Quebec" rev="8" srcmd5="bf6b7a77608fc277589f5a103d9049f0"/>
+        <sourcediff key="e341fd4b35ef666287f9853dd8a24671">
+          <old project="home:mr_receiver" package="Quebec" rev="8" srcmd5="3b55a3048dffa708bf156227ce3cc8fb"/>
+          <new project="home:madam_submitter" package="Quebec" rev="14" srcmd5="3a5362068f781c4226a3446b2c93fad2"/>
           <files>
             <file state="changed">
-              <old name="_config" md5="89e55b294b1ada0045972482cd97312f" size="71"/>
-              <new name="_config" md5="ac7cbfcdb3cc1481949164825042cbbc" size="54"/>
+              <old name="_config" md5="4f7a85fa2eeaff019d61537a23dd429b" size="62"/>
+              <new name="_config" md5="1327892009efd20f0a58b7186d4b2735" size="70"/>
               <diff lines="5">@@ -1,1 +1,1 @@
-        -Non est et. Debitis inventore necessitatibus. Deleniti beatae officiis.
+        -Ducimus nemo eos. Dolores nobis delectus. Est placeat dolorum.
         \ No newline at end of file
-        +Eos vel aut. Enim saepe eaque. Est voluptas molestias.
+        +Non sed eos. Ut exercitationem animi. Voluptates voluptatibus dolores.
         \ No newline at end of file
         </diff>
             </file>
             <file state="changed">
-              <old name="somefile.txt" md5="e815af7acb7571ac2250a1a35fc02e9a" size="64"/>
-              <new name="somefile.txt" md5="9b68d21636271f84b8322522f8242105" size="61"/>
+              <old name="somefile.txt" md5="7bcdd74a73c2d2d67362357044d1869b" size="69"/>
+              <new name="somefile.txt" md5="26e30a5a49db1d3fbd85dcc61e02f0b4" size="59"/>
               <diff lines="5">@@ -1,1 +1,1 @@
-        -Qui ut rerum. Magnam deleniti veritatis. Aperiam quo voluptatem.
+        -Et qui consequuntur. Inventore cumque libero. Sed consequuntur rerum.
         \ No newline at end of file
-        +Est recusandae quo. Occaecati esse minima. Porro maxime odit.
+        +Nobis sunt quis. Aliquid qui nihil. Quas consequatur culpa.
         \ No newline at end of file
         </diff>
             </file>
@@ -401,7 +401,7 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Mon, 18 Oct 2021 14:49:14 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:25 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:madam_submitter/Quebec
@@ -427,15 +427,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '291'
+      - '293'
     body:
       encoding: UTF-8
       string: |
-        <directory name="Quebec" rev="8" vrev="8" srcmd5="bf6b7a77608fc277589f5a103d9049f0">
-          <entry name="_config" md5="ac7cbfcdb3cc1481949164825042cbbc" size="54" mtime="1634568553"/>
-          <entry name="somefile.txt" md5="9b68d21636271f84b8322522f8242105" size="61" mtime="1634568553"/>
+        <directory name="Quebec" rev="14" vrev="14" srcmd5="3a5362068f781c4226a3446b2c93fad2">
+          <entry name="_config" md5="1327892009efd20f0a58b7186d4b2735" size="70" mtime="1677089185"/>
+          <entry name="somefile.txt" md5="26e30a5a49db1d3fbd85dcc61e02f0b4" size="59" mtime="1677089185"/>
         </directory>
-  recorded_at: Mon, 18 Oct 2021 14:49:14 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:25 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:madam_submitter/Quebec?cmd=diff&expand=1&filelimit=10000&opackage=Quebec&oproject=home:mr_receiver&tarlimit=10000&view=xml&withissues=1
@@ -459,7 +459,7 @@ http_interactions:
       Content-Type:
       - text/xml
       Content-Length:
-      - '1178'
+      - '1189'
       Cache-Control:
       - no-cache
       Connection:
@@ -467,27 +467,27 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="86ce2f67c48b3397bb33333dac73f33f">
-          <old project="home:mr_receiver" package="Quebec" rev="6" srcmd5="c3cb98b2a4cedd388f9a25627e48a090"/>
-          <new project="home:madam_submitter" package="Quebec" rev="8" srcmd5="bf6b7a77608fc277589f5a103d9049f0"/>
+        <sourcediff key="e341fd4b35ef666287f9853dd8a24671">
+          <old project="home:mr_receiver" package="Quebec" rev="8" srcmd5="3b55a3048dffa708bf156227ce3cc8fb"/>
+          <new project="home:madam_submitter" package="Quebec" rev="14" srcmd5="3a5362068f781c4226a3446b2c93fad2"/>
           <files>
             <file state="changed">
-              <old name="_config" md5="89e55b294b1ada0045972482cd97312f" size="71"/>
-              <new name="_config" md5="ac7cbfcdb3cc1481949164825042cbbc" size="54"/>
+              <old name="_config" md5="4f7a85fa2eeaff019d61537a23dd429b" size="62"/>
+              <new name="_config" md5="1327892009efd20f0a58b7186d4b2735" size="70"/>
               <diff lines="5">@@ -1,1 +1,1 @@
-        -Non est et. Debitis inventore necessitatibus. Deleniti beatae officiis.
+        -Ducimus nemo eos. Dolores nobis delectus. Est placeat dolorum.
         \ No newline at end of file
-        +Eos vel aut. Enim saepe eaque. Est voluptas molestias.
+        +Non sed eos. Ut exercitationem animi. Voluptates voluptatibus dolores.
         \ No newline at end of file
         </diff>
             </file>
             <file state="changed">
-              <old name="somefile.txt" md5="e815af7acb7571ac2250a1a35fc02e9a" size="64"/>
-              <new name="somefile.txt" md5="9b68d21636271f84b8322522f8242105" size="61"/>
+              <old name="somefile.txt" md5="7bcdd74a73c2d2d67362357044d1869b" size="69"/>
+              <new name="somefile.txt" md5="26e30a5a49db1d3fbd85dcc61e02f0b4" size="59"/>
               <diff lines="5">@@ -1,1 +1,1 @@
-        -Qui ut rerum. Magnam deleniti veritatis. Aperiam quo voluptatem.
+        -Et qui consequuntur. Inventore cumque libero. Sed consequuntur rerum.
         \ No newline at end of file
-        +Est recusandae quo. Occaecati esse minima. Porro maxime odit.
+        +Nobis sunt quis. Aliquid qui nihil. Quas consequatur culpa.
         \ No newline at end of file
         </diff>
             </file>
@@ -495,7 +495,7 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Mon, 18 Oct 2021 14:49:14 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:25 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:madam_submitter/Quebec
@@ -504,7 +504,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 85fdc7b2-b16c-4793-80c8-e5ceaacd5a57
+      - 2bba8081-777b-4e27-93cf-b1520e5a210d
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -523,18 +523,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '291'
+      - '293'
     body:
       encoding: UTF-8
       string: |
-        <directory name="Quebec" rev="8" vrev="8" srcmd5="bf6b7a77608fc277589f5a103d9049f0">
-          <entry name="_config" md5="ac7cbfcdb3cc1481949164825042cbbc" size="54" mtime="1634568553"/>
-          <entry name="somefile.txt" md5="9b68d21636271f84b8322522f8242105" size="61" mtime="1634568553"/>
+        <directory name="Quebec" rev="14" vrev="14" srcmd5="3a5362068f781c4226a3446b2c93fad2">
+          <entry name="_config" md5="1327892009efd20f0a58b7186d4b2735" size="70" mtime="1677089185"/>
+          <entry name="somefile.txt" md5="26e30a5a49db1d3fbd85dcc61e02f0b4" size="59" mtime="1677089185"/>
         </directory>
-  recorded_at: Mon, 18 Oct 2021 14:49:20 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:26 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:madam_submitter/Quebec?expand=1&rev=8
+    uri: http://backend:5352/source/home:madam_submitter/Quebec?expand=1&rev=14
     body:
       encoding: US-ASCII
       string: ''
@@ -557,60 +557,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '291'
+      - '293'
     body:
       encoding: UTF-8
       string: |
-        <directory name="Quebec" rev="8" vrev="8" srcmd5="bf6b7a77608fc277589f5a103d9049f0">
-          <entry name="_config" md5="ac7cbfcdb3cc1481949164825042cbbc" size="54" mtime="1634568553"/>
-          <entry name="somefile.txt" md5="9b68d21636271f84b8322522f8242105" size="61" mtime="1634568553"/>
+        <directory name="Quebec" rev="14" vrev="14" srcmd5="3a5362068f781c4226a3446b2c93fad2">
+          <entry name="_config" md5="1327892009efd20f0a58b7186d4b2735" size="70" mtime="1677089185"/>
+          <entry name="somefile.txt" md5="26e30a5a49db1d3fbd85dcc61e02f0b4" size="59" mtime="1677089185"/>
         </directory>
-  recorded_at: Mon, 18 Oct 2021 14:49:20 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:27 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:madam_submitter/Quebec
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Request-Id:
-      - 85fdc7b2-b16c-4793-80c8-e5ceaacd5a57
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '291'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="Quebec" rev="8" vrev="8" srcmd5="bf6b7a77608fc277589f5a103d9049f0">
-          <entry name="_config" md5="ac7cbfcdb3cc1481949164825042cbbc" size="54" mtime="1634568553"/>
-          <entry name="somefile.txt" md5="9b68d21636271f84b8322522f8242105" size="61" mtime="1634568553"/>
-        </directory>
-  recorded_at: Mon, 18 Oct 2021 14:49:20 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:madam_submitter/Quebec
+    uri: http://backend:5352/source/home:madam_submitter/Quebec/_history?deleted=1&meta=1&rev=14
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - 85fdc7b2-b16c-4793-80c8-e5ceaacd5a57
+      - 2bba8081-777b-4e27-93cf-b1520e5a210d
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -629,104 +593,164 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '291'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="Quebec" rev="8" vrev="8" srcmd5="bf6b7a77608fc277589f5a103d9049f0">
-          <entry name="_config" md5="ac7cbfcdb3cc1481949164825042cbbc" size="54" mtime="1634568553"/>
-          <entry name="somefile.txt" md5="9b68d21636271f84b8322522f8242105" size="61" mtime="1634568553"/>
-        </directory>
-  recorded_at: Mon, 18 Oct 2021 14:49:20 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:madam_submitter/Quebec/_history
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '1487'
+      - '31'
     body:
       encoding: UTF-8
       string: |
         <revisionlist>
-          <revision rev="1" vrev="1">
-            <srcmd5>d1ad41345309e76c6020235a9446d03d</srcmd5>
-            <version>unknown</version>
-            <time>1634568266</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="2" vrev="2">
-            <srcmd5>53480dc0a7dde395f4bd574fc3e0711b</srcmd5>
-            <version>unknown</version>
-            <time>1634568266</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="3" vrev="3">
-            <srcmd5>46591f44118cb3e2ee28ec2df9cf1193</srcmd5>
-            <version>unknown</version>
-            <time>1634568419</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="4" vrev="4">
-            <srcmd5>1012f617c00fa08bb37a9b102948edd8</srcmd5>
-            <version>unknown</version>
-            <time>1634568419</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="5" vrev="5">
-            <srcmd5>4ac45c25222bf25aa097b4ed0b63f9d0</srcmd5>
-            <version>unknown</version>
-            <time>1634568493</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="6" vrev="6">
-            <srcmd5>e0c74fad0eac27539a9e7d7283a6da34</srcmd5>
-            <version>unknown</version>
-            <time>1634568493</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="7" vrev="7">
-            <srcmd5>4808c559b68d4cbc7690b6ffb66005ab</srcmd5>
-            <version>unknown</version>
-            <time>1634568553</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="8" vrev="8">
-            <srcmd5>bf6b7a77608fc277589f5a103d9049f0</srcmd5>
-            <version>unknown</version>
-            <time>1634568553</time>
-            <user>unknown</user>
-          </revision>
         </revisionlist>
-  recorded_at: Mon, 18 Oct 2021 14:49:20 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:27 GMT
 - request:
     method: get
-    uri: http://backend:5352/build/home:madam_submitter/_result?package=Quebec&view=status
+    uri: http://backend:5352/source/home:madam_submitter/Quebec
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - 57e36c26-ef02-4c91-b06c-9ede6be6c8e5
+      - 2bba8081-777b-4e27-93cf-b1520e5a210d
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '293'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="Quebec" rev="14" vrev="14" srcmd5="3a5362068f781c4226a3446b2c93fad2">
+          <entry name="_config" md5="1327892009efd20f0a58b7186d4b2735" size="70" mtime="1677089185"/>
+          <entry name="somefile.txt" md5="26e30a5a49db1d3fbd85dcc61e02f0b4" size="59" mtime="1677089185"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:06:27 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:madam_submitter/Quebec
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 2bba8081-777b-4e27-93cf-b1520e5a210d
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '293'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="Quebec" rev="14" vrev="14" srcmd5="3a5362068f781c4226a3446b2c93fad2">
+          <entry name="_config" md5="1327892009efd20f0a58b7186d4b2735" size="70" mtime="1677089185"/>
+          <entry name="somefile.txt" md5="26e30a5a49db1d3fbd85dcc61e02f0b4" size="59" mtime="1677089185"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:06:27 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:madam_submitter/Quebec/_history?deleted=1&meta=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 2bba8081-777b-4e27-93cf-b1520e5a210d
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Wed, 22 Feb 2023 18:06:27 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:madam_submitter/Quebec
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 87268be9-9b62-4f17-baf7-88e274b396ec
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '293'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="Quebec" rev="14" vrev="14" srcmd5="3a5362068f781c4226a3446b2c93fad2">
+          <entry name="_config" md5="1327892009efd20f0a58b7186d4b2735" size="70" mtime="1677089185"/>
+          <entry name="somefile.txt" md5="26e30a5a49db1d3fbd85dcc61e02f0b4" size="59" mtime="1677089185"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:06:27 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:madam_submitter/_result?lastbuild=1&locallink=1&multibuild=1&package=Quebec&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 87268be9-9b62-4f17-baf7-88e274b396ec
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -751,42 +775,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Mon, 18 Oct 2021 14:49:20 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:madam_submitter/Quebec?view=info
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Request-Id:
-      - 3d2acc05-d65f-4c8e-bc32-2a8ea053f7cb
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '224'
-    body:
-      encoding: UTF-8
-      string: |
-        <sourceinfo package="Quebec" rev="8" vrev="8" srcmd5="bf6b7a77608fc277589f5a103d9049f0" verifymd5="bf6b7a77608fc277589f5a103d9049f0">
-          <error>bad build configuration, no build type defined or detected</error>
-        </sourceinfo>
-  recorded_at: Mon, 18 Oct 2021 14:49:21 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:27 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:madam_submitter/Quebec
@@ -795,7 +784,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 3d2acc05-d65f-4c8e-bc32-2a8ea053f7cb
+      - ad5a7d88-195d-48c3-8d66-03d8884e088b
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -814,15 +803,154 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '291'
+      - '293'
     body:
       encoding: UTF-8
       string: |
-        <directory name="Quebec" rev="8" vrev="8" srcmd5="bf6b7a77608fc277589f5a103d9049f0">
-          <entry name="_config" md5="ac7cbfcdb3cc1481949164825042cbbc" size="54" mtime="1634568553"/>
-          <entry name="somefile.txt" md5="9b68d21636271f84b8322522f8242105" size="61" mtime="1634568553"/>
+        <directory name="Quebec" rev="14" vrev="14" srcmd5="3a5362068f781c4226a3446b2c93fad2">
+          <entry name="_config" md5="1327892009efd20f0a58b7186d4b2735" size="70" mtime="1677089185"/>
+          <entry name="somefile.txt" md5="26e30a5a49db1d3fbd85dcc61e02f0b4" size="59" mtime="1677089185"/>
         </directory>
-  recorded_at: Mon, 18 Oct 2021 14:49:21 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:27 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:madam_submitter/_result?lastbuild=1&locallink=1&multibuild=1&package=Quebec&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - ad5a7d88-195d-48c3-8d66-03d8884e088b
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 18:06:27 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:madam_submitter/_result?package=Quebec&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 61d8280e-5bbe-44c2-8b52-46129ed67c9d
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 18:06:27 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:madam_submitter/Quebec?view=info
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - e7e5449d-da53-499f-9fb5-8fb08f57ab02
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '226'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourceinfo package="Quebec" rev="14" vrev="14" srcmd5="3a5362068f781c4226a3446b2c93fad2" verifymd5="3a5362068f781c4226a3446b2c93fad2">
+          <error>bad build configuration, no build type defined or detected</error>
+        </sourceinfo>
+  recorded_at: Wed, 22 Feb 2023 18:06:27 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:madam_submitter/Quebec
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - e7e5449d-da53-499f-9fb5-8fb08f57ab02
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '293'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="Quebec" rev="14" vrev="14" srcmd5="3a5362068f781c4226a3446b2c93fad2">
+          <entry name="_config" md5="1327892009efd20f0a58b7186d4b2735" size="70" mtime="1677089185"/>
+          <entry name="somefile.txt" md5="26e30a5a49db1d3fbd85dcc61e02f0b4" size="59" mtime="1677089185"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:06:27 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:madam_submitter/Quebec?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -850,18 +978,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '314'
+      - '315'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="8220e80f139db11302b69cc50abb9b4c">
+        <sourcediff key="651258c6e210327d9877065cdd80700c">
           <old project="home:madam_submitter" package="Quebec" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:madam_submitter" package="Quebec" rev="8" srcmd5="bf6b7a77608fc277589f5a103d9049f0"/>
+          <new project="home:madam_submitter" package="Quebec" rev="14" srcmd5="3a5362068f781c4226a3446b2c93fad2"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Mon, 18 Oct 2021 14:49:21 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:27 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:madam_submitter/Quebec
@@ -870,7 +998,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 4007a882-6af3-4f6c-8bf5-15cbd75f0d30
+      - 5a6cc46b-9d31-4594-bab6-5a473b97ef70
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -889,18 +1017,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '291'
+      - '293'
     body:
       encoding: UTF-8
       string: |
-        <directory name="Quebec" rev="8" vrev="8" srcmd5="bf6b7a77608fc277589f5a103d9049f0">
-          <entry name="_config" md5="ac7cbfcdb3cc1481949164825042cbbc" size="54" mtime="1634568553"/>
-          <entry name="somefile.txt" md5="9b68d21636271f84b8322522f8242105" size="61" mtime="1634568553"/>
+        <directory name="Quebec" rev="14" vrev="14" srcmd5="3a5362068f781c4226a3446b2c93fad2">
+          <entry name="_config" md5="1327892009efd20f0a58b7186d4b2735" size="70" mtime="1677089185"/>
+          <entry name="somefile.txt" md5="26e30a5a49db1d3fbd85dcc61e02f0b4" size="59" mtime="1677089185"/>
         </directory>
-  recorded_at: Mon, 18 Oct 2021 14:49:22 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:29 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/home:madam_submitter/Quebec?cmd=diff&expand=1&nodiff=1&opackage=Quebec&oproject=home:mr_receiver&rev=8
+    uri: http://backend:5352/source/home:madam_submitter/Quebec?cmd=diff&expand=1&nodiff=1&opackage=Quebec&oproject=home:mr_receiver&rev=14
     body:
       encoding: UTF-8
       string: ''
@@ -908,7 +1036,7 @@ http_interactions:
       Content-Type:
       - application/octet-stream
       X-Request-Id:
-      - 4007a882-6af3-4f6c-8bf5-15cbd75f0d30
+      - 5a6cc46b-9d31-4594-bab6-5a473b97ef70
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -939,16 +1067,16 @@ http_interactions:
         ++++++ somefile.txt
         --- somefile.txt
         +++ somefile.txt
-  recorded_at: Mon, 18 Oct 2021 14:49:22 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:29 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:madam_submitter/Quebec?expand=1&rev=8
+    uri: http://backend:5352/source/home:madam_submitter/Quebec?expand=1&rev=14
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - 4007a882-6af3-4f6c-8bf5-15cbd75f0d30
+      - 5a6cc46b-9d31-4594-bab6-5a473b97ef70
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -967,149 +1095,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '291'
+      - '293'
     body:
       encoding: UTF-8
       string: |
-        <directory name="Quebec" rev="8" vrev="8" srcmd5="bf6b7a77608fc277589f5a103d9049f0">
-          <entry name="_config" md5="ac7cbfcdb3cc1481949164825042cbbc" size="54" mtime="1634568553"/>
-          <entry name="somefile.txt" md5="9b68d21636271f84b8322522f8242105" size="61" mtime="1634568553"/>
+        <directory name="Quebec" rev="14" vrev="14" srcmd5="3a5362068f781c4226a3446b2c93fad2">
+          <entry name="_config" md5="1327892009efd20f0a58b7186d4b2735" size="70" mtime="1677089185"/>
+          <entry name="somefile.txt" md5="26e30a5a49db1d3fbd85dcc61e02f0b4" size="59" mtime="1677089185"/>
         </directory>
-  recorded_at: Mon, 18 Oct 2021 14:49:22 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:madam_submitter/Quebec
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Request-Id:
-      - 4007a882-6af3-4f6c-8bf5-15cbd75f0d30
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '291'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="Quebec" rev="8" vrev="8" srcmd5="bf6b7a77608fc277589f5a103d9049f0">
-          <entry name="_config" md5="ac7cbfcdb3cc1481949164825042cbbc" size="54" mtime="1634568553"/>
-          <entry name="somefile.txt" md5="9b68d21636271f84b8322522f8242105" size="61" mtime="1634568553"/>
-        </directory>
-  recorded_at: Mon, 18 Oct 2021 14:49:23 GMT
-- request:
-    method: post
-    uri: http://backend:5352/source/home:madam_submitter/Quebec?cmd=diff&expand=1&filelimit=10000&opackage=Quebec&oproject=home:mr_receiver&rev=8&tarlimit=10000&view=xml&withissues=1
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      Content-Type:
-      - application/octet-stream
-      X-Request-Id:
-      - 4007a882-6af3-4f6c-8bf5-15cbd75f0d30
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Content-Length:
-      - '1178'
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-    body:
-      encoding: UTF-8
-      string: |
-        <sourcediff key="86ce2f67c48b3397bb33333dac73f33f">
-          <old project="home:mr_receiver" package="Quebec" rev="6" srcmd5="c3cb98b2a4cedd388f9a25627e48a090"/>
-          <new project="home:madam_submitter" package="Quebec" rev="8" srcmd5="bf6b7a77608fc277589f5a103d9049f0"/>
-          <files>
-            <file state="changed">
-              <old name="_config" md5="89e55b294b1ada0045972482cd97312f" size="71"/>
-              <new name="_config" md5="ac7cbfcdb3cc1481949164825042cbbc" size="54"/>
-              <diff lines="5">@@ -1,1 +1,1 @@
-        -Non est et. Debitis inventore necessitatibus. Deleniti beatae officiis.
-        \ No newline at end of file
-        +Eos vel aut. Enim saepe eaque. Est voluptas molestias.
-        \ No newline at end of file
-        </diff>
-            </file>
-            <file state="changed">
-              <old name="somefile.txt" md5="e815af7acb7571ac2250a1a35fc02e9a" size="64"/>
-              <new name="somefile.txt" md5="9b68d21636271f84b8322522f8242105" size="61"/>
-              <diff lines="5">@@ -1,1 +1,1 @@
-        -Qui ut rerum. Magnam deleniti veritatis. Aperiam quo voluptatem.
-        \ No newline at end of file
-        +Est recusandae quo. Occaecati esse minima. Porro maxime odit.
-        \ No newline at end of file
-        </diff>
-            </file>
-          </files>
-          <issues>
-          </issues>
-        </sourcediff>
-  recorded_at: Mon, 18 Oct 2021 14:49:23 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:mr_receiver/Quebec
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Request-Id:
-      - 9cf0c0d6-f26a-4f15-acd4-f3c84139f0e5
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '291'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="Quebec" rev="6" vrev="6" srcmd5="c3cb98b2a4cedd388f9a25627e48a090">
-          <entry name="_config" md5="89e55b294b1ada0045972482cd97312f" size="71" mtime="1634568553"/>
-          <entry name="somefile.txt" md5="e815af7acb7571ac2250a1a35fc02e9a" size="64" mtime="1634568554"/>
-        </directory>
-  recorded_at: Mon, 18 Oct 2021 14:49:23 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:29 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:madam_submitter/Quebec
@@ -1118,7 +1112,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 8a83ad8b-7c84-4ef6-8abf-afc92fa53839
+      - 5a6cc46b-9d31-4594-bab6-5a473b97ef70
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1137,18 +1131,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '291'
+      - '293'
     body:
       encoding: UTF-8
       string: |
-        <directory name="Quebec" rev="8" vrev="8" srcmd5="bf6b7a77608fc277589f5a103d9049f0">
-          <entry name="_config" md5="ac7cbfcdb3cc1481949164825042cbbc" size="54" mtime="1634568553"/>
-          <entry name="somefile.txt" md5="9b68d21636271f84b8322522f8242105" size="61" mtime="1634568553"/>
+        <directory name="Quebec" rev="14" vrev="14" srcmd5="3a5362068f781c4226a3446b2c93fad2">
+          <entry name="_config" md5="1327892009efd20f0a58b7186d4b2735" size="70" mtime="1677089185"/>
+          <entry name="somefile.txt" md5="26e30a5a49db1d3fbd85dcc61e02f0b4" size="59" mtime="1677089185"/>
         </directory>
-  recorded_at: Mon, 18 Oct 2021 14:49:23 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:29 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/home:madam_submitter/Quebec?cacheonly=1&cmd=diff&expand=1&filelimit=10000&opackage=Quebec&oproject=home:mr_receiver&rev=8&tarlimit=10000&view=xml&withissues=1
+    uri: http://backend:5352/source/home:madam_submitter/Quebec?cmd=diff&expand=1&filelimit=10000&opackage=Quebec&oproject=home:mr_receiver&rev=14&tarlimit=10000&view=xml&withissues=1
     body:
       encoding: UTF-8
       string: ''
@@ -1156,7 +1150,7 @@ http_interactions:
       Content-Type:
       - application/octet-stream
       X-Request-Id:
-      - 8a83ad8b-7c84-4ef6-8abf-afc92fa53839
+      - 5a6cc46b-9d31-4594-bab6-5a473b97ef70
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1171,7 +1165,7 @@ http_interactions:
       Content-Type:
       - text/xml
       Content-Length:
-      - '1178'
+      - '1189'
       Cache-Control:
       - no-cache
       Connection:
@@ -1179,27 +1173,27 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="86ce2f67c48b3397bb33333dac73f33f">
-          <old project="home:mr_receiver" package="Quebec" rev="6" srcmd5="c3cb98b2a4cedd388f9a25627e48a090"/>
-          <new project="home:madam_submitter" package="Quebec" rev="8" srcmd5="bf6b7a77608fc277589f5a103d9049f0"/>
+        <sourcediff key="e341fd4b35ef666287f9853dd8a24671">
+          <old project="home:mr_receiver" package="Quebec" rev="8" srcmd5="3b55a3048dffa708bf156227ce3cc8fb"/>
+          <new project="home:madam_submitter" package="Quebec" rev="14" srcmd5="3a5362068f781c4226a3446b2c93fad2"/>
           <files>
             <file state="changed">
-              <old name="_config" md5="89e55b294b1ada0045972482cd97312f" size="71"/>
-              <new name="_config" md5="ac7cbfcdb3cc1481949164825042cbbc" size="54"/>
+              <old name="_config" md5="4f7a85fa2eeaff019d61537a23dd429b" size="62"/>
+              <new name="_config" md5="1327892009efd20f0a58b7186d4b2735" size="70"/>
               <diff lines="5">@@ -1,1 +1,1 @@
-        -Non est et. Debitis inventore necessitatibus. Deleniti beatae officiis.
+        -Ducimus nemo eos. Dolores nobis delectus. Est placeat dolorum.
         \ No newline at end of file
-        +Eos vel aut. Enim saepe eaque. Est voluptas molestias.
+        +Non sed eos. Ut exercitationem animi. Voluptates voluptatibus dolores.
         \ No newline at end of file
         </diff>
             </file>
             <file state="changed">
-              <old name="somefile.txt" md5="e815af7acb7571ac2250a1a35fc02e9a" size="64"/>
-              <new name="somefile.txt" md5="9b68d21636271f84b8322522f8242105" size="61"/>
+              <old name="somefile.txt" md5="7bcdd74a73c2d2d67362357044d1869b" size="69"/>
+              <new name="somefile.txt" md5="26e30a5a49db1d3fbd85dcc61e02f0b4" size="59"/>
               <diff lines="5">@@ -1,1 +1,1 @@
-        -Qui ut rerum. Magnam deleniti veritatis. Aperiam quo voluptatem.
+        -Et qui consequuntur. Inventore cumque libero. Sed consequuntur rerum.
         \ No newline at end of file
-        +Est recusandae quo. Occaecati esse minima. Porro maxime odit.
+        +Nobis sunt quis. Aliquid qui nihil. Quas consequatur culpa.
         \ No newline at end of file
         </diff>
             </file>
@@ -1207,7 +1201,7 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Mon, 18 Oct 2021 14:49:23 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:29 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:mr_receiver/Quebec
@@ -1216,7 +1210,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 8a83ad8b-7c84-4ef6-8abf-afc92fa53839
+      - 2aa5ac53-4c9b-418d-8236-38db563941cb
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1239,11 +1233,145 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="Quebec" rev="6" vrev="6" srcmd5="c3cb98b2a4cedd388f9a25627e48a090">
-          <entry name="_config" md5="89e55b294b1ada0045972482cd97312f" size="71" mtime="1634568553"/>
-          <entry name="somefile.txt" md5="e815af7acb7571ac2250a1a35fc02e9a" size="64" mtime="1634568554"/>
+        <directory name="Quebec" rev="8" vrev="8" srcmd5="3b55a3048dffa708bf156227ce3cc8fb">
+          <entry name="_config" md5="4f7a85fa2eeaff019d61537a23dd429b" size="62" mtime="1677089185"/>
+          <entry name="somefile.txt" md5="7bcdd74a73c2d2d67362357044d1869b" size="69" mtime="1677089185"/>
         </directory>
-  recorded_at: Mon, 18 Oct 2021 14:49:23 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:29 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:madam_submitter/Quebec
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 6068f7bf-3e95-4933-8e82-dfe412ecce33
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '293'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="Quebec" rev="14" vrev="14" srcmd5="3a5362068f781c4226a3446b2c93fad2">
+          <entry name="_config" md5="1327892009efd20f0a58b7186d4b2735" size="70" mtime="1677089185"/>
+          <entry name="somefile.txt" md5="26e30a5a49db1d3fbd85dcc61e02f0b4" size="59" mtime="1677089185"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:06:29 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/home:madam_submitter/Quebec?cacheonly=1&cmd=diff&expand=1&filelimit=10000&opackage=Quebec&oproject=home:mr_receiver&rev=14&tarlimit=10000&view=xml&withissues=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      X-Request-Id:
+      - 6068f7bf-3e95-4933-8e82-dfe412ecce33
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '1189'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="e341fd4b35ef666287f9853dd8a24671">
+          <old project="home:mr_receiver" package="Quebec" rev="8" srcmd5="3b55a3048dffa708bf156227ce3cc8fb"/>
+          <new project="home:madam_submitter" package="Quebec" rev="14" srcmd5="3a5362068f781c4226a3446b2c93fad2"/>
+          <files>
+            <file state="changed">
+              <old name="_config" md5="4f7a85fa2eeaff019d61537a23dd429b" size="62"/>
+              <new name="_config" md5="1327892009efd20f0a58b7186d4b2735" size="70"/>
+              <diff lines="5">@@ -1,1 +1,1 @@
+        -Ducimus nemo eos. Dolores nobis delectus. Est placeat dolorum.
+        \ No newline at end of file
+        +Non sed eos. Ut exercitationem animi. Voluptates voluptatibus dolores.
+        \ No newline at end of file
+        </diff>
+            </file>
+            <file state="changed">
+              <old name="somefile.txt" md5="7bcdd74a73c2d2d67362357044d1869b" size="69"/>
+              <new name="somefile.txt" md5="26e30a5a49db1d3fbd85dcc61e02f0b4" size="59"/>
+              <diff lines="5">@@ -1,1 +1,1 @@
+        -Et qui consequuntur. Inventore cumque libero. Sed consequuntur rerum.
+        \ No newline at end of file
+        +Nobis sunt quis. Aliquid qui nihil. Quas consequatur culpa.
+        \ No newline at end of file
+        </diff>
+            </file>
+          </files>
+          <issues>
+          </issues>
+        </sourcediff>
+  recorded_at: Wed, 22 Feb 2023 18:06:29 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:mr_receiver/Quebec
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 6068f7bf-3e95-4933-8e82-dfe412ecce33
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '291'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="Quebec" rev="8" vrev="8" srcmd5="3b55a3048dffa708bf156227ce3cc8fb">
+          <entry name="_config" md5="4f7a85fa2eeaff019d61537a23dd429b" size="62" mtime="1677089185"/>
+          <entry name="somefile.txt" md5="7bcdd74a73c2d2d67362357044d1869b" size="69" mtime="1677089185"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:06:29 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:madam_submitter/_result?package=Quebec&view=status
@@ -1252,7 +1380,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - c5a2f858-0467-40ac-8772-1a2f46623f22
+      - 5a5ea4d8-8fb1-4a01-a700-80023f2e4d11
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1277,5 +1405,5 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Mon, 18 Oct 2021 14:49:23 GMT
-recorded_with: VCR 6.0.0
+  recorded_at: Wed, 22 Feb 2023 18:06:29 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/ImageTemplates/branching/branch_image_template.yml
+++ b/src/api/spec/cassettes/ImageTemplates/branching/branch_image_template.yml
@@ -39,7 +39,7 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-  recorded_at: Tue, 01 Feb 2022 14:52:26 GMT
+  recorded_at: Wed, 22 Feb 2023 17:57:56 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/_meta?user=user_1
@@ -47,7 +47,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="my_project">
-          <title>Cover Her Face</title>
+          <title>Recalled to Life</title>
           <description/>
         </project>
     headers:
@@ -69,15 +69,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '101'
+      - '103'
     body:
       encoding: UTF-8
       string: |
         <project name="my_project">
-          <title>Cover Her Face</title>
+          <title>Recalled to Life</title>
           <description></description>
         </project>
-  recorded_at: Tue, 01 Feb 2022 14:52:27 GMT
+  recorded_at: Wed, 22 Feb 2023 17:57:56 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/first_package/_meta?user=user_2
@@ -86,7 +86,7 @@ http_interactions:
       string: |
         <package name="first_package" project="my_project">
           <title>a</title>
-          <description>Molestiae accusamus expedita commodi.</description>
+          <description>Qui dolore totam similique.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -107,21 +107,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '149'
+      - '139'
     body:
       encoding: UTF-8
       string: |
         <package name="first_package" project="my_project">
           <title>a</title>
-          <description>Molestiae accusamus expedita commodi.</description>
+          <description>Qui dolore totam similique.</description>
         </package>
-  recorded_at: Tue, 01 Feb 2022 14:52:27 GMT
+  recorded_at: Wed, 22 Feb 2023 17:57:57 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/first_package/_config
     body:
       encoding: UTF-8
-      string: Non unde doloribus. Cum inventore neque. Ut perspiciatis veritatis.
+      string: Similique aliquid aut. Saepe ut fugiat. Ducimus magni sit.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -146,20 +146,20 @@ http_interactions:
       encoding: UTF-8
       string: |
         <revision rev="5" vrev="5">
-          <srcmd5>520996fd4e98827448fbeebf6c5df00d</srcmd5>
+          <srcmd5>78bf5cabd170cf7387501214d719f5cb</srcmd5>
           <version>unknown</version>
-          <time>1643727147</time>
+          <time>1677088677</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Tue, 01 Feb 2022 14:52:27 GMT
+  recorded_at: Wed, 22 Feb 2023 17:57:57 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/first_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Fuga consequatur sequi. Porro debitis provident. Quo quas repellat.
+      string: Aliquam voluptatem facere. Tempora rerum dolorem. Accusamus nam ut.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -184,14 +184,14 @@ http_interactions:
       encoding: UTF-8
       string: |
         <revision rev="6" vrev="6">
-          <srcmd5>5a6193059261e5efbd93672258924543</srcmd5>
+          <srcmd5>75636523146b8634e20e82e205dcc741</srcmd5>
           <version>unknown</version>
-          <time>1643727147</time>
+          <time>1677088677</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Tue, 01 Feb 2022 14:52:27 GMT
+  recorded_at: Wed, 22 Feb 2023 17:57:57 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/second_package/_meta?user=user_3
@@ -200,7 +200,7 @@ http_interactions:
       string: |
         <package name="second_package" project="my_project">
           <title>c</title>
-          <description>Neque aut dolore at.</description>
+          <description>Nobis officia aliquid in.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -221,22 +221,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '133'
+      - '138'
     body:
       encoding: UTF-8
       string: |
         <package name="second_package" project="my_project">
           <title>c</title>
-          <description>Neque aut dolore at.</description>
+          <description>Nobis officia aliquid in.</description>
         </package>
-  recorded_at: Tue, 01 Feb 2022 14:52:27 GMT
+  recorded_at: Wed, 22 Feb 2023 17:57:57 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/second_package/_config
     body:
       encoding: UTF-8
-      string: Laudantium veritatis autem. Rem consequuntur occaecati. Deserunt iste
-        eaque.
+      string: Qui blanditiis quasi. Voluptatem nisi qui. Itaque et id.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -261,20 +260,20 @@ http_interactions:
       encoding: UTF-8
       string: |
         <revision rev="5" vrev="5">
-          <srcmd5>40a1a79fdda560d5f90c8318c6350511</srcmd5>
+          <srcmd5>b7fb5e11e6fed9fbd796f88dcd036502</srcmd5>
           <version>unknown</version>
-          <time>1643727147</time>
+          <time>1677088677</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Tue, 01 Feb 2022 14:52:28 GMT
+  recorded_at: Wed, 22 Feb 2023 17:57:57 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/second_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Et aut et. Consequatur rerum blanditiis. Sit animi ea.
+      string: Officia totam quos. Corrupti eos hic. Hic deleniti dolorum.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -299,14 +298,14 @@ http_interactions:
       encoding: UTF-8
       string: |
         <revision rev="6" vrev="6">
-          <srcmd5>4bd571b947b0c354bfade51a8f27f0e2</srcmd5>
+          <srcmd5>055f157b268ebdbaff27e03a1d2060ee</srcmd5>
           <version>unknown</version>
-          <time>1643727148</time>
+          <time>1677088677</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Tue, 01 Feb 2022 14:52:28 GMT
+  recorded_at: Wed, 22 Feb 2023 17:57:57 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/third_package/_meta?user=user_4
@@ -315,7 +314,7 @@ http_interactions:
       string: |
         <package name="third_package" project="my_project">
           <title>b</title>
-          <description>Nemo aliquid est cum.</description>
+          <description>Aperiam labore omnis voluptatem.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -336,21 +335,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '133'
+      - '144'
     body:
       encoding: UTF-8
       string: |
         <package name="third_package" project="my_project">
           <title>b</title>
-          <description>Nemo aliquid est cum.</description>
+          <description>Aperiam labore omnis voluptatem.</description>
         </package>
-  recorded_at: Tue, 01 Feb 2022 14:52:28 GMT
+  recorded_at: Wed, 22 Feb 2023 17:57:57 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/third_package/_config
     body:
       encoding: UTF-8
-      string: Iusto sed nihil. Fugit laboriosam dolore. Sapiente neque quia.
+      string: Rerum repudiandae distinctio. Beatae et cumque. Cupiditate debitis non.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -375,20 +374,20 @@ http_interactions:
       encoding: UTF-8
       string: |
         <revision rev="5" vrev="5">
-          <srcmd5>50b8a2bd02e6952813598c44c0b11812</srcmd5>
+          <srcmd5>97e06856f779fe73bbb9cde9c6c63d5c</srcmd5>
           <version>unknown</version>
-          <time>1643727148</time>
+          <time>1677088677</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Tue, 01 Feb 2022 14:52:28 GMT
+  recorded_at: Wed, 22 Feb 2023 17:57:57 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/third_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Qui amet porro. Laboriosam dolor dignissimos. Molestiae et esse.
+      string: Non consectetur qui. Sunt expedita sed. Autem et ullam.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -413,14 +412,14 @@ http_interactions:
       encoding: UTF-8
       string: |
         <revision rev="6" vrev="6">
-          <srcmd5>c56995d9deeebb8e8b0c9c0cfca7e7e7</srcmd5>
+          <srcmd5>0032d4845c61e59d70b2702c1bb70560</srcmd5>
           <version>unknown</version>
-          <time>1643727148</time>
+          <time>1677088677</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Tue, 01 Feb 2022 14:52:28 GMT
+  recorded_at: Wed, 22 Feb 2023 17:57:57 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/package_with_kiwi_image/_meta?user=user_5
@@ -428,8 +427,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="my_project">
-          <title>The Heart Is Deceitful Above All Things</title>
-          <description>Quo et quia aliquam.</description>
+          <title>A Confederacy of Dunces</title>
+          <description>Nemo id possimus voluptate.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -450,15 +449,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '180'
+      - '171'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="my_project">
-          <title>The Heart Is Deceitful Above All Things</title>
-          <description>Quo et quia aliquam.</description>
+          <title>A Confederacy of Dunces</title>
+          <description>Nemo id possimus voluptate.</description>
         </package>
-  recorded_at: Tue, 01 Feb 2022 14:52:29 GMT
+  recorded_at: Wed, 22 Feb 2023 17:57:57 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/package_with_kiwi_image/package_with_kiwi_image.kiwi
@@ -495,12 +494,12 @@ http_interactions:
         <revision rev="3" vrev="3">
           <srcmd5>801c545be09c1c468ff2d99b40415aac</srcmd5>
           <version>0.0.1</version>
-          <time>1643727149</time>
+          <time>1677088677</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Tue, 01 Feb 2022 14:52:29 GMT
+  recorded_at: Wed, 22 Feb 2023 17:57:57 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/package_with_kiwi_image/_meta?user=user_5
@@ -508,8 +507,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="my_project">
-          <title>The Heart Is Deceitful Above All Things</title>
-          <description>Quo et quia aliquam.</description>
+          <title>A Confederacy of Dunces</title>
+          <description>Nemo id possimus voluptate.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -530,15 +529,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '180'
+      - '171'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="my_project">
-          <title>The Heart Is Deceitful Above All Things</title>
-          <description>Quo et quia aliquam.</description>
+          <title>A Confederacy of Dunces</title>
+          <description>Nemo id possimus voluptate.</description>
         </package>
-  recorded_at: Tue, 01 Feb 2022 14:52:29 GMT
+  recorded_at: Wed, 22 Feb 2023 17:57:57 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/package_with_kiwi_image
@@ -569,9 +568,9 @@ http_interactions:
       encoding: UTF-8
       string: |
         <directory name="package_with_kiwi_image" rev="3" vrev="3" srcmd5="801c545be09c1c468ff2d99b40415aac">
-          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1643726947"/>
+          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1677064926"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:52:29 GMT
+  recorded_at: Wed, 22 Feb 2023 17:57:57 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/_project/_attribute?meta=1&user=tom
@@ -600,18 +599,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '166'
+      - '165'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="10">
-          <srcmd5>27ce8d61f366d838e5f97a7144da6b05</srcmd5>
-          <time>1643727149</time>
+        <revision rev="7">
+          <srcmd5>7e2ee269cb9aa353e2aa28c5dfec4d03</srcmd5>
+          <time>1677088677</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Tue, 01 Feb 2022 14:52:29 GMT
+  recorded_at: Wed, 22 Feb 2023 17:57:57 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/first_package
@@ -620,7 +619,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 79adeb18-014b-497a-92d1-e1de5ccd7119
+      - 6c59afc6-4262-4f6c-87ee-9c6d476c23a5
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -643,11 +642,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="first_package" rev="6" vrev="6" srcmd5="5a6193059261e5efbd93672258924543">
-          <entry name="_config" md5="1e4a44ce18d6c210ebf198631f23b7ce" size="67" mtime="1643727147"/>
-          <entry name="somefile.txt" md5="a7f6fe54478a42abeb929dbded390e11" size="67" mtime="1643727147"/>
+        <directory name="first_package" rev="6" vrev="6" srcmd5="75636523146b8634e20e82e205dcc741">
+          <entry name="_config" md5="f69d35d06f7b54d8c8aaa84af2681cb3" size="58" mtime="1677088677"/>
+          <entry name="somefile.txt" md5="0f2416116d94550631676b18b16d5a2b" size="67" mtime="1677088677"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:52:32 GMT
+  recorded_at: Wed, 22 Feb 2023 17:57:57 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/first_package?expand=0
@@ -656,7 +655,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 79adeb18-014b-497a-92d1-e1de5ccd7119
+      - 6c59afc6-4262-4f6c-87ee-9c6d476c23a5
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -679,11 +678,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="first_package" rev="6" vrev="6" srcmd5="5a6193059261e5efbd93672258924543">
-          <entry name="_config" md5="1e4a44ce18d6c210ebf198631f23b7ce" size="67" mtime="1643727147"/>
-          <entry name="somefile.txt" md5="a7f6fe54478a42abeb929dbded390e11" size="67" mtime="1643727147"/>
+        <directory name="first_package" rev="6" vrev="6" srcmd5="75636523146b8634e20e82e205dcc741">
+          <entry name="_config" md5="f69d35d06f7b54d8c8aaa84af2681cb3" size="58" mtime="1677088677"/>
+          <entry name="somefile.txt" md5="0f2416116d94550631676b18b16d5a2b" size="67" mtime="1677088677"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:52:32 GMT
+  recorded_at: Wed, 22 Feb 2023 17:57:57 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/second_package
@@ -692,7 +691,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 79adeb18-014b-497a-92d1-e1de5ccd7119
+      - 6c59afc6-4262-4f6c-87ee-9c6d476c23a5
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -715,11 +714,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="second_package" rev="6" vrev="6" srcmd5="4bd571b947b0c354bfade51a8f27f0e2">
-          <entry name="_config" md5="29fc9e02f1d0931d8ade149e6f06c600" size="76" mtime="1643727147"/>
-          <entry name="somefile.txt" md5="14352fa93342e84aa2300172d03322f1" size="54" mtime="1643727148"/>
+        <directory name="second_package" rev="6" vrev="6" srcmd5="055f157b268ebdbaff27e03a1d2060ee">
+          <entry name="_config" md5="5601a0d621508ca7f3e41db9cdfcb91d" size="56" mtime="1677088677"/>
+          <entry name="somefile.txt" md5="a2af3efd0634fb08044de0b592af6250" size="59" mtime="1677088677"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:52:32 GMT
+  recorded_at: Wed, 22 Feb 2023 17:57:57 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/second_package?expand=0
@@ -728,7 +727,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 79adeb18-014b-497a-92d1-e1de5ccd7119
+      - 6c59afc6-4262-4f6c-87ee-9c6d476c23a5
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -751,11 +750,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="second_package" rev="6" vrev="6" srcmd5="4bd571b947b0c354bfade51a8f27f0e2">
-          <entry name="_config" md5="29fc9e02f1d0931d8ade149e6f06c600" size="76" mtime="1643727147"/>
-          <entry name="somefile.txt" md5="14352fa93342e84aa2300172d03322f1" size="54" mtime="1643727148"/>
+        <directory name="second_package" rev="6" vrev="6" srcmd5="055f157b268ebdbaff27e03a1d2060ee">
+          <entry name="_config" md5="5601a0d621508ca7f3e41db9cdfcb91d" size="56" mtime="1677088677"/>
+          <entry name="somefile.txt" md5="a2af3efd0634fb08044de0b592af6250" size="59" mtime="1677088677"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:52:32 GMT
+  recorded_at: Wed, 22 Feb 2023 17:57:57 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/third_package
@@ -764,7 +763,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 79adeb18-014b-497a-92d1-e1de5ccd7119
+      - 6c59afc6-4262-4f6c-87ee-9c6d476c23a5
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -787,11 +786,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="third_package" rev="6" vrev="6" srcmd5="c56995d9deeebb8e8b0c9c0cfca7e7e7">
-          <entry name="_config" md5="c7004b4072054dd863ae4301d4503ab9" size="62" mtime="1643727148"/>
-          <entry name="somefile.txt" md5="850c9e8bd873ee37147dfc7f9cfda778" size="64" mtime="1643727148"/>
+        <directory name="third_package" rev="6" vrev="6" srcmd5="0032d4845c61e59d70b2702c1bb70560">
+          <entry name="_config" md5="76ae07b1bd4804a788458d5ed12e9556" size="71" mtime="1677088677"/>
+          <entry name="somefile.txt" md5="ca168ef2f03c136c4762e9e0310db712" size="55" mtime="1677088677"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:52:32 GMT
+  recorded_at: Wed, 22 Feb 2023 17:57:57 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/third_package?expand=0
@@ -800,7 +799,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 79adeb18-014b-497a-92d1-e1de5ccd7119
+      - 6c59afc6-4262-4f6c-87ee-9c6d476c23a5
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -823,11 +822,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="third_package" rev="6" vrev="6" srcmd5="c56995d9deeebb8e8b0c9c0cfca7e7e7">
-          <entry name="_config" md5="c7004b4072054dd863ae4301d4503ab9" size="62" mtime="1643727148"/>
-          <entry name="somefile.txt" md5="850c9e8bd873ee37147dfc7f9cfda778" size="64" mtime="1643727148"/>
+        <directory name="third_package" rev="6" vrev="6" srcmd5="0032d4845c61e59d70b2702c1bb70560">
+          <entry name="_config" md5="76ae07b1bd4804a788458d5ed12e9556" size="71" mtime="1677088677"/>
+          <entry name="somefile.txt" md5="ca168ef2f03c136c4762e9e0310db712" size="55" mtime="1677088677"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:52:32 GMT
+  recorded_at: Wed, 22 Feb 2023 17:57:57 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/package_with_kiwi_image
@@ -836,7 +835,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 79adeb18-014b-497a-92d1-e1de5ccd7119
+      - 6c59afc6-4262-4f6c-87ee-9c6d476c23a5
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -860,9 +859,9 @@ http_interactions:
       encoding: UTF-8
       string: |
         <directory name="package_with_kiwi_image" rev="3" vrev="3" srcmd5="801c545be09c1c468ff2d99b40415aac">
-          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1643726947"/>
+          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1677064926"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:52:32 GMT
+  recorded_at: Wed, 22 Feb 2023 17:57:57 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/package_with_kiwi_image?expand=0
@@ -871,7 +870,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 79adeb18-014b-497a-92d1-e1de5ccd7119
+      - 6c59afc6-4262-4f6c-87ee-9c6d476c23a5
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -895,9 +894,9 @@ http_interactions:
       encoding: UTF-8
       string: |
         <directory name="package_with_kiwi_image" rev="3" vrev="3" srcmd5="801c545be09c1c468ff2d99b40415aac">
-          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1643726947"/>
+          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1677064926"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:52:32 GMT
+  recorded_at: Wed, 22 Feb 2023 17:57:57 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom/_result?code=unresolvable&view=status
@@ -906,7 +905,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - d6e66298-37ea-49d7-bd30-d32b543c59ee
+      - f2f5ed0f-284a-453b-a9fd-77582fee53fb
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -931,7 +930,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Tue, 01 Feb 2022 14:52:34 GMT
+  recorded_at: Wed, 22 Feb 2023 17:57:58 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom/_keyinfo?donotcreatecert=1&withsslcert=1
@@ -940,7 +939,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - d6e66298-37ea-49d7-bd30-d32b543c59ee
+      - f2f5ed0f-284a-453b-a9fd-77582fee53fb
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -959,11 +958,39 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '11'
+      - '1639'
     body:
       encoding: UTF-8
-      string: "<keyinfo/>\n"
-  recorded_at: Tue, 01 Feb 2022 14:52:34 GMT
+      string: |
+        <keyinfo project="home:tom">
+          <pubkey keyid="cfaa8e084a26fafa" userid="home:tom OBS Project &lt;home:tom@private&gt;" algo="rsa" keysize="2048" expires="1741880605" fingerprint="5c29 f588 f5b8 c2c4 6069 ff08 cfaa 8e08 4a26 fafa">-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+        mQENBGO0TR0BCADlQ4FwIb9gBi9DUkkC7MvIpu1QI6n1yLdv93X53Tc4kRmE0F5v
+        LD3qihj+ENLuF+CpK15JXzM5pwswcO/UzNs1pJjEDBef8Bw10RTQZy88qGdwaEbH
+        v+LZnt/8UzH1DfTccN/7ana/ZnZFDkztHq1syw2VL+dK2w+JcA7xmD4SzD4DBhgJ
+        UfxvZT9prdXbr8GyIqYdInDqnmexdeYZCaVJlcLlIHI/z2k9/Yfofnu4tA0GBXVJ
+        MnRfkdLEyRPaVNMBz8ITw+5naiv+pj9jV3dKKxaMblCMPOPoUWrT8hEUZyravYtR
+        uiKjl/4nCePyRypatKJUL6i1i93UoF2JGI0BABEBAAG0J2hvbWU6dG9tIE9CUyBQ
+        cm9qZWN0IDxob21lOnRvbUBwcml2YXRlPokBVAQTAQgAPhYhBFwp9Yj1uMLEYGn/
+        CM+qjghKJvr6BQJjtE0dAhsDBQkEHrAABQsJCAcCBhUKCQgLAgQWAgMBAh4BAheA
+        AAoJEM+qjghKJvr6+pwIAN/0N8BgUOIUpsx2oOx7z5+CoJb9kEBgeIZeQ/HSvfYR
+        0Lec22ztbuNehj0OpP6inL7lfREThEKlc0u/wKMB9VgtsVyQfUrEuDQUQyxU4SvO
+        JWdo05+nSfX5x7tU33uMc9YPy/VfJs/E0boJJuwR/OexCa4U96Qz2fQnj2WHgt3t
+        SXUMkxbUd3RU24PCdfJnDq/hl75tx8uI01f/IcIimEoHLsNPotPGELnstHKrMpUp
+        gjkWouCSq4VlE8Wrr8kvsf+/lD4rOqCTTcSqs6Pj9ytEDr6pYZGMj0gmGrSWd25G
+        o1YyY/rmenLKH9WQJ4f8AojkVnqt9YVzxgwXvMu42biJATMEEwEIAB0WIQQGTN2V
+        wCe8seo248C/9fknuEcc6wUCY7RNHgAKCRC/9fknuEcc6xEkCACvwrBh1UlV9EM/
+        p5hqlzT+VOlcXSAtLRfAElPtyYY0mleof0+AxDM32z2cPiGieUOAW/HK7eXHJCb2
+        uYosjrO1D8CLUPZ9DM0X5bLicxux2JBtbxV0F9kkEc+p0a+jbi/sE8Ao0vStZD5r
+        cJoUSEiglRKS+uC+VsJbqpDhL7+w7lvL9ItG5uszkTukLb7eMlpi6yve3WWapEiN
+        eXyF09dSJbe0B9wOB8ilw8qOmmCEVElug0044fxq+0Aam6LXCfuC8BEx8YqmGnED
+        jYotxAOCpnQ01KzF4PbGogHn8G86s0btjiayWfed3Cs42O1UC9i+USPe0D2L5lXg
+        QDgCOz2L
+        =nUQx
+        -----END PGP PUBLIC KEY BLOCK-----
+        </pubkey>
+        </keyinfo>
+  recorded_at: Wed, 22 Feb 2023 17:57:59 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom/_result?view=summary
@@ -972,7 +999,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 83deeb14-811a-4697-a32b-2faf5ac969ac
+      - 01ae34c8-0eca-4a68-bf6f-37d3d7df79de
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -997,7 +1024,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Tue, 01 Feb 2022 14:52:34 GMT
+  recorded_at: Wed, 22 Feb 2023 17:57:59 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/first_package
@@ -1006,7 +1033,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - afdcef79-0b4c-4e83-8af1-08f60975c2d3
+      - d6ba732a-96b2-4d60-b6e2-3964cdc475cd
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1029,11 +1056,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="first_package" rev="6" vrev="6" srcmd5="5a6193059261e5efbd93672258924543">
-          <entry name="_config" md5="1e4a44ce18d6c210ebf198631f23b7ce" size="67" mtime="1643727147"/>
-          <entry name="somefile.txt" md5="a7f6fe54478a42abeb929dbded390e11" size="67" mtime="1643727147"/>
+        <directory name="first_package" rev="6" vrev="6" srcmd5="75636523146b8634e20e82e205dcc741">
+          <entry name="_config" md5="f69d35d06f7b54d8c8aaa84af2681cb3" size="58" mtime="1677088677"/>
+          <entry name="somefile.txt" md5="0f2416116d94550631676b18b16d5a2b" size="67" mtime="1677088677"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:52:34 GMT
+  recorded_at: Wed, 22 Feb 2023 17:57:59 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/first_package?expand=0
@@ -1042,7 +1069,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - afdcef79-0b4c-4e83-8af1-08f60975c2d3
+      - d6ba732a-96b2-4d60-b6e2-3964cdc475cd
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1065,11 +1092,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="first_package" rev="6" vrev="6" srcmd5="5a6193059261e5efbd93672258924543">
-          <entry name="_config" md5="1e4a44ce18d6c210ebf198631f23b7ce" size="67" mtime="1643727147"/>
-          <entry name="somefile.txt" md5="a7f6fe54478a42abeb929dbded390e11" size="67" mtime="1643727147"/>
+        <directory name="first_package" rev="6" vrev="6" srcmd5="75636523146b8634e20e82e205dcc741">
+          <entry name="_config" md5="f69d35d06f7b54d8c8aaa84af2681cb3" size="58" mtime="1677088677"/>
+          <entry name="somefile.txt" md5="0f2416116d94550631676b18b16d5a2b" size="67" mtime="1677088677"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:52:34 GMT
+  recorded_at: Wed, 22 Feb 2023 17:57:59 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/second_package
@@ -1078,7 +1105,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - afdcef79-0b4c-4e83-8af1-08f60975c2d3
+      - d6ba732a-96b2-4d60-b6e2-3964cdc475cd
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1101,11 +1128,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="second_package" rev="6" vrev="6" srcmd5="4bd571b947b0c354bfade51a8f27f0e2">
-          <entry name="_config" md5="29fc9e02f1d0931d8ade149e6f06c600" size="76" mtime="1643727147"/>
-          <entry name="somefile.txt" md5="14352fa93342e84aa2300172d03322f1" size="54" mtime="1643727148"/>
+        <directory name="second_package" rev="6" vrev="6" srcmd5="055f157b268ebdbaff27e03a1d2060ee">
+          <entry name="_config" md5="5601a0d621508ca7f3e41db9cdfcb91d" size="56" mtime="1677088677"/>
+          <entry name="somefile.txt" md5="a2af3efd0634fb08044de0b592af6250" size="59" mtime="1677088677"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:52:34 GMT
+  recorded_at: Wed, 22 Feb 2023 17:57:59 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/second_package?expand=0
@@ -1114,7 +1141,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - afdcef79-0b4c-4e83-8af1-08f60975c2d3
+      - d6ba732a-96b2-4d60-b6e2-3964cdc475cd
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1137,11 +1164,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="second_package" rev="6" vrev="6" srcmd5="4bd571b947b0c354bfade51a8f27f0e2">
-          <entry name="_config" md5="29fc9e02f1d0931d8ade149e6f06c600" size="76" mtime="1643727147"/>
-          <entry name="somefile.txt" md5="14352fa93342e84aa2300172d03322f1" size="54" mtime="1643727148"/>
+        <directory name="second_package" rev="6" vrev="6" srcmd5="055f157b268ebdbaff27e03a1d2060ee">
+          <entry name="_config" md5="5601a0d621508ca7f3e41db9cdfcb91d" size="56" mtime="1677088677"/>
+          <entry name="somefile.txt" md5="a2af3efd0634fb08044de0b592af6250" size="59" mtime="1677088677"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:52:34 GMT
+  recorded_at: Wed, 22 Feb 2023 17:57:59 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/third_package
@@ -1150,7 +1177,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - afdcef79-0b4c-4e83-8af1-08f60975c2d3
+      - d6ba732a-96b2-4d60-b6e2-3964cdc475cd
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1173,11 +1200,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="third_package" rev="6" vrev="6" srcmd5="c56995d9deeebb8e8b0c9c0cfca7e7e7">
-          <entry name="_config" md5="c7004b4072054dd863ae4301d4503ab9" size="62" mtime="1643727148"/>
-          <entry name="somefile.txt" md5="850c9e8bd873ee37147dfc7f9cfda778" size="64" mtime="1643727148"/>
+        <directory name="third_package" rev="6" vrev="6" srcmd5="0032d4845c61e59d70b2702c1bb70560">
+          <entry name="_config" md5="76ae07b1bd4804a788458d5ed12e9556" size="71" mtime="1677088677"/>
+          <entry name="somefile.txt" md5="ca168ef2f03c136c4762e9e0310db712" size="55" mtime="1677088677"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:52:34 GMT
+  recorded_at: Wed, 22 Feb 2023 17:57:59 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/third_package?expand=0
@@ -1186,7 +1213,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - afdcef79-0b4c-4e83-8af1-08f60975c2d3
+      - d6ba732a-96b2-4d60-b6e2-3964cdc475cd
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1209,11 +1236,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="third_package" rev="6" vrev="6" srcmd5="c56995d9deeebb8e8b0c9c0cfca7e7e7">
-          <entry name="_config" md5="c7004b4072054dd863ae4301d4503ab9" size="62" mtime="1643727148"/>
-          <entry name="somefile.txt" md5="850c9e8bd873ee37147dfc7f9cfda778" size="64" mtime="1643727148"/>
+        <directory name="third_package" rev="6" vrev="6" srcmd5="0032d4845c61e59d70b2702c1bb70560">
+          <entry name="_config" md5="76ae07b1bd4804a788458d5ed12e9556" size="71" mtime="1677088677"/>
+          <entry name="somefile.txt" md5="ca168ef2f03c136c4762e9e0310db712" size="55" mtime="1677088677"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:52:34 GMT
+  recorded_at: Wed, 22 Feb 2023 17:57:59 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/package_with_kiwi_image
@@ -1222,7 +1249,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - afdcef79-0b4c-4e83-8af1-08f60975c2d3
+      - d6ba732a-96b2-4d60-b6e2-3964cdc475cd
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1246,9 +1273,9 @@ http_interactions:
       encoding: UTF-8
       string: |
         <directory name="package_with_kiwi_image" rev="3" vrev="3" srcmd5="801c545be09c1c468ff2d99b40415aac">
-          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1643726947"/>
+          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1677064926"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:52:34 GMT
+  recorded_at: Wed, 22 Feb 2023 17:57:59 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/package_with_kiwi_image?expand=0
@@ -1257,7 +1284,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - afdcef79-0b4c-4e83-8af1-08f60975c2d3
+      - d6ba732a-96b2-4d60-b6e2-3964cdc475cd
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1281,9 +1308,9 @@ http_interactions:
       encoding: UTF-8
       string: |
         <directory name="package_with_kiwi_image" rev="3" vrev="3" srcmd5="801c545be09c1c468ff2d99b40415aac">
-          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1643726947"/>
+          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1677064926"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:52:34 GMT
+  recorded_at: Wed, 22 Feb 2023 17:57:59 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/second_package?expand=1
@@ -1292,7 +1319,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - a3c4879d-c507-4da0-a531-f36bb6e86a01
+      - b9035085-3d49-46ad-afc6-16ccb4a5a0c5
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1315,11 +1342,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="second_package" rev="6" vrev="6" srcmd5="4bd571b947b0c354bfade51a8f27f0e2">
-          <entry name="_config" md5="29fc9e02f1d0931d8ade149e6f06c600" size="76" mtime="1643727147"/>
-          <entry name="somefile.txt" md5="14352fa93342e84aa2300172d03322f1" size="54" mtime="1643727148"/>
+        <directory name="second_package" rev="6" vrev="6" srcmd5="055f157b268ebdbaff27e03a1d2060ee">
+          <entry name="_config" md5="5601a0d621508ca7f3e41db9cdfcb91d" size="56" mtime="1677088677"/>
+          <entry name="somefile.txt" md5="a2af3efd0634fb08044de0b592af6250" size="59" mtime="1677088677"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:52:35 GMT
+  recorded_at: Wed, 22 Feb 2023 17:57:59 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/second_package?rev=6
@@ -1328,7 +1355,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - a3c4879d-c507-4da0-a531-f36bb6e86a01
+      - b9035085-3d49-46ad-afc6-16ccb4a5a0c5
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1351,11 +1378,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="second_package" rev="6" vrev="6" srcmd5="4bd571b947b0c354bfade51a8f27f0e2">
-          <entry name="_config" md5="29fc9e02f1d0931d8ade149e6f06c600" size="76" mtime="1643727147"/>
-          <entry name="somefile.txt" md5="14352fa93342e84aa2300172d03322f1" size="54" mtime="1643727148"/>
+        <directory name="second_package" rev="6" vrev="6" srcmd5="055f157b268ebdbaff27e03a1d2060ee">
+          <entry name="_config" md5="5601a0d621508ca7f3e41db9cdfcb91d" size="56" mtime="1677088677"/>
+          <entry name="somefile.txt" md5="a2af3efd0634fb08044de0b592af6250" size="59" mtime="1677088677"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:52:35 GMT
+  recorded_at: Wed, 22 Feb 2023 17:57:59 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22second_package%22%20and%20linkinfo/@project=%22my_project%22%20and%20@project=%22my_project%22)
@@ -1389,7 +1416,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Tue, 01 Feb 2022 14:52:35 GMT
+  recorded_at: Wed, 22 Feb 2023 17:57:59 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:my_project/_meta?user=tom
@@ -1403,7 +1430,7 @@ http_interactions:
         </project>
     headers:
       X-Request-Id:
-      - a3c4879d-c507-4da0-a531-f36bb6e86a01
+      - b9035085-3d49-46ad-afc6-16ccb4a5a0c5
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1431,7 +1458,7 @@ http_interactions:
           <description>This project was created for package second_package via attribute OBS:Maintained</description>
           <person userid="tom" role="maintainer"/>
         </project>
-  recorded_at: Tue, 01 Feb 2022 14:52:35 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:07 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:my_project/_project/_attribute?meta=1&user=tom
@@ -1440,12 +1467,12 @@ http_interactions:
       string: |
         <attributes>
           <attribute name="AutoCleanup" namespace="OBS">
-            <value>2022-02-15 14:52:35 +0000</value>
+            <value>2023-03-08 17:58:07 +0000</value>
           </attribute>
         </attributes>
     headers:
       X-Request-Id:
-      - a3c4879d-c507-4da0-a531-f36bb6e86a01
+      - b9035085-3d49-46ad-afc6-16ccb4a5a0c5
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1469,13 +1496,13 @@ http_interactions:
       encoding: UTF-8
       string: |
         <revision rev="8">
-          <srcmd5>7356f58dab9083e222970acd4db046b2</srcmd5>
-          <time>1643727155</time>
+          <srcmd5>f2dd4d745010d68f8b72ae20b9683bf4</srcmd5>
+          <time>1677088687</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Tue, 01 Feb 2022 14:52:35 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:07 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:my_project/custom_name/_meta?user=tom
@@ -1484,7 +1511,7 @@ http_interactions:
       string: |
         <package name="custom_name" project="home:tom:branches:my_project">
           <title>c</title>
-          <description>Neque aut dolore at.</description>
+          <description>Nobis officia aliquid in.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1505,18 +1532,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '148'
+      - '153'
     body:
       encoding: UTF-8
       string: |
         <package name="custom_name" project="home:tom:branches:my_project">
           <title>c</title>
-          <description>Neque aut dolore at.</description>
+          <description>Nobis officia aliquid in.</description>
         </package>
-  recorded_at: Tue, 01 Feb 2022 14:52:35 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:07 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/home:tom:branches:my_project/custom_name?cmd=branch&noservice=1&opackage=second_package&oproject=my_project&orev=4bd571b947b0c354bfade51a8f27f0e2&user=tom
+    uri: http://backend:5352/source/home:tom:branches:my_project/custom_name?cmd=branch&noservice=1&opackage=second_package&oproject=my_project&orev=055f157b268ebdbaff27e03a1d2060ee&user=tom
     body:
       encoding: UTF-8
       string: ''
@@ -1545,15 +1572,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="2" vrev="2">
-          <srcmd5>5f23f2d4e55315f75ecf64348932ec41</srcmd5>
+        <revision rev="4" vrev="4">
+          <srcmd5>5ac8d6cfb41d4d42c0d7e7ef6fcaa273</srcmd5>
           <version>unknown</version>
-          <time>1643727156</time>
+          <time>1677088687</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Tue, 01 Feb 2022 14:52:36 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:07 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:my_project/custom_name/_meta?user=tom
@@ -1562,7 +1589,7 @@ http_interactions:
       string: |
         <package name="custom_name" project="home:tom:branches:my_project">
           <title>c</title>
-          <description>Neque aut dolore at.</description>
+          <description>Nobis officia aliquid in.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1583,15 +1610,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '148'
+      - '153'
     body:
       encoding: UTF-8
       string: |
         <package name="custom_name" project="home:tom:branches:my_project">
           <title>c</title>
-          <description>Neque aut dolore at.</description>
+          <description>Nobis officia aliquid in.</description>
         </package>
-  recorded_at: Tue, 01 Feb 2022 14:52:36 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:07 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/custom_name
@@ -1621,13 +1648,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="custom_name" rev="2" vrev="2" srcmd5="5f23f2d4e55315f75ecf64348932ec41">
-          <linkinfo project="my_project" package="second_package" rev="4bd571b947b0c354bfade51a8f27f0e2" srcmd5="4bd571b947b0c354bfade51a8f27f0e2" baserev="4bd571b947b0c354bfade51a8f27f0e2" xsrcmd5="f156e71afa6c68b77773d8a471a580ab" lsrcmd5="5f23f2d4e55315f75ecf64348932ec41"/>
-          <entry name="_config" md5="29fc9e02f1d0931d8ade149e6f06c600" size="76" mtime="1643727147"/>
-          <entry name="_link" md5="d1335b5d364e570eb0ee6cce6cca86e9" size="182" mtime="1643727155"/>
-          <entry name="somefile.txt" md5="14352fa93342e84aa2300172d03322f1" size="54" mtime="1643727148"/>
+        <directory name="custom_name" rev="4" vrev="4" srcmd5="5ac8d6cfb41d4d42c0d7e7ef6fcaa273">
+          <linkinfo project="my_project" package="second_package" rev="055f157b268ebdbaff27e03a1d2060ee" srcmd5="055f157b268ebdbaff27e03a1d2060ee" baserev="055f157b268ebdbaff27e03a1d2060ee" xsrcmd5="c7a21355aaa4b47f244f7156ac8c88f3" lsrcmd5="5ac8d6cfb41d4d42c0d7e7ef6fcaa273"/>
+          <entry name="_config" md5="5601a0d621508ca7f3e41db9cdfcb91d" size="56" mtime="1677088677"/>
+          <entry name="_link" md5="4cf56ebd40df356acef06107b749a37d" size="182" mtime="1677088687"/>
+          <entry name="somefile.txt" md5="a2af3efd0634fb08044de0b592af6250" size="59" mtime="1677088677"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:52:36 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:07 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/custom_name?view=info
@@ -1636,7 +1663,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - a3c4879d-c507-4da0-a531-f36bb6e86a01
+      - b9035085-3d49-46ad-afc6-16ccb4a5a0c5
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1659,11 +1686,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="custom_name" rev="2" vrev="2" srcmd5="f156e71afa6c68b77773d8a471a580ab" lsrcmd5="5f23f2d4e55315f75ecf64348932ec41" verifymd5="4bd571b947b0c354bfade51a8f27f0e2">
+        <sourceinfo package="custom_name" rev="4" vrev="4" srcmd5="c7a21355aaa4b47f244f7156ac8c88f3" lsrcmd5="5ac8d6cfb41d4d42c0d7e7ef6fcaa273" verifymd5="055f157b268ebdbaff27e03a1d2060ee">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="my_project" package="second_package"/>
         </sourceinfo>
-  recorded_at: Tue, 01 Feb 2022 14:52:36 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:07 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/custom_name
@@ -1672,7 +1699,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - a3c4879d-c507-4da0-a531-f36bb6e86a01
+      - b9035085-3d49-46ad-afc6-16ccb4a5a0c5
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1695,13 +1722,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="custom_name" rev="2" vrev="2" srcmd5="5f23f2d4e55315f75ecf64348932ec41">
-          <linkinfo project="my_project" package="second_package" rev="4bd571b947b0c354bfade51a8f27f0e2" srcmd5="4bd571b947b0c354bfade51a8f27f0e2" baserev="4bd571b947b0c354bfade51a8f27f0e2" xsrcmd5="f156e71afa6c68b77773d8a471a580ab" lsrcmd5="5f23f2d4e55315f75ecf64348932ec41"/>
-          <entry name="_config" md5="29fc9e02f1d0931d8ade149e6f06c600" size="76" mtime="1643727147"/>
-          <entry name="_link" md5="d1335b5d364e570eb0ee6cce6cca86e9" size="182" mtime="1643727155"/>
-          <entry name="somefile.txt" md5="14352fa93342e84aa2300172d03322f1" size="54" mtime="1643727148"/>
+        <directory name="custom_name" rev="4" vrev="4" srcmd5="5ac8d6cfb41d4d42c0d7e7ef6fcaa273">
+          <linkinfo project="my_project" package="second_package" rev="055f157b268ebdbaff27e03a1d2060ee" srcmd5="055f157b268ebdbaff27e03a1d2060ee" baserev="055f157b268ebdbaff27e03a1d2060ee" xsrcmd5="c7a21355aaa4b47f244f7156ac8c88f3" lsrcmd5="5ac8d6cfb41d4d42c0d7e7ef6fcaa273"/>
+          <entry name="_config" md5="5601a0d621508ca7f3e41db9cdfcb91d" size="56" mtime="1677088677"/>
+          <entry name="_link" md5="4cf56ebd40df356acef06107b749a37d" size="182" mtime="1677088687"/>
+          <entry name="somefile.txt" md5="a2af3efd0634fb08044de0b592af6250" size="59" mtime="1677088677"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:52:36 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:07 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:my_project/custom_name?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -1733,14 +1760,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="f99bde841790268b61ba5d08dafd79a7">
+        <sourcediff key="a976316c43ded65b80f40d9151775366">
           <old project="home:tom:branches:my_project" package="custom_name" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:tom:branches:my_project" package="custom_name" rev="2" srcmd5="5f23f2d4e55315f75ecf64348932ec41"/>
+          <new project="home:tom:branches:my_project" package="custom_name" rev="4" srcmd5="5ac8d6cfb41d4d42c0d7e7ef6fcaa273"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Tue, 01 Feb 2022 14:52:36 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:07 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:my_project/custom_name?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -1772,14 +1799,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="d47155578ff658c840c4eeb84ca07c2c">
-          <old project="my_project" package="second_package" rev="4bd571b947b0c354bfade51a8f27f0e2" srcmd5="4bd571b947b0c354bfade51a8f27f0e2"/>
-          <new project="home:tom:branches:my_project" package="custom_name" rev="f156e71afa6c68b77773d8a471a580ab" srcmd5="f156e71afa6c68b77773d8a471a580ab"/>
+        <sourcediff key="febdeec98e20860e05beadebe46d869a">
+          <old project="my_project" package="second_package" rev="055f157b268ebdbaff27e03a1d2060ee" srcmd5="055f157b268ebdbaff27e03a1d2060ee"/>
+          <new project="home:tom:branches:my_project" package="custom_name" rev="c7a21355aaa4b47f244f7156ac8c88f3" srcmd5="c7a21355aaa4b47f244f7156ac8c88f3"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Tue, 01 Feb 2022 14:52:36 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:07 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:my_project/_meta?user=tom
@@ -1796,7 +1823,7 @@ http_interactions:
         </project>
     headers:
       X-Request-Id:
-      - a3c4879d-c507-4da0-a531-f36bb6e86a01
+      - b9035085-3d49-46ad-afc6-16ccb4a5a0c5
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1827,7 +1854,7 @@ http_interactions:
             <disable/>
           </publish>
         </project>
-  recorded_at: Tue, 01 Feb 2022 14:52:37 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:07 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/custom_name
@@ -1836,7 +1863,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - a3c4879d-c507-4da0-a531-f36bb6e86a01
+      - b9035085-3d49-46ad-afc6-16ccb4a5a0c5
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1859,13 +1886,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="custom_name" rev="2" vrev="2" srcmd5="5f23f2d4e55315f75ecf64348932ec41">
-          <linkinfo project="my_project" package="second_package" rev="4bd571b947b0c354bfade51a8f27f0e2" srcmd5="4bd571b947b0c354bfade51a8f27f0e2" baserev="4bd571b947b0c354bfade51a8f27f0e2" xsrcmd5="f156e71afa6c68b77773d8a471a580ab" lsrcmd5="5f23f2d4e55315f75ecf64348932ec41"/>
-          <entry name="_config" md5="29fc9e02f1d0931d8ade149e6f06c600" size="76" mtime="1643727147"/>
-          <entry name="_link" md5="d1335b5d364e570eb0ee6cce6cca86e9" size="182" mtime="1643727155"/>
-          <entry name="somefile.txt" md5="14352fa93342e84aa2300172d03322f1" size="54" mtime="1643727148"/>
+        <directory name="custom_name" rev="4" vrev="4" srcmd5="5ac8d6cfb41d4d42c0d7e7ef6fcaa273">
+          <linkinfo project="my_project" package="second_package" rev="055f157b268ebdbaff27e03a1d2060ee" srcmd5="055f157b268ebdbaff27e03a1d2060ee" baserev="055f157b268ebdbaff27e03a1d2060ee" xsrcmd5="c7a21355aaa4b47f244f7156ac8c88f3" lsrcmd5="5ac8d6cfb41d4d42c0d7e7ef6fcaa273"/>
+          <entry name="_config" md5="5601a0d621508ca7f3e41db9cdfcb91d" size="56" mtime="1677088677"/>
+          <entry name="_link" md5="4cf56ebd40df356acef06107b749a37d" size="182" mtime="1677088687"/>
+          <entry name="somefile.txt" md5="a2af3efd0634fb08044de0b592af6250" size="59" mtime="1677088677"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:52:37 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:07 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/second_package?view=info
@@ -1874,7 +1901,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - fba50e0d-4c8e-4e1d-9ef9-3bbb4eed90c3
+      - ec3958dc-d70c-4e2a-8dc7-167642ec3e0c
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1897,10 +1924,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="second_package" rev="6" vrev="6" srcmd5="4bd571b947b0c354bfade51a8f27f0e2" verifymd5="4bd571b947b0c354bfade51a8f27f0e2">
+        <sourceinfo package="second_package" rev="6" vrev="6" srcmd5="055f157b268ebdbaff27e03a1d2060ee" verifymd5="055f157b268ebdbaff27e03a1d2060ee">
           <error>bad build configuration, no build type defined or detected</error>
         </sourceinfo>
-  recorded_at: Tue, 01 Feb 2022 14:52:37 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:07 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/second_package
@@ -1909,7 +1936,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - fba50e0d-4c8e-4e1d-9ef9-3bbb4eed90c3
+      - ec3958dc-d70c-4e2a-8dc7-167642ec3e0c
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1932,11 +1959,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="second_package" rev="6" vrev="6" srcmd5="4bd571b947b0c354bfade51a8f27f0e2">
-          <entry name="_config" md5="29fc9e02f1d0931d8ade149e6f06c600" size="76" mtime="1643727147"/>
-          <entry name="somefile.txt" md5="14352fa93342e84aa2300172d03322f1" size="54" mtime="1643727148"/>
+        <directory name="second_package" rev="6" vrev="6" srcmd5="055f157b268ebdbaff27e03a1d2060ee">
+          <entry name="_config" md5="5601a0d621508ca7f3e41db9cdfcb91d" size="56" mtime="1677088677"/>
+          <entry name="somefile.txt" md5="a2af3efd0634fb08044de0b592af6250" size="59" mtime="1677088677"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:52:37 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:07 GMT
 - request:
     method: post
     uri: http://backend:5352/source/my_project/second_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -1968,14 +1995,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="6274e7897f60a63e362bba93dcaea7c5">
+        <sourcediff key="bbea7b25ea4d75abbabf50477c4bbfec">
           <old project="my_project" package="second_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="my_project" package="second_package" rev="6" srcmd5="4bd571b947b0c354bfade51a8f27f0e2"/>
+          <new project="my_project" package="second_package" rev="6" srcmd5="055f157b268ebdbaff27e03a1d2060ee"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Tue, 01 Feb 2022 14:52:37 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:08 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/custom_name
@@ -1984,7 +2011,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - fba50e0d-4c8e-4e1d-9ef9-3bbb4eed90c3
+      - ec3958dc-d70c-4e2a-8dc7-167642ec3e0c
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -2007,16 +2034,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="custom_name" rev="2" vrev="2" srcmd5="5f23f2d4e55315f75ecf64348932ec41">
-          <linkinfo project="my_project" package="second_package" rev="4bd571b947b0c354bfade51a8f27f0e2" srcmd5="4bd571b947b0c354bfade51a8f27f0e2" baserev="4bd571b947b0c354bfade51a8f27f0e2" xsrcmd5="f156e71afa6c68b77773d8a471a580ab" lsrcmd5="5f23f2d4e55315f75ecf64348932ec41"/>
-          <entry name="_config" md5="29fc9e02f1d0931d8ade149e6f06c600" size="76" mtime="1643727147"/>
-          <entry name="_link" md5="d1335b5d364e570eb0ee6cce6cca86e9" size="182" mtime="1643727155"/>
-          <entry name="somefile.txt" md5="14352fa93342e84aa2300172d03322f1" size="54" mtime="1643727148"/>
+        <directory name="custom_name" rev="4" vrev="4" srcmd5="5ac8d6cfb41d4d42c0d7e7ef6fcaa273">
+          <linkinfo project="my_project" package="second_package" rev="055f157b268ebdbaff27e03a1d2060ee" srcmd5="055f157b268ebdbaff27e03a1d2060ee" baserev="055f157b268ebdbaff27e03a1d2060ee" xsrcmd5="c7a21355aaa4b47f244f7156ac8c88f3" lsrcmd5="5ac8d6cfb41d4d42c0d7e7ef6fcaa273"/>
+          <entry name="_config" md5="5601a0d621508ca7f3e41db9cdfcb91d" size="56" mtime="1677088677"/>
+          <entry name="_link" md5="4cf56ebd40df356acef06107b749a37d" size="182" mtime="1677088687"/>
+          <entry name="somefile.txt" md5="a2af3efd0634fb08044de0b592af6250" size="59" mtime="1677088677"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:52:37 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:08 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:tom:branches:my_project/custom_name?expand=1&rev=2
+    uri: http://backend:5352/source/home:tom:branches:my_project/custom_name?expand=1&rev=4
     body:
       encoding: US-ASCII
       string: ''
@@ -2043,21 +2070,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="custom_name" rev="f156e71afa6c68b77773d8a471a580ab" vrev="2" srcmd5="f156e71afa6c68b77773d8a471a580ab">
-          <linkinfo project="my_project" package="second_package" rev="4bd571b947b0c354bfade51a8f27f0e2" srcmd5="4bd571b947b0c354bfade51a8f27f0e2" baserev="4bd571b947b0c354bfade51a8f27f0e2" lsrcmd5="5f23f2d4e55315f75ecf64348932ec41"/>
-          <entry name="_config" md5="29fc9e02f1d0931d8ade149e6f06c600" size="76" mtime="1643727147"/>
-          <entry name="somefile.txt" md5="14352fa93342e84aa2300172d03322f1" size="54" mtime="1643727148"/>
+        <directory name="custom_name" rev="c7a21355aaa4b47f244f7156ac8c88f3" vrev="4" srcmd5="c7a21355aaa4b47f244f7156ac8c88f3">
+          <linkinfo project="my_project" package="second_package" rev="055f157b268ebdbaff27e03a1d2060ee" srcmd5="055f157b268ebdbaff27e03a1d2060ee" baserev="055f157b268ebdbaff27e03a1d2060ee" lsrcmd5="5ac8d6cfb41d4d42c0d7e7ef6fcaa273"/>
+          <entry name="_config" md5="5601a0d621508ca7f3e41db9cdfcb91d" size="56" mtime="1677088677"/>
+          <entry name="somefile.txt" md5="a2af3efd0634fb08044de0b592af6250" size="59" mtime="1677088677"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:52:37 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:08 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:tom:branches:my_project/custom_name
+    uri: http://backend:5352/source/home:tom:branches:my_project/custom_name/_history?deleted=1&meta=1&rev=4
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - fba50e0d-4c8e-4e1d-9ef9-3bbb4eed90c3
+      - ec3958dc-d70c-4e2a-8dc7-167642ec3e0c
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -2076,108 +2103,132 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '659'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="custom_name" rev="2" vrev="2" srcmd5="5f23f2d4e55315f75ecf64348932ec41">
-          <linkinfo project="my_project" package="second_package" rev="4bd571b947b0c354bfade51a8f27f0e2" srcmd5="4bd571b947b0c354bfade51a8f27f0e2" baserev="4bd571b947b0c354bfade51a8f27f0e2" xsrcmd5="f156e71afa6c68b77773d8a471a580ab" lsrcmd5="5f23f2d4e55315f75ecf64348932ec41"/>
-          <entry name="_config" md5="29fc9e02f1d0931d8ade149e6f06c600" size="76" mtime="1643727147"/>
-          <entry name="_link" md5="d1335b5d364e570eb0ee6cce6cca86e9" size="182" mtime="1643727155"/>
-          <entry name="somefile.txt" md5="14352fa93342e84aa2300172d03322f1" size="54" mtime="1643727148"/>
-        </directory>
-  recorded_at: Tue, 01 Feb 2022 14:52:37 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:tom:branches:my_project/custom_name
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Request-Id:
-      - fba50e0d-4c8e-4e1d-9ef9-3bbb4eed90c3
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '659'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="custom_name" rev="2" vrev="2" srcmd5="5f23f2d4e55315f75ecf64348932ec41">
-          <linkinfo project="my_project" package="second_package" rev="4bd571b947b0c354bfade51a8f27f0e2" srcmd5="4bd571b947b0c354bfade51a8f27f0e2" baserev="4bd571b947b0c354bfade51a8f27f0e2" xsrcmd5="f156e71afa6c68b77773d8a471a580ab" lsrcmd5="5f23f2d4e55315f75ecf64348932ec41"/>
-          <entry name="_config" md5="29fc9e02f1d0931d8ade149e6f06c600" size="76" mtime="1643727147"/>
-          <entry name="_link" md5="d1335b5d364e570eb0ee6cce6cca86e9" size="182" mtime="1643727155"/>
-          <entry name="somefile.txt" md5="14352fa93342e84aa2300172d03322f1" size="54" mtime="1643727148"/>
-        </directory>
-  recorded_at: Tue, 01 Feb 2022 14:52:37 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:tom:branches:my_project/custom_name/_history
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '387'
+      - '31'
     body:
       encoding: UTF-8
       string: |
         <revisionlist>
-          <revision rev="1" vrev="1">
-            <srcmd5>e85d2a822c0199f3ec59eb76e5db8f66</srcmd5>
-            <version>unknown</version>
-            <time>1643726963</time>
-            <user>tom</user>
-          </revision>
-          <revision rev="2" vrev="2">
-            <srcmd5>5f23f2d4e55315f75ecf64348932ec41</srcmd5>
-            <version>unknown</version>
-            <time>1643727156</time>
-            <user>tom</user>
-          </revision>
         </revisionlist>
-  recorded_at: Tue, 01 Feb 2022 14:52:37 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:08 GMT
 - request:
     method: get
-    uri: http://backend:5352/build/home:tom:branches:my_project/_result?package=custom_name&view=status
+    uri: http://backend:5352/source/home:tom:branches:my_project/custom_name
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - 5313b435-1c40-47d2-a40c-4343c0352c3f
+      - ec3958dc-d70c-4e2a-8dc7-167642ec3e0c
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '659'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="custom_name" rev="4" vrev="4" srcmd5="5ac8d6cfb41d4d42c0d7e7ef6fcaa273">
+          <linkinfo project="my_project" package="second_package" rev="055f157b268ebdbaff27e03a1d2060ee" srcmd5="055f157b268ebdbaff27e03a1d2060ee" baserev="055f157b268ebdbaff27e03a1d2060ee" xsrcmd5="c7a21355aaa4b47f244f7156ac8c88f3" lsrcmd5="5ac8d6cfb41d4d42c0d7e7ef6fcaa273"/>
+          <entry name="_config" md5="5601a0d621508ca7f3e41db9cdfcb91d" size="56" mtime="1677088677"/>
+          <entry name="_link" md5="4cf56ebd40df356acef06107b749a37d" size="182" mtime="1677088687"/>
+          <entry name="somefile.txt" md5="a2af3efd0634fb08044de0b592af6250" size="59" mtime="1677088677"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 17:58:08 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:tom:branches:my_project/custom_name
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - ec3958dc-d70c-4e2a-8dc7-167642ec3e0c
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '659'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="custom_name" rev="4" vrev="4" srcmd5="5ac8d6cfb41d4d42c0d7e7ef6fcaa273">
+          <linkinfo project="my_project" package="second_package" rev="055f157b268ebdbaff27e03a1d2060ee" srcmd5="055f157b268ebdbaff27e03a1d2060ee" baserev="055f157b268ebdbaff27e03a1d2060ee" xsrcmd5="c7a21355aaa4b47f244f7156ac8c88f3" lsrcmd5="5ac8d6cfb41d4d42c0d7e7ef6fcaa273"/>
+          <entry name="_config" md5="5601a0d621508ca7f3e41db9cdfcb91d" size="56" mtime="1677088677"/>
+          <entry name="_link" md5="4cf56ebd40df356acef06107b749a37d" size="182" mtime="1677088687"/>
+          <entry name="somefile.txt" md5="a2af3efd0634fb08044de0b592af6250" size="59" mtime="1677088677"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 17:58:08 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:tom:branches:my_project/custom_name/_history?deleted=1&meta=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - ec3958dc-d70c-4e2a-8dc7-167642ec3e0c
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Wed, 22 Feb 2023 17:58:08 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:tom:branches:my_project/_result?lastbuild=1&locallink=1&multibuild=1&package=custom_name&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - bd37bb93-a843-495e-8475-4e6c4273d839
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -2202,5 +2253,73 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Tue, 01 Feb 2022 14:52:37 GMT
-recorded_with: VCR 6.0.0
+  recorded_at: Wed, 22 Feb 2023 17:58:08 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:tom:branches:my_project/_result?lastbuild=1&locallink=1&multibuild=1&package=custom_name&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 53fa17c7-fb67-4075-8826-cd1724192a14
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 17:58:08 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:tom:branches:my_project/_result?package=custom_name&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 3d4934c3-bd9b-4b78-b68a-086aea05f1ab
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 17:58:08 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/MaintenanceWorkflow/maintenance_workflow.yml
+++ b/src/api/spec/cassettes/MaintenanceWorkflow/maintenance_workflow.yml
@@ -2,14 +2,14 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/home:user_1/_meta?user=user_1
+    uri: http://backend:5352/source/home:user_46/_meta?user=user_46
     body:
       encoding: UTF-8
       string: |
-        <project name="home:user_1">
+        <project name="home:user_46">
           <title/>
           <description/>
-          <person userid="user_1" role="maintainer"/>
+          <person userid="user_46" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -30,24 +30,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '134'
+      - '136'
     body:
       encoding: UTF-8
       string: |
-        <project name="home:user_1">
+        <project name="home:user_46">
           <title></title>
           <description></description>
-          <person userid="user_1" role="maintainer"/>
+          <person userid="user_46" role="maintainer"/>
         </project>
-  recorded_at: Tue, 22 Jun 2021 11:09:19 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:06 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/ProjectWithRepo/_meta?user=user_1
+    uri: http://backend:5352/source/ProjectWithRepo/_meta?user=user_46
     body:
       encoding: UTF-8
       string: |
         <project name="ProjectWithRepo">
-          <title>The Man Within</title>
+          <title>Alone on a Wide, Wide Sea</title>
           <description/>
         </project>
     headers:
@@ -69,23 +69,23 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '106'
+      - '117'
     body:
       encoding: UTF-8
       string: |
         <project name="ProjectWithRepo">
-          <title>The Man Within</title>
+          <title>Alone on a Wide, Wide Sea</title>
           <description></description>
         </project>
-  recorded_at: Tue, 22 Jun 2021 11:09:19 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:06 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/ProjectWithRepo:Update/_meta?user=user_1
+    uri: http://backend:5352/source/ProjectWithRepo:Update/_meta?user=user_46
     body:
       encoding: UTF-8
       string: |
         <project name="ProjectWithRepo:Update" kind="maintenance_release">
-          <title>Of Human Bondage</title>
+          <title>The Soldier's Art</title>
           <description/>
         </project>
     headers:
@@ -107,18 +107,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '142'
+      - '143'
     body:
       encoding: UTF-8
       string: |
         <project name="ProjectWithRepo:Update" kind="maintenance_release">
-          <title>Of Human Bondage</title>
+          <title>The Soldier's Art</title>
           <description></description>
         </project>
-  recorded_at: Tue, 22 Jun 2021 11:09:19 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:06 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/ProjectWithRepo/_project/_attribute?meta=1&user=user_1
+    uri: http://backend:5352/source/ProjectWithRepo/_project/_attribute?meta=1&user=user_46
     body:
       encoding: UTF-8
       string: |
@@ -146,26 +146,26 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '168'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="2">
-          <srcmd5>e2c8b2d219800fe778b180fe18495c04</srcmd5>
-          <time>1624360160</time>
-          <user>user_1</user>
+        <revision rev="28">
+          <srcmd5>56c53f1e862ddf976a3fe7bf161dd86a</srcmd5>
+          <time>1677089167</time>
+          <user>user_46</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Tue, 22 Jun 2021 11:09:20 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:07 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/ProjectWithRepo:Update/_meta?user=user_1
+    uri: http://backend:5352/source/ProjectWithRepo:Update/_meta?user=user_46
     body:
       encoding: UTF-8
       string: |
         <project name="ProjectWithRepo:Update" kind="maintenance_release">
-          <title>Of Human Bondage</title>
+          <title>The Soldier's Art</title>
           <description/>
           <link project="ProjectWithRepo"/>
         </project>
@@ -188,16 +188,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '178'
+      - '179'
     body:
       encoding: UTF-8
       string: |
         <project name="ProjectWithRepo:Update" kind="maintenance_release">
-          <title>Of Human Bondage</title>
+          <title>The Soldier's Art</title>
           <description></description>
           <link project="ProjectWithRepo"/>
         </project>
-  recorded_at: Tue, 22 Jun 2021 11:09:20 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:07 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:maintenance_coord/_meta?user=maintenance_coord
@@ -237,10 +237,10 @@ http_interactions:
           <description></description>
           <person userid="maintenance_coord" role="maintainer"/>
         </project>
-  recorded_at: Tue, 22 Jun 2021 11:09:20 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:07 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/MaintenanceProject/_meta?user=user_1
+    uri: http://backend:5352/source/MaintenanceProject/_meta?user=user_46
     body:
       encoding: UTF-8
       string: |
@@ -283,10 +283,10 @@ http_interactions:
             <disable/>
           </build>
         </project>
-  recorded_at: Tue, 22 Jun 2021 11:09:20 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:07 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/MaintenanceProject/_project/_attribute?meta=1&user=user_1
+    uri: http://backend:5352/source/MaintenanceProject/_project/_attribute?meta=1&user=user_46
     body:
       encoding: UTF-8
       string: |
@@ -312,21 +312,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '168'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="6">
-          <srcmd5>a23515688b83c3e64677f52aece7e26b</srcmd5>
-          <time>1624360160</time>
-          <user>user_1</user>
+        <revision rev="12">
+          <srcmd5>e6178909cd140e7432dd891cb188ad6f</srcmd5>
+          <time>1677089167</time>
+          <user>user_46</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Tue, 22 Jun 2021 11:09:20 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:07 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/MaintenanceProject/_meta?user=user_1
+    uri: http://backend:5352/source/MaintenanceProject/_meta?user=user_46
     body:
       encoding: UTF-8
       string: |
@@ -375,7 +375,7 @@ http_interactions:
             <disable/>
           </build>
         </project>
-  recorded_at: Tue, 22 Jun 2021 11:09:20 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:07 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject/patchinfo/_meta?user=maintenance_coord
@@ -431,7 +431,7 @@ http_interactions:
             <disable/>
           </useforbuild>
         </package>
-  recorded_at: Tue, 22 Jun 2021 11:09:20 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:07 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject/patchinfo/_patchinfo?comment=generated%20by%20createpatchinfo%20call&user=maintenance_coord
@@ -468,15 +468,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1" vrev="1">
+        <revision rev="3" vrev="3">
           <srcmd5>7c79565cf2a5793c8092ebecfe0a912a</srcmd5>
           <version>unknown</version>
-          <time>1624360160</time>
+          <time>1677089167</time>
           <user>maintenance_coord</user>
           <comment>generated by createpatchinfo call</comment>
           <requestid/>
         </revision>
-  recorded_at: Tue, 22 Jun 2021 11:09:20 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:07 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject/patchinfo/_meta?user=maintenance_coord
@@ -532,7 +532,7 @@ http_interactions:
             <disable/>
           </useforbuild>
         </package>
-  recorded_at: Tue, 22 Jun 2021 11:09:20 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:07 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject/patchinfo
@@ -562,10 +562,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="patchinfo" rev="1" vrev="1" srcmd5="7c79565cf2a5793c8092ebecfe0a912a">
-          <entry name="_patchinfo" md5="ea890f2483d4b7e7255d64ef4dbb1d43" size="174" mtime="1624360160"/>
+        <directory name="patchinfo" rev="3" vrev="3" srcmd5="7c79565cf2a5793c8092ebecfe0a912a">
+          <entry name="_patchinfo" md5="ea890f2483d4b7e7255d64ef4dbb1d43" size="174" mtime="1677064901"/>
         </directory>
-  recorded_at: Tue, 22 Jun 2021 11:09:20 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:07 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject/patchinfo?view=info
@@ -595,10 +595,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="patchinfo" rev="1" vrev="1" srcmd5="7c79565cf2a5793c8092ebecfe0a912a" verifymd5="7c79565cf2a5793c8092ebecfe0a912a">
+        <sourceinfo package="patchinfo" rev="3" vrev="3" srcmd5="7c79565cf2a5793c8092ebecfe0a912a" verifymd5="7c79565cf2a5793c8092ebecfe0a912a">
           <filename>_patchinfo</filename>
         </sourceinfo>
-  recorded_at: Tue, 22 Jun 2021 11:09:20 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:07 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject/patchinfo
@@ -628,10 +628,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="patchinfo" rev="1" vrev="1" srcmd5="7c79565cf2a5793c8092ebecfe0a912a">
-          <entry name="_patchinfo" md5="ea890f2483d4b7e7255d64ef4dbb1d43" size="174" mtime="1624360160"/>
+        <directory name="patchinfo" rev="3" vrev="3" srcmd5="7c79565cf2a5793c8092ebecfe0a912a">
+          <entry name="_patchinfo" md5="ea890f2483d4b7e7255d64ef4dbb1d43" size="174" mtime="1677064901"/>
         </directory>
-  recorded_at: Tue, 22 Jun 2021 11:09:20 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:07 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject/patchinfo/_patchinfo
@@ -668,10 +668,10 @@ http_interactions:
           <summary>Fake comment</summary>
           <description/>
         </patchinfo>
-  recorded_at: Tue, 22 Jun 2021 11:09:20 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:07 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/MaintenanceProject/_project/_attribute?meta=1&user=user_1
+    uri: http://backend:5352/source/MaintenanceProject/_project/_attribute?meta=1&user=user_46
     body:
       encoding: UTF-8
       string: |
@@ -697,18 +697,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '168'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="8">
-          <srcmd5>c74e2562b32d9aa148cebaa346c50376</srcmd5>
-          <time>1624360160</time>
-          <user>user_1</user>
+        <revision rev="14">
+          <srcmd5>6f2bb89dd5d4c78df634f17fee9bb5a0</srcmd5>
+          <time>1677089167</time>
+          <user>user_46</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Tue, 22 Jun 2021 11:09:20 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:07 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/_meta?user=tom
@@ -748,7 +748,7 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-  recorded_at: Tue, 22 Jun 2021 11:09:21 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:07 GMT
 - request:
     method: put
     uri: http://backend:5352/source/ProjectWithRepo/ProjectWithRepo_package/_meta?user=tom
@@ -756,8 +756,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package" project="ProjectWithRepo">
-          <title>Look to Windward</title>
-          <description>Vitae placeat voluptate eaque.</description>
+          <title>Unweaving the Rainbow</title>
+          <description>Autem at omnis nulla.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -778,21 +778,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '172'
+      - '168'
     body:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package" project="ProjectWithRepo">
-          <title>Look to Windward</title>
-          <description>Vitae placeat voluptate eaque.</description>
+          <title>Unweaving the Rainbow</title>
+          <description>Autem at omnis nulla.</description>
         </package>
-  recorded_at: Tue, 22 Jun 2021 11:09:27 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:08 GMT
 - request:
     method: put
     uri: http://backend:5352/source/ProjectWithRepo/ProjectWithRepo_package/_config
     body:
       encoding: UTF-8
-      string: Sapiente dolorem sed. Id distinctio est. Quas dolorem impedit.
+      string: Excepturi quis cum. Dolores delectus dolorum. Doloremque nobis voluptatem.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -816,21 +816,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1" vrev="1">
-          <srcmd5>665328b02721a30b94ab04156e9e704a</srcmd5>
+        <revision rev="5" vrev="5">
+          <srcmd5>2f9ec3623732d5297f771a6a378a9803</srcmd5>
           <version>unknown</version>
-          <time>1624360167</time>
+          <time>1677089168</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Tue, 22 Jun 2021 11:09:27 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:08 GMT
 - request:
     method: put
     uri: http://backend:5352/source/ProjectWithRepo/ProjectWithRepo_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Pariatur eum blanditiis. Non labore porro. Officia non unde.
+      string: Exercitationem neque nam. Et aut architecto. Eos culpa est.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -854,15 +854,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="2" vrev="2">
-          <srcmd5>2c6109033c5937a5528ec21af10e04ef</srcmd5>
+        <revision rev="6" vrev="6">
+          <srcmd5>e83ea096f3fd3c64494e21941c685f6f</srcmd5>
           <version>unknown</version>
-          <time>1624360167</time>
+          <time>1677089168</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Tue, 22 Jun 2021 11:09:27 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:08 GMT
 - request:
     method: get
     uri: http://backend:5352/source/ProjectWithRepo/ProjectWithRepo_package
@@ -871,7 +871,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 4c3ecaea-369e-4026-a934-8dd7c32c9fcd
+      - 1af87534-ce93-4514-9cb5-fa4f96d8c1a4
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -894,14 +894,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="2c6109033c5937a5528ec21af10e04ef">
-          <entry name="_config" md5="46cccf6ebc7684f1ef2c7d8f2db417bd" size="62" mtime="1624360167"/>
-          <entry name="somefile.txt" md5="42adbaa46956c814fabac93750ee8931" size="60" mtime="1624360167"/>
+        <directory name="ProjectWithRepo_package" rev="6" vrev="6" srcmd5="e83ea096f3fd3c64494e21941c685f6f">
+          <entry name="_config" md5="ca5a602718fd6de59987f678c2d641bd" size="74" mtime="1677089168"/>
+          <entry name="somefile.txt" md5="3b293450a072f3211239c7377e3cca78" size="59" mtime="1677089168"/>
         </directory>
-  recorded_at: Tue, 22 Jun 2021 11:09:27 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:08 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/ProjectWithRepo/ProjectWithRepo_package?expand=1&rev=2
+    uri: http://backend:5352/source/ProjectWithRepo/ProjectWithRepo_package?expand=1&rev=6
     body:
       encoding: US-ASCII
       string: ''
@@ -928,64 +928,124 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="2c6109033c5937a5528ec21af10e04ef">
-          <entry name="_config" md5="46cccf6ebc7684f1ef2c7d8f2db417bd" size="62" mtime="1624360167"/>
-          <entry name="somefile.txt" md5="42adbaa46956c814fabac93750ee8931" size="60" mtime="1624360167"/>
+        <directory name="ProjectWithRepo_package" rev="6" vrev="6" srcmd5="e83ea096f3fd3c64494e21941c685f6f">
+          <entry name="_config" md5="ca5a602718fd6de59987f678c2d641bd" size="74" mtime="1677089168"/>
+          <entry name="somefile.txt" md5="3b293450a072f3211239c7377e3cca78" size="59" mtime="1677089168"/>
         </directory>
-  recorded_at: Tue, 22 Jun 2021 11:09:27 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:08 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/ProjectWithRepo/ProjectWithRepo_package/_history
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '395'
-    body:
-      encoding: UTF-8
-      string: |
-        <revisionlist>
-          <revision rev="1" vrev="1">
-            <srcmd5>665328b02721a30b94ab04156e9e704a</srcmd5>
-            <version>unknown</version>
-            <time>1624360167</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="2" vrev="2">
-            <srcmd5>2c6109033c5937a5528ec21af10e04ef</srcmd5>
-            <version>unknown</version>
-            <time>1624360167</time>
-            <user>unknown</user>
-          </revision>
-        </revisionlist>
-  recorded_at: Tue, 22 Jun 2021 11:09:27 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/ProjectWithRepo:Update/_result?locallink=1&multibuild=1&package=ProjectWithRepo_package&view=status
+    uri: http://backend:5352/source/ProjectWithRepo/ProjectWithRepo_package/_history?deleted=1&meta=1&rev=6
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - 92c7d63d-1d57-45ab-addc-1ac8e44c057a
+      - 1af87534-ce93-4514-9cb5-fa4f96d8c1a4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Wed, 22 Feb 2023 18:06:09 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/ProjectWithRepo/ProjectWithRepo_package/_history?deleted=1&meta=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 1af87534-ce93-4514-9cb5-fa4f96d8c1a4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Wed, 22 Feb 2023 18:06:09 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/ProjectWithRepo/ProjectWithRepo_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - d43bcbc4-11f2-4b63-b3d1-b8211b9a6ad8
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '308'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="ProjectWithRepo_package" rev="6" vrev="6" srcmd5="e83ea096f3fd3c64494e21941c685f6f">
+          <entry name="_config" md5="ca5a602718fd6de59987f678c2d641bd" size="74" mtime="1677089168"/>
+          <entry name="somefile.txt" md5="3b293450a072f3211239c7377e3cca78" size="59" mtime="1677089168"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:06:09 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/ProjectWithRepo:Update/_result?lastbuild=1&locallink=1&multibuild=1&package=ProjectWithRepo_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - d43bcbc4-11f2-4b63-b3d1-b8211b9a6ad8
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1010,7 +1070,111 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Tue, 22 Jun 2021 11:09:27 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:09 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/ProjectWithRepo/ProjectWithRepo_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 56807fd1-788c-4db0-8d67-863527e61665
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '308'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="ProjectWithRepo_package" rev="6" vrev="6" srcmd5="e83ea096f3fd3c64494e21941c685f6f">
+          <entry name="_config" md5="ca5a602718fd6de59987f678c2d641bd" size="74" mtime="1677089168"/>
+          <entry name="somefile.txt" md5="3b293450a072f3211239c7377e3cca78" size="59" mtime="1677089168"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:06:09 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/ProjectWithRepo:Update/_result?lastbuild=1&locallink=1&multibuild=1&package=ProjectWithRepo_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 56807fd1-788c-4db0-8d67-863527e61665
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 18:06:09 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/ProjectWithRepo:Update/_result?lastbuild=0&locallink=1&multibuild=1&package=ProjectWithRepo_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - cbc27e68-130c-4670-9a74-f08fa577aecc
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 18:06:09 GMT
 - request:
     method: get
     uri: http://backend:5352/build/ProjectWithRepo:Update/_result?package=ProjectWithRepo_package&view=status
@@ -1019,7 +1183,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - cce85a08-43bb-4f9b-ad8e-50618678ec41
+      - 38689466-8b73-46a5-a3ec-be1e6c88f6e9
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1044,7 +1208,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Tue, 22 Jun 2021 11:09:27 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:09 GMT
 - request:
     method: get
     uri: http://backend:5352/source/ProjectWithRepo/ProjectWithRepo_package
@@ -1053,7 +1217,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 642cf823-514d-40cb-ae0e-9927b396f386
+      - 3e64ce3c-6b1b-41e7-9d5e-55197ed76c5f
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1076,117 +1240,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="2c6109033c5937a5528ec21af10e04ef">
-          <entry name="_config" md5="46cccf6ebc7684f1ef2c7d8f2db417bd" size="62" mtime="1624360167"/>
-          <entry name="somefile.txt" md5="42adbaa46956c814fabac93750ee8931" size="60" mtime="1624360167"/>
+        <directory name="ProjectWithRepo_package" rev="6" vrev="6" srcmd5="e83ea096f3fd3c64494e21941c685f6f">
+          <entry name="_config" md5="ca5a602718fd6de59987f678c2d641bd" size="74" mtime="1677089168"/>
+          <entry name="somefile.txt" md5="3b293450a072f3211239c7377e3cca78" size="59" mtime="1677089168"/>
         </directory>
-  recorded_at: Tue, 22 Jun 2021 11:09:28 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/ProjectWithRepo/ProjectWithRepo_package?expand=1&rev=2
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '308'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="2c6109033c5937a5528ec21af10e04ef">
-          <entry name="_config" md5="46cccf6ebc7684f1ef2c7d8f2db417bd" size="62" mtime="1624360167"/>
-          <entry name="somefile.txt" md5="42adbaa46956c814fabac93750ee8931" size="60" mtime="1624360167"/>
-        </directory>
-  recorded_at: Tue, 22 Jun 2021 11:09:28 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/ProjectWithRepo/ProjectWithRepo_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Request-Id:
-      - 2d9531e3-ad7a-4049-86f2-6b3859ef8c30
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '308'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="2c6109033c5937a5528ec21af10e04ef">
-          <entry name="_config" md5="46cccf6ebc7684f1ef2c7d8f2db417bd" size="62" mtime="1624360167"/>
-          <entry name="somefile.txt" md5="42adbaa46956c814fabac93750ee8931" size="60" mtime="1624360167"/>
-        </directory>
-  recorded_at: Tue, 22 Jun 2021 11:09:28 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/ProjectWithRepo/ProjectWithRepo_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Request-Id:
-      - 28dc5319-dee4-4de6-a7eb-f0783af9735c
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '308'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="2c6109033c5937a5528ec21af10e04ef">
-          <entry name="_config" md5="46cccf6ebc7684f1ef2c7d8f2db417bd" size="62" mtime="1624360167"/>
-          <entry name="somefile.txt" md5="42adbaa46956c814fabac93750ee8931" size="60" mtime="1624360167"/>
-        </directory>
-  recorded_at: Tue, 22 Jun 2021 11:09:28 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:09 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22ProjectWithRepo_package%22%20and%20linkinfo/@project=%22ProjectWithRepo:Update%22%20and%20starts-with(@project,%22MaintenanceProject:%22))
@@ -1197,7 +1255,7 @@ http_interactions:
       Content-Type:
       - application/octet-stream
       X-Request-Id:
-      - ebc9c93b-e819-4e63-bc94-c49507813891
+      - 22ccfd79-e030-4c3e-8f41-28530714ae6b
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1216,13 +1274,14 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '27'
+      - '125'
     body:
       encoding: UTF-8
       string: |
         <collection>
+          <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0"/>
         </collection>
-  recorded_at: Tue, 22 Jun 2021 11:09:29 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:10 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22ProjectWithRepo_package%22%20and%20linkinfo/@project=%22ProjectWithRepo%22%20and%20@project=%22ProjectWithRepo%22)
@@ -1256,7 +1315,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Tue, 22 Jun 2021 11:09:29 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:10 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/_meta?user=tom
@@ -1270,7 +1329,7 @@ http_interactions:
         </project>
     headers:
       X-Request-Id:
-      - ebc9c93b-e819-4e63-bc94-c49507813891
+      - 22ccfd79-e030-4c3e-8f41-28530714ae6b
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1298,51 +1357,7 @@ http_interactions:
           <description>This project was created for package ProjectWithRepo_package via attribute OBS:Maintained</description>
           <person userid="tom" role="maintainer"/>
         </project>
-  recorded_at: Tue, 22 Jun 2021 11:09:29 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/_project/_attribute?meta=1&user=tom
-    body:
-      encoding: UTF-8
-      string: |
-        <attributes>
-          <attribute name="AutoCleanup" namespace="OBS">
-            <value>2021-06-25 11:09:29 +0000</value>
-          </attribute>
-        </attributes>
-    headers:
-      X-Request-Id:
-      - ebc9c93b-e819-4e63-bc94-c49507813891
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '165'
-    body:
-      encoding: UTF-8
-      string: |
-        <revision rev="2">
-          <srcmd5>bbd994e3a826399d9290d3e4a82c8a05</srcmd5>
-          <time>1624360169</time>
-          <user>tom</user>
-          <comment></comment>
-          <requestid/>
-        </revision>
-  recorded_at: Tue, 22 Jun 2021 11:09:29 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:10 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package/_meta?user=tom
@@ -1350,8 +1365,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package" project="home:tom:branches:ProjectWithRepo:Update">
-          <title>Look to Windward</title>
-          <description>Vitae placeat voluptate eaque.</description>
+          <title>Unweaving the Rainbow</title>
+          <description>Autem at omnis nulla.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1372,15 +1387,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '197'
+      - '193'
     body:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package" project="home:tom:branches:ProjectWithRepo:Update">
-          <title>Look to Windward</title>
-          <description>Vitae placeat voluptate eaque.</description>
+          <title>Unweaving the Rainbow</title>
+          <description>Autem at omnis nulla.</description>
         </package>
-  recorded_at: Tue, 22 Jun 2021 11:09:29 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:10 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=branch&noservice=1&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update&user=tom
@@ -1412,15 +1427,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1" vrev="1">
-          <srcmd5>654fdc0fd9f66e436c45bcf669da70be</srcmd5>
+        <revision rev="3" vrev="3">
+          <srcmd5>42232744f4274ea47dfbfeeba0c26d9d</srcmd5>
           <version>unknown</version>
-          <time>1624360169</time>
+          <time>1677089170</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Tue, 22 Jun 2021 11:09:29 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:10 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package/_meta?user=tom
@@ -1428,8 +1443,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package" project="home:tom:branches:ProjectWithRepo:Update">
-          <title>Look to Windward</title>
-          <description>Vitae placeat voluptate eaque.</description>
+          <title>Unweaving the Rainbow</title>
+          <description>Autem at omnis nulla.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1450,15 +1465,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '197'
+      - '193'
     body:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package" project="home:tom:branches:ProjectWithRepo:Update">
-          <title>Look to Windward</title>
-          <description>Vitae placeat voluptate eaque.</description>
+          <title>Unweaving the Rainbow</title>
+          <description>Autem at omnis nulla.</description>
         </package>
-  recorded_at: Tue, 22 Jun 2021 11:09:29 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:10 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -1488,13 +1503,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="1" vrev="1" srcmd5="654fdc0fd9f66e436c45bcf669da70be">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="2c6109033c5937a5528ec21af10e04ef" baserev="2c6109033c5937a5528ec21af10e04ef" xsrcmd5="7ce5c95a929addc38797511bda3ca221" lsrcmd5="654fdc0fd9f66e436c45bcf669da70be"/>
-          <entry name="_config" md5="46cccf6ebc7684f1ef2c7d8f2db417bd" size="62" mtime="1624360167"/>
-          <entry name="_link" md5="af47fbc9f021527458be31d8c3d650bc" size="130" mtime="1624360169"/>
-          <entry name="somefile.txt" md5="42adbaa46956c814fabac93750ee8931" size="60" mtime="1624360167"/>
+        <directory name="ProjectWithRepo_package" rev="3" vrev="3" srcmd5="42232744f4274ea47dfbfeeba0c26d9d">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e83ea096f3fd3c64494e21941c685f6f" baserev="e83ea096f3fd3c64494e21941c685f6f" xsrcmd5="215c50d9b8d031d9d4b3eb18ba39296c" lsrcmd5="42232744f4274ea47dfbfeeba0c26d9d"/>
+          <entry name="_config" md5="ca5a602718fd6de59987f678c2d641bd" size="74" mtime="1677089168"/>
+          <entry name="_link" md5="3500919b1ba7cde7a8a011415239d587" size="130" mtime="1677089170"/>
+          <entry name="somefile.txt" md5="3b293450a072f3211239c7377e3cca78" size="59" mtime="1677089168"/>
         </directory>
-  recorded_at: Tue, 22 Jun 2021 11:09:29 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:10 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?view=info
@@ -1503,7 +1518,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - ebc9c93b-e819-4e63-bc94-c49507813891
+      - 22ccfd79-e030-4c3e-8f41-28530714ae6b
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1526,12 +1541,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="ProjectWithRepo_package" rev="1" vrev="3" srcmd5="7ce5c95a929addc38797511bda3ca221" lsrcmd5="654fdc0fd9f66e436c45bcf669da70be" verifymd5="2c6109033c5937a5528ec21af10e04ef">
+        <sourceinfo package="ProjectWithRepo_package" rev="3" vrev="9" srcmd5="215c50d9b8d031d9d4b3eb18ba39296c" lsrcmd5="42232744f4274ea47dfbfeeba0c26d9d" verifymd5="e83ea096f3fd3c64494e21941c685f6f">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="ProjectWithRepo:Update" package="ProjectWithRepo_package"/>
           <linked project="ProjectWithRepo" package="ProjectWithRepo_package"/>
         </sourceinfo>
-  recorded_at: Tue, 22 Jun 2021 11:09:29 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:10 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -1540,7 +1555,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - ebc9c93b-e819-4e63-bc94-c49507813891
+      - 22ccfd79-e030-4c3e-8f41-28530714ae6b
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1563,13 +1578,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="1" vrev="1" srcmd5="654fdc0fd9f66e436c45bcf669da70be">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="2c6109033c5937a5528ec21af10e04ef" baserev="2c6109033c5937a5528ec21af10e04ef" xsrcmd5="7ce5c95a929addc38797511bda3ca221" lsrcmd5="654fdc0fd9f66e436c45bcf669da70be"/>
-          <entry name="_config" md5="46cccf6ebc7684f1ef2c7d8f2db417bd" size="62" mtime="1624360167"/>
-          <entry name="_link" md5="af47fbc9f021527458be31d8c3d650bc" size="130" mtime="1624360169"/>
-          <entry name="somefile.txt" md5="42adbaa46956c814fabac93750ee8931" size="60" mtime="1624360167"/>
+        <directory name="ProjectWithRepo_package" rev="3" vrev="3" srcmd5="42232744f4274ea47dfbfeeba0c26d9d">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e83ea096f3fd3c64494e21941c685f6f" baserev="e83ea096f3fd3c64494e21941c685f6f" xsrcmd5="215c50d9b8d031d9d4b3eb18ba39296c" lsrcmd5="42232744f4274ea47dfbfeeba0c26d9d"/>
+          <entry name="_config" md5="ca5a602718fd6de59987f678c2d641bd" size="74" mtime="1677089168"/>
+          <entry name="_link" md5="3500919b1ba7cde7a8a011415239d587" size="130" mtime="1677089170"/>
+          <entry name="somefile.txt" md5="3b293450a072f3211239c7377e3cca78" size="59" mtime="1677089168"/>
         </directory>
-  recorded_at: Tue, 22 Jun 2021 11:09:29 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:10 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -1601,14 +1616,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="f85b1e8efa474ff93f9e5267ac68b3fd">
+        <sourcediff key="cb5c299653bd477cea33b32cb9078afb">
           <old project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="1" srcmd5="654fdc0fd9f66e436c45bcf669da70be"/>
+          <new project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="3" srcmd5="42232744f4274ea47dfbfeeba0c26d9d"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Tue, 22 Jun 2021 11:09:29 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:10 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -1640,12 +1655,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="0c8d52402e80bd854d84da2579bd3d6b">
-          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="2c6109033c5937a5528ec21af10e04ef" srcmd5="2c6109033c5937a5528ec21af10e04ef"/>
-          <new project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="7ce5c95a929addc38797511bda3ca221" srcmd5="7ce5c95a929addc38797511bda3ca221"/>
+        <sourcediff key="4de874821d2d84f62fc9a628b01a970a">
+          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="e83ea096f3fd3c64494e21941c685f6f" srcmd5="e83ea096f3fd3c64494e21941c685f6f"/>
+          <new project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="215c50d9b8d031d9d4b3eb18ba39296c" srcmd5="215c50d9b8d031d9d4b3eb18ba39296c"/>
           <files/>
         </sourcediff>
-  recorded_at: Tue, 22 Jun 2021 11:09:29 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:10 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/_meta?user=tom
@@ -1667,7 +1682,7 @@ http_interactions:
         </project>
     headers:
       X-Request-Id:
-      - ebc9c93b-e819-4e63-bc94-c49507813891
+      - 22ccfd79-e030-4c3e-8f41-28530714ae6b
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1703,7 +1718,7 @@ http_interactions:
             <arch>i586</arch>
           </repository>
         </project>
-  recorded_at: Tue, 22 Jun 2021 11:09:29 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:10 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -1712,7 +1727,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 5be94f65-7b91-4cc9-95d8-038515100efa
+      - 1aa6fc67-4457-480a-9086-a04600c5fb9a
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1735,13 +1750,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="1" vrev="1" srcmd5="654fdc0fd9f66e436c45bcf669da70be">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="2c6109033c5937a5528ec21af10e04ef" baserev="2c6109033c5937a5528ec21af10e04ef" xsrcmd5="7ce5c95a929addc38797511bda3ca221" lsrcmd5="654fdc0fd9f66e436c45bcf669da70be"/>
-          <entry name="_config" md5="46cccf6ebc7684f1ef2c7d8f2db417bd" size="62" mtime="1624360167"/>
-          <entry name="_link" md5="af47fbc9f021527458be31d8c3d650bc" size="130" mtime="1624360169"/>
-          <entry name="somefile.txt" md5="42adbaa46956c814fabac93750ee8931" size="60" mtime="1624360167"/>
+        <directory name="ProjectWithRepo_package" rev="3" vrev="3" srcmd5="42232744f4274ea47dfbfeeba0c26d9d">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e83ea096f3fd3c64494e21941c685f6f" baserev="e83ea096f3fd3c64494e21941c685f6f" xsrcmd5="215c50d9b8d031d9d4b3eb18ba39296c" lsrcmd5="42232744f4274ea47dfbfeeba0c26d9d"/>
+          <entry name="_config" md5="ca5a602718fd6de59987f678c2d641bd" size="74" mtime="1677089168"/>
+          <entry name="_link" md5="3500919b1ba7cde7a8a011415239d587" size="130" mtime="1677089170"/>
+          <entry name="somefile.txt" md5="3b293450a072f3211239c7377e3cca78" size="59" mtime="1677089168"/>
         </directory>
-  recorded_at: Tue, 22 Jun 2021 11:09:29 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:10 GMT
 - request:
     method: get
     uri: http://backend:5352/source/ProjectWithRepo:Update/ProjectWithRepo_package
@@ -1771,11 +1786,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="2c6109033c5937a5528ec21af10e04ef">
-          <entry name="_config" md5="46cccf6ebc7684f1ef2c7d8f2db417bd" size="62" mtime="1624360167"/>
-          <entry name="somefile.txt" md5="42adbaa46956c814fabac93750ee8931" size="60" mtime="1624360167"/>
+        <directory name="ProjectWithRepo_package" rev="6" vrev="6" srcmd5="e83ea096f3fd3c64494e21941c685f6f">
+          <entry name="_config" md5="ca5a602718fd6de59987f678c2d641bd" size="74" mtime="1677089168"/>
+          <entry name="somefile.txt" md5="3b293450a072f3211239c7377e3cca78" size="59" mtime="1677089168"/>
         </directory>
-  recorded_at: Tue, 22 Jun 2021 11:09:29 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:10 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -1784,7 +1799,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 5be94f65-7b91-4cc9-95d8-038515100efa
+      - 1aa6fc67-4457-480a-9086-a04600c5fb9a
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1807,16 +1822,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="1" vrev="1" srcmd5="654fdc0fd9f66e436c45bcf669da70be">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="2c6109033c5937a5528ec21af10e04ef" baserev="2c6109033c5937a5528ec21af10e04ef" xsrcmd5="7ce5c95a929addc38797511bda3ca221" lsrcmd5="654fdc0fd9f66e436c45bcf669da70be"/>
-          <entry name="_config" md5="46cccf6ebc7684f1ef2c7d8f2db417bd" size="62" mtime="1624360167"/>
-          <entry name="_link" md5="af47fbc9f021527458be31d8c3d650bc" size="130" mtime="1624360169"/>
-          <entry name="somefile.txt" md5="42adbaa46956c814fabac93750ee8931" size="60" mtime="1624360167"/>
+        <directory name="ProjectWithRepo_package" rev="3" vrev="3" srcmd5="42232744f4274ea47dfbfeeba0c26d9d">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e83ea096f3fd3c64494e21941c685f6f" baserev="e83ea096f3fd3c64494e21941c685f6f" xsrcmd5="215c50d9b8d031d9d4b3eb18ba39296c" lsrcmd5="42232744f4274ea47dfbfeeba0c26d9d"/>
+          <entry name="_config" md5="ca5a602718fd6de59987f678c2d641bd" size="74" mtime="1677089168"/>
+          <entry name="_link" md5="3500919b1ba7cde7a8a011415239d587" size="130" mtime="1677089170"/>
+          <entry name="somefile.txt" md5="3b293450a072f3211239c7377e3cca78" size="59" mtime="1677089168"/>
         </directory>
-  recorded_at: Tue, 22 Jun 2021 11:09:29 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:10 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?expand=1&rev=1
+    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?expand=1&rev=3
     body:
       encoding: US-ASCII
       string: ''
@@ -1843,21 +1858,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="7ce5c95a929addc38797511bda3ca221" vrev="3" srcmd5="7ce5c95a929addc38797511bda3ca221">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="2c6109033c5937a5528ec21af10e04ef" baserev="2c6109033c5937a5528ec21af10e04ef" lsrcmd5="654fdc0fd9f66e436c45bcf669da70be"/>
-          <entry name="_config" md5="46cccf6ebc7684f1ef2c7d8f2db417bd" size="62" mtime="1624360167"/>
-          <entry name="somefile.txt" md5="42adbaa46956c814fabac93750ee8931" size="60" mtime="1624360167"/>
+        <directory name="ProjectWithRepo_package" rev="215c50d9b8d031d9d4b3eb18ba39296c" vrev="9" srcmd5="215c50d9b8d031d9d4b3eb18ba39296c">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e83ea096f3fd3c64494e21941c685f6f" baserev="e83ea096f3fd3c64494e21941c685f6f" lsrcmd5="42232744f4274ea47dfbfeeba0c26d9d"/>
+          <entry name="_config" md5="ca5a602718fd6de59987f678c2d641bd" size="74" mtime="1677089168"/>
+          <entry name="somefile.txt" md5="3b293450a072f3211239c7377e3cca78" size="59" mtime="1677089168"/>
         </directory>
-  recorded_at: Tue, 22 Jun 2021 11:09:29 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:10 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
+    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package/_history?deleted=1&meta=1&rev=3
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - 5be94f65-7b91-4cc9-95d8-038515100efa
+      - 1aa6fc67-4457-480a-9086-a04600c5fb9a
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1876,102 +1891,132 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '653'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="ProjectWithRepo_package" rev="1" vrev="1" srcmd5="654fdc0fd9f66e436c45bcf669da70be">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="2c6109033c5937a5528ec21af10e04ef" baserev="2c6109033c5937a5528ec21af10e04ef" xsrcmd5="7ce5c95a929addc38797511bda3ca221" lsrcmd5="654fdc0fd9f66e436c45bcf669da70be"/>
-          <entry name="_config" md5="46cccf6ebc7684f1ef2c7d8f2db417bd" size="62" mtime="1624360167"/>
-          <entry name="_link" md5="af47fbc9f021527458be31d8c3d650bc" size="130" mtime="1624360169"/>
-          <entry name="somefile.txt" md5="42adbaa46956c814fabac93750ee8931" size="60" mtime="1624360167"/>
-        </directory>
-  recorded_at: Tue, 22 Jun 2021 11:09:30 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Request-Id:
-      - 5be94f65-7b91-4cc9-95d8-038515100efa
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '653'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="ProjectWithRepo_package" rev="1" vrev="1" srcmd5="654fdc0fd9f66e436c45bcf669da70be">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="2c6109033c5937a5528ec21af10e04ef" baserev="2c6109033c5937a5528ec21af10e04ef" xsrcmd5="7ce5c95a929addc38797511bda3ca221" lsrcmd5="654fdc0fd9f66e436c45bcf669da70be"/>
-          <entry name="_config" md5="46cccf6ebc7684f1ef2c7d8f2db417bd" size="62" mtime="1624360167"/>
-          <entry name="_link" md5="af47fbc9f021527458be31d8c3d650bc" size="130" mtime="1624360169"/>
-          <entry name="somefile.txt" md5="42adbaa46956c814fabac93750ee8931" size="60" mtime="1624360167"/>
-        </directory>
-  recorded_at: Tue, 22 Jun 2021 11:09:30 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package/_history
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '209'
+      - '31'
     body:
       encoding: UTF-8
       string: |
         <revisionlist>
-          <revision rev="1" vrev="1">
-            <srcmd5>654fdc0fd9f66e436c45bcf669da70be</srcmd5>
-            <version>unknown</version>
-            <time>1624360169</time>
-            <user>tom</user>
-          </revision>
         </revisionlist>
-  recorded_at: Tue, 22 Jun 2021 11:09:30 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:10 GMT
 - request:
     method: get
-    uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?locallink=1&multibuild=1&package=ProjectWithRepo_package&view=status
+    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - 1b28c451-a78b-4b42-adb4-26969910c8a2
+      - 1aa6fc67-4457-480a-9086-a04600c5fb9a
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '653'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="ProjectWithRepo_package" rev="3" vrev="3" srcmd5="42232744f4274ea47dfbfeeba0c26d9d">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e83ea096f3fd3c64494e21941c685f6f" baserev="e83ea096f3fd3c64494e21941c685f6f" xsrcmd5="215c50d9b8d031d9d4b3eb18ba39296c" lsrcmd5="42232744f4274ea47dfbfeeba0c26d9d"/>
+          <entry name="_config" md5="ca5a602718fd6de59987f678c2d641bd" size="74" mtime="1677089168"/>
+          <entry name="_link" md5="3500919b1ba7cde7a8a011415239d587" size="130" mtime="1677089170"/>
+          <entry name="somefile.txt" md5="3b293450a072f3211239c7377e3cca78" size="59" mtime="1677089168"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:06:10 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 1aa6fc67-4457-480a-9086-a04600c5fb9a
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '653'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="ProjectWithRepo_package" rev="3" vrev="3" srcmd5="42232744f4274ea47dfbfeeba0c26d9d">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e83ea096f3fd3c64494e21941c685f6f" baserev="e83ea096f3fd3c64494e21941c685f6f" xsrcmd5="215c50d9b8d031d9d4b3eb18ba39296c" lsrcmd5="42232744f4274ea47dfbfeeba0c26d9d"/>
+          <entry name="_config" md5="ca5a602718fd6de59987f678c2d641bd" size="74" mtime="1677089168"/>
+          <entry name="_link" md5="3500919b1ba7cde7a8a011415239d587" size="130" mtime="1677089170"/>
+          <entry name="somefile.txt" md5="3b293450a072f3211239c7377e3cca78" size="59" mtime="1677089168"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:06:10 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package/_history?deleted=1&meta=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 1aa6fc67-4457-480a-9086-a04600c5fb9a
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Wed, 22 Feb 2023 18:06:10 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?lastbuild=1&locallink=1&multibuild=1&package=ProjectWithRepo_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - c6d02066-08c8-4675-802c-88b6bb7a816e
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1997,7 +2042,77 @@ http_interactions:
         <resultlist state="d717409be2592c96becbdc11142f1468">
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="broken" state="broken" details="no build type (ProjectWithRepo:Update)"/>
         </resultlist>
-  recorded_at: Tue, 22 Jun 2021 11:09:30 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:10 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?lastbuild=1&locallink=1&multibuild=1&package=ProjectWithRepo_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 1acac36d-e189-4e96-b0df-18883738cbbf
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '247'
+    body:
+      encoding: UTF-8
+      string: |
+        <resultlist state="d717409be2592c96becbdc11142f1468">
+          <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="broken" state="broken" details="no build type (ProjectWithRepo:Update)"/>
+        </resultlist>
+  recorded_at: Wed, 22 Feb 2023 18:06:10 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?lastbuild=0&locallink=1&multibuild=1&package=ProjectWithRepo_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - ea61e089-4eb7-4905-ba59-19f2d88a4958
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '247'
+    body:
+      encoding: UTF-8
+      string: |
+        <resultlist state="d717409be2592c96becbdc11142f1468">
+          <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="broken" state="broken" details="no build type (ProjectWithRepo:Update)"/>
+        </resultlist>
+  recorded_at: Wed, 22 Feb 2023 18:06:11 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?package=ProjectWithRepo_package&view=status
@@ -2006,7 +2121,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 97227384-a096-44fe-be60-20477dcb4c8d
+      - 769fa86f-5620-47ef-ae04-0b88b8ad76ce
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -2032,228 +2147,7 @@ http_interactions:
         <resultlist state="d717409be2592c96becbdc11142f1468">
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="broken" state="broken" details="no build type (ProjectWithRepo:Update)"/>
         </resultlist>
-  recorded_at: Tue, 22 Jun 2021 11:09:30 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Request-Id:
-      - 891aefb0-0e62-4065-8bb9-499952c5a641
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '653'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="ProjectWithRepo_package" rev="1" vrev="1" srcmd5="654fdc0fd9f66e436c45bcf669da70be">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="2c6109033c5937a5528ec21af10e04ef" baserev="2c6109033c5937a5528ec21af10e04ef" xsrcmd5="7ce5c95a929addc38797511bda3ca221" lsrcmd5="654fdc0fd9f66e436c45bcf669da70be"/>
-          <entry name="_config" md5="46cccf6ebc7684f1ef2c7d8f2db417bd" size="62" mtime="1624360167"/>
-          <entry name="_link" md5="af47fbc9f021527458be31d8c3d650bc" size="130" mtime="1624360169"/>
-          <entry name="somefile.txt" md5="42adbaa46956c814fabac93750ee8931" size="60" mtime="1624360167"/>
-        </directory>
-  recorded_at: Tue, 22 Jun 2021 11:09:30 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/ProjectWithRepo:Update/ProjectWithRepo_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '308'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="2c6109033c5937a5528ec21af10e04ef">
-          <entry name="_config" md5="46cccf6ebc7684f1ef2c7d8f2db417bd" size="62" mtime="1624360167"/>
-          <entry name="somefile.txt" md5="42adbaa46956c814fabac93750ee8931" size="60" mtime="1624360167"/>
-        </directory>
-  recorded_at: Tue, 22 Jun 2021 11:09:30 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Request-Id:
-      - 891aefb0-0e62-4065-8bb9-499952c5a641
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '653'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="ProjectWithRepo_package" rev="1" vrev="1" srcmd5="654fdc0fd9f66e436c45bcf669da70be">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="2c6109033c5937a5528ec21af10e04ef" baserev="2c6109033c5937a5528ec21af10e04ef" xsrcmd5="7ce5c95a929addc38797511bda3ca221" lsrcmd5="654fdc0fd9f66e436c45bcf669da70be"/>
-          <entry name="_config" md5="46cccf6ebc7684f1ef2c7d8f2db417bd" size="62" mtime="1624360167"/>
-          <entry name="_link" md5="af47fbc9f021527458be31d8c3d650bc" size="130" mtime="1624360169"/>
-          <entry name="somefile.txt" md5="42adbaa46956c814fabac93750ee8931" size="60" mtime="1624360167"/>
-        </directory>
-  recorded_at: Tue, 22 Jun 2021 11:09:30 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?expand=1&rev=1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '548'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="ProjectWithRepo_package" rev="7ce5c95a929addc38797511bda3ca221" vrev="3" srcmd5="7ce5c95a929addc38797511bda3ca221">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="2c6109033c5937a5528ec21af10e04ef" baserev="2c6109033c5937a5528ec21af10e04ef" lsrcmd5="654fdc0fd9f66e436c45bcf669da70be"/>
-          <entry name="_config" md5="46cccf6ebc7684f1ef2c7d8f2db417bd" size="62" mtime="1624360167"/>
-          <entry name="somefile.txt" md5="42adbaa46956c814fabac93750ee8931" size="60" mtime="1624360167"/>
-        </directory>
-  recorded_at: Tue, 22 Jun 2021 11:09:30 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Request-Id:
-      - 891aefb0-0e62-4065-8bb9-499952c5a641
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '653'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="ProjectWithRepo_package" rev="1" vrev="1" srcmd5="654fdc0fd9f66e436c45bcf669da70be">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="2c6109033c5937a5528ec21af10e04ef" baserev="2c6109033c5937a5528ec21af10e04ef" xsrcmd5="7ce5c95a929addc38797511bda3ca221" lsrcmd5="654fdc0fd9f66e436c45bcf669da70be"/>
-          <entry name="_config" md5="46cccf6ebc7684f1ef2c7d8f2db417bd" size="62" mtime="1624360167"/>
-          <entry name="_link" md5="af47fbc9f021527458be31d8c3d650bc" size="130" mtime="1624360169"/>
-          <entry name="somefile.txt" md5="42adbaa46956c814fabac93750ee8931" size="60" mtime="1624360167"/>
-        </directory>
-  recorded_at: Tue, 22 Jun 2021 11:09:30 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Request-Id:
-      - 891aefb0-0e62-4065-8bb9-499952c5a641
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '653'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="ProjectWithRepo_package" rev="1" vrev="1" srcmd5="654fdc0fd9f66e436c45bcf669da70be">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="2c6109033c5937a5528ec21af10e04ef" baserev="2c6109033c5937a5528ec21af10e04ef" xsrcmd5="7ce5c95a929addc38797511bda3ca221" lsrcmd5="654fdc0fd9f66e436c45bcf669da70be"/>
-          <entry name="_config" md5="46cccf6ebc7684f1ef2c7d8f2db417bd" size="62" mtime="1624360167"/>
-          <entry name="_link" md5="af47fbc9f021527458be31d8c3d650bc" size="130" mtime="1624360169"/>
-          <entry name="somefile.txt" md5="42adbaa46956c814fabac93750ee8931" size="60" mtime="1624360167"/>
-        </directory>
-  recorded_at: Tue, 22 Jun 2021 11:09:30 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:11 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package/DUMMY_FILE
@@ -2283,15 +2177,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="2" vrev="2">
-          <srcmd5>ce4cc59f8a846502437cfa9b5280a123</srcmd5>
+        <revision rev="4" vrev="4">
+          <srcmd5>6e0e59c49ec80131659564768dd1e126</srcmd5>
           <version>unknown</version>
-          <time>1624360170</time>
+          <time>1677089171</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Tue, 22 Jun 2021 11:09:30 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:11 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?code=unresolvable&view=status
@@ -2300,7 +2194,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 0b5e96d0-4445-4b10-b10d-2c64ac424032
+      - c9deb872-877e-43de-8317-53bdb482e349
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -2326,7 +2220,7 @@ http_interactions:
         <resultlist state="d717409be2592c96becbdc11142f1468">
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="broken" state="broken" details="no build type (ProjectWithRepo:Update)"/>
         </resultlist>
-  recorded_at: Tue, 22 Jun 2021 11:09:30 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:11 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/_keyinfo?donotcreatecert=1&withsslcert=1
@@ -2335,7 +2229,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 0b5e96d0-4445-4b10-b10d-2c64ac424032
+      - c9deb872-877e-43de-8317-53bdb482e349
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -2354,11 +2248,39 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '11'
+      - '1639'
     body:
       encoding: UTF-8
-      string: "<keyinfo/>\n"
-  recorded_at: Tue, 22 Jun 2021 11:09:30 GMT
+      string: |
+        <keyinfo project="home:tom">
+          <pubkey keyid="cfaa8e084a26fafa" userid="home:tom OBS Project &lt;home:tom@private&gt;" algo="rsa" keysize="2048" expires="1741880605" fingerprint="5c29 f588 f5b8 c2c4 6069 ff08 cfaa 8e08 4a26 fafa">-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+        mQENBGO0TR0BCADlQ4FwIb9gBi9DUkkC7MvIpu1QI6n1yLdv93X53Tc4kRmE0F5v
+        LD3qihj+ENLuF+CpK15JXzM5pwswcO/UzNs1pJjEDBef8Bw10RTQZy88qGdwaEbH
+        v+LZnt/8UzH1DfTccN/7ana/ZnZFDkztHq1syw2VL+dK2w+JcA7xmD4SzD4DBhgJ
+        UfxvZT9prdXbr8GyIqYdInDqnmexdeYZCaVJlcLlIHI/z2k9/Yfofnu4tA0GBXVJ
+        MnRfkdLEyRPaVNMBz8ITw+5naiv+pj9jV3dKKxaMblCMPOPoUWrT8hEUZyravYtR
+        uiKjl/4nCePyRypatKJUL6i1i93UoF2JGI0BABEBAAG0J2hvbWU6dG9tIE9CUyBQ
+        cm9qZWN0IDxob21lOnRvbUBwcml2YXRlPokBVAQTAQgAPhYhBFwp9Yj1uMLEYGn/
+        CM+qjghKJvr6BQJjtE0dAhsDBQkEHrAABQsJCAcCBhUKCQgLAgQWAgMBAh4BAheA
+        AAoJEM+qjghKJvr6+pwIAN/0N8BgUOIUpsx2oOx7z5+CoJb9kEBgeIZeQ/HSvfYR
+        0Lec22ztbuNehj0OpP6inL7lfREThEKlc0u/wKMB9VgtsVyQfUrEuDQUQyxU4SvO
+        JWdo05+nSfX5x7tU33uMc9YPy/VfJs/E0boJJuwR/OexCa4U96Qz2fQnj2WHgt3t
+        SXUMkxbUd3RU24PCdfJnDq/hl75tx8uI01f/IcIimEoHLsNPotPGELnstHKrMpUp
+        gjkWouCSq4VlE8Wrr8kvsf+/lD4rOqCTTcSqs6Pj9ytEDr6pYZGMj0gmGrSWd25G
+        o1YyY/rmenLKH9WQJ4f8AojkVnqt9YVzxgwXvMu42biJATMEEwEIAB0WIQQGTN2V
+        wCe8seo248C/9fknuEcc6wUCY7RNHgAKCRC/9fknuEcc6xEkCACvwrBh1UlV9EM/
+        p5hqlzT+VOlcXSAtLRfAElPtyYY0mleof0+AxDM32z2cPiGieUOAW/HK7eXHJCb2
+        uYosjrO1D8CLUPZ9DM0X5bLicxux2JBtbxV0F9kkEc+p0a+jbi/sE8Ao0vStZD5r
+        cJoUSEiglRKS+uC+VsJbqpDhL7+w7lvL9ItG5uszkTukLb7eMlpi6yve3WWapEiN
+        eXyF09dSJbe0B9wOB8ilw8qOmmCEVElug0044fxq+0Aam6LXCfuC8BEx8YqmGnED
+        jYotxAOCpnQ01KzF4PbGogHn8G86s0btjiayWfed3Cs42O1UC9i+USPe0D2L5lXg
+        QDgCOz2L
+        =nUQx
+        -----END PGP PUBLIC KEY BLOCK-----
+        </pubkey>
+        </keyinfo>
+  recorded_at: Wed, 22 Feb 2023 18:06:11 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?view=summary
@@ -2367,7 +2289,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - d1fae3a8-c7af-4083-bbf7-bfd7a308e9f7
+      - ee847d21-0712-4e99-9097-71b6c5c212bc
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -2395,42 +2317,7 @@ http_interactions:
             <summary/>
           </result>
         </resultlist>
-  recorded_at: Tue, 22 Jun 2021 11:09:31 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?code=unresolvable&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Request-Id:
-      - a9851b74-4914-4679-b644-b0f83337fa2d
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '247'
-    body:
-      encoding: UTF-8
-      string: |
-        <resultlist state="d717409be2592c96becbdc11142f1468">
-          <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="broken" state="broken" details="no build type (ProjectWithRepo:Update)"/>
-        </resultlist>
-  recorded_at: Tue, 22 Jun 2021 11:09:31 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:11 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -2439,7 +2326,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 0db851b9-b04f-4dc7-acf6-e2c11cf9dd71
+      - a40482d9-e64c-494e-90b3-9562f30de212
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -2462,14 +2349,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="ce4cc59f8a846502437cfa9b5280a123">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="2c6109033c5937a5528ec21af10e04ef" baserev="2c6109033c5937a5528ec21af10e04ef" xsrcmd5="89ea42b77174833f1114bad0670c14a5" lsrcmd5="ce4cc59f8a846502437cfa9b5280a123"/>
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1624360170"/>
-          <entry name="_config" md5="46cccf6ebc7684f1ef2c7d8f2db417bd" size="62" mtime="1624360167"/>
-          <entry name="_link" md5="af47fbc9f021527458be31d8c3d650bc" size="130" mtime="1624360169"/>
-          <entry name="somefile.txt" md5="42adbaa46956c814fabac93750ee8931" size="60" mtime="1624360167"/>
+        <directory name="ProjectWithRepo_package" rev="4" vrev="4" srcmd5="6e0e59c49ec80131659564768dd1e126">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e83ea096f3fd3c64494e21941c685f6f" baserev="e83ea096f3fd3c64494e21941c685f6f" xsrcmd5="620fcea8705aeeea23c1acb8fd6ac73c" lsrcmd5="6e0e59c49ec80131659564768dd1e126"/>
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1677064904"/>
+          <entry name="_config" md5="ca5a602718fd6de59987f678c2d641bd" size="74" mtime="1677089168"/>
+          <entry name="_link" md5="3500919b1ba7cde7a8a011415239d587" size="130" mtime="1677089170"/>
+          <entry name="somefile.txt" md5="3b293450a072f3211239c7377e3cca78" size="59" mtime="1677089168"/>
         </directory>
-  recorded_at: Tue, 22 Jun 2021 11:09:32 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:12 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -2478,7 +2365,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 0db851b9-b04f-4dc7-acf6-e2c11cf9dd71
+      - a40482d9-e64c-494e-90b3-9562f30de212
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -2501,14 +2388,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="ce4cc59f8a846502437cfa9b5280a123">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="2c6109033c5937a5528ec21af10e04ef" baserev="2c6109033c5937a5528ec21af10e04ef" xsrcmd5="89ea42b77174833f1114bad0670c14a5" lsrcmd5="ce4cc59f8a846502437cfa9b5280a123"/>
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1624360170"/>
-          <entry name="_config" md5="46cccf6ebc7684f1ef2c7d8f2db417bd" size="62" mtime="1624360167"/>
-          <entry name="_link" md5="af47fbc9f021527458be31d8c3d650bc" size="130" mtime="1624360169"/>
-          <entry name="somefile.txt" md5="42adbaa46956c814fabac93750ee8931" size="60" mtime="1624360167"/>
+        <directory name="ProjectWithRepo_package" rev="4" vrev="4" srcmd5="6e0e59c49ec80131659564768dd1e126">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e83ea096f3fd3c64494e21941c685f6f" baserev="e83ea096f3fd3c64494e21941c685f6f" xsrcmd5="620fcea8705aeeea23c1acb8fd6ac73c" lsrcmd5="6e0e59c49ec80131659564768dd1e126"/>
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1677064904"/>
+          <entry name="_config" md5="ca5a602718fd6de59987f678c2d641bd" size="74" mtime="1677089168"/>
+          <entry name="_link" md5="3500919b1ba7cde7a8a011415239d587" size="130" mtime="1677089170"/>
+          <entry name="somefile.txt" md5="3b293450a072f3211239c7377e3cca78" size="59" mtime="1677089168"/>
         </directory>
-  recorded_at: Tue, 22 Jun 2021 11:09:32 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:12 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -2517,7 +2404,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 0db851b9-b04f-4dc7-acf6-e2c11cf9dd71
+      - a40482d9-e64c-494e-90b3-9562f30de212
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -2540,14 +2427,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="ce4cc59f8a846502437cfa9b5280a123">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="2c6109033c5937a5528ec21af10e04ef" baserev="2c6109033c5937a5528ec21af10e04ef" xsrcmd5="89ea42b77174833f1114bad0670c14a5" lsrcmd5="ce4cc59f8a846502437cfa9b5280a123"/>
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1624360170"/>
-          <entry name="_config" md5="46cccf6ebc7684f1ef2c7d8f2db417bd" size="62" mtime="1624360167"/>
-          <entry name="_link" md5="af47fbc9f021527458be31d8c3d650bc" size="130" mtime="1624360169"/>
-          <entry name="somefile.txt" md5="42adbaa46956c814fabac93750ee8931" size="60" mtime="1624360167"/>
+        <directory name="ProjectWithRepo_package" rev="4" vrev="4" srcmd5="6e0e59c49ec80131659564768dd1e126">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e83ea096f3fd3c64494e21941c685f6f" baserev="e83ea096f3fd3c64494e21941c685f6f" xsrcmd5="620fcea8705aeeea23c1acb8fd6ac73c" lsrcmd5="6e0e59c49ec80131659564768dd1e126"/>
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1677064904"/>
+          <entry name="_config" md5="ca5a602718fd6de59987f678c2d641bd" size="74" mtime="1677089168"/>
+          <entry name="_link" md5="3500919b1ba7cde7a8a011415239d587" size="130" mtime="1677089170"/>
+          <entry name="somefile.txt" md5="3b293450a072f3211239c7377e3cca78" size="59" mtime="1677089168"/>
         </directory>
-  recorded_at: Tue, 22 Jun 2021 11:09:32 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:12 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=diff&expand=1&nodiff=1&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update
@@ -2558,7 +2445,7 @@ http_interactions:
       Content-Type:
       - application/octet-stream
       X-Request-Id:
-      - 0db851b9-b04f-4dc7-acf6-e2c11cf9dd71
+      - a40482d9-e64c-494e-90b3-9562f30de212
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -2592,7 +2479,7 @@ http_interactions:
         ++++++ DUMMY_FILE (new)
         --- DUMMY_FILE
         +++ DUMMY_FILE
-  recorded_at: Tue, 22 Jun 2021 11:09:32 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:12 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?expand=1
@@ -2601,7 +2488,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 0db851b9-b04f-4dc7-acf6-e2c11cf9dd71
+      - a40482d9-e64c-494e-90b3-9562f30de212
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -2620,17 +2507,105 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '644'
+      - '645'
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="89ea42b77174833f1114bad0670c14a5" vrev="4" srcmd5="89ea42b77174833f1114bad0670c14a5">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="2c6109033c5937a5528ec21af10e04ef" baserev="2c6109033c5937a5528ec21af10e04ef" lsrcmd5="ce4cc59f8a846502437cfa9b5280a123"/>
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1624360170"/>
-          <entry name="_config" md5="46cccf6ebc7684f1ef2c7d8f2db417bd" size="62" mtime="1624360167"/>
-          <entry name="somefile.txt" md5="42adbaa46956c814fabac93750ee8931" size="60" mtime="1624360167"/>
+        <directory name="ProjectWithRepo_package" rev="620fcea8705aeeea23c1acb8fd6ac73c" vrev="10" srcmd5="620fcea8705aeeea23c1acb8fd6ac73c">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e83ea096f3fd3c64494e21941c685f6f" baserev="e83ea096f3fd3c64494e21941c685f6f" lsrcmd5="6e0e59c49ec80131659564768dd1e126"/>
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1677064904"/>
+          <entry name="_config" md5="ca5a602718fd6de59987f678c2d641bd" size="74" mtime="1677089168"/>
+          <entry name="somefile.txt" md5="3b293450a072f3211239c7377e3cca78" size="59" mtime="1677089168"/>
         </directory>
-  recorded_at: Tue, 22 Jun 2021 11:09:32 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:12 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - a40482d9-e64c-494e-90b3-9562f30de212
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '749'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="ProjectWithRepo_package" rev="4" vrev="4" srcmd5="6e0e59c49ec80131659564768dd1e126">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e83ea096f3fd3c64494e21941c685f6f" baserev="e83ea096f3fd3c64494e21941c685f6f" xsrcmd5="620fcea8705aeeea23c1acb8fd6ac73c" lsrcmd5="6e0e59c49ec80131659564768dd1e126"/>
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1677064904"/>
+          <entry name="_config" md5="ca5a602718fd6de59987f678c2d641bd" size="74" mtime="1677089168"/>
+          <entry name="_link" md5="3500919b1ba7cde7a8a011415239d587" size="130" mtime="1677089170"/>
+          <entry name="somefile.txt" md5="3b293450a072f3211239c7377e3cca78" size="59" mtime="1677089168"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:06:12 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=diff&expand=1&filelimit=10000&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update&rev=620fcea8705aeeea23c1acb8fd6ac73c&tarlimit=10000&view=xml&withissues=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      X-Request-Id:
+      - a40482d9-e64c-494e-90b3-9562f30de212
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '608'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="75a5f6886344c882d5ec2b6d963a4b70">
+          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="6" srcmd5="e83ea096f3fd3c64494e21941c685f6f"/>
+          <new project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="620fcea8705aeeea23c1acb8fd6ac73c" srcmd5="620fcea8705aeeea23c1acb8fd6ac73c"/>
+          <files>
+            <file state="added">
+              <new name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5"/>
+              <diff lines="3">@@ -0,0 +1,1 @@
+        +dummy
+        \ No newline at end of file
+        </diff>
+            </file>
+          </files>
+          <issues>
+          </issues>
+        </sourcediff>
+  recorded_at: Wed, 22 Feb 2023 18:06:12 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?code=unresolvable&view=status
@@ -2639,7 +2614,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 3642d308-ac48-4f48-bd45-a63e3fd55d14
+      - 64c6c466-aaa5-4e4a-85f7-0bb9584e023c
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -2665,7 +2640,7 @@ http_interactions:
         <resultlist state="d717409be2592c96becbdc11142f1468">
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="broken" state="broken" details="no build type (ProjectWithRepo:Update)"/>
         </resultlist>
-  recorded_at: Tue, 22 Jun 2021 11:09:32 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:12 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?view=summary
@@ -2674,7 +2649,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 0603c06d-6738-4552-b0c2-912386578386
+      - e758b371-80a0-4c45-bae7-78994a41ca58
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -2702,42 +2677,7 @@ http_interactions:
             <summary/>
           </result>
         </resultlist>
-  recorded_at: Tue, 22 Jun 2021 11:09:32 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?code=unresolvable&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Request-Id:
-      - 531e356a-9224-45d7-a765-794f74a6a2ae
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '247'
-    body:
-      encoding: UTF-8
-      string: |
-        <resultlist state="d717409be2592c96becbdc11142f1468">
-          <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="broken" state="broken" details="no build type (ProjectWithRepo:Update)"/>
-        </resultlist>
-  recorded_at: Tue, 22 Jun 2021 11:09:32 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:12 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -2746,7 +2686,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 15729289-a535-4c31-a3df-62d4e35a6511
+      - 4b2496a9-64ea-4ae4-a886-18d7eec4d553
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -2769,17 +2709,17 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="ce4cc59f8a846502437cfa9b5280a123">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="2c6109033c5937a5528ec21af10e04ef" baserev="2c6109033c5937a5528ec21af10e04ef" xsrcmd5="89ea42b77174833f1114bad0670c14a5" lsrcmd5="ce4cc59f8a846502437cfa9b5280a123"/>
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1624360170"/>
-          <entry name="_config" md5="46cccf6ebc7684f1ef2c7d8f2db417bd" size="62" mtime="1624360167"/>
-          <entry name="_link" md5="af47fbc9f021527458be31d8c3d650bc" size="130" mtime="1624360169"/>
-          <entry name="somefile.txt" md5="42adbaa46956c814fabac93750ee8931" size="60" mtime="1624360167"/>
+        <directory name="ProjectWithRepo_package" rev="4" vrev="4" srcmd5="6e0e59c49ec80131659564768dd1e126">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e83ea096f3fd3c64494e21941c685f6f" baserev="e83ea096f3fd3c64494e21941c685f6f" xsrcmd5="620fcea8705aeeea23c1acb8fd6ac73c" lsrcmd5="6e0e59c49ec80131659564768dd1e126"/>
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1677064904"/>
+          <entry name="_config" md5="ca5a602718fd6de59987f678c2d641bd" size="74" mtime="1677089168"/>
+          <entry name="_link" md5="3500919b1ba7cde7a8a011415239d587" size="130" mtime="1677089170"/>
+          <entry name="somefile.txt" md5="3b293450a072f3211239c7377e3cca78" size="59" mtime="1677089168"/>
         </directory>
-  recorded_at: Tue, 22 Jun 2021 11:09:35 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:15 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=diff&expand=1&filelimit=10000&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update&rev=89ea42b77174833f1114bad0670c14a5&tarlimit=10000&view=xml&withissues=1
+    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=diff&expand=1&filelimit=10000&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update&rev=620fcea8705aeeea23c1acb8fd6ac73c&tarlimit=10000&view=xml&withissues=1
     body:
       encoding: UTF-8
       string: ''
@@ -2787,7 +2727,7 @@ http_interactions:
       Content-Type:
       - application/octet-stream
       X-Request-Id:
-      - 15729289-a535-4c31-a3df-62d4e35a6511
+      - 4b2496a9-64ea-4ae4-a886-18d7eec4d553
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -2801,18 +2741,18 @@ http_interactions:
     headers:
       Content-Type:
       - text/xml
+      Content-Length:
+      - '608'
       Cache-Control:
       - no-cache
       Connection:
       - close
-      Content-Length:
-      - '608'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="9d5a63e8dcab023b1090d3ec44b105a1">
-          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="2" srcmd5="2c6109033c5937a5528ec21af10e04ef"/>
-          <new project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="89ea42b77174833f1114bad0670c14a5" srcmd5="89ea42b77174833f1114bad0670c14a5"/>
+        <sourcediff key="75a5f6886344c882d5ec2b6d963a4b70">
+          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="6" srcmd5="e83ea096f3fd3c64494e21941c685f6f"/>
+          <new project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="620fcea8705aeeea23c1acb8fd6ac73c" srcmd5="620fcea8705aeeea23c1acb8fd6ac73c"/>
           <files>
             <file state="added">
               <new name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5"/>
@@ -2825,16 +2765,16 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Tue, 22 Jun 2021 11:09:35 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:15 GMT
 - request:
     method: get
-    uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?locallink=1&multibuild=1&package=ProjectWithRepo_package&view=status
+    uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?lastbuild=0&locallink=1&multibuild=1&package=ProjectWithRepo_package&view=status
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - f2ac9e82-01c5-4b41-a1e5-0211d2dc2603
+      - fa10f835-91d8-4593-90d2-0072840cdc0f
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -2860,7 +2800,7 @@ http_interactions:
         <resultlist state="d717409be2592c96becbdc11142f1468">
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="broken" state="broken" details="no build type (ProjectWithRepo:Update)"/>
         </resultlist>
-  recorded_at: Tue, 22 Jun 2021 11:09:35 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:15 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?package=ProjectWithRepo_package&view=status
@@ -2869,7 +2809,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 07b547d0-60a6-4c9d-96a4-58f7620f4e03
+      - b32e44dd-d23a-4f0a-9b97-1c638c3ce151
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -2895,7 +2835,7 @@ http_interactions:
         <resultlist state="d717409be2592c96becbdc11142f1468">
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="broken" state="broken" details="no build type (ProjectWithRepo:Update)"/>
         </resultlist>
-  recorded_at: Tue, 22 Jun 2021 11:09:35 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:15 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -2904,7 +2844,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 3294593a-15b6-468f-9b8f-76a11ff53b01
+      - '09394bb3-2da9-40db-b0ba-b0040128ffef'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -2927,23 +2867,23 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="ce4cc59f8a846502437cfa9b5280a123">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="2c6109033c5937a5528ec21af10e04ef" baserev="2c6109033c5937a5528ec21af10e04ef" xsrcmd5="89ea42b77174833f1114bad0670c14a5" lsrcmd5="ce4cc59f8a846502437cfa9b5280a123"/>
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1624360170"/>
-          <entry name="_config" md5="46cccf6ebc7684f1ef2c7d8f2db417bd" size="62" mtime="1624360167"/>
-          <entry name="_link" md5="af47fbc9f021527458be31d8c3d650bc" size="130" mtime="1624360169"/>
-          <entry name="somefile.txt" md5="42adbaa46956c814fabac93750ee8931" size="60" mtime="1624360167"/>
+        <directory name="ProjectWithRepo_package" rev="4" vrev="4" srcmd5="6e0e59c49ec80131659564768dd1e126">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e83ea096f3fd3c64494e21941c685f6f" baserev="e83ea096f3fd3c64494e21941c685f6f" xsrcmd5="620fcea8705aeeea23c1acb8fd6ac73c" lsrcmd5="6e0e59c49ec80131659564768dd1e126"/>
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1677064904"/>
+          <entry name="_config" md5="ca5a602718fd6de59987f678c2d641bd" size="74" mtime="1677089168"/>
+          <entry name="_link" md5="3500919b1ba7cde7a8a011415239d587" size="130" mtime="1677089170"/>
+          <entry name="somefile.txt" md5="3b293450a072f3211239c7377e3cca78" size="59" mtime="1677089168"/>
         </directory>
-  recorded_at: Tue, 22 Jun 2021 11:09:35 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:15 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?expand=1&rev=89ea42b77174833f1114bad0670c14a5
+    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?expand=1&rev=620fcea8705aeeea23c1acb8fd6ac73c
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - 3294593a-15b6-468f-9b8f-76a11ff53b01
+      - '09394bb3-2da9-40db-b0ba-b0040128ffef'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -2966,22 +2906,22 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="89ea42b77174833f1114bad0670c14a5" srcmd5="89ea42b77174833f1114bad0670c14a5">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="2c6109033c5937a5528ec21af10e04ef" baserev="2c6109033c5937a5528ec21af10e04ef" lsrcmd5="ce4cc59f8a846502437cfa9b5280a123"/>
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1624360170"/>
-          <entry name="_config" md5="46cccf6ebc7684f1ef2c7d8f2db417bd" size="62" mtime="1624360167"/>
-          <entry name="somefile.txt" md5="42adbaa46956c814fabac93750ee8931" size="60" mtime="1624360167"/>
+        <directory name="ProjectWithRepo_package" rev="620fcea8705aeeea23c1acb8fd6ac73c" srcmd5="620fcea8705aeeea23c1acb8fd6ac73c">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e83ea096f3fd3c64494e21941c685f6f" baserev="e83ea096f3fd3c64494e21941c685f6f" lsrcmd5="6e0e59c49ec80131659564768dd1e126"/>
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1677064904"/>
+          <entry name="_config" md5="ca5a602718fd6de59987f678c2d641bd" size="74" mtime="1677089168"/>
+          <entry name="somefile.txt" md5="3b293450a072f3211239c7377e3cca78" size="59" mtime="1677089168"/>
         </directory>
-  recorded_at: Tue, 22 Jun 2021 11:09:35 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:15 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?expand=1&rev=89ea42b77174833f1114bad0670c14a5
+    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?expand=1&rev=620fcea8705aeeea23c1acb8fd6ac73c
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - 3294593a-15b6-468f-9b8f-76a11ff53b01
+      - '09394bb3-2da9-40db-b0ba-b0040128ffef'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -3004,13 +2944,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="89ea42b77174833f1114bad0670c14a5" srcmd5="89ea42b77174833f1114bad0670c14a5">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="2c6109033c5937a5528ec21af10e04ef" baserev="2c6109033c5937a5528ec21af10e04ef" lsrcmd5="ce4cc59f8a846502437cfa9b5280a123"/>
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1624360170"/>
-          <entry name="_config" md5="46cccf6ebc7684f1ef2c7d8f2db417bd" size="62" mtime="1624360167"/>
-          <entry name="somefile.txt" md5="42adbaa46956c814fabac93750ee8931" size="60" mtime="1624360167"/>
+        <directory name="ProjectWithRepo_package" rev="620fcea8705aeeea23c1acb8fd6ac73c" srcmd5="620fcea8705aeeea23c1acb8fd6ac73c">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e83ea096f3fd3c64494e21941c685f6f" baserev="e83ea096f3fd3c64494e21941c685f6f" lsrcmd5="6e0e59c49ec80131659564768dd1e126"/>
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1677064904"/>
+          <entry name="_config" md5="ca5a602718fd6de59987f678c2d641bd" size="74" mtime="1677089168"/>
+          <entry name="somefile.txt" md5="3b293450a072f3211239c7377e3cca78" size="59" mtime="1677089168"/>
         </directory>
-  recorded_at: Tue, 22 Jun 2021 11:09:35 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:15 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/_meta?requestid=1&user=maintenance_coord
@@ -3031,7 +2971,7 @@ http_interactions:
         </project>
     headers:
       X-Request-Id:
-      - 3294593a-15b6-468f-9b8f-76a11ff53b01
+      - '09394bb3-2da9-40db-b0ba-b0040128ffef'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -3066,7 +3006,7 @@ http_interactions:
             <disable/>
           </publish>
         </project>
-  recorded_at: Tue, 22 Jun 2021 11:09:35 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:15 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -3075,7 +3015,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 3294593a-15b6-468f-9b8f-76a11ff53b01
+      - '09394bb3-2da9-40db-b0ba-b0040128ffef'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -3098,14 +3038,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="ce4cc59f8a846502437cfa9b5280a123">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="2c6109033c5937a5528ec21af10e04ef" baserev="2c6109033c5937a5528ec21af10e04ef" xsrcmd5="89ea42b77174833f1114bad0670c14a5" lsrcmd5="ce4cc59f8a846502437cfa9b5280a123"/>
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1624360170"/>
-          <entry name="_config" md5="46cccf6ebc7684f1ef2c7d8f2db417bd" size="62" mtime="1624360167"/>
-          <entry name="_link" md5="af47fbc9f021527458be31d8c3d650bc" size="130" mtime="1624360169"/>
-          <entry name="somefile.txt" md5="42adbaa46956c814fabac93750ee8931" size="60" mtime="1624360167"/>
+        <directory name="ProjectWithRepo_package" rev="4" vrev="4" srcmd5="6e0e59c49ec80131659564768dd1e126">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e83ea096f3fd3c64494e21941c685f6f" baserev="e83ea096f3fd3c64494e21941c685f6f" xsrcmd5="620fcea8705aeeea23c1acb8fd6ac73c" lsrcmd5="6e0e59c49ec80131659564768dd1e126"/>
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1677064904"/>
+          <entry name="_config" md5="ca5a602718fd6de59987f678c2d641bd" size="74" mtime="1677089168"/>
+          <entry name="_link" md5="3500919b1ba7cde7a8a011415239d587" size="130" mtime="1677089170"/>
+          <entry name="somefile.txt" md5="3b293450a072f3211239c7377e3cca78" size="59" mtime="1677089168"/>
         </directory>
-  recorded_at: Tue, 22 Jun 2021 11:09:36 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:15 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22ProjectWithRepo_package%22%20and%20linkinfo/@project=%22ProjectWithRepo:Update%22%20and%20starts-with(@project,%22MaintenanceProject:%22))
@@ -3116,7 +3056,7 @@ http_interactions:
       Content-Type:
       - application/octet-stream
       X-Request-Id:
-      - 3294593a-15b6-468f-9b8f-76a11ff53b01
+      - '09394bb3-2da9-40db-b0ba-b0040128ffef'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -3135,13 +3075,14 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '27'
+      - '125'
     body:
       encoding: UTF-8
       string: |
         <collection>
+          <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0"/>
         </collection>
-  recorded_at: Tue, 22 Jun 2021 11:09:36 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:15 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22ProjectWithRepo_package%22%20and%20linkinfo/@project=%22ProjectWithRepo%22%20and%20@project=%22ProjectWithRepo%22)
@@ -3175,7 +3116,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Tue, 22 Jun 2021 11:09:36 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:15 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update/_meta?user=maintenance_coord
@@ -3183,8 +3124,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title>Look to Windward</title>
-          <description>Vitae placeat voluptate eaque.</description>
+          <title>Unweaving the Rainbow</title>
+          <description>Autem at omnis nulla.</description>
           <releasename>ProjectWithRepo_package</releasename>
         </package>
     headers:
@@ -3206,16 +3147,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '253'
+      - '249'
     body:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title>Look to Windward</title>
-          <description>Vitae placeat voluptate eaque.</description>
+          <title>Unweaving the Rainbow</title>
+          <description>Autem at omnis nulla.</description>
           <releasename>ProjectWithRepo_package</releasename>
         </package>
-  recorded_at: Tue, 22 Jun 2021 11:09:36 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:15 GMT
 - request:
     method: post
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=branch&extendvrev=1&noservice=1&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update&user=maintenance_coord
@@ -3247,15 +3188,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1" vrev="1">
-          <srcmd5>8cdbf4889cded6e88a9cb004a6a2cf00</srcmd5>
+        <revision rev="3" vrev="3">
+          <srcmd5>b282555378ff0a2c77152620aa519de7</srcmd5>
           <version>unknown</version>
-          <time>1624360176</time>
+          <time>1677089175</time>
           <user>maintenance_coord</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Tue, 22 Jun 2021 11:09:36 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:16 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update/_meta?user=maintenance_coord
@@ -3263,8 +3204,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title>Look to Windward</title>
-          <description>Vitae placeat voluptate eaque.</description>
+          <title>Unweaving the Rainbow</title>
+          <description>Autem at omnis nulla.</description>
           <releasename>ProjectWithRepo_package</releasename>
         </package>
     headers:
@@ -3286,16 +3227,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '253'
+      - '249'
     body:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title>Look to Windward</title>
-          <description>Vitae placeat voluptate eaque.</description>
+          <title>Unweaving the Rainbow</title>
+          <description>Autem at omnis nulla.</description>
           <releasename>ProjectWithRepo_package</releasename>
         </package>
-  recorded_at: Tue, 22 Jun 2021 11:09:36 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:16 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -3325,13 +3266,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="1" vrev="1" srcmd5="8cdbf4889cded6e88a9cb004a6a2cf00">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="2c6109033c5937a5528ec21af10e04ef" baserev="2c6109033c5937a5528ec21af10e04ef" xsrcmd5="7c01df5fb12bce18624762785ca97afe" lsrcmd5="8cdbf4889cded6e88a9cb004a6a2cf00"/>
-          <entry name="_config" md5="46cccf6ebc7684f1ef2c7d8f2db417bd" size="62" mtime="1624360167"/>
-          <entry name="_link" md5="b3b062350540f7a8bf257877eb5a2cb3" size="175" mtime="1624360176"/>
-          <entry name="somefile.txt" md5="42adbaa46956c814fabac93750ee8931" size="60" mtime="1624360167"/>
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="3" vrev="3" srcmd5="b282555378ff0a2c77152620aa519de7">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e83ea096f3fd3c64494e21941c685f6f" baserev="e83ea096f3fd3c64494e21941c685f6f" xsrcmd5="619e6918fe6f97058fe4f69f1705cfc0" lsrcmd5="b282555378ff0a2c77152620aa519de7"/>
+          <entry name="_config" md5="ca5a602718fd6de59987f678c2d641bd" size="74" mtime="1677089168"/>
+          <entry name="_link" md5="0a6a1e8d3b4c6b56c2e16cacdfc499ec" size="175" mtime="1677089175"/>
+          <entry name="somefile.txt" md5="3b293450a072f3211239c7377e3cca78" size="59" mtime="1677089168"/>
         </directory>
-  recorded_at: Tue, 22 Jun 2021 11:09:36 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:16 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?view=info
@@ -3340,7 +3281,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 3294593a-15b6-468f-9b8f-76a11ff53b01
+      - '09394bb3-2da9-40db-b0ba-b0040128ffef'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -3363,12 +3304,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="1" vrev="3.2" srcmd5="7c01df5fb12bce18624762785ca97afe" lsrcmd5="8cdbf4889cded6e88a9cb004a6a2cf00" verifymd5="2c6109033c5937a5528ec21af10e04ef">
+        <sourceinfo package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="3" vrev="7.4" srcmd5="619e6918fe6f97058fe4f69f1705cfc0" lsrcmd5="b282555378ff0a2c77152620aa519de7" verifymd5="e83ea096f3fd3c64494e21941c685f6f">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="ProjectWithRepo:Update" package="ProjectWithRepo_package"/>
           <linked project="ProjectWithRepo" package="ProjectWithRepo_package"/>
         </sourceinfo>
-  recorded_at: Tue, 22 Jun 2021 11:09:36 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:16 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -3377,7 +3318,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 3294593a-15b6-468f-9b8f-76a11ff53b01
+      - '09394bb3-2da9-40db-b0ba-b0040128ffef'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -3400,13 +3341,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="1" vrev="1" srcmd5="8cdbf4889cded6e88a9cb004a6a2cf00">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="2c6109033c5937a5528ec21af10e04ef" baserev="2c6109033c5937a5528ec21af10e04ef" xsrcmd5="7c01df5fb12bce18624762785ca97afe" lsrcmd5="8cdbf4889cded6e88a9cb004a6a2cf00"/>
-          <entry name="_config" md5="46cccf6ebc7684f1ef2c7d8f2db417bd" size="62" mtime="1624360167"/>
-          <entry name="_link" md5="b3b062350540f7a8bf257877eb5a2cb3" size="175" mtime="1624360176"/>
-          <entry name="somefile.txt" md5="42adbaa46956c814fabac93750ee8931" size="60" mtime="1624360167"/>
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="3" vrev="3" srcmd5="b282555378ff0a2c77152620aa519de7">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e83ea096f3fd3c64494e21941c685f6f" baserev="e83ea096f3fd3c64494e21941c685f6f" xsrcmd5="619e6918fe6f97058fe4f69f1705cfc0" lsrcmd5="b282555378ff0a2c77152620aa519de7"/>
+          <entry name="_config" md5="ca5a602718fd6de59987f678c2d641bd" size="74" mtime="1677089168"/>
+          <entry name="_link" md5="0a6a1e8d3b4c6b56c2e16cacdfc499ec" size="175" mtime="1677089175"/>
+          <entry name="somefile.txt" md5="3b293450a072f3211239c7377e3cca78" size="59" mtime="1677089168"/>
         </directory>
-  recorded_at: Tue, 22 Jun 2021 11:09:36 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:16 GMT
 - request:
     method: post
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -3438,14 +3379,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="03b09eb6e7f1c62733e9e811a284b4f3">
+        <sourcediff key="3174385753d0c834f6bd326a992422d0">
           <old project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="1" srcmd5="8cdbf4889cded6e88a9cb004a6a2cf00"/>
+          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="3" srcmd5="b282555378ff0a2c77152620aa519de7"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Tue, 22 Jun 2021 11:09:36 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:16 GMT
 - request:
     method: post
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -3477,14 +3418,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="0de6c22580b0a40bc4132d1e3c1b6fd8">
-          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="2c6109033c5937a5528ec21af10e04ef" srcmd5="2c6109033c5937a5528ec21af10e04ef"/>
-          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="7c01df5fb12bce18624762785ca97afe" srcmd5="7c01df5fb12bce18624762785ca97afe"/>
+        <sourcediff key="ac83016cc5b1e7d4de0c19a92b66dfe6">
+          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="e83ea096f3fd3c64494e21941c685f6f" srcmd5="e83ea096f3fd3c64494e21941c685f6f"/>
+          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="619e6918fe6f97058fe4f69f1705cfc0" srcmd5="619e6918fe6f97058fe4f69f1705cfc0"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Tue, 22 Jun 2021 11:09:36 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:16 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update/_meta?user=maintenance_coord
@@ -3492,8 +3433,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title>Look to Windward</title>
-          <description>Vitae placeat voluptate eaque.</description>
+          <title>Unweaving the Rainbow</title>
+          <description>Autem at omnis nulla.</description>
           <releasename>ProjectWithRepo_package</releasename>
           <build>
             <enable repository="ProjectWithRepo_Update"/>
@@ -3518,19 +3459,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '324'
+      - '320'
     body:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title>Look to Windward</title>
-          <description>Vitae placeat voluptate eaque.</description>
+          <title>Unweaving the Rainbow</title>
+          <description>Autem at omnis nulla.</description>
           <releasename>ProjectWithRepo_package</releasename>
           <build>
             <enable repository="ProjectWithRepo_Update"/>
           </build>
         </package>
-  recorded_at: Tue, 22 Jun 2021 11:09:36 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:16 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -3539,7 +3480,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 3294593a-15b6-468f-9b8f-76a11ff53b01
+      - '09394bb3-2da9-40db-b0ba-b0040128ffef'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -3562,13 +3503,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="1" vrev="1" srcmd5="8cdbf4889cded6e88a9cb004a6a2cf00">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="2c6109033c5937a5528ec21af10e04ef" baserev="2c6109033c5937a5528ec21af10e04ef" xsrcmd5="7c01df5fb12bce18624762785ca97afe" lsrcmd5="8cdbf4889cded6e88a9cb004a6a2cf00"/>
-          <entry name="_config" md5="46cccf6ebc7684f1ef2c7d8f2db417bd" size="62" mtime="1624360167"/>
-          <entry name="_link" md5="b3b062350540f7a8bf257877eb5a2cb3" size="175" mtime="1624360176"/>
-          <entry name="somefile.txt" md5="42adbaa46956c814fabac93750ee8931" size="60" mtime="1624360167"/>
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="3" vrev="3" srcmd5="b282555378ff0a2c77152620aa519de7">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e83ea096f3fd3c64494e21941c685f6f" baserev="e83ea096f3fd3c64494e21941c685f6f" xsrcmd5="619e6918fe6f97058fe4f69f1705cfc0" lsrcmd5="b282555378ff0a2c77152620aa519de7"/>
+          <entry name="_config" md5="ca5a602718fd6de59987f678c2d641bd" size="74" mtime="1677089168"/>
+          <entry name="_link" md5="0a6a1e8d3b4c6b56c2e16cacdfc499ec" size="175" mtime="1677089175"/>
+          <entry name="somefile.txt" md5="3b293450a072f3211239c7377e3cca78" size="59" mtime="1677089168"/>
         </directory>
-  recorded_at: Tue, 22 Jun 2021 11:09:36 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:16 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -3577,7 +3518,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 3294593a-15b6-468f-9b8f-76a11ff53b01
+      - '09394bb3-2da9-40db-b0ba-b0040128ffef'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -3600,13 +3541,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="1" vrev="1" srcmd5="8cdbf4889cded6e88a9cb004a6a2cf00">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="2c6109033c5937a5528ec21af10e04ef" baserev="2c6109033c5937a5528ec21af10e04ef" xsrcmd5="7c01df5fb12bce18624762785ca97afe" lsrcmd5="8cdbf4889cded6e88a9cb004a6a2cf00"/>
-          <entry name="_config" md5="46cccf6ebc7684f1ef2c7d8f2db417bd" size="62" mtime="1624360167"/>
-          <entry name="_link" md5="b3b062350540f7a8bf257877eb5a2cb3" size="175" mtime="1624360176"/>
-          <entry name="somefile.txt" md5="42adbaa46956c814fabac93750ee8931" size="60" mtime="1624360167"/>
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="3" vrev="3" srcmd5="b282555378ff0a2c77152620aa519de7">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e83ea096f3fd3c64494e21941c685f6f" baserev="e83ea096f3fd3c64494e21941c685f6f" xsrcmd5="619e6918fe6f97058fe4f69f1705cfc0" lsrcmd5="b282555378ff0a2c77152620aa519de7"/>
+          <entry name="_config" md5="ca5a602718fd6de59987f678c2d641bd" size="74" mtime="1677089168"/>
+          <entry name="_link" md5="0a6a1e8d3b4c6b56c2e16cacdfc499ec" size="175" mtime="1677089175"/>
+          <entry name="somefile.txt" md5="3b293450a072f3211239c7377e3cca78" size="59" mtime="1677089168"/>
         </directory>
-  recorded_at: Tue, 22 Jun 2021 11:09:36 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:16 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -3615,7 +3556,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 3294593a-15b6-468f-9b8f-76a11ff53b01
+      - '09394bb3-2da9-40db-b0ba-b0040128ffef'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -3638,13 +3579,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="1" vrev="1" srcmd5="8cdbf4889cded6e88a9cb004a6a2cf00">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="2c6109033c5937a5528ec21af10e04ef" baserev="2c6109033c5937a5528ec21af10e04ef" xsrcmd5="7c01df5fb12bce18624762785ca97afe" lsrcmd5="8cdbf4889cded6e88a9cb004a6a2cf00"/>
-          <entry name="_config" md5="46cccf6ebc7684f1ef2c7d8f2db417bd" size="62" mtime="1624360167"/>
-          <entry name="_link" md5="b3b062350540f7a8bf257877eb5a2cb3" size="175" mtime="1624360176"/>
-          <entry name="somefile.txt" md5="42adbaa46956c814fabac93750ee8931" size="60" mtime="1624360167"/>
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="3" vrev="3" srcmd5="b282555378ff0a2c77152620aa519de7">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e83ea096f3fd3c64494e21941c685f6f" baserev="e83ea096f3fd3c64494e21941c685f6f" xsrcmd5="619e6918fe6f97058fe4f69f1705cfc0" lsrcmd5="b282555378ff0a2c77152620aa519de7"/>
+          <entry name="_config" md5="ca5a602718fd6de59987f678c2d641bd" size="74" mtime="1677089168"/>
+          <entry name="_link" md5="0a6a1e8d3b4c6b56c2e16cacdfc499ec" size="175" mtime="1677089175"/>
+          <entry name="somefile.txt" md5="3b293450a072f3211239c7377e3cca78" size="59" mtime="1677089168"/>
         </directory>
-  recorded_at: Tue, 22 Jun 2021 11:09:36 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:16 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22ProjectWithRepo_package%22%20and%20linkinfo/@project=%22ProjectWithRepo%22%20and%20@project=%22ProjectWithRepo%22)
@@ -3678,7 +3619,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Tue, 22 Jun 2021 11:09:36 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:16 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/_meta?user=maintenance_coord
@@ -3704,7 +3645,7 @@ http_interactions:
         </project>
     headers:
       X-Request-Id:
-      - 3294593a-15b6-468f-9b8f-76a11ff53b01
+      - '09394bb3-2da9-40db-b0ba-b0040128ffef'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -3744,7 +3685,7 @@ http_interactions:
             <arch>i586</arch>
           </repository>
         </project>
-  recorded_at: Tue, 22 Jun 2021 11:09:37 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:16 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/_meta?user=maintenance_coord
@@ -3770,7 +3711,7 @@ http_interactions:
         </project>
     headers:
       X-Request-Id:
-      - 3294593a-15b6-468f-9b8f-76a11ff53b01
+      - '09394bb3-2da9-40db-b0ba-b0040128ffef'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -3810,10 +3751,10 @@ http_interactions:
             <arch>i586</arch>
           </repository>
         </project>
-  recorded_at: Tue, 22 Jun 2021 11:09:37 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:16 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=copy&comment=Maintenance%20incident%20copy%20from%20project%20home:tom:branches:ProjectWithRepo:Update&expand=1&keeplink=1&opackage=ProjectWithRepo_package&oproject=home:tom:branches:ProjectWithRepo:Update&orev=89ea42b77174833f1114bad0670c14a5&requestid=1&user=maintenance_coord&withacceptinfo=1
+    uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=copy&comment=Maintenance%20incident%20copy%20from%20project%20home:tom:branches:ProjectWithRepo:Update&expand=1&keeplink=1&opackage=ProjectWithRepo_package&oproject=home:tom:branches:ProjectWithRepo:Update&orev=620fcea8705aeeea23c1acb8fd6ac73c&requestid=1&user=maintenance_coord&withacceptinfo=1
     body:
       encoding: UTF-8
       string: ''
@@ -3821,7 +3762,7 @@ http_interactions:
       Content-Type:
       - application/octet-stream
       X-Request-Id:
-      - 3294593a-15b6-468f-9b8f-76a11ff53b01
+      - '09394bb3-2da9-40db-b0ba-b0040128ffef'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -3844,16 +3785,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="2" vrev="2">
-          <srcmd5>0951ee6645c9bb5908aafd22339f65f4</srcmd5>
+        <revision rev="4" vrev="4">
+          <srcmd5>96667e65796c53042942660dd9f7f37c</srcmd5>
           <version>unknown</version>
-          <time>1624360177</time>
+          <time>1677089177</time>
           <user>maintenance_coord</user>
           <comment>Maintenance incident copy from project home:tom:branches:ProjectWithRepo:Update</comment>
           <requestid>1</requestid>
-          <acceptinfo rev="2" srcmd5="0951ee6645c9bb5908aafd22339f65f4" osrcmd5="8cdbf4889cded6e88a9cb004a6a2cf00" xsrcmd5="2ceea48f04803b56cf3e2f8d3cd39ee7" oxsrcmd5="7c01df5fb12bce18624762785ca97afe"/>
+          <acceptinfo rev="4" srcmd5="96667e65796c53042942660dd9f7f37c" osrcmd5="b282555378ff0a2c77152620aa519de7" xsrcmd5="bd4ffbf3690114ef2991f3997c4b7c01" oxsrcmd5="619e6918fe6f97058fe4f69f1705cfc0"/>
         </revision>
-  recorded_at: Tue, 22 Jun 2021 11:09:37 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:17 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update/_meta?user=maintenance_coord
@@ -3861,8 +3802,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title>Look to Windward</title>
-          <description>Vitae placeat voluptate eaque.</description>
+          <title>Unweaving the Rainbow</title>
+          <description>Autem at omnis nulla.</description>
           <releasename>ProjectWithRepo_package</releasename>
           <build>
             <enable repository="ProjectWithRepo_Update"/>
@@ -3887,19 +3828,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '324'
+      - '320'
     body:
       encoding: UTF-8
       string: |
         <package name="ProjectWithRepo_package.ProjectWithRepo_Update" project="MaintenanceProject:0">
-          <title>Look to Windward</title>
-          <description>Vitae placeat voluptate eaque.</description>
+          <title>Unweaving the Rainbow</title>
+          <description>Autem at omnis nulla.</description>
           <releasename>ProjectWithRepo_package</releasename>
           <build>
             <enable repository="ProjectWithRepo_Update"/>
           </build>
         </package>
-  recorded_at: Tue, 22 Jun 2021 11:09:37 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:17 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -3929,14 +3870,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="2" vrev="2" srcmd5="0951ee6645c9bb5908aafd22339f65f4">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="2c6109033c5937a5528ec21af10e04ef" baserev="2c6109033c5937a5528ec21af10e04ef" xsrcmd5="2ceea48f04803b56cf3e2f8d3cd39ee7" lsrcmd5="0951ee6645c9bb5908aafd22339f65f4"/>
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1624360170"/>
-          <entry name="_config" md5="46cccf6ebc7684f1ef2c7d8f2db417bd" size="62" mtime="1624360167"/>
-          <entry name="_link" md5="b3b062350540f7a8bf257877eb5a2cb3" size="175" mtime="1624360176"/>
-          <entry name="somefile.txt" md5="42adbaa46956c814fabac93750ee8931" size="60" mtime="1624360167"/>
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="4" vrev="4" srcmd5="96667e65796c53042942660dd9f7f37c">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e83ea096f3fd3c64494e21941c685f6f" baserev="e83ea096f3fd3c64494e21941c685f6f" xsrcmd5="bd4ffbf3690114ef2991f3997c4b7c01" lsrcmd5="96667e65796c53042942660dd9f7f37c"/>
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1677064904"/>
+          <entry name="_config" md5="ca5a602718fd6de59987f678c2d641bd" size="74" mtime="1677089168"/>
+          <entry name="_link" md5="0a6a1e8d3b4c6b56c2e16cacdfc499ec" size="175" mtime="1677089175"/>
+          <entry name="somefile.txt" md5="3b293450a072f3211239c7377e3cca78" size="59" mtime="1677089168"/>
         </directory>
-  recorded_at: Tue, 22 Jun 2021 11:09:37 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:17 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?view=info
@@ -3945,7 +3886,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 3294593a-15b6-468f-9b8f-76a11ff53b01
+      - '09394bb3-2da9-40db-b0ba-b0040128ffef'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -3968,12 +3909,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="2" vrev="3.3" srcmd5="2ceea48f04803b56cf3e2f8d3cd39ee7" lsrcmd5="0951ee6645c9bb5908aafd22339f65f4" verifymd5="eadd2ff08237c2e4640b924c0133cc87">
+        <sourceinfo package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="4" vrev="7.5" srcmd5="bd4ffbf3690114ef2991f3997c4b7c01" lsrcmd5="96667e65796c53042942660dd9f7f37c" verifymd5="6c5ca411e22de1a646f3404300d74e3c">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="ProjectWithRepo:Update" package="ProjectWithRepo_package"/>
           <linked project="ProjectWithRepo" package="ProjectWithRepo_package"/>
         </sourceinfo>
-  recorded_at: Tue, 22 Jun 2021 11:09:37 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:17 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update
@@ -3982,7 +3923,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 3294593a-15b6-468f-9b8f-76a11ff53b01
+      - '09394bb3-2da9-40db-b0ba-b0040128ffef'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -4005,14 +3946,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="2" vrev="2" srcmd5="0951ee6645c9bb5908aafd22339f65f4">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="2c6109033c5937a5528ec21af10e04ef" baserev="2c6109033c5937a5528ec21af10e04ef" xsrcmd5="2ceea48f04803b56cf3e2f8d3cd39ee7" lsrcmd5="0951ee6645c9bb5908aafd22339f65f4"/>
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1624360170"/>
-          <entry name="_config" md5="46cccf6ebc7684f1ef2c7d8f2db417bd" size="62" mtime="1624360167"/>
-          <entry name="_link" md5="b3b062350540f7a8bf257877eb5a2cb3" size="175" mtime="1624360176"/>
-          <entry name="somefile.txt" md5="42adbaa46956c814fabac93750ee8931" size="60" mtime="1624360167"/>
+        <directory name="ProjectWithRepo_package.ProjectWithRepo_Update" rev="4" vrev="4" srcmd5="96667e65796c53042942660dd9f7f37c">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e83ea096f3fd3c64494e21941c685f6f" baserev="e83ea096f3fd3c64494e21941c685f6f" xsrcmd5="bd4ffbf3690114ef2991f3997c4b7c01" lsrcmd5="96667e65796c53042942660dd9f7f37c"/>
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1677064904"/>
+          <entry name="_config" md5="ca5a602718fd6de59987f678c2d641bd" size="74" mtime="1677089168"/>
+          <entry name="_link" md5="0a6a1e8d3b4c6b56c2e16cacdfc499ec" size="175" mtime="1677089175"/>
+          <entry name="somefile.txt" md5="3b293450a072f3211239c7377e3cca78" size="59" mtime="1677089168"/>
         </directory>
-  recorded_at: Tue, 22 Jun 2021 11:09:37 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:17 GMT
 - request:
     method: post
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -4044,14 +3985,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="b41c9e99613aad8d5b3051795d13c622">
+        <sourcediff key="2ad56145c6740bc69b750b323d37c6af">
           <old project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="2" srcmd5="0951ee6645c9bb5908aafd22339f65f4"/>
+          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="4" srcmd5="96667e65796c53042942660dd9f7f37c"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Tue, 22 Jun 2021 11:09:37 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:17 GMT
 - request:
     method: post
     uri: http://backend:5352/source/MaintenanceProject:0/ProjectWithRepo_package.ProjectWithRepo_Update?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -4083,14 +4024,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="6c159205d13355d2bb255c1f676e0067">
-          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="2c6109033c5937a5528ec21af10e04ef" srcmd5="2c6109033c5937a5528ec21af10e04ef"/>
-          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="2ceea48f04803b56cf3e2f8d3cd39ee7" srcmd5="2ceea48f04803b56cf3e2f8d3cd39ee7"/>
+        <sourcediff key="c2a538cccb571271ecc126291b0d693e">
+          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="e83ea096f3fd3c64494e21941c685f6f" srcmd5="e83ea096f3fd3c64494e21941c685f6f"/>
+          <new project="MaintenanceProject:0" package="ProjectWithRepo_package.ProjectWithRepo_Update" rev="bd4ffbf3690114ef2991f3997c4b7c01" srcmd5="bd4ffbf3690114ef2991f3997c4b7c01"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Tue, 22 Jun 2021 11:09:37 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:17 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/_meta?comment=maintenance_incident%20request%201&requestid=1&user=maintenance_coord
@@ -4116,7 +4057,7 @@ http_interactions:
         </project>
     headers:
       X-Request-Id:
-      - 3294593a-15b6-468f-9b8f-76a11ff53b01
+      - '09394bb3-2da9-40db-b0ba-b0040128ffef'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -4156,7 +4097,7 @@ http_interactions:
             <arch>i586</arch>
           </repository>
         </project>
-  recorded_at: Tue, 22 Jun 2021 11:09:37 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:17 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_meta?user=maintenance_coord
@@ -4212,7 +4153,7 @@ http_interactions:
             <disable/>
           </useforbuild>
         </package>
-  recorded_at: Tue, 22 Jun 2021 11:09:37 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:17 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo?comment=generated%20by%20request%20id%201%20accept%20call&user=maintenance_coord
@@ -4228,7 +4169,7 @@ http_interactions:
         </patchinfo>
     headers:
       X-Request-Id:
-      - 3294593a-15b6-468f-9b8f-76a11ff53b01
+      - '09394bb3-2da9-40db-b0ba-b0040128ffef'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -4251,15 +4192,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1" vrev="1">
+        <revision rev="4" vrev="4">
           <srcmd5>53b684c8c2dbc9672bb230d024c87a14</srcmd5>
           <version>unknown</version>
-          <time>1624360177</time>
+          <time>1677089177</time>
           <user>maintenance_coord</user>
           <comment>generated by request id 1 accept call</comment>
           <requestid/>
         </revision>
-  recorded_at: Tue, 22 Jun 2021 11:09:37 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:17 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_meta?user=maintenance_coord
@@ -4315,7 +4256,7 @@ http_interactions:
             <disable/>
           </useforbuild>
         </package>
-  recorded_at: Tue, 22 Jun 2021 11:09:37 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:17 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo
@@ -4345,10 +4286,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="patchinfo" rev="1" vrev="1" srcmd5="53b684c8c2dbc9672bb230d024c87a14">
-          <entry name="_patchinfo" md5="34e0b04fccfd75faea0577efe7cd9ead" size="208" mtime="1624360177"/>
+        <directory name="patchinfo" rev="4" vrev="4" srcmd5="53b684c8c2dbc9672bb230d024c87a14">
+          <entry name="_patchinfo" md5="34e0b04fccfd75faea0577efe7cd9ead" size="208" mtime="1677064910"/>
         </directory>
-  recorded_at: Tue, 22 Jun 2021 11:09:37 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:17 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo?view=info
@@ -4357,7 +4298,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 3294593a-15b6-468f-9b8f-76a11ff53b01
+      - '09394bb3-2da9-40db-b0ba-b0040128ffef'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -4380,10 +4321,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="patchinfo" rev="1" vrev="1" srcmd5="53b684c8c2dbc9672bb230d024c87a14" verifymd5="53b684c8c2dbc9672bb230d024c87a14">
+        <sourceinfo package="patchinfo" rev="4" vrev="4" srcmd5="53b684c8c2dbc9672bb230d024c87a14" verifymd5="53b684c8c2dbc9672bb230d024c87a14">
           <filename>_patchinfo</filename>
         </sourceinfo>
-  recorded_at: Tue, 22 Jun 2021 11:09:37 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:17 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo
@@ -4392,7 +4333,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 3294593a-15b6-468f-9b8f-76a11ff53b01
+      - '09394bb3-2da9-40db-b0ba-b0040128ffef'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -4415,10 +4356,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="patchinfo" rev="1" vrev="1" srcmd5="53b684c8c2dbc9672bb230d024c87a14">
-          <entry name="_patchinfo" md5="34e0b04fccfd75faea0577efe7cd9ead" size="208" mtime="1624360177"/>
+        <directory name="patchinfo" rev="4" vrev="4" srcmd5="53b684c8c2dbc9672bb230d024c87a14">
+          <entry name="_patchinfo" md5="34e0b04fccfd75faea0577efe7cd9ead" size="208" mtime="1677064910"/>
         </directory>
-  recorded_at: Tue, 22 Jun 2021 11:09:37 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:17 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -4455,7 +4396,7 @@ http_interactions:
           <summary>I want the update</summary>
           <description>I want the update</description>
         </patchinfo>
-  recorded_at: Tue, 22 Jun 2021 11:09:37 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:17 GMT
 - request:
     method: get
     uri: http://backend:5352/build/MaintenanceProject:0/_result?view=binarylist
@@ -4464,7 +4405,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - eb49e771-9bbd-48be-8c32-3bca320a73d3
+      - baf3d471-d263-41c9-a51d-da7582143ddc
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -4490,7 +4431,7 @@ http_interactions:
         <resultlist state="1ebb8da631fca74768ff14657f9f6921">
           <result project="MaintenanceProject:0" repository="ProjectWithRepo_Update" arch="i586" code="broken" state="broken" details="no build type (ProjectWithRepo:Update)"/>
         </resultlist>
-  recorded_at: Tue, 22 Jun 2021 11:09:38 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:17 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -4527,7 +4468,7 @@ http_interactions:
           <summary>I want the update</summary>
           <description>I want the update</description>
         </patchinfo>
-  recorded_at: Tue, 22 Jun 2021 11:09:38 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:17 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -4564,7 +4505,7 @@ http_interactions:
           <summary>I want the update</summary>
           <description>I want the update</description>
         </patchinfo>
-  recorded_at: Tue, 22 Jun 2021 11:09:38 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:18 GMT
 - request:
     method: get
     uri: http://backend:5352/build/MaintenanceProject:0/_result?view=binarylist
@@ -4573,7 +4514,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - b3728ea9-fb12-4398-8a5e-b8f687d2c8e6
+      - 64d96ae1-d263-45d0-9696-76875b4df5b8
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -4599,7 +4540,7 @@ http_interactions:
         <resultlist state="1ebb8da631fca74768ff14657f9f6921">
           <result project="MaintenanceProject:0" repository="ProjectWithRepo_Update" arch="i586" code="broken" state="broken" details="no build type (ProjectWithRepo:Update)"/>
         </resultlist>
-  recorded_at: Tue, 22 Jun 2021 11:09:38 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:18 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -4636,7 +4577,7 @@ http_interactions:
           <summary>I want the update</summary>
           <description>I want the update</description>
         </patchinfo>
-  recorded_at: Tue, 22 Jun 2021 11:09:38 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:18 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -4673,116 +4614,7 @@ http_interactions:
           <summary>I want the update</summary>
           <description>I want the update</description>
         </patchinfo>
-  recorded_at: Tue, 22 Jun 2021 11:09:38 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/MaintenanceProject:0/_result?view=binarylist
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Request-Id:
-      - 8c66ded5-ad99-4f57-844f-f4ee8c8cab38
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '237'
-    body:
-      encoding: UTF-8
-      string: |
-        <resultlist state="1ebb8da631fca74768ff14657f9f6921">
-          <result project="MaintenanceProject:0" repository="ProjectWithRepo_Update" arch="i586" code="broken" state="broken" details="no build type (ProjectWithRepo:Update)"/>
-        </resultlist>
-  recorded_at: Tue, 22 Jun 2021 11:09:39 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/octet-stream
-      Content-Length:
-      - '208'
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-    body:
-      encoding: UTF-8
-      string: |-
-        <patchinfo incident="0">
-          <category>recommended</category>
-          <rating>low</rating>
-          <packager>tom</packager>
-          <summary>I want the update</summary>
-          <description>I want the update</description>
-        </patchinfo>
-  recorded_at: Tue, 22 Jun 2021 11:09:39 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/octet-stream
-      Content-Length:
-      - '208'
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-    body:
-      encoding: UTF-8
-      string: |-
-        <patchinfo incident="0">
-          <category>recommended</category>
-          <rating>low</rating>
-          <packager>tom</packager>
-          <summary>I want the update</summary>
-          <description>I want the update</description>
-        </patchinfo>
-  recorded_at: Tue, 22 Jun 2021 11:09:39 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:18 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo?user=maintenance_coord
@@ -4799,7 +4631,7 @@ http_interactions:
         </patchinfo>
     headers:
       X-Request-Id:
-      - 8c66ded5-ad99-4f57-844f-f4ee8c8cab38
+      - 64d96ae1-d263-45d0-9696-76875b4df5b8
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -4822,15 +4654,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="2" vrev="2">
+        <revision rev="5" vrev="5">
           <srcmd5>d07dfcdc0bb71ab61e7d0c85c4a68c71</srcmd5>
           <version>unknown</version>
-          <time>1624360179</time>
+          <time>1677089178</time>
           <user>maintenance_coord</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Tue, 22 Jun 2021 11:09:39 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:18 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_meta?user=maintenance_coord
@@ -4886,7 +4718,7 @@ http_interactions:
             <disable/>
           </useforbuild>
         </package>
-  recorded_at: Tue, 22 Jun 2021 11:09:39 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:18 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo
@@ -4916,10 +4748,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="patchinfo" rev="2" vrev="2" srcmd5="d07dfcdc0bb71ab61e7d0c85c4a68c71">
-          <entry name="_patchinfo" md5="7fd692cf9ae54961b5c5a22aa13e29c0" size="347" mtime="1624360179"/>
+        <directory name="patchinfo" rev="5" vrev="5" srcmd5="d07dfcdc0bb71ab61e7d0c85c4a68c71">
+          <entry name="_patchinfo" md5="7fd692cf9ae54961b5c5a22aa13e29c0" size="347" mtime="1677064912"/>
         </directory>
-  recorded_at: Tue, 22 Jun 2021 11:09:39 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:18 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo?view=info
@@ -4928,7 +4760,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 8c66ded5-ad99-4f57-844f-f4ee8c8cab38
+      - 64d96ae1-d263-45d0-9696-76875b4df5b8
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -4951,10 +4783,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="patchinfo" rev="2" vrev="2" srcmd5="d07dfcdc0bb71ab61e7d0c85c4a68c71" verifymd5="d07dfcdc0bb71ab61e7d0c85c4a68c71">
+        <sourceinfo package="patchinfo" rev="5" vrev="5" srcmd5="d07dfcdc0bb71ab61e7d0c85c4a68c71" verifymd5="d07dfcdc0bb71ab61e7d0c85c4a68c71">
           <filename>_patchinfo</filename>
         </sourceinfo>
-  recorded_at: Tue, 22 Jun 2021 11:09:39 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:19 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo
@@ -4963,7 +4795,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 8c66ded5-ad99-4f57-844f-f4ee8c8cab38
+      - 64d96ae1-d263-45d0-9696-76875b4df5b8
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -4986,10 +4818,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="patchinfo" rev="2" vrev="2" srcmd5="d07dfcdc0bb71ab61e7d0c85c4a68c71">
-          <entry name="_patchinfo" md5="7fd692cf9ae54961b5c5a22aa13e29c0" size="347" mtime="1624360179"/>
+        <directory name="patchinfo" rev="5" vrev="5" srcmd5="d07dfcdc0bb71ab61e7d0c85c4a68c71">
+          <entry name="_patchinfo" md5="7fd692cf9ae54961b5c5a22aa13e29c0" size="347" mtime="1677064912"/>
         </directory>
-  recorded_at: Tue, 22 Jun 2021 11:09:39 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:19 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -5027,7 +4859,7 @@ http_interactions:
           <description>Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing</description>
           <stopped>locked!</stopped>
         </patchinfo>
-  recorded_at: Tue, 22 Jun 2021 11:09:39 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:19 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -5065,7 +4897,7 @@ http_interactions:
           <description>Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing</description>
           <stopped>locked!</stopped>
         </patchinfo>
-  recorded_at: Tue, 22 Jun 2021 11:09:39 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:19 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -5103,83 +4935,7 @@ http_interactions:
           <description>Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing</description>
           <stopped>locked!</stopped>
         </patchinfo>
-  recorded_at: Tue, 22 Jun 2021 11:09:39 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/octet-stream
-      Content-Length:
-      - '347'
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-    body:
-      encoding: UTF-8
-      string: |
-        <patchinfo incident="0">
-          <packager>tom</packager>
-          <category>recommended</category>
-          <rating>low</rating>
-          <summary>ProjectWithRepo_package is much better than the old one</summary>
-          <description>Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing</description>
-          <stopped>locked!</stopped>
-        </patchinfo>
-  recorded_at: Tue, 22 Jun 2021 11:09:39 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/octet-stream
-      Content-Length:
-      - '347'
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-    body:
-      encoding: UTF-8
-      string: |
-        <patchinfo incident="0">
-          <packager>tom</packager>
-          <category>recommended</category>
-          <rating>low</rating>
-          <summary>ProjectWithRepo_package is much better than the old one</summary>
-          <description>Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing</description>
-          <stopped>locked!</stopped>
-        </patchinfo>
-  recorded_at: Tue, 22 Jun 2021 11:09:39 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:19 GMT
 - request:
     method: get
     uri: http://backend:5352/build/MaintenanceProject:0/_result?view=binarylist
@@ -5188,7 +4944,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - ef442497-d6ca-4128-a530-0dde83e1b691
+      - 66804761-8647-4110-89d2-bd8e342799f0
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -5214,7 +4970,7 @@ http_interactions:
         <resultlist state="1ebb8da631fca74768ff14657f9f6921">
           <result project="MaintenanceProject:0" repository="ProjectWithRepo_Update" arch="i586" code="broken" state="broken" details="no build type (ProjectWithRepo:Update)"/>
         </resultlist>
-  recorded_at: Tue, 22 Jun 2021 11:09:40 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:19 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -5252,7 +5008,7 @@ http_interactions:
           <description>Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing</description>
           <stopped>locked!</stopped>
         </patchinfo>
-  recorded_at: Tue, 22 Jun 2021 11:09:40 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:19 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -5290,7 +5046,7 @@ http_interactions:
           <description>Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing</description>
           <stopped>locked!</stopped>
         </patchinfo>
-  recorded_at: Tue, 22 Jun 2021 11:09:40 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:19 GMT
 - request:
     method: get
     uri: http://backend:5352/build/MaintenanceProject:0/_result?view=binarylist
@@ -5299,7 +5055,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - b5b06c20-dd32-408c-81c6-d2d4bcc83002
+      - 5790a280-2ece-4692-bdd4-f9d10a44cc41
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -5325,7 +5081,7 @@ http_interactions:
         <resultlist state="1ebb8da631fca74768ff14657f9f6921">
           <result project="MaintenanceProject:0" repository="ProjectWithRepo_Update" arch="i586" code="broken" state="broken" details="no build type (ProjectWithRepo:Update)"/>
         </resultlist>
-  recorded_at: Tue, 22 Jun 2021 11:09:40 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:19 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -5363,7 +5119,7 @@ http_interactions:
           <description>Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing</description>
           <stopped>locked!</stopped>
         </patchinfo>
-  recorded_at: Tue, 22 Jun 2021 11:09:40 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:19 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -5401,118 +5157,7 @@ http_interactions:
           <description>Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing</description>
           <stopped>locked!</stopped>
         </patchinfo>
-  recorded_at: Tue, 22 Jun 2021 11:09:40 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/MaintenanceProject:0/_result?view=binarylist
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Request-Id:
-      - 66c467fb-f07d-423b-bb39-b8502ce90cb8
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '237'
-    body:
-      encoding: UTF-8
-      string: |
-        <resultlist state="1ebb8da631fca74768ff14657f9f6921">
-          <result project="MaintenanceProject:0" repository="ProjectWithRepo_Update" arch="i586" code="broken" state="broken" details="no build type (ProjectWithRepo:Update)"/>
-        </resultlist>
-  recorded_at: Tue, 22 Jun 2021 11:09:40 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/octet-stream
-      Content-Length:
-      - '347'
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-    body:
-      encoding: UTF-8
-      string: |
-        <patchinfo incident="0">
-          <packager>tom</packager>
-          <category>recommended</category>
-          <rating>low</rating>
-          <summary>ProjectWithRepo_package is much better than the old one</summary>
-          <description>Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing</description>
-          <stopped>locked!</stopped>
-        </patchinfo>
-  recorded_at: Tue, 22 Jun 2021 11:09:40 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/octet-stream
-      Content-Length:
-      - '347'
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-    body:
-      encoding: UTF-8
-      string: |
-        <patchinfo incident="0">
-          <packager>tom</packager>
-          <category>recommended</category>
-          <rating>low</rating>
-          <summary>ProjectWithRepo_package is much better than the old one</summary>
-          <description>Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing</description>
-          <stopped>locked!</stopped>
-        </patchinfo>
-  recorded_at: Tue, 22 Jun 2021 11:09:40 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:19 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo?user=maintenance_coord
@@ -5528,7 +5173,7 @@ http_interactions:
         </patchinfo>
     headers:
       X-Request-Id:
-      - 66c467fb-f07d-423b-bb39-b8502ce90cb8
+      - 5790a280-2ece-4692-bdd4-f9d10a44cc41
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -5551,15 +5196,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="3" vrev="3">
+        <revision rev="6" vrev="6">
           <srcmd5>177d57906eba63ae56a64a367592144a</srcmd5>
           <version>unknown</version>
-          <time>1624360180</time>
+          <time>1677089180</time>
           <user>maintenance_coord</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Tue, 22 Jun 2021 11:09:40 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:20 GMT
 - request:
     method: put
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_meta?user=maintenance_coord
@@ -5615,7 +5260,7 @@ http_interactions:
             <disable/>
           </useforbuild>
         </package>
-  recorded_at: Tue, 22 Jun 2021 11:09:40 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:20 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo
@@ -5645,10 +5290,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="patchinfo" rev="3" vrev="3" srcmd5="177d57906eba63ae56a64a367592144a">
-          <entry name="_patchinfo" md5="ac29f7f1abd9ef43afeb43fc7737c007" size="318" mtime="1624360180"/>
+        <directory name="patchinfo" rev="6" vrev="6" srcmd5="177d57906eba63ae56a64a367592144a">
+          <entry name="_patchinfo" md5="ac29f7f1abd9ef43afeb43fc7737c007" size="318" mtime="1677064913"/>
         </directory>
-  recorded_at: Tue, 22 Jun 2021 11:09:40 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:20 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo?view=info
@@ -5657,7 +5302,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 66c467fb-f07d-423b-bb39-b8502ce90cb8
+      - 5790a280-2ece-4692-bdd4-f9d10a44cc41
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -5680,10 +5325,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="patchinfo" rev="3" vrev="3" srcmd5="177d57906eba63ae56a64a367592144a" verifymd5="177d57906eba63ae56a64a367592144a">
+        <sourceinfo package="patchinfo" rev="6" vrev="6" srcmd5="177d57906eba63ae56a64a367592144a" verifymd5="177d57906eba63ae56a64a367592144a">
           <filename>_patchinfo</filename>
         </sourceinfo>
-  recorded_at: Tue, 22 Jun 2021 11:09:40 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:20 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo
@@ -5692,7 +5337,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 66c467fb-f07d-423b-bb39-b8502ce90cb8
+      - 5790a280-2ece-4692-bdd4-f9d10a44cc41
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -5715,10 +5360,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="patchinfo" rev="3" vrev="3" srcmd5="177d57906eba63ae56a64a367592144a">
-          <entry name="_patchinfo" md5="ac29f7f1abd9ef43afeb43fc7737c007" size="318" mtime="1624360180"/>
+        <directory name="patchinfo" rev="6" vrev="6" srcmd5="177d57906eba63ae56a64a367592144a">
+          <entry name="_patchinfo" md5="ac29f7f1abd9ef43afeb43fc7737c007" size="318" mtime="1677064913"/>
         </directory>
-  recorded_at: Tue, 22 Jun 2021 11:09:40 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:20 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -5755,7 +5400,7 @@ http_interactions:
           <summary>ProjectWithRepo_package is much better than the old one</summary>
           <description>Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing</description>
         </patchinfo>
-  recorded_at: Tue, 22 Jun 2021 11:09:40 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:20 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -5792,7 +5437,7 @@ http_interactions:
           <summary>ProjectWithRepo_package is much better than the old one</summary>
           <description>Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing</description>
         </patchinfo>
-  recorded_at: Tue, 22 Jun 2021 11:09:40 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:20 GMT
 - request:
     method: get
     uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo
@@ -5829,81 +5474,7 @@ http_interactions:
           <summary>ProjectWithRepo_package is much better than the old one</summary>
           <description>Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing</description>
         </patchinfo>
-  recorded_at: Tue, 22 Jun 2021 11:09:40 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/octet-stream
-      Content-Length:
-      - '318'
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-    body:
-      encoding: UTF-8
-      string: |
-        <patchinfo incident="0">
-          <packager>tom</packager>
-          <category>recommended</category>
-          <rating>low</rating>
-          <summary>ProjectWithRepo_package is much better than the old one</summary>
-          <description>Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing</description>
-        </patchinfo>
-  recorded_at: Tue, 22 Jun 2021 11:09:41 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/MaintenanceProject:0/patchinfo/_patchinfo
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/octet-stream
-      Content-Length:
-      - '318'
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-    body:
-      encoding: UTF-8
-      string: |
-        <patchinfo incident="0">
-          <packager>tom</packager>
-          <category>recommended</category>
-          <rating>low</rating>
-          <summary>ProjectWithRepo_package is much better than the old one</summary>
-          <description>Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing, Fixes nothing</description>
-        </patchinfo>
-  recorded_at: Tue, 22 Jun 2021 11:09:41 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:20 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?code=unresolvable&view=status
@@ -5912,7 +5483,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - dc1b102d-a3d6-4343-bbb4-ddad55afcba3
+      - 47879786-b91c-459e-bc23-fa1c391063f1
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -5938,7 +5509,7 @@ http_interactions:
         <resultlist state="d717409be2592c96becbdc11142f1468">
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="broken" state="broken" details="no build type (ProjectWithRepo:Update)"/>
         </resultlist>
-  recorded_at: Tue, 22 Jun 2021 11:09:42 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:21 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?view=summary
@@ -5947,7 +5518,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - c9583166-d50e-44f3-bcd3-c0909bb67934
+      - 4d9e01bb-7cd3-40e5-9d6c-f180a3c6efc5
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -5975,42 +5546,7 @@ http_interactions:
             <summary/>
           </result>
         </resultlist>
-  recorded_at: Tue, 22 Jun 2021 11:09:43 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?code=unresolvable&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Request-Id:
-      - 61fef40e-6a64-453b-8810-b30a2c0b9c5e
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '247'
-    body:
-      encoding: UTF-8
-      string: |
-        <resultlist state="d717409be2592c96becbdc11142f1468">
-          <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="broken" state="broken" details="no build type (ProjectWithRepo:Update)"/>
-        </resultlist>
-  recorded_at: Tue, 22 Jun 2021 11:09:43 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:22 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -6019,7 +5555,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 2afa3b59-c0cb-4f2a-88f8-5c5a7bc0ac9a
+      - 93e2089d-796e-488c-9368-bba21f77ae73
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -6042,14 +5578,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="ce4cc59f8a846502437cfa9b5280a123">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="2c6109033c5937a5528ec21af10e04ef" baserev="2c6109033c5937a5528ec21af10e04ef" xsrcmd5="89ea42b77174833f1114bad0670c14a5" lsrcmd5="ce4cc59f8a846502437cfa9b5280a123"/>
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1624360170"/>
-          <entry name="_config" md5="46cccf6ebc7684f1ef2c7d8f2db417bd" size="62" mtime="1624360167"/>
-          <entry name="_link" md5="af47fbc9f021527458be31d8c3d650bc" size="130" mtime="1624360169"/>
-          <entry name="somefile.txt" md5="42adbaa46956c814fabac93750ee8931" size="60" mtime="1624360167"/>
+        <directory name="ProjectWithRepo_package" rev="4" vrev="4" srcmd5="6e0e59c49ec80131659564768dd1e126">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e83ea096f3fd3c64494e21941c685f6f" baserev="e83ea096f3fd3c64494e21941c685f6f" xsrcmd5="620fcea8705aeeea23c1acb8fd6ac73c" lsrcmd5="6e0e59c49ec80131659564768dd1e126"/>
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1677064904"/>
+          <entry name="_config" md5="ca5a602718fd6de59987f678c2d641bd" size="74" mtime="1677089168"/>
+          <entry name="_link" md5="3500919b1ba7cde7a8a011415239d587" size="130" mtime="1677089170"/>
+          <entry name="somefile.txt" md5="3b293450a072f3211239c7377e3cca78" size="59" mtime="1677089168"/>
         </directory>
-  recorded_at: Tue, 22 Jun 2021 11:09:43 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:22 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -6058,7 +5594,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 2afa3b59-c0cb-4f2a-88f8-5c5a7bc0ac9a
+      - 93e2089d-796e-488c-9368-bba21f77ae73
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -6081,14 +5617,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="ce4cc59f8a846502437cfa9b5280a123">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="2c6109033c5937a5528ec21af10e04ef" baserev="2c6109033c5937a5528ec21af10e04ef" xsrcmd5="89ea42b77174833f1114bad0670c14a5" lsrcmd5="ce4cc59f8a846502437cfa9b5280a123"/>
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1624360170"/>
-          <entry name="_config" md5="46cccf6ebc7684f1ef2c7d8f2db417bd" size="62" mtime="1624360167"/>
-          <entry name="_link" md5="af47fbc9f021527458be31d8c3d650bc" size="130" mtime="1624360169"/>
-          <entry name="somefile.txt" md5="42adbaa46956c814fabac93750ee8931" size="60" mtime="1624360167"/>
+        <directory name="ProjectWithRepo_package" rev="4" vrev="4" srcmd5="6e0e59c49ec80131659564768dd1e126">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e83ea096f3fd3c64494e21941c685f6f" baserev="e83ea096f3fd3c64494e21941c685f6f" xsrcmd5="620fcea8705aeeea23c1acb8fd6ac73c" lsrcmd5="6e0e59c49ec80131659564768dd1e126"/>
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1677064904"/>
+          <entry name="_config" md5="ca5a602718fd6de59987f678c2d641bd" size="74" mtime="1677089168"/>
+          <entry name="_link" md5="3500919b1ba7cde7a8a011415239d587" size="130" mtime="1677089170"/>
+          <entry name="somefile.txt" md5="3b293450a072f3211239c7377e3cca78" size="59" mtime="1677089168"/>
         </directory>
-  recorded_at: Tue, 22 Jun 2021 11:09:43 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:22 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
@@ -6097,7 +5633,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 2afa3b59-c0cb-4f2a-88f8-5c5a7bc0ac9a
+      - 93e2089d-796e-488c-9368-bba21f77ae73
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -6120,14 +5656,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="2" vrev="2" srcmd5="ce4cc59f8a846502437cfa9b5280a123">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="2c6109033c5937a5528ec21af10e04ef" baserev="2c6109033c5937a5528ec21af10e04ef" xsrcmd5="89ea42b77174833f1114bad0670c14a5" lsrcmd5="ce4cc59f8a846502437cfa9b5280a123"/>
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1624360170"/>
-          <entry name="_config" md5="46cccf6ebc7684f1ef2c7d8f2db417bd" size="62" mtime="1624360167"/>
-          <entry name="_link" md5="af47fbc9f021527458be31d8c3d650bc" size="130" mtime="1624360169"/>
-          <entry name="somefile.txt" md5="42adbaa46956c814fabac93750ee8931" size="60" mtime="1624360167"/>
+        <directory name="ProjectWithRepo_package" rev="4" vrev="4" srcmd5="6e0e59c49ec80131659564768dd1e126">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e83ea096f3fd3c64494e21941c685f6f" baserev="e83ea096f3fd3c64494e21941c685f6f" xsrcmd5="620fcea8705aeeea23c1acb8fd6ac73c" lsrcmd5="6e0e59c49ec80131659564768dd1e126"/>
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1677064904"/>
+          <entry name="_config" md5="ca5a602718fd6de59987f678c2d641bd" size="74" mtime="1677089168"/>
+          <entry name="_link" md5="3500919b1ba7cde7a8a011415239d587" size="130" mtime="1677089170"/>
+          <entry name="somefile.txt" md5="3b293450a072f3211239c7377e3cca78" size="59" mtime="1677089168"/>
         </directory>
-  recorded_at: Tue, 22 Jun 2021 11:09:43 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:22 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=diff&expand=1&nodiff=1&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update
@@ -6138,7 +5674,7 @@ http_interactions:
       Content-Type:
       - application/octet-stream
       X-Request-Id:
-      - 2afa3b59-c0cb-4f2a-88f8-5c5a7bc0ac9a
+      - 93e2089d-796e-488c-9368-bba21f77ae73
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -6172,7 +5708,7 @@ http_interactions:
         ++++++ DUMMY_FILE (new)
         --- DUMMY_FILE
         +++ DUMMY_FILE
-  recorded_at: Tue, 22 Jun 2021 11:09:44 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:22 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?expand=1
@@ -6181,7 +5717,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 2afa3b59-c0cb-4f2a-88f8-5c5a7bc0ac9a
+      - 93e2089d-796e-488c-9368-bba21f77ae73
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -6200,17 +5736,105 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '644'
+      - '645'
     body:
       encoding: UTF-8
       string: |
-        <directory name="ProjectWithRepo_package" rev="89ea42b77174833f1114bad0670c14a5" vrev="4" srcmd5="89ea42b77174833f1114bad0670c14a5">
-          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="2c6109033c5937a5528ec21af10e04ef" baserev="2c6109033c5937a5528ec21af10e04ef" lsrcmd5="ce4cc59f8a846502437cfa9b5280a123"/>
-          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1624360170"/>
-          <entry name="_config" md5="46cccf6ebc7684f1ef2c7d8f2db417bd" size="62" mtime="1624360167"/>
-          <entry name="somefile.txt" md5="42adbaa46956c814fabac93750ee8931" size="60" mtime="1624360167"/>
+        <directory name="ProjectWithRepo_package" rev="620fcea8705aeeea23c1acb8fd6ac73c" vrev="10" srcmd5="620fcea8705aeeea23c1acb8fd6ac73c">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e83ea096f3fd3c64494e21941c685f6f" baserev="e83ea096f3fd3c64494e21941c685f6f" lsrcmd5="6e0e59c49ec80131659564768dd1e126"/>
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1677064904"/>
+          <entry name="_config" md5="ca5a602718fd6de59987f678c2d641bd" size="74" mtime="1677089168"/>
+          <entry name="somefile.txt" md5="3b293450a072f3211239c7377e3cca78" size="59" mtime="1677089168"/>
         </directory>
-  recorded_at: Tue, 22 Jun 2021 11:09:44 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:22 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 93e2089d-796e-488c-9368-bba21f77ae73
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '749'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="ProjectWithRepo_package" rev="4" vrev="4" srcmd5="6e0e59c49ec80131659564768dd1e126">
+          <linkinfo project="ProjectWithRepo:Update" package="ProjectWithRepo_package" srcmd5="e83ea096f3fd3c64494e21941c685f6f" baserev="e83ea096f3fd3c64494e21941c685f6f" xsrcmd5="620fcea8705aeeea23c1acb8fd6ac73c" lsrcmd5="6e0e59c49ec80131659564768dd1e126"/>
+          <entry name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5" mtime="1677064904"/>
+          <entry name="_config" md5="ca5a602718fd6de59987f678c2d641bd" size="74" mtime="1677089168"/>
+          <entry name="_link" md5="3500919b1ba7cde7a8a011415239d587" size="130" mtime="1677089170"/>
+          <entry name="somefile.txt" md5="3b293450a072f3211239c7377e3cca78" size="59" mtime="1677089168"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:06:23 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/home:tom:branches:ProjectWithRepo:Update/ProjectWithRepo_package?cmd=diff&expand=1&filelimit=10000&opackage=ProjectWithRepo_package&oproject=ProjectWithRepo:Update&rev=620fcea8705aeeea23c1acb8fd6ac73c&tarlimit=10000&view=xml&withissues=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      X-Request-Id:
+      - 93e2089d-796e-488c-9368-bba21f77ae73
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '608'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="75a5f6886344c882d5ec2b6d963a4b70">
+          <old project="ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="6" srcmd5="e83ea096f3fd3c64494e21941c685f6f"/>
+          <new project="home:tom:branches:ProjectWithRepo:Update" package="ProjectWithRepo_package" rev="620fcea8705aeeea23c1acb8fd6ac73c" srcmd5="620fcea8705aeeea23c1acb8fd6ac73c"/>
+          <files>
+            <file state="added">
+              <new name="DUMMY_FILE" md5="275876e34cf609db118f3d84b799a790" size="5"/>
+              <diff lines="3">@@ -0,0 +1,1 @@
+        +dummy
+        \ No newline at end of file
+        </diff>
+            </file>
+          </files>
+          <issues>
+          </issues>
+        </sourcediff>
+  recorded_at: Wed, 22 Feb 2023 18:06:23 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?code=unresolvable&view=status
@@ -6219,7 +5843,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 2ea5482e-921c-4629-ae28-030d03d24305
+      - 15e7682f-0520-4ca2-a353-d4f275511df8
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -6245,7 +5869,7 @@ http_interactions:
         <resultlist state="d717409be2592c96becbdc11142f1468">
           <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="broken" state="broken" details="no build type (ProjectWithRepo:Update)"/>
         </resultlist>
-  recorded_at: Tue, 22 Jun 2021 11:09:44 GMT
+  recorded_at: Wed, 22 Feb 2023 18:06:23 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?view=summary
@@ -6254,7 +5878,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 2e6db83b-4540-4575-9f8e-677002a671fd
+      - d9204409-ec06-4f3f-9df4-4a1f8a932405
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -6282,40 +5906,5 @@ http_interactions:
             <summary/>
           </result>
         </resultlist>
-  recorded_at: Tue, 22 Jun 2021 11:09:44 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:tom:branches:ProjectWithRepo:Update/_result?code=unresolvable&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Request-Id:
-      - 57e817f2-3064-4544-9c30-7df235168d1d
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '247'
-    body:
-      encoding: UTF-8
-      string: |
-        <resultlist state="d717409be2592c96becbdc11142f1468">
-          <result project="home:tom:branches:ProjectWithRepo:Update" repository="repository_2" arch="i586" code="broken" state="broken" details="no build type (ProjectWithRepo:Update)"/>
-        </resultlist>
-  recorded_at: Tue, 22 Jun 2021 11:09:44 GMT
-recorded_with: VCR 6.0.0
+  recorded_at: Wed, 22 Feb 2023 18:06:23 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Packages/Viewing_a_package_that/has_a_mime_like_suffix_in_it_s_name.yml
+++ b/src/api/spec/cassettes/Packages/Viewing_a_package_that/has_a_mime_like_suffix_in_it_s_name.yml
@@ -39,16 +39,16 @@ http_interactions:
           <description></description>
           <person userid="package_test_user" role="maintainer"/>
         </project>
-  recorded_at: Fri, 25 Jun 2021 11:33:21 GMT
+  recorded_at: Wed, 22 Feb 2023 17:59:00 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=user_39
+    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=user_28
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>The Moving Toyshop</title>
-          <description>Quae nesciunt assumenda libero.</description>
+          <title>Let Us Now Praise Famous Men</title>
+          <description>Nemo quaerat qui ipsa.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -69,21 +69,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '172'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>The Moving Toyshop</title>
-          <description>Quae nesciunt assumenda libero.</description>
+          <title>Let Us Now Praise Famous Men</title>
+          <description>Nemo quaerat qui ipsa.</description>
         </package>
-  recorded_at: Fri, 25 Jun 2021 11:33:21 GMT
+  recorded_at: Wed, 22 Feb 2023 17:59:00 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_config
     body:
       encoding: UTF-8
-      string: Et quaerat nihil. Et consequatur eum. Nulla repudiandae ea.
+      string: Accusamus earum ab. Et quod dolore. Tempora occaecati laudantium.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -107,21 +107,22 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="18" vrev="18">
-          <srcmd5>54dc2e2080f3efdce7f5f09915fb32e2</srcmd5>
+        <revision rev="61" vrev="61">
+          <srcmd5>ac231eab00c74825adbd15e5cef21fc0</srcmd5>
           <version>unknown</version>
-          <time>1624620801</time>
+          <time>1677088740</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Fri, 25 Jun 2021 11:33:21 GMT
+  recorded_at: Wed, 22 Feb 2023 17:59:00 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Ex amet modi. Nulla molestiae veniam. Enim est non.
+      string: Dolorem commodi nostrum. Voluptatem consequatur voluptatum. Est maiores
+        minima.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -145,15 +146,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="19" vrev="19">
-          <srcmd5>154771f7d36cafbcffc792b89a91f158</srcmd5>
+        <revision rev="62" vrev="62">
+          <srcmd5>2d90deced6a920701c01e2f6ffd54ae4</srcmd5>
           <version>unknown</version>
-          <time>1624620801</time>
+          <time>1677088740</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Fri, 25 Jun 2021 11:33:21 GMT
+  recorded_at: Wed, 22 Feb 2023 17:59:00 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/_meta?user=other_package_test_user
@@ -193,16 +194,16 @@ http_interactions:
           <description></description>
           <person userid="other_package_test_user" role="maintainer"/>
         </project>
-  recorded_at: Fri, 25 Jun 2021 11:33:21 GMT
+  recorded_at: Wed, 22 Feb 2023 17:59:00 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=user_40
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=user_29
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>Have His Carcase</title>
-          <description>Alias at qui reiciendis.</description>
+          <title>Surprised by Joy</title>
+          <description>At impedit omnis sit.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -223,21 +224,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '175'
+      - '172'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>Have His Carcase</title>
-          <description>Alias at qui reiciendis.</description>
+          <title>Surprised by Joy</title>
+          <description>At impedit omnis sit.</description>
         </package>
-  recorded_at: Fri, 25 Jun 2021 11:33:21 GMT
+  recorded_at: Wed, 22 Feb 2023 17:59:00 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_config
     body:
       encoding: UTF-8
-      string: Id culpa fugit. Alias quam aperiam. Enim rem assumenda.
+      string: Totam molestias animi. Tempora iusto enim. Est voluptas corrupti.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -261,21 +262,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="17" vrev="17">
-          <srcmd5>330284f6d8374e75db6d57c45b37cbef</srcmd5>
+        <revision rev="55" vrev="55">
+          <srcmd5>e4ac47cf9cc29cc4fd768c826eb0cd1b</srcmd5>
           <version>unknown</version>
-          <time>1624620801</time>
+          <time>1677088740</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Fri, 25 Jun 2021 11:33:21 GMT
+  recorded_at: Wed, 22 Feb 2023 17:59:00 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Nobis ea alias. Assumenda nobis possimus. Doloremque omnis id.
+      string: Qui recusandae ut. Et ducimus nostrum. Magni iusto quo.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -299,15 +300,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="18" vrev="18">
-          <srcmd5>baebae86f020449f483a8f0b91ad0653</srcmd5>
+        <revision rev="56" vrev="56">
+          <srcmd5>cbdb36b4f6e9a50617199c1fb09a08ac</srcmd5>
           <version>unknown</version>
-          <time>1624620801</time>
+          <time>1677088740</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Fri, 25 Jun 2021 11:33:21 GMT
+  recorded_at: Wed, 22 Feb 2023 17:59:00 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test.json/_meta?user=package_test_user
@@ -315,7 +316,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test.json" project="home:package_test_user">
-          <title>Pale Kings and Princes</title>
+          <title>The House of Mirth</title>
           <description>A package with a mime type suffix</description>
         </package>
     headers:
@@ -337,15 +338,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '174'
+      - '170'
     body:
       encoding: UTF-8
       string: |
         <package name="test.json" project="home:package_test_user">
-          <title>Pale Kings and Princes</title>
+          <title>The House of Mirth</title>
           <description>A package with a mime type suffix</description>
         </package>
-  recorded_at: Fri, 25 Jun 2021 11:33:21 GMT
+  recorded_at: Wed, 22 Feb 2023 17:59:00 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test.json
@@ -354,7 +355,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 04ff5948-ba01-48af-af4a-97501052b13c
+      - 63a95ec0-8d9b-40ed-9f13-ee9a83dc1935
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -379,7 +380,7 @@ http_interactions:
       string: |
         <directory name="test.json" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Fri, 25 Jun 2021 11:33:21 GMT
+  recorded_at: Wed, 22 Feb 2023 17:59:00 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test.json?expand=1
@@ -411,5 +412,209 @@ http_interactions:
       string: |
         <directory name="test.json" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Fri, 25 Jun 2021 11:33:21 GMT
-recorded_with: VCR 6.0.0
+  recorded_at: Wed, 22 Feb 2023 17:59:00 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test.json/_history?deleted=1&meta=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 63a95ec0-8d9b-40ed-9f13-ee9a83dc1935
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Wed, 22 Feb 2023 17:59:00 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 8333aa4f-0a36-47f6-aaf4-f664da388660
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '84'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test.json" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 17:59:00 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:package_test_user/_result?lastbuild=1&locallink=1&multibuild=1&package=test.json&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 8333aa4f-0a36-47f6-aaf4-f664da388660
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 17:59:00 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 813a0055-7b6a-4abc-8d2c-73ef42e54951
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '84'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test.json" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 17:59:00 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:package_test_user/_result?lastbuild=1&locallink=1&multibuild=1&package=test.json&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 813a0055-7b6a-4abc-8d2c-73ef42e54951
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 17:59:00 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:package_test_user/_result?package=test.json&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - e041b1b6-8e17-429a-b07e-3e87f50bfc27
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 17:59:01 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Packages/Viewing_a_package_that/has_derived_packages.yml
+++ b/src/api/spec/cassettes/Packages/Viewing_a_package_that/has_derived_packages.yml
@@ -39,16 +39,16 @@ http_interactions:
           <description></description>
           <person userid="package_test_user" role="maintainer"/>
         </project>
-  recorded_at: Thu, 03 Nov 2022 09:44:55 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:56 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=user_39
+    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=user_26
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>Time of our Darkness</title>
-          <description>Qui omnis soluta adipisci.</description>
+          <title>It's a Battlefield</title>
+          <description>Quos et in omnis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -69,21 +69,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '168'
+      - '157'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>Time of our Darkness</title>
-          <description>Qui omnis soluta adipisci.</description>
+          <title>It's a Battlefield</title>
+          <description>Quos et in omnis.</description>
         </package>
-  recorded_at: Thu, 03 Nov 2022 09:44:56 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:56 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_config
     body:
       encoding: UTF-8
-      string: Quo qui ab. Quia accusamus ea. Ut id at.
+      string: Quia sed iusto. Non repellat necessitatibus. Tempora tenetur cum.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -107,21 +107,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="65" vrev="65">
-          <srcmd5>8d0a1eff40158b08cb3cf4200e017401</srcmd5>
+        <revision rev="59" vrev="59">
+          <srcmd5>b7010d32f7a000183e42b0d62bbd02d6</srcmd5>
           <version>unknown</version>
-          <time>1667468696</time>
+          <time>1677088736</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 03 Nov 2022 09:44:56 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:57 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Nesciunt et possimus. Velit architecto asperiores. Cum repellat tempore.
+      string: Consequuntur assumenda consectetur. Quo aut incidunt. Maxime et placeat.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -145,15 +145,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="66" vrev="66">
-          <srcmd5>ce6cbe50db351086e2d8be3d42079d0e</srcmd5>
+        <revision rev="60" vrev="60">
+          <srcmd5>8b520d9d4da544ed78e7603a34883005</srcmd5>
           <version>unknown</version>
-          <time>1667468696</time>
+          <time>1677088737</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 03 Nov 2022 09:44:56 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:57 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/_meta?user=other_package_test_user
@@ -193,16 +193,16 @@ http_interactions:
           <description></description>
           <person userid="other_package_test_user" role="maintainer"/>
         </project>
-  recorded_at: Thu, 03 Nov 2022 09:44:56 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:57 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=user_40
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=user_27
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>Recalled to Life</title>
-          <description>Perspiciatis sit mollitia dicta.</description>
+          <title>The Moving Toyshop</title>
+          <description>Amet voluptatem nemo sapiente.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -228,16 +228,16 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>Recalled to Life</title>
-          <description>Perspiciatis sit mollitia dicta.</description>
+          <title>The Moving Toyshop</title>
+          <description>Amet voluptatem nemo sapiente.</description>
         </package>
-  recorded_at: Thu, 03 Nov 2022 09:44:56 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:57 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_config
     body:
       encoding: UTF-8
-      string: Enim assumenda eius. Ut maiores voluptate. Velit ratione dolorum.
+      string: Voluptas sed adipisci. Accusamus eligendi eos. Rem deserunt aut.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -261,21 +261,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="59" vrev="59">
-          <srcmd5>0321643be34bb367639df429e2c6b93b</srcmd5>
+        <revision rev="53" vrev="53">
+          <srcmd5>c2efd8041848edfa1d33f516bdc19ae0</srcmd5>
           <version>unknown</version>
-          <time>1667468696</time>
+          <time>1677088737</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 03 Nov 2022 09:44:56 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:57 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Omnis maxime expedita. Aperiam fugiat dicta. Accusamus non dolorem.
+      string: Reprehenderit ut sint. Soluta velit repudiandae. Cumque placeat tenetur.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -299,15 +299,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="60" vrev="60">
-          <srcmd5>2df58b109291c1dcaf9831c4beda3f2c</srcmd5>
+        <revision rev="54" vrev="54">
+          <srcmd5>a5f356b08f41a327b393163555053a2a</srcmd5>
           <version>unknown</version>
-          <time>1667468696</time>
+          <time>1677088737</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 03 Nov 2022 09:44:56 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:57 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22test_package%22%20and%20linkinfo/@project=%22home:package_test_user%22%20and%20@project=%22home:package_test_user%22)
@@ -341,7 +341,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 03 Nov 2022 09:44:56 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:57 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/_meta?user=package_test_user
@@ -381,49 +381,7 @@ http_interactions:
           <description>This project was created for package test_package via attribute OBS:Maintained</description>
           <person userid="package_test_user" role="maintainer"/>
         </project>
-  recorded_at: Thu, 03 Nov 2022 09:44:56 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/_project/_attribute?meta=1&user=package_test_user
-    body:
-      encoding: UTF-8
-      string: |
-        <attributes>
-          <attribute name="AutoCleanup" namespace="OBS">
-            <value>2022-11-06 09:44:56 +0000</value>
-          </attribute>
-        </attributes>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '180'
-    body:
-      encoding: UTF-8
-      string: |
-        <revision rev="14">
-          <srcmd5>5bcb3e2449f83aad07709f80a43f50f4</srcmd5>
-          <time>1667468696</time>
-          <user>package_test_user</user>
-          <comment></comment>
-          <requestid/>
-        </revision>
-  recorded_at: Thu, 03 Nov 2022 09:44:56 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:57 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package/_meta?user=package_test_user
@@ -431,8 +389,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user:branches:home:package_test_user">
-          <title>Time of our Darkness</title>
-          <description>Qui omnis soluta adipisci.</description>
+          <title>It's a Battlefield</title>
+          <description>Quos et in omnis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -453,15 +411,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '200'
+      - '189'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user:branches:home:package_test_user">
-          <title>Time of our Darkness</title>
-          <description>Qui omnis soluta adipisci.</description>
+          <title>It's a Battlefield</title>
+          <description>Quos et in omnis.</description>
         </package>
-  recorded_at: Thu, 03 Nov 2022 09:44:56 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:57 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package?cmd=branch&noservice=1&opackage=test_package&oproject=home:package_test_user&user=package_test_user
@@ -493,15 +451,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="5" vrev="5">
-          <srcmd5>8583c5aaece15c4087ddf575cd5686e2</srcmd5>
+        <revision rev="6" vrev="6">
+          <srcmd5>5a690c5691f9d85c184a7000b2da5ec8</srcmd5>
           <version>unknown</version>
-          <time>1667468696</time>
+          <time>1677088737</time>
           <user>package_test_user</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 03 Nov 2022 09:44:56 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:57 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package/_meta?user=package_test_user
@@ -509,8 +467,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user:branches:home:package_test_user">
-          <title>Time of our Darkness</title>
-          <description>Qui omnis soluta adipisci.</description>
+          <title>It's a Battlefield</title>
+          <description>Quos et in omnis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -531,15 +489,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '200'
+      - '189'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user:branches:home:package_test_user">
-          <title>Time of our Darkness</title>
-          <description>Qui omnis soluta adipisci.</description>
+          <title>It's a Battlefield</title>
+          <description>Quos et in omnis.</description>
         </package>
-  recorded_at: Thu, 03 Nov 2022 09:44:56 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:57 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package
@@ -569,14 +527,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="5" vrev="5" srcmd5="8583c5aaece15c4087ddf575cd5686e2">
-          <linkinfo project="home:package_test_user" package="test_package" srcmd5="ce6cbe50db351086e2d8be3d42079d0e" baserev="ce6cbe50db351086e2d8be3d42079d0e" xsrcmd5="0771eff96b4b2e35abfe4f69c34e0640" lsrcmd5="8583c5aaece15c4087ddf575cd5686e2"/>
-          <entry name="_config" md5="87f386dd3812791669268e746c1dc0eb" size="40" mtime="1667468696"/>
-          <entry name="_link" md5="54f9f12d9816759171a2ea216e57116c" size="130" mtime="1667468696"/>
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1666872407"/>
-          <entry name="somefile.txt" md5="864aba786506c8374a541713031f6b5e" size="72" mtime="1667468696"/>
+        <directory name="test_package" rev="6" vrev="6" srcmd5="5a690c5691f9d85c184a7000b2da5ec8">
+          <linkinfo project="home:package_test_user" package="test_package" srcmd5="8b520d9d4da544ed78e7603a34883005" baserev="8b520d9d4da544ed78e7603a34883005" xsrcmd5="6f5b0476115dc44cafb1e94b833ad65d" lsrcmd5="5a690c5691f9d85c184a7000b2da5ec8"/>
+          <entry name="_config" md5="3ff2ff8feafcf6597922f748a95293b0" size="65" mtime="1677088736"/>
+          <entry name="_link" md5="d44ff36e91a2895f766d85df3ce0197c" size="130" mtime="1677088737"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="3009f3c981b57d18a9d871f7f9ddbf76" size="72" mtime="1677088737"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:56 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:57 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package?view=info
@@ -606,11 +564,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="test_package" rev="5" vrev="71" srcmd5="0771eff96b4b2e35abfe4f69c34e0640" lsrcmd5="8583c5aaece15c4087ddf575cd5686e2" verifymd5="ce6cbe50db351086e2d8be3d42079d0e">
+        <sourceinfo package="test_package" rev="6" vrev="66" srcmd5="6f5b0476115dc44cafb1e94b833ad65d" lsrcmd5="5a690c5691f9d85c184a7000b2da5ec8" verifymd5="8b520d9d4da544ed78e7603a34883005">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="home:package_test_user" package="test_package"/>
         </sourceinfo>
-  recorded_at: Thu, 03 Nov 2022 09:44:56 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:57 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package
@@ -640,14 +598,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="5" vrev="5" srcmd5="8583c5aaece15c4087ddf575cd5686e2">
-          <linkinfo project="home:package_test_user" package="test_package" srcmd5="ce6cbe50db351086e2d8be3d42079d0e" baserev="ce6cbe50db351086e2d8be3d42079d0e" xsrcmd5="0771eff96b4b2e35abfe4f69c34e0640" lsrcmd5="8583c5aaece15c4087ddf575cd5686e2"/>
-          <entry name="_config" md5="87f386dd3812791669268e746c1dc0eb" size="40" mtime="1667468696"/>
-          <entry name="_link" md5="54f9f12d9816759171a2ea216e57116c" size="130" mtime="1667468696"/>
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1666872407"/>
-          <entry name="somefile.txt" md5="864aba786506c8374a541713031f6b5e" size="72" mtime="1667468696"/>
+        <directory name="test_package" rev="6" vrev="6" srcmd5="5a690c5691f9d85c184a7000b2da5ec8">
+          <linkinfo project="home:package_test_user" package="test_package" srcmd5="8b520d9d4da544ed78e7603a34883005" baserev="8b520d9d4da544ed78e7603a34883005" xsrcmd5="6f5b0476115dc44cafb1e94b833ad65d" lsrcmd5="5a690c5691f9d85c184a7000b2da5ec8"/>
+          <entry name="_config" md5="3ff2ff8feafcf6597922f748a95293b0" size="65" mtime="1677088736"/>
+          <entry name="_link" md5="d44ff36e91a2895f766d85df3ce0197c" size="130" mtime="1677088737"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="3009f3c981b57d18a9d871f7f9ddbf76" size="72" mtime="1677088737"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:56 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:57 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -679,14 +637,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="110b9c37b3df001033c65d62f377d281">
+        <sourcediff key="ef1c1170610d05348c207c6ba0bac497">
           <old project="home:package_test_user:branches:home:package_test_user" package="test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:package_test_user:branches:home:package_test_user" package="test_package" rev="5" srcmd5="8583c5aaece15c4087ddf575cd5686e2"/>
+          <new project="home:package_test_user:branches:home:package_test_user" package="test_package" rev="6" srcmd5="5a690c5691f9d85c184a7000b2da5ec8"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 03 Nov 2022 09:44:56 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:57 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -718,12 +676,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="cc664317054a4ba8a14099e871905526">
-          <old project="home:package_test_user" package="test_package" rev="ce6cbe50db351086e2d8be3d42079d0e" srcmd5="ce6cbe50db351086e2d8be3d42079d0e"/>
-          <new project="home:package_test_user:branches:home:package_test_user" package="test_package" rev="0771eff96b4b2e35abfe4f69c34e0640" srcmd5="0771eff96b4b2e35abfe4f69c34e0640"/>
+        <sourcediff key="5839d7a454c3a46d15e5cf77f9a6a47e">
+          <old project="home:package_test_user" package="test_package" rev="8b520d9d4da544ed78e7603a34883005" srcmd5="8b520d9d4da544ed78e7603a34883005"/>
+          <new project="home:package_test_user:branches:home:package_test_user" package="test_package" rev="6f5b0476115dc44cafb1e94b833ad65d" srcmd5="6f5b0476115dc44cafb1e94b833ad65d"/>
           <files/>
         </sourcediff>
-  recorded_at: Thu, 03 Nov 2022 09:44:56 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:57 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/_meta?user=package_test_user
@@ -769,7 +727,7 @@ http_interactions:
             <disable/>
           </publish>
         </project>
-  recorded_at: Thu, 03 Nov 2022 09:44:56 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:57 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package
@@ -778,7 +736,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 69fc96c6-7689-4645-bb58-c43ea86fc897
+      - 78ec5d83-906b-4431-bb48-17be286bfb3e
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -801,15 +759,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="66" vrev="66" srcmd5="ce6cbe50db351086e2d8be3d42079d0e">
-          <entry name="_config" md5="87f386dd3812791669268e746c1dc0eb" size="40" mtime="1667468696"/>
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1666872407"/>
-          <entry name="somefile.txt" md5="864aba786506c8374a541713031f6b5e" size="72" mtime="1667468696"/>
+        <directory name="test_package" rev="60" vrev="60" srcmd5="8b520d9d4da544ed78e7603a34883005">
+          <entry name="_config" md5="3ff2ff8feafcf6597922f748a95293b0" size="65" mtime="1677088736"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="3009f3c981b57d18a9d871f7f9ddbf76" size="72" mtime="1677088737"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:56 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:57 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package?expand=1&rev=66
+    uri: http://backend:5352/source/home:package_test_user/test_package?expand=1&rev=60
     body:
       encoding: US-ASCII
       string: ''
@@ -836,19 +794,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="66" vrev="66" srcmd5="ce6cbe50db351086e2d8be3d42079d0e">
-          <entry name="_config" md5="87f386dd3812791669268e746c1dc0eb" size="40" mtime="1667468696"/>
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1666872407"/>
-          <entry name="somefile.txt" md5="864aba786506c8374a541713031f6b5e" size="72" mtime="1667468696"/>
+        <directory name="test_package" rev="60" vrev="60" srcmd5="8b520d9d4da544ed78e7603a34883005">
+          <entry name="_config" md5="3ff2ff8feafcf6597922f748a95293b0" size="65" mtime="1677088736"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="3009f3c981b57d18a9d871f7f9ddbf76" size="72" mtime="1677088737"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:56 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:57 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package/_history
+    uri: http://backend:5352/source/home:package_test_user/test_package/_history?deleted=1&meta=1&rev=60
     body:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - 78ec5d83-906b-4431-bb48-17be286bfb3e
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -867,409 +827,47 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '12197'
+      - '31'
     body:
       encoding: UTF-8
       string: |
         <revisionlist>
-          <revision rev="1" vrev="1">
-            <srcmd5>39430fe8eee11d74cd66e844e4647460</srcmd5>
-            <version>unknown</version>
-            <time>1666872405</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="2" vrev="2">
-            <srcmd5>369f1f23c6e11646161fe2e58127cc94</srcmd5>
-            <version>unknown</version>
-            <time>1666872405</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="3" vrev="3">
-            <srcmd5>e9c93f298abf3792c17a179e8472ef9f</srcmd5>
-            <version>unknown</version>
-            <time>1666872407</time>
-            <user>package_test_user</user>
-          </revision>
-          <revision rev="4" vrev="4">
-            <srcmd5>fe92ad389a77abc1c103e2b9abeb4d99</srcmd5>
-            <version>unknown</version>
-            <time>1667463244</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="5" vrev="5">
-            <srcmd5>c38595498e0e6cfcc304c9c0363c1476</srcmd5>
-            <version>unknown</version>
-            <time>1667463244</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="6" vrev="6">
-            <srcmd5>84ee2ec656c59bd2153d002321f4afed</srcmd5>
-            <version>unknown</version>
-            <time>1667464481</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="7" vrev="7">
-            <srcmd5>39185b1b7acbb1786bd3ab2a461ddb69</srcmd5>
-            <version>unknown</version>
-            <time>1667464481</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="8" vrev="8">
-            <srcmd5>f784cdc3453800dbf0347a0f80682de2</srcmd5>
-            <version>unknown</version>
-            <time>1667464736</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="9" vrev="9">
-            <srcmd5>b461ceaf1249dba9dfcb3c248e6be809</srcmd5>
-            <version>unknown</version>
-            <time>1667464736</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="10" vrev="10">
-            <srcmd5>d21b050db05f7a5c5ccaf6af362560b3</srcmd5>
-            <version>unknown</version>
-            <time>1667464744</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="11" vrev="11">
-            <srcmd5>6c635f1ad23df59a0d3da4effca55c71</srcmd5>
-            <version>unknown</version>
-            <time>1667464744</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="12" vrev="12">
-            <srcmd5>40e8fb03938d2be24413380673a7e494</srcmd5>
-            <version>unknown</version>
-            <time>1667464747</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="13" vrev="13">
-            <srcmd5>3baaad250de2dc0f0833d4a836972648</srcmd5>
-            <version>unknown</version>
-            <time>1667464747</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="14" vrev="14">
-            <srcmd5>3baaad250de2dc0f0833d4a836972648</srcmd5>
-            <version>unknown</version>
-            <time>1667464749</time>
-            <user>package_test_user</user>
-          </revision>
-          <revision rev="15" vrev="15">
-            <srcmd5>ba9b79ed65f5fbde153f78ffb08af146</srcmd5>
-            <version>unknown</version>
-            <time>1667464750</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="16" vrev="16">
-            <srcmd5>79762bab8a8fa6ec862b32f62cf72d21</srcmd5>
-            <version>unknown</version>
-            <time>1667464750</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="17" vrev="17">
-            <srcmd5>88366b20f7f01e5827dfd8091508fb25</srcmd5>
-            <version>unknown</version>
-            <time>1667464753</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="18" vrev="18">
-            <srcmd5>2436790b5946d1856306b2f0b2d1ab6f</srcmd5>
-            <version>unknown</version>
-            <time>1667464753</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="19" vrev="19">
-            <srcmd5>3e039aad3db23f9f4917e08eac60a922</srcmd5>
-            <version>unknown</version>
-            <time>1667464756</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="20" vrev="20">
-            <srcmd5>b9edb66d37ede13f625bdb4d688fe74b</srcmd5>
-            <version>unknown</version>
-            <time>1667464756</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="21" vrev="21">
-            <srcmd5>877721342ea4fa6a0c3cc3ccf5edb32f</srcmd5>
-            <version>unknown</version>
-            <time>1667464758</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="22" vrev="22">
-            <srcmd5>c12af4a22a92e27620ca9e743717bf04</srcmd5>
-            <version>unknown</version>
-            <time>1667464759</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="23" vrev="23">
-            <srcmd5>a9a24333f356400418c7d95da2c8be6f</srcmd5>
-            <version>unknown</version>
-            <time>1667464761</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="24" vrev="24">
-            <srcmd5>b0970bac3733ca0cdae917aad8bb79c7</srcmd5>
-            <version>unknown</version>
-            <time>1667464761</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="25" vrev="25">
-            <srcmd5>f2b4518bdfd16a84f51209ed78b5b8d1</srcmd5>
-            <version>unknown</version>
-            <time>1667464763</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="26" vrev="26">
-            <srcmd5>77238d237dbeac212945f06bc408917d</srcmd5>
-            <version>unknown</version>
-            <time>1667464763</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="27" vrev="27">
-            <srcmd5>39fa3baab4fe94f2caf25d450b0de8ed</srcmd5>
-            <version>unknown</version>
-            <time>1667464764</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="28" vrev="28">
-            <srcmd5>29698713fcf342ef8a376aba0146e61e</srcmd5>
-            <version>unknown</version>
-            <time>1667464764</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="29" vrev="29">
-            <srcmd5>0644c5bf6d37cc286692525419a61114</srcmd5>
-            <version>unknown</version>
-            <time>1667464767</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="30" vrev="30">
-            <srcmd5>ebe46e62b0cf0c963807e63d7d79485d</srcmd5>
-            <version>unknown</version>
-            <time>1667464767</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="31" vrev="31">
-            <srcmd5>da264a18d7117b5e853dab9f7339db08</srcmd5>
-            <version>unknown</version>
-            <time>1667464769</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="32" vrev="32">
-            <srcmd5>2a60f7a399bc383527fed10f88e493d7</srcmd5>
-            <version>unknown</version>
-            <time>1667464769</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="33" vrev="33">
-            <srcmd5>1930014cab69064a0384087ce2e0b649</srcmd5>
-            <version>unknown</version>
-            <time>1667464771</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="34" vrev="34">
-            <srcmd5>14a73a182d6dc32e8c6746b1a5f430b2</srcmd5>
-            <version>unknown</version>
-            <time>1667464771</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="35" vrev="35">
-            <srcmd5>8d36b298cd242ca4acf6f3857ea615d0</srcmd5>
-            <version>unknown</version>
-            <time>1667464774</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="36" vrev="36">
-            <srcmd5>757e5cf4a62cb7594cee98f44d5c5dfb</srcmd5>
-            <version>unknown</version>
-            <time>1667464774</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="37" vrev="37">
-            <srcmd5>c8218281e235eafe25a450a4af6795ea</srcmd5>
-            <version>unknown</version>
-            <time>1667464775</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="38" vrev="38">
-            <srcmd5>b34f256914adbd35d9416158188693ea</srcmd5>
-            <version>unknown</version>
-            <time>1667464775</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="39" vrev="39">
-            <srcmd5>866f12af510fe05a2aeb121833699dcd</srcmd5>
-            <version>unknown</version>
-            <time>1667464777</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="40" vrev="40">
-            <srcmd5>6b85a9444f69f8ade3246fd8f18c31a8</srcmd5>
-            <version>unknown</version>
-            <time>1667464777</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="41" vrev="41">
-            <srcmd5>3c730dc91073299ab81340b5c59b0cc3</srcmd5>
-            <version>unknown</version>
-            <time>1667464780</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="42" vrev="42">
-            <srcmd5>7cb8b74c1b67b7ab1c93ce7a7a2dbf72</srcmd5>
-            <version>unknown</version>
-            <time>1667464780</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="43" vrev="43">
-            <srcmd5>66fa604b63a4f143d1caed7c1fb7c12a</srcmd5>
-            <version>unknown</version>
-            <time>1667464782</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="44" vrev="44">
-            <srcmd5>80b9a02067224efd1d68aa9d79f14815</srcmd5>
-            <version>unknown</version>
-            <time>1667464782</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="45" vrev="45">
-            <srcmd5>02a2333bf072af09166c7e4eeeaa303d</srcmd5>
-            <version>unknown</version>
-            <time>1667464785</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="46" vrev="46">
-            <srcmd5>1a63fe0d41fe30b67d00493f1365da44</srcmd5>
-            <version>unknown</version>
-            <time>1667464785</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="47" vrev="47">
-            <srcmd5>735f8731e38f3c18bdaf5b34fa028ed8</srcmd5>
-            <version>unknown</version>
-            <time>1667464833</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="48" vrev="48">
-            <srcmd5>6af8bcd4b3c37ac1985609d7e2f141b2</srcmd5>
-            <version>unknown</version>
-            <time>1667464833</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="49" vrev="49">
-            <srcmd5>7e32b7d5850a80b1c460fa714ca5d4a5</srcmd5>
-            <version>unknown</version>
-            <time>1667464837</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="50" vrev="50">
-            <srcmd5>c80e563fdbc8e21508c8106b45be243a</srcmd5>
-            <version>unknown</version>
-            <time>1667464837</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="51" vrev="51">
-            <srcmd5>996c5eedf4e4f21229e7d8168695c8de</srcmd5>
-            <version>unknown</version>
-            <time>1667464840</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="52" vrev="52">
-            <srcmd5>055645f5c03a5a9675fd93f61eee3a2c</srcmd5>
-            <version>unknown</version>
-            <time>1667464840</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="53" vrev="53">
-            <srcmd5>0641c4fa40cc067d60f65fb905a63789</srcmd5>
-            <version>unknown</version>
-            <time>1667466962</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="54" vrev="54">
-            <srcmd5>c11f1fcb78d77216c74e9bf3a2c2c160</srcmd5>
-            <version>unknown</version>
-            <time>1667466962</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="55" vrev="55">
-            <srcmd5>c11f1fcb78d77216c74e9bf3a2c2c160</srcmd5>
-            <version>unknown</version>
-            <time>1667467792</time>
-            <user>package_test_user</user>
-          </revision>
-          <revision rev="56" vrev="56">
-            <srcmd5>65eba0f2c74b847bd64e354a3b6e21ce</srcmd5>
-            <version>unknown</version>
-            <time>1667468654</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="57" vrev="57">
-            <srcmd5>1f939eb34ca2fca015459856a4038515</srcmd5>
-            <version>unknown</version>
-            <time>1667468654</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="58" vrev="58">
-            <srcmd5>1f939eb34ca2fca015459856a4038515</srcmd5>
-            <version>unknown</version>
-            <time>1667468659</time>
-            <user>package_test_user</user>
-          </revision>
-          <revision rev="59" vrev="59">
-            <srcmd5>65aff4b2f0c39844b5a507b6ee8ac76b</srcmd5>
-            <version>unknown</version>
-            <time>1667468662</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="60" vrev="60">
-            <srcmd5>d8e4b959841c2f46207746c6a4af9313</srcmd5>
-            <version>unknown</version>
-            <time>1667468662</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="61" vrev="61">
-            <srcmd5>36764a3550cde304eb2dd39c2f230fd9</srcmd5>
-            <version>unknown</version>
-            <time>1667468666</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="62" vrev="62">
-            <srcmd5>2fcfa49dc0b011c276200e205760c94a</srcmd5>
-            <version>unknown</version>
-            <time>1667468666</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="63" vrev="63">
-            <srcmd5>720b5088e661cb7701b405b8fb549f43</srcmd5>
-            <version>unknown</version>
-            <time>1667468672</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="64" vrev="64">
-            <srcmd5>e3ca29257f3aa7a8f6341888d520caf7</srcmd5>
-            <version>unknown</version>
-            <time>1667468672</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="65" vrev="65">
-            <srcmd5>8d0a1eff40158b08cb3cf4200e017401</srcmd5>
-            <version>unknown</version>
-            <time>1667468696</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="66" vrev="66">
-            <srcmd5>ce6cbe50db351086e2d8be3d42079d0e</srcmd5>
-            <version>unknown</version>
-            <time>1667468696</time>
-            <user>unknown</user>
-          </revision>
         </revisionlist>
-  recorded_at: Thu, 03 Nov 2022 09:44:56 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:57 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package/_history?deleted=1&meta=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 78ec5d83-906b-4431-bb48-17be286bfb3e
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Wed, 22 Feb 2023 17:58:57 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package
@@ -1278,7 +876,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 38f1f650-6a51-4355-b758-f4abde19d642
+      - 77fb7bf2-e2d4-465b-ba24-18ba2418ed26
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1301,12 +899,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="66" vrev="66" srcmd5="ce6cbe50db351086e2d8be3d42079d0e">
-          <entry name="_config" md5="87f386dd3812791669268e746c1dc0eb" size="40" mtime="1667468696"/>
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1666872407"/>
-          <entry name="somefile.txt" md5="864aba786506c8374a541713031f6b5e" size="72" mtime="1667468696"/>
+        <directory name="test_package" rev="60" vrev="60" srcmd5="8b520d9d4da544ed78e7603a34883005">
+          <entry name="_config" md5="3ff2ff8feafcf6597922f748a95293b0" size="65" mtime="1677088736"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="3009f3c981b57d18a9d871f7f9ddbf76" size="72" mtime="1677088737"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:57 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:57 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:package_test_user/_result?lastbuild=1&locallink=1&multibuild=1&package=test_package&view=status
@@ -1315,7 +913,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 38f1f650-6a51-4355-b758-f4abde19d642
+      - 77fb7bf2-e2d4-465b-ba24-18ba2418ed26
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1340,7 +938,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:44:57 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:57 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package
@@ -1349,7 +947,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 0ed2d33e-83e5-4e55-9d85-8089c059eb5a
+      - 90dc7733-e58a-4d0b-9dc3-517bca1c6f96
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1372,12 +970,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="66" vrev="66" srcmd5="ce6cbe50db351086e2d8be3d42079d0e">
-          <entry name="_config" md5="87f386dd3812791669268e746c1dc0eb" size="40" mtime="1667468696"/>
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1666872407"/>
-          <entry name="somefile.txt" md5="864aba786506c8374a541713031f6b5e" size="72" mtime="1667468696"/>
+        <directory name="test_package" rev="60" vrev="60" srcmd5="8b520d9d4da544ed78e7603a34883005">
+          <entry name="_config" md5="3ff2ff8feafcf6597922f748a95293b0" size="65" mtime="1677088736"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="3009f3c981b57d18a9d871f7f9ddbf76" size="72" mtime="1677088737"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:57 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:57 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:package_test_user/_result?lastbuild=1&locallink=1&multibuild=1&package=test_package&view=status
@@ -1386,7 +984,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 0ed2d33e-83e5-4e55-9d85-8089c059eb5a
+      - 90dc7733-e58a-4d0b-9dc3-517bca1c6f96
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1411,7 +1009,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:44:57 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:57 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:package_test_user/_result?package=test_package&view=status
@@ -1420,7 +1018,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - baacf8ab-35aa-4193-9dd8-dc5946b8f219
+      - 281c6064-26c6-4f4f-92c9-ca88aa769300
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1445,7 +1043,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:44:57 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:58 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package?view=info
@@ -1454,7 +1052,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 3ff90a68-db1c-4fbe-8ca9-b2c8a9765981
+      - 57c1e343-5d0a-4ec0-9907-aedffb99b736
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1477,10 +1075,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="test_package" rev="66" vrev="66" srcmd5="ce6cbe50db351086e2d8be3d42079d0e" verifymd5="ce6cbe50db351086e2d8be3d42079d0e">
+        <sourceinfo package="test_package" rev="60" vrev="60" srcmd5="8b520d9d4da544ed78e7603a34883005" verifymd5="8b520d9d4da544ed78e7603a34883005">
           <error>bad build configuration, no build type defined or detected</error>
         </sourceinfo>
-  recorded_at: Thu, 03 Nov 2022 09:44:58 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:59 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package
@@ -1489,7 +1087,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 3ff90a68-db1c-4fbe-8ca9-b2c8a9765981
+      - 57c1e343-5d0a-4ec0-9907-aedffb99b736
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1512,12 +1110,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="66" vrev="66" srcmd5="ce6cbe50db351086e2d8be3d42079d0e">
-          <entry name="_config" md5="87f386dd3812791669268e746c1dc0eb" size="40" mtime="1667468696"/>
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1666872407"/>
-          <entry name="somefile.txt" md5="864aba786506c8374a541713031f6b5e" size="72" mtime="1667468696"/>
+        <directory name="test_package" rev="60" vrev="60" srcmd5="8b520d9d4da544ed78e7603a34883005">
+          <entry name="_config" md5="3ff2ff8feafcf6597922f748a95293b0" size="65" mtime="1677088736"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="3009f3c981b57d18a9d871f7f9ddbf76" size="72" mtime="1677088737"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:58 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:59 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:package_test_user/test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -1549,14 +1147,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="7203195ba9f565900b2763f2095d910d">
+        <sourcediff key="03c61ef4f3e4fad6996fcacc7f599e30">
           <old project="home:package_test_user" package="test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:package_test_user" package="test_package" rev="66" srcmd5="ce6cbe50db351086e2d8be3d42079d0e"/>
+          <new project="home:package_test_user" package="test_package" rev="60" srcmd5="8b520d9d4da544ed78e7603a34883005"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 03 Nov 2022 09:44:58 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:59 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package
@@ -1565,7 +1163,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 3ff90a68-db1c-4fbe-8ca9-b2c8a9765981
+      - 57c1e343-5d0a-4ec0-9907-aedffb99b736
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1588,17 +1186,17 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="5" vrev="5" srcmd5="8583c5aaece15c4087ddf575cd5686e2">
-          <linkinfo project="home:package_test_user" package="test_package" srcmd5="ce6cbe50db351086e2d8be3d42079d0e" baserev="ce6cbe50db351086e2d8be3d42079d0e" xsrcmd5="0771eff96b4b2e35abfe4f69c34e0640" lsrcmd5="8583c5aaece15c4087ddf575cd5686e2"/>
-          <entry name="_config" md5="87f386dd3812791669268e746c1dc0eb" size="40" mtime="1667468696"/>
-          <entry name="_link" md5="54f9f12d9816759171a2ea216e57116c" size="130" mtime="1667468696"/>
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1666872407"/>
-          <entry name="somefile.txt" md5="864aba786506c8374a541713031f6b5e" size="72" mtime="1667468696"/>
+        <directory name="test_package" rev="6" vrev="6" srcmd5="5a690c5691f9d85c184a7000b2da5ec8">
+          <linkinfo project="home:package_test_user" package="test_package" srcmd5="8b520d9d4da544ed78e7603a34883005" baserev="8b520d9d4da544ed78e7603a34883005" xsrcmd5="6f5b0476115dc44cafb1e94b833ad65d" lsrcmd5="5a690c5691f9d85c184a7000b2da5ec8"/>
+          <entry name="_config" md5="3ff2ff8feafcf6597922f748a95293b0" size="65" mtime="1677088736"/>
+          <entry name="_link" md5="d44ff36e91a2895f766d85df3ce0197c" size="130" mtime="1677088737"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="3009f3c981b57d18a9d871f7f9ddbf76" size="72" mtime="1677088737"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:58 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:59 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package?expand=1&rev=5
+    uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package?expand=1&rev=6
     body:
       encoding: US-ASCII
       string: ''
@@ -1625,20 +1223,22 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="0771eff96b4b2e35abfe4f69c34e0640" vrev="71" srcmd5="0771eff96b4b2e35abfe4f69c34e0640">
-          <linkinfo project="home:package_test_user" package="test_package" srcmd5="ce6cbe50db351086e2d8be3d42079d0e" baserev="ce6cbe50db351086e2d8be3d42079d0e" lsrcmd5="8583c5aaece15c4087ddf575cd5686e2"/>
-          <entry name="_config" md5="87f386dd3812791669268e746c1dc0eb" size="40" mtime="1667468696"/>
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1666872407"/>
-          <entry name="somefile.txt" md5="864aba786506c8374a541713031f6b5e" size="72" mtime="1667468696"/>
+        <directory name="test_package" rev="6f5b0476115dc44cafb1e94b833ad65d" vrev="66" srcmd5="6f5b0476115dc44cafb1e94b833ad65d">
+          <linkinfo project="home:package_test_user" package="test_package" srcmd5="8b520d9d4da544ed78e7603a34883005" baserev="8b520d9d4da544ed78e7603a34883005" lsrcmd5="5a690c5691f9d85c184a7000b2da5ec8"/>
+          <entry name="_config" md5="3ff2ff8feafcf6597922f748a95293b0" size="65" mtime="1677088736"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="3009f3c981b57d18a9d871f7f9ddbf76" size="72" mtime="1677088737"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:58 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:59 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package/_history
+    uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package/_history?deleted=1&meta=1&rev=6
     body:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - 57c1e343-5d0a-4ec0-9907-aedffb99b736
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1657,43 +1257,47 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '991'
+      - '31'
     body:
       encoding: UTF-8
       string: |
         <revisionlist>
-          <revision rev="1" vrev="1">
-            <srcmd5>e03486d0f6943568c4c7bd081393fc1d</srcmd5>
-            <version>unknown</version>
-            <time>1667464482</time>
-            <user>package_test_user</user>
-          </revision>
-          <revision rev="2" vrev="2">
-            <srcmd5>fc95940058c36155a4ffa184a061763e</srcmd5>
-            <version>unknown</version>
-            <time>1667464761</time>
-            <user>package_test_user</user>
-          </revision>
-          <revision rev="3" vrev="3">
-            <srcmd5>62311e8abbc98b1c464bddb9a5a19e37</srcmd5>
-            <version>unknown</version>
-            <time>1667464764</time>
-            <user>package_test_user</user>
-          </revision>
-          <revision rev="4" vrev="4">
-            <srcmd5>c2a7ec6c10d6e89545f1ecb6567ca40a</srcmd5>
-            <version>unknown</version>
-            <time>1667466962</time>
-            <user>package_test_user</user>
-          </revision>
-          <revision rev="5" vrev="5">
-            <srcmd5>8583c5aaece15c4087ddf575cd5686e2</srcmd5>
-            <version>unknown</version>
-            <time>1667468696</time>
-            <user>package_test_user</user>
-          </revision>
         </revisionlist>
-  recorded_at: Thu, 03 Nov 2022 09:44:58 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:59 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package/_history?deleted=1&meta=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 57c1e343-5d0a-4ec0-9907-aedffb99b736
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Wed, 22 Feb 2023 17:58:59 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:package_test_user:branches:home:package_test_user/_result?lastbuild=1&locallink=1&multibuild=1&package=test_package&view=status
@@ -1702,7 +1306,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 3134f815-debb-4e09-aaec-a09315e751c7
+      - dd96e606-06c4-469e-98fe-8baea3b17818
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1727,7 +1331,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:44:58 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:59 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:package_test_user:branches:home:package_test_user/_result?lastbuild=1&locallink=1&multibuild=1&package=test_package&view=status
@@ -1736,7 +1340,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - ce7c7032-f17e-4e5a-9222-b68ea42687db
+      - 600c76dd-c7a9-4821-af46-a00a208c33aa
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1761,7 +1365,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:44:58 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:59 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:package_test_user:branches:home:package_test_user/_result?package=test_package&view=status
@@ -1770,7 +1374,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - d3e7dd4d-d257-405e-8d2e-b05bc9291a22
+      - 31a026e2-1f6a-4f53-a054-21e9bd1441ce
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1795,5 +1399,5 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:44:59 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:59 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Packages/Viewing_a_package_that/was_branched.yml
+++ b/src/api/spec/cassettes/Packages/Viewing_a_package_that/was_branched.yml
@@ -39,16 +39,16 @@ http_interactions:
           <description></description>
           <person userid="package_test_user" role="maintainer"/>
         </project>
-  recorded_at: Fri, 25 Jun 2021 11:33:23 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:55 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=user_41
+    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=user_24
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>Brandy of the Damned</title>
-          <description>Perferendis nihil omnis assumenda.</description>
+          <title>Of Human Bondage</title>
+          <description>Rerum quia adipisci odit.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -69,21 +69,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '176'
+      - '163'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>Brandy of the Damned</title>
-          <description>Perferendis nihil omnis assumenda.</description>
+          <title>Of Human Bondage</title>
+          <description>Rerum quia adipisci odit.</description>
         </package>
-  recorded_at: Fri, 25 Jun 2021 11:33:23 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:55 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_config
     body:
       encoding: UTF-8
-      string: Vitae dignissimos natus. Est voluptatibus qui. Aut odio nisi.
+      string: Cum et doloremque. Voluptas est et. Iure eius dolore.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -107,21 +107,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="20" vrev="20">
-          <srcmd5>f73851ae8824a8390c5e9124dbcb90d4</srcmd5>
+        <revision rev="57" vrev="57">
+          <srcmd5>e005978745a58f02e82b77cd6e102e21</srcmd5>
           <version>unknown</version>
-          <time>1624620803</time>
+          <time>1677088735</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Fri, 25 Jun 2021 11:33:23 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:55 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Saepe qui quis. Ut sequi quia. Odio autem adipisci.
+      string: Qui voluptatem nam. Similique veniam vel. Neque omnis illo.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -145,15 +145,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="21" vrev="21">
-          <srcmd5>93bde33fce2f50ad0aca9c2b68953b54</srcmd5>
+        <revision rev="58" vrev="58">
+          <srcmd5>cd820d2414f7a0bb01a9d1c788555a74</srcmd5>
           <version>unknown</version>
-          <time>1624620803</time>
+          <time>1677088735</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Fri, 25 Jun 2021 11:33:23 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:55 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/_meta?user=other_package_test_user
@@ -193,16 +193,16 @@ http_interactions:
           <description></description>
           <person userid="other_package_test_user" role="maintainer"/>
         </project>
-  recorded_at: Fri, 25 Jun 2021 11:33:23 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:55 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=user_42
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=user_25
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>Alone on a Wide, Wide Sea</title>
-          <description>Dolorem atque voluptatibus culpa.</description>
+          <title>The Yellow Meads of Asphodel</title>
+          <description>Sed aut qui eum.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -223,21 +223,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '193'
+      - '179'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>Alone on a Wide, Wide Sea</title>
-          <description>Dolorem atque voluptatibus culpa.</description>
+          <title>The Yellow Meads of Asphodel</title>
+          <description>Sed aut qui eum.</description>
         </package>
-  recorded_at: Fri, 25 Jun 2021 11:33:23 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:55 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_config
     body:
       encoding: UTF-8
-      string: Laboriosam cum debitis. Qui molestiae et. Dolor quia suscipit.
+      string: Qui qui nemo. Quia ex provident. Incidunt pariatur molestiae.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -261,21 +261,22 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="19" vrev="19">
-          <srcmd5>cdb90ffa529306ac7f0fa6de58ff5b7a</srcmd5>
+        <revision rev="51" vrev="51">
+          <srcmd5>ff7a64dc723ae2afaea32def74d55f8d</srcmd5>
           <version>unknown</version>
-          <time>1624620803</time>
+          <time>1677088735</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Fri, 25 Jun 2021 11:33:23 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:55 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Voluptate sed et. Quae a rerum. Libero vel quod.
+      string: Dolorem pariatur molestiae. Commodi dolore nostrum. Adipisci facilis
+        aut.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -299,15 +300,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="20" vrev="20">
-          <srcmd5>9846750f46c2fe0f8c73a7f74abf7f67</srcmd5>
+        <revision rev="52" vrev="52">
+          <srcmd5>68e9b68a91604e6c7a0072966d5ea2c7</srcmd5>
           <version>unknown</version>
-          <time>1624620803</time>
+          <time>1677088735</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Fri, 25 Jun 2021 11:33:23 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:55 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22test_package%22%20and%20linkinfo/@project=%22home:package_test_user%22%20and%20@project=%22home:package_test_user%22)
@@ -341,7 +342,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Fri, 25 Jun 2021 11:33:23 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:55 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/_meta?user=package_test_user
@@ -381,7 +382,7 @@ http_interactions:
           <description>This project was created for package test_package via attribute OBS:Maintained</description>
           <person userid="package_test_user" role="maintainer"/>
         </project>
-  recorded_at: Fri, 25 Jun 2021 11:33:23 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:55 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package/_meta?user=package_test_user
@@ -389,8 +390,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user:branches:home:package_test_user">
-          <title>Brandy of the Damned</title>
-          <description>Perferendis nihil omnis assumenda.</description>
+          <title>Of Human Bondage</title>
+          <description>Rerum quia adipisci odit.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -411,15 +412,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '195'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user:branches:home:package_test_user">
-          <title>Brandy of the Damned</title>
-          <description>Perferendis nihil omnis assumenda.</description>
+          <title>Of Human Bondage</title>
+          <description>Rerum quia adipisci odit.</description>
         </package>
-  recorded_at: Fri, 25 Jun 2021 11:33:23 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:55 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package?cmd=branch&noservice=1&opackage=test_package&oproject=home:package_test_user&user=package_test_user
@@ -451,15 +452,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1" vrev="1">
-          <srcmd5>3e03008b9003aeba88940c12737b168a</srcmd5>
+        <revision rev="5" vrev="5">
+          <srcmd5>ff4e212866793fab82b20148dd63d36a</srcmd5>
           <version>unknown</version>
-          <time>1624620803</time>
+          <time>1677088735</time>
           <user>package_test_user</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Fri, 25 Jun 2021 11:33:23 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:55 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package/_meta?user=package_test_user
@@ -467,8 +468,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user:branches:home:package_test_user">
-          <title>Brandy of the Damned</title>
-          <description>Perferendis nihil omnis assumenda.</description>
+          <title>Of Human Bondage</title>
+          <description>Rerum quia adipisci odit.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -489,15 +490,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '208'
+      - '195'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user:branches:home:package_test_user">
-          <title>Brandy of the Damned</title>
-          <description>Perferendis nihil omnis assumenda.</description>
+          <title>Of Human Bondage</title>
+          <description>Rerum quia adipisci odit.</description>
         </package>
-  recorded_at: Fri, 25 Jun 2021 11:33:23 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:55 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package
@@ -527,14 +528,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="1" vrev="1" srcmd5="3e03008b9003aeba88940c12737b168a">
-          <linkinfo project="home:package_test_user" package="test_package" srcmd5="93bde33fce2f50ad0aca9c2b68953b54" baserev="93bde33fce2f50ad0aca9c2b68953b54" xsrcmd5="e649a85e194ed6fc60f40152577ef4ac" lsrcmd5="3e03008b9003aeba88940c12737b168a"/>
-          <entry name="_config" md5="a5f7f583533f86a71576a41da6b36af1" size="61" mtime="1624620803"/>
-          <entry name="_link" md5="7fee1eb3a95e3427c260db0c7ced88e9" size="130" mtime="1624620803"/>
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1624620688"/>
-          <entry name="somefile.txt" md5="dd6c0d70a63530a638fa6db468f88bdb" size="51" mtime="1624620803"/>
+        <directory name="test_package" rev="5" vrev="5" srcmd5="ff4e212866793fab82b20148dd63d36a">
+          <linkinfo project="home:package_test_user" package="test_package" srcmd5="cd820d2414f7a0bb01a9d1c788555a74" baserev="cd820d2414f7a0bb01a9d1c788555a74" xsrcmd5="83c82bb0c680cc97acc77821f96065d4" lsrcmd5="ff4e212866793fab82b20148dd63d36a"/>
+          <entry name="_config" md5="44b854a108eb792ebdca95d924851096" size="53" mtime="1677088735"/>
+          <entry name="_link" md5="c9dba395beba629d25efb4245666f847" size="130" mtime="1677088735"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="2ca6ccf41c11a44a9e52c8f477af3a51" size="59" mtime="1677088735"/>
         </directory>
-  recorded_at: Fri, 25 Jun 2021 11:33:23 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:55 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package?view=info
@@ -564,11 +565,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="test_package" rev="1" vrev="22" srcmd5="e649a85e194ed6fc60f40152577ef4ac" lsrcmd5="3e03008b9003aeba88940c12737b168a" verifymd5="93bde33fce2f50ad0aca9c2b68953b54">
+        <sourceinfo package="test_package" rev="5" vrev="63" srcmd5="83c82bb0c680cc97acc77821f96065d4" lsrcmd5="ff4e212866793fab82b20148dd63d36a" verifymd5="cd820d2414f7a0bb01a9d1c788555a74">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="home:package_test_user" package="test_package"/>
         </sourceinfo>
-  recorded_at: Fri, 25 Jun 2021 11:33:23 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:55 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package
@@ -598,14 +599,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="1" vrev="1" srcmd5="3e03008b9003aeba88940c12737b168a">
-          <linkinfo project="home:package_test_user" package="test_package" srcmd5="93bde33fce2f50ad0aca9c2b68953b54" baserev="93bde33fce2f50ad0aca9c2b68953b54" xsrcmd5="e649a85e194ed6fc60f40152577ef4ac" lsrcmd5="3e03008b9003aeba88940c12737b168a"/>
-          <entry name="_config" md5="a5f7f583533f86a71576a41da6b36af1" size="61" mtime="1624620803"/>
-          <entry name="_link" md5="7fee1eb3a95e3427c260db0c7ced88e9" size="130" mtime="1624620803"/>
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1624620688"/>
-          <entry name="somefile.txt" md5="dd6c0d70a63530a638fa6db468f88bdb" size="51" mtime="1624620803"/>
+        <directory name="test_package" rev="5" vrev="5" srcmd5="ff4e212866793fab82b20148dd63d36a">
+          <linkinfo project="home:package_test_user" package="test_package" srcmd5="cd820d2414f7a0bb01a9d1c788555a74" baserev="cd820d2414f7a0bb01a9d1c788555a74" xsrcmd5="83c82bb0c680cc97acc77821f96065d4" lsrcmd5="ff4e212866793fab82b20148dd63d36a"/>
+          <entry name="_config" md5="44b854a108eb792ebdca95d924851096" size="53" mtime="1677088735"/>
+          <entry name="_link" md5="c9dba395beba629d25efb4245666f847" size="130" mtime="1677088735"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="2ca6ccf41c11a44a9e52c8f477af3a51" size="59" mtime="1677088735"/>
         </directory>
-  recorded_at: Fri, 25 Jun 2021 11:33:23 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:55 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -637,14 +638,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="649e180aac374645b9bac708ebf6db28">
+        <sourcediff key="c009947da7acd30090f5c612c98a249d">
           <old project="home:package_test_user:branches:home:package_test_user" package="test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:package_test_user:branches:home:package_test_user" package="test_package" rev="1" srcmd5="3e03008b9003aeba88940c12737b168a"/>
+          <new project="home:package_test_user:branches:home:package_test_user" package="test_package" rev="5" srcmd5="ff4e212866793fab82b20148dd63d36a"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Fri, 25 Jun 2021 11:33:23 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:55 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -676,12 +677,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="4e2b2bb2606a562d37de19d5dd33b4ad">
-          <old project="home:package_test_user" package="test_package" rev="93bde33fce2f50ad0aca9c2b68953b54" srcmd5="93bde33fce2f50ad0aca9c2b68953b54"/>
-          <new project="home:package_test_user:branches:home:package_test_user" package="test_package" rev="e649a85e194ed6fc60f40152577ef4ac" srcmd5="e649a85e194ed6fc60f40152577ef4ac"/>
+        <sourcediff key="ebeac9ff518ce6ac9d57642196922877">
+          <old project="home:package_test_user" package="test_package" rev="cd820d2414f7a0bb01a9d1c788555a74" srcmd5="cd820d2414f7a0bb01a9d1c788555a74"/>
+          <new project="home:package_test_user:branches:home:package_test_user" package="test_package" rev="83c82bb0c680cc97acc77821f96065d4" srcmd5="83c82bb0c680cc97acc77821f96065d4"/>
           <files/>
         </sourcediff>
-  recorded_at: Fri, 25 Jun 2021 11:33:23 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:55 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/_meta?user=package_test_user
@@ -727,7 +728,7 @@ http_interactions:
             <disable/>
           </publish>
         </project>
-  recorded_at: Fri, 25 Jun 2021 11:33:23 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:55 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package?view=info
@@ -736,7 +737,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 0c51527c-42aa-4bb6-a0bb-9f7dc7be8a5f
+      - 61e80875-0862-4ccb-8533-179da1f3d415
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -759,10 +760,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="test_package" rev="21" vrev="21" srcmd5="93bde33fce2f50ad0aca9c2b68953b54" verifymd5="93bde33fce2f50ad0aca9c2b68953b54">
+        <sourceinfo package="test_package" rev="58" vrev="58" srcmd5="cd820d2414f7a0bb01a9d1c788555a74" verifymd5="cd820d2414f7a0bb01a9d1c788555a74">
           <error>bad build configuration, no build type defined or detected</error>
         </sourceinfo>
-  recorded_at: Fri, 25 Jun 2021 11:33:24 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:56 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package
@@ -771,7 +772,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 0c51527c-42aa-4bb6-a0bb-9f7dc7be8a5f
+      - 61e80875-0862-4ccb-8533-179da1f3d415
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -794,12 +795,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="21" vrev="21" srcmd5="93bde33fce2f50ad0aca9c2b68953b54">
-          <entry name="_config" md5="a5f7f583533f86a71576a41da6b36af1" size="61" mtime="1624620803"/>
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1624620688"/>
-          <entry name="somefile.txt" md5="dd6c0d70a63530a638fa6db468f88bdb" size="51" mtime="1624620803"/>
+        <directory name="test_package" rev="58" vrev="58" srcmd5="cd820d2414f7a0bb01a9d1c788555a74">
+          <entry name="_config" md5="44b854a108eb792ebdca95d924851096" size="53" mtime="1677088735"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="2ca6ccf41c11a44a9e52c8f477af3a51" size="59" mtime="1677088735"/>
         </directory>
-  recorded_at: Fri, 25 Jun 2021 11:33:24 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:56 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:package_test_user/test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -831,14 +832,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="b6ce35572399fc8748526838be94d4fe">
+        <sourcediff key="8599ccdf600ee6543165d3fc57d58103">
           <old project="home:package_test_user" package="test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:package_test_user" package="test_package" rev="21" srcmd5="93bde33fce2f50ad0aca9c2b68953b54"/>
+          <new project="home:package_test_user" package="test_package" rev="58" srcmd5="cd820d2414f7a0bb01a9d1c788555a74"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Fri, 25 Jun 2021 11:33:24 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:56 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package
@@ -847,7 +848,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 0c51527c-42aa-4bb6-a0bb-9f7dc7be8a5f
+      - 61e80875-0862-4ccb-8533-179da1f3d415
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -870,17 +871,17 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="1" vrev="1" srcmd5="3e03008b9003aeba88940c12737b168a">
-          <linkinfo project="home:package_test_user" package="test_package" srcmd5="93bde33fce2f50ad0aca9c2b68953b54" baserev="93bde33fce2f50ad0aca9c2b68953b54" xsrcmd5="e649a85e194ed6fc60f40152577ef4ac" lsrcmd5="3e03008b9003aeba88940c12737b168a"/>
-          <entry name="_config" md5="a5f7f583533f86a71576a41da6b36af1" size="61" mtime="1624620803"/>
-          <entry name="_link" md5="7fee1eb3a95e3427c260db0c7ced88e9" size="130" mtime="1624620803"/>
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1624620688"/>
-          <entry name="somefile.txt" md5="dd6c0d70a63530a638fa6db468f88bdb" size="51" mtime="1624620803"/>
+        <directory name="test_package" rev="5" vrev="5" srcmd5="ff4e212866793fab82b20148dd63d36a">
+          <linkinfo project="home:package_test_user" package="test_package" srcmd5="cd820d2414f7a0bb01a9d1c788555a74" baserev="cd820d2414f7a0bb01a9d1c788555a74" xsrcmd5="83c82bb0c680cc97acc77821f96065d4" lsrcmd5="ff4e212866793fab82b20148dd63d36a"/>
+          <entry name="_config" md5="44b854a108eb792ebdca95d924851096" size="53" mtime="1677088735"/>
+          <entry name="_link" md5="c9dba395beba629d25efb4245666f847" size="130" mtime="1677088735"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="2ca6ccf41c11a44a9e52c8f477af3a51" size="59" mtime="1677088735"/>
         </directory>
-  recorded_at: Fri, 25 Jun 2021 11:33:24 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:56 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package?expand=1&rev=1
+    uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package?expand=1&rev=5
     body:
       encoding: US-ASCII
       string: ''
@@ -907,20 +908,22 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="e649a85e194ed6fc60f40152577ef4ac" vrev="22" srcmd5="e649a85e194ed6fc60f40152577ef4ac">
-          <linkinfo project="home:package_test_user" package="test_package" srcmd5="93bde33fce2f50ad0aca9c2b68953b54" baserev="93bde33fce2f50ad0aca9c2b68953b54" lsrcmd5="3e03008b9003aeba88940c12737b168a"/>
-          <entry name="_config" md5="a5f7f583533f86a71576a41da6b36af1" size="61" mtime="1624620803"/>
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1624620688"/>
-          <entry name="somefile.txt" md5="dd6c0d70a63530a638fa6db468f88bdb" size="51" mtime="1624620803"/>
+        <directory name="test_package" rev="83c82bb0c680cc97acc77821f96065d4" vrev="63" srcmd5="83c82bb0c680cc97acc77821f96065d4">
+          <linkinfo project="home:package_test_user" package="test_package" srcmd5="cd820d2414f7a0bb01a9d1c788555a74" baserev="cd820d2414f7a0bb01a9d1c788555a74" lsrcmd5="ff4e212866793fab82b20148dd63d36a"/>
+          <entry name="_config" md5="44b854a108eb792ebdca95d924851096" size="53" mtime="1677088735"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="2ca6ccf41c11a44a9e52c8f477af3a51" size="59" mtime="1677088735"/>
         </directory>
-  recorded_at: Fri, 25 Jun 2021 11:33:24 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:56 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package/_history
+    uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package/_history?deleted=1&meta=1&rev=5
     body:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - 61e80875-0862-4ccb-8533-179da1f3d415
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -939,17 +942,147 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '223'
+      - '31'
     body:
       encoding: UTF-8
       string: |
         <revisionlist>
-          <revision rev="1" vrev="1">
-            <srcmd5>3e03008b9003aeba88940c12737b168a</srcmd5>
-            <version>unknown</version>
-            <time>1624620803</time>
-            <user>package_test_user</user>
-          </revision>
         </revisionlist>
-  recorded_at: Fri, 25 Jun 2021 11:33:24 GMT
-recorded_with: VCR 6.0.0
+  recorded_at: Wed, 22 Feb 2023 17:58:56 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user:branches:home:package_test_user/test_package/_history?deleted=1&meta=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 61e80875-0862-4ccb-8533-179da1f3d415
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Wed, 22 Feb 2023 17:58:56 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:package_test_user:branches:home:package_test_user/_result?lastbuild=1&locallink=1&multibuild=1&package=test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - df7b795a-8c34-4570-a1ef-b8c098892ba0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 17:58:56 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:package_test_user:branches:home:package_test_user/_result?lastbuild=1&locallink=1&multibuild=1&package=test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - aed1f928-e70e-4f0d-9a11-35a358e6a8b5
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 17:58:56 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:package_test_user:branches:home:package_test_user/_result?package=test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 5461f95c-84a2-4716-a127-37b9d3cf43db
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 17:58:56 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Packages/adding_a_valid_file.yml
+++ b/src/api/spec/cassettes/Packages/adding_a_valid_file.yml
@@ -39,7 +39,7 @@ http_interactions:
           <description></description>
           <person userid="package_test_user" role="maintainer"/>
         </project>
-  recorded_at: Thu, 03 Nov 2022 09:44:14 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:16 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=user_1
@@ -47,8 +47,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>Behold the Man</title>
-          <description>Quis enim odit aut.</description>
+          <title>The Way Through the Woods</title>
+          <description>Dolor culpa tempora consequuntur.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -69,21 +69,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '155'
+      - '180'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>Behold the Man</title>
-          <description>Quis enim odit aut.</description>
+          <title>The Way Through the Woods</title>
+          <description>Dolor culpa tempora consequuntur.</description>
         </package>
-  recorded_at: Thu, 03 Nov 2022 09:44:14 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:17 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_config
     body:
       encoding: UTF-8
-      string: Ut omnis et. Laboriosam fuga ab. Qui voluptatum accusantium.
+      string: Culpa libero cum. Non earum id. Qui sapiente et.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -107,21 +107,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="56" vrev="56">
-          <srcmd5>65eba0f2c74b847bd64e354a3b6e21ce</srcmd5>
+        <revision rev="63" vrev="63">
+          <srcmd5>b9ffe042ca4a5ab0c863fa5ad41821f1</srcmd5>
           <version>unknown</version>
-          <time>1667468654</time>
+          <time>1677089057</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 03 Nov 2022 09:44:14 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:17 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Expedita ullam recusandae. In excepturi illo. Ex tempora odio.
+      string: Quia eligendi odit. Aliquid qui qui. Natus corrupti mollitia.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -145,15 +145,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="57" vrev="57">
-          <srcmd5>1f939eb34ca2fca015459856a4038515</srcmd5>
+        <revision rev="64" vrev="64">
+          <srcmd5>c832925a61302391edf832509e0eb195</srcmd5>
           <version>unknown</version>
-          <time>1667468654</time>
+          <time>1677089057</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 03 Nov 2022 09:44:14 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:17 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/_meta?user=other_package_test_user
@@ -193,7 +193,7 @@ http_interactions:
           <description></description>
           <person userid="other_package_test_user" role="maintainer"/>
         </project>
-  recorded_at: Thu, 03 Nov 2022 09:44:14 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:17 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=user_2
@@ -201,8 +201,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>A Swiftly Tilting Planet</title>
-          <description>Sapiente et enim minus.</description>
+          <title>The Moving Finger</title>
+          <description>Vitae aut laborum repellendus.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -228,16 +228,16 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>A Swiftly Tilting Planet</title>
-          <description>Sapiente et enim minus.</description>
+          <title>The Moving Finger</title>
+          <description>Vitae aut laborum repellendus.</description>
         </package>
-  recorded_at: Thu, 03 Nov 2022 09:44:15 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:17 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_config
     body:
       encoding: UTF-8
-      string: Praesentium suscipit quia. Illum eveniet fugit. Voluptatem natus aperiam.
+      string: Non dolore in. Expedita autem laudantium. Quod molestiae quae.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -261,21 +261,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="51" vrev="51">
-          <srcmd5>2f00c05340e4eba7a824b06df8f13e5a</srcmd5>
+        <revision rev="57" vrev="57">
+          <srcmd5>28473c8e0ad5c3d4f9d83bc7917a91f3</srcmd5>
           <version>unknown</version>
-          <time>1667468655</time>
+          <time>1677089057</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 03 Nov 2022 09:44:15 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:17 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Non ea omnis. Repudiandae rerum aut. Quia quam ducimus.
+      string: Tempore cum nemo. Quia doloremque inventore. Quia odit qui.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -299,15 +299,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="52" vrev="52">
-          <srcmd5>a6c88fe740d6dab660a1befa5a1f7ebb</srcmd5>
+        <revision rev="58" vrev="58">
+          <srcmd5>cbc6c49b48375fdf767aec4e7436e392</srcmd5>
           <version>unknown</version>
-          <time>1667468655</time>
+          <time>1677089057</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 03 Nov 2022 09:44:15 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:17 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package
@@ -316,7 +316,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - dd65dd37-0cba-4699-8101-db0a72528571
+      - 9f102970-33bc-4c7e-b601-e76948985600
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -339,15 +339,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="57" vrev="57" srcmd5="1f939eb34ca2fca015459856a4038515">
-          <entry name="_config" md5="979e1b425c373c02ed6cb4aa879c0a0f" size="60" mtime="1667468654"/>
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1666872407"/>
-          <entry name="somefile.txt" md5="3b6e6f4ce75dee69847100e0131e2e74" size="62" mtime="1667468654"/>
+        <directory name="test_package" rev="64" vrev="64" srcmd5="c832925a61302391edf832509e0eb195">
+          <entry name="_config" md5="989d47313b2bbb987e4a7ff1ffbbc857" size="48" mtime="1677089057"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="21fd51a9401e348d8281cb06e82bf9d3" size="61" mtime="1677089057"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:18 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:23 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package?expand=1&rev=57
+    uri: http://backend:5352/source/home:package_test_user/test_package?expand=1&rev=64
     body:
       encoding: US-ASCII
       string: ''
@@ -374,58 +374,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="57" vrev="57" srcmd5="1f939eb34ca2fca015459856a4038515">
-          <entry name="_config" md5="979e1b425c373c02ed6cb4aa879c0a0f" size="60" mtime="1667468654"/>
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1666872407"/>
-          <entry name="somefile.txt" md5="3b6e6f4ce75dee69847100e0131e2e74" size="62" mtime="1667468654"/>
+        <directory name="test_package" rev="64" vrev="64" srcmd5="c832925a61302391edf832509e0eb195">
+          <entry name="_config" md5="989d47313b2bbb987e4a7ff1ffbbc857" size="48" mtime="1677089057"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="21fd51a9401e348d8281cb06e82bf9d3" size="61" mtime="1677089057"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:18 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:23 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Request-Id:
-      - dd65dd37-0cba-4699-8101-db0a72528571
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '393'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="test_package" rev="57" vrev="57" srcmd5="1f939eb34ca2fca015459856a4038515">
-          <entry name="_config" md5="979e1b425c373c02ed6cb4aa879c0a0f" size="60" mtime="1667468654"/>
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1666872407"/>
-          <entry name="somefile.txt" md5="3b6e6f4ce75dee69847100e0131e2e74" size="62" mtime="1667468654"/>
-        </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:18 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package
+    uri: http://backend:5352/source/home:package_test_user/test_package/_history?deleted=1&meta=1&rev=64
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - dd65dd37-0cba-4699-8101-db0a72528571
+      - 9f102970-33bc-4c7e-b601-e76948985600
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -444,390 +407,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '393'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="test_package" rev="57" vrev="57" srcmd5="1f939eb34ca2fca015459856a4038515">
-          <entry name="_config" md5="979e1b425c373c02ed6cb4aa879c0a0f" size="60" mtime="1667468654"/>
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1666872407"/>
-          <entry name="somefile.txt" md5="3b6e6f4ce75dee69847100e0131e2e74" size="62" mtime="1667468654"/>
-        </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:18 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package/_history
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '10531'
+      - '31'
     body:
       encoding: UTF-8
       string: |
         <revisionlist>
-          <revision rev="1" vrev="1">
-            <srcmd5>39430fe8eee11d74cd66e844e4647460</srcmd5>
-            <version>unknown</version>
-            <time>1666872405</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="2" vrev="2">
-            <srcmd5>369f1f23c6e11646161fe2e58127cc94</srcmd5>
-            <version>unknown</version>
-            <time>1666872405</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="3" vrev="3">
-            <srcmd5>e9c93f298abf3792c17a179e8472ef9f</srcmd5>
-            <version>unknown</version>
-            <time>1666872407</time>
-            <user>package_test_user</user>
-          </revision>
-          <revision rev="4" vrev="4">
-            <srcmd5>fe92ad389a77abc1c103e2b9abeb4d99</srcmd5>
-            <version>unknown</version>
-            <time>1667463244</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="5" vrev="5">
-            <srcmd5>c38595498e0e6cfcc304c9c0363c1476</srcmd5>
-            <version>unknown</version>
-            <time>1667463244</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="6" vrev="6">
-            <srcmd5>84ee2ec656c59bd2153d002321f4afed</srcmd5>
-            <version>unknown</version>
-            <time>1667464481</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="7" vrev="7">
-            <srcmd5>39185b1b7acbb1786bd3ab2a461ddb69</srcmd5>
-            <version>unknown</version>
-            <time>1667464481</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="8" vrev="8">
-            <srcmd5>f784cdc3453800dbf0347a0f80682de2</srcmd5>
-            <version>unknown</version>
-            <time>1667464736</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="9" vrev="9">
-            <srcmd5>b461ceaf1249dba9dfcb3c248e6be809</srcmd5>
-            <version>unknown</version>
-            <time>1667464736</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="10" vrev="10">
-            <srcmd5>d21b050db05f7a5c5ccaf6af362560b3</srcmd5>
-            <version>unknown</version>
-            <time>1667464744</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="11" vrev="11">
-            <srcmd5>6c635f1ad23df59a0d3da4effca55c71</srcmd5>
-            <version>unknown</version>
-            <time>1667464744</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="12" vrev="12">
-            <srcmd5>40e8fb03938d2be24413380673a7e494</srcmd5>
-            <version>unknown</version>
-            <time>1667464747</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="13" vrev="13">
-            <srcmd5>3baaad250de2dc0f0833d4a836972648</srcmd5>
-            <version>unknown</version>
-            <time>1667464747</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="14" vrev="14">
-            <srcmd5>3baaad250de2dc0f0833d4a836972648</srcmd5>
-            <version>unknown</version>
-            <time>1667464749</time>
-            <user>package_test_user</user>
-          </revision>
-          <revision rev="15" vrev="15">
-            <srcmd5>ba9b79ed65f5fbde153f78ffb08af146</srcmd5>
-            <version>unknown</version>
-            <time>1667464750</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="16" vrev="16">
-            <srcmd5>79762bab8a8fa6ec862b32f62cf72d21</srcmd5>
-            <version>unknown</version>
-            <time>1667464750</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="17" vrev="17">
-            <srcmd5>88366b20f7f01e5827dfd8091508fb25</srcmd5>
-            <version>unknown</version>
-            <time>1667464753</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="18" vrev="18">
-            <srcmd5>2436790b5946d1856306b2f0b2d1ab6f</srcmd5>
-            <version>unknown</version>
-            <time>1667464753</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="19" vrev="19">
-            <srcmd5>3e039aad3db23f9f4917e08eac60a922</srcmd5>
-            <version>unknown</version>
-            <time>1667464756</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="20" vrev="20">
-            <srcmd5>b9edb66d37ede13f625bdb4d688fe74b</srcmd5>
-            <version>unknown</version>
-            <time>1667464756</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="21" vrev="21">
-            <srcmd5>877721342ea4fa6a0c3cc3ccf5edb32f</srcmd5>
-            <version>unknown</version>
-            <time>1667464758</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="22" vrev="22">
-            <srcmd5>c12af4a22a92e27620ca9e743717bf04</srcmd5>
-            <version>unknown</version>
-            <time>1667464759</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="23" vrev="23">
-            <srcmd5>a9a24333f356400418c7d95da2c8be6f</srcmd5>
-            <version>unknown</version>
-            <time>1667464761</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="24" vrev="24">
-            <srcmd5>b0970bac3733ca0cdae917aad8bb79c7</srcmd5>
-            <version>unknown</version>
-            <time>1667464761</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="25" vrev="25">
-            <srcmd5>f2b4518bdfd16a84f51209ed78b5b8d1</srcmd5>
-            <version>unknown</version>
-            <time>1667464763</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="26" vrev="26">
-            <srcmd5>77238d237dbeac212945f06bc408917d</srcmd5>
-            <version>unknown</version>
-            <time>1667464763</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="27" vrev="27">
-            <srcmd5>39fa3baab4fe94f2caf25d450b0de8ed</srcmd5>
-            <version>unknown</version>
-            <time>1667464764</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="28" vrev="28">
-            <srcmd5>29698713fcf342ef8a376aba0146e61e</srcmd5>
-            <version>unknown</version>
-            <time>1667464764</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="29" vrev="29">
-            <srcmd5>0644c5bf6d37cc286692525419a61114</srcmd5>
-            <version>unknown</version>
-            <time>1667464767</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="30" vrev="30">
-            <srcmd5>ebe46e62b0cf0c963807e63d7d79485d</srcmd5>
-            <version>unknown</version>
-            <time>1667464767</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="31" vrev="31">
-            <srcmd5>da264a18d7117b5e853dab9f7339db08</srcmd5>
-            <version>unknown</version>
-            <time>1667464769</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="32" vrev="32">
-            <srcmd5>2a60f7a399bc383527fed10f88e493d7</srcmd5>
-            <version>unknown</version>
-            <time>1667464769</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="33" vrev="33">
-            <srcmd5>1930014cab69064a0384087ce2e0b649</srcmd5>
-            <version>unknown</version>
-            <time>1667464771</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="34" vrev="34">
-            <srcmd5>14a73a182d6dc32e8c6746b1a5f430b2</srcmd5>
-            <version>unknown</version>
-            <time>1667464771</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="35" vrev="35">
-            <srcmd5>8d36b298cd242ca4acf6f3857ea615d0</srcmd5>
-            <version>unknown</version>
-            <time>1667464774</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="36" vrev="36">
-            <srcmd5>757e5cf4a62cb7594cee98f44d5c5dfb</srcmd5>
-            <version>unknown</version>
-            <time>1667464774</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="37" vrev="37">
-            <srcmd5>c8218281e235eafe25a450a4af6795ea</srcmd5>
-            <version>unknown</version>
-            <time>1667464775</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="38" vrev="38">
-            <srcmd5>b34f256914adbd35d9416158188693ea</srcmd5>
-            <version>unknown</version>
-            <time>1667464775</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="39" vrev="39">
-            <srcmd5>866f12af510fe05a2aeb121833699dcd</srcmd5>
-            <version>unknown</version>
-            <time>1667464777</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="40" vrev="40">
-            <srcmd5>6b85a9444f69f8ade3246fd8f18c31a8</srcmd5>
-            <version>unknown</version>
-            <time>1667464777</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="41" vrev="41">
-            <srcmd5>3c730dc91073299ab81340b5c59b0cc3</srcmd5>
-            <version>unknown</version>
-            <time>1667464780</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="42" vrev="42">
-            <srcmd5>7cb8b74c1b67b7ab1c93ce7a7a2dbf72</srcmd5>
-            <version>unknown</version>
-            <time>1667464780</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="43" vrev="43">
-            <srcmd5>66fa604b63a4f143d1caed7c1fb7c12a</srcmd5>
-            <version>unknown</version>
-            <time>1667464782</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="44" vrev="44">
-            <srcmd5>80b9a02067224efd1d68aa9d79f14815</srcmd5>
-            <version>unknown</version>
-            <time>1667464782</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="45" vrev="45">
-            <srcmd5>02a2333bf072af09166c7e4eeeaa303d</srcmd5>
-            <version>unknown</version>
-            <time>1667464785</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="46" vrev="46">
-            <srcmd5>1a63fe0d41fe30b67d00493f1365da44</srcmd5>
-            <version>unknown</version>
-            <time>1667464785</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="47" vrev="47">
-            <srcmd5>735f8731e38f3c18bdaf5b34fa028ed8</srcmd5>
-            <version>unknown</version>
-            <time>1667464833</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="48" vrev="48">
-            <srcmd5>6af8bcd4b3c37ac1985609d7e2f141b2</srcmd5>
-            <version>unknown</version>
-            <time>1667464833</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="49" vrev="49">
-            <srcmd5>7e32b7d5850a80b1c460fa714ca5d4a5</srcmd5>
-            <version>unknown</version>
-            <time>1667464837</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="50" vrev="50">
-            <srcmd5>c80e563fdbc8e21508c8106b45be243a</srcmd5>
-            <version>unknown</version>
-            <time>1667464837</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="51" vrev="51">
-            <srcmd5>996c5eedf4e4f21229e7d8168695c8de</srcmd5>
-            <version>unknown</version>
-            <time>1667464840</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="52" vrev="52">
-            <srcmd5>055645f5c03a5a9675fd93f61eee3a2c</srcmd5>
-            <version>unknown</version>
-            <time>1667464840</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="53" vrev="53">
-            <srcmd5>0641c4fa40cc067d60f65fb905a63789</srcmd5>
-            <version>unknown</version>
-            <time>1667466962</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="54" vrev="54">
-            <srcmd5>c11f1fcb78d77216c74e9bf3a2c2c160</srcmd5>
-            <version>unknown</version>
-            <time>1667466962</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="55" vrev="55">
-            <srcmd5>c11f1fcb78d77216c74e9bf3a2c2c160</srcmd5>
-            <version>unknown</version>
-            <time>1667467792</time>
-            <user>package_test_user</user>
-          </revision>
-          <revision rev="56" vrev="56">
-            <srcmd5>65eba0f2c74b847bd64e354a3b6e21ce</srcmd5>
-            <version>unknown</version>
-            <time>1667468654</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="57" vrev="57">
-            <srcmd5>1f939eb34ca2fca015459856a4038515</srcmd5>
-            <version>unknown</version>
-            <time>1667468654</time>
-            <user>unknown</user>
-          </revision>
         </revisionlist>
-  recorded_at: Thu, 03 Nov 2022 09:44:18 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:23 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package
@@ -836,7 +422,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - c5320d7a-eb55-4799-9ee1-426276807103
+      - 9f102970-33bc-4c7e-b601-e76948985600
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -859,12 +445,120 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="57" vrev="57" srcmd5="1f939eb34ca2fca015459856a4038515">
-          <entry name="_config" md5="979e1b425c373c02ed6cb4aa879c0a0f" size="60" mtime="1667468654"/>
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1666872407"/>
-          <entry name="somefile.txt" md5="3b6e6f4ce75dee69847100e0131e2e74" size="62" mtime="1667468654"/>
+        <directory name="test_package" rev="64" vrev="64" srcmd5="c832925a61302391edf832509e0eb195">
+          <entry name="_config" md5="989d47313b2bbb987e4a7ff1ffbbc857" size="48" mtime="1677089057"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="21fd51a9401e348d8281cb06e82bf9d3" size="61" mtime="1677089057"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:18 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:23 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 9f102970-33bc-4c7e-b601-e76948985600
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '393'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test_package" rev="64" vrev="64" srcmd5="c832925a61302391edf832509e0eb195">
+          <entry name="_config" md5="989d47313b2bbb987e4a7ff1ffbbc857" size="48" mtime="1677089057"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="21fd51a9401e348d8281cb06e82bf9d3" size="61" mtime="1677089057"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:04:23 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package/_history?deleted=1&meta=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 9f102970-33bc-4c7e-b601-e76948985600
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Wed, 22 Feb 2023 18:04:23 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 5e7f1d57-f3b2-4979-bd7e-216b8a4325c2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '393'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test_package" rev="64" vrev="64" srcmd5="c832925a61302391edf832509e0eb195">
+          <entry name="_config" md5="989d47313b2bbb987e4a7ff1ffbbc857" size="48" mtime="1677089057"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="21fd51a9401e348d8281cb06e82bf9d3" size="61" mtime="1677089057"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:04:24 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:package_test_user/_result?lastbuild=1&locallink=1&multibuild=1&package=test_package&view=status
@@ -873,7 +567,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - c5320d7a-eb55-4799-9ee1-426276807103
+      - 5e7f1d57-f3b2-4979-bd7e-216b8a4325c2
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -898,7 +592,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:44:18 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:24 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package
@@ -907,7 +601,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 185f0ae1-cc53-4c61-887c-796cfaed3365
+      - 6a693e79-c72b-46d2-b054-32530eb79597
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -930,12 +624,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="57" vrev="57" srcmd5="1f939eb34ca2fca015459856a4038515">
-          <entry name="_config" md5="979e1b425c373c02ed6cb4aa879c0a0f" size="60" mtime="1667468654"/>
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1666872407"/>
-          <entry name="somefile.txt" md5="3b6e6f4ce75dee69847100e0131e2e74" size="62" mtime="1667468654"/>
+        <directory name="test_package" rev="64" vrev="64" srcmd5="c832925a61302391edf832509e0eb195">
+          <entry name="_config" md5="989d47313b2bbb987e4a7ff1ffbbc857" size="48" mtime="1677089057"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="21fd51a9401e348d8281cb06e82bf9d3" size="61" mtime="1677089057"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:18 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:24 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:package_test_user/_result?lastbuild=1&locallink=1&multibuild=1&package=test_package&view=status
@@ -944,7 +638,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 185f0ae1-cc53-4c61-887c-796cfaed3365
+      - 6a693e79-c72b-46d2-b054-32530eb79597
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -969,7 +663,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:44:18 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:24 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:package_test_user/_result?package=test_package&view=status
@@ -978,7 +672,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - eccef33c-027e-4762-9771-bc7b07eac21e
+      - 685ebc47-272b-489f-8aef-f620d32dc1bc
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1003,7 +697,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:44:19 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:24 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package
@@ -1012,7 +706,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 1562a533-f9d5-487b-a1b3-1bc940c1b294
+      - 3a4b85a3-145f-464e-9436-89fa1fd3bda9
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1035,12 +729,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="57" vrev="57" srcmd5="1f939eb34ca2fca015459856a4038515">
-          <entry name="_config" md5="979e1b425c373c02ed6cb4aa879c0a0f" size="60" mtime="1667468654"/>
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1666872407"/>
-          <entry name="somefile.txt" md5="3b6e6f4ce75dee69847100e0131e2e74" size="62" mtime="1667468654"/>
+        <directory name="test_package" rev="64" vrev="64" srcmd5="c832925a61302391edf832509e0eb195">
+          <entry name="_config" md5="989d47313b2bbb987e4a7ff1ffbbc857" size="48" mtime="1677089057"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="21fd51a9401e348d8281cb06e82bf9d3" size="61" mtime="1677089057"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:19 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:24 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package
@@ -1049,7 +743,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 6e5908f3-dc41-4cdd-a514-b99b4640e5b3
+      - fd504c28-10c2-4269-90cf-e66c07d6488d
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1072,12 +766,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="57" vrev="57" srcmd5="1f939eb34ca2fca015459856a4038515">
-          <entry name="_config" md5="979e1b425c373c02ed6cb4aa879c0a0f" size="60" mtime="1667468654"/>
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1666872407"/>
-          <entry name="somefile.txt" md5="3b6e6f4ce75dee69847100e0131e2e74" size="62" mtime="1667468654"/>
+        <directory name="test_package" rev="64" vrev="64" srcmd5="c832925a61302391edf832509e0eb195">
+          <entry name="_config" md5="989d47313b2bbb987e4a7ff1ffbbc857" size="48" mtime="1677089057"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="21fd51a9401e348d8281cb06e82bf9d3" size="61" mtime="1677089057"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:19 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:24 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/new_file?user=package_test_user
@@ -1086,7 +780,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 6e5908f3-dc41-4cdd-a514-b99b4640e5b3
+      - fd504c28-10c2-4269-90cf-e66c07d6488d
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1109,15 +803,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="58" vrev="58">
-          <srcmd5>1f939eb34ca2fca015459856a4038515</srcmd5>
+        <revision rev="65" vrev="65">
+          <srcmd5>c832925a61302391edf832509e0eb195</srcmd5>
           <version>unknown</version>
-          <time>1667468659</time>
+          <time>1677089064</time>
           <user>package_test_user</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 03 Nov 2022 09:44:19 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:24 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=package_test_user
@@ -1125,8 +819,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>Behold the Man</title>
-          <description>Quis enim odit aut.</description>
+          <title>The Way Through the Woods</title>
+          <description>Dolor culpa tempora consequuntur.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1147,15 +841,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '155'
+      - '180'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>Behold the Man</title>
-          <description>Quis enim odit aut.</description>
+          <title>The Way Through the Woods</title>
+          <description>Dolor culpa tempora consequuntur.</description>
         </package>
-  recorded_at: Thu, 03 Nov 2022 09:44:19 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:24 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package
@@ -1185,12 +879,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="58" vrev="58" srcmd5="1f939eb34ca2fca015459856a4038515">
-          <entry name="_config" md5="979e1b425c373c02ed6cb4aa879c0a0f" size="60" mtime="1667468654"/>
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1666872407"/>
-          <entry name="somefile.txt" md5="3b6e6f4ce75dee69847100e0131e2e74" size="62" mtime="1667468654"/>
+        <directory name="test_package" rev="65" vrev="65" srcmd5="c832925a61302391edf832509e0eb195">
+          <entry name="_config" md5="989d47313b2bbb987e4a7ff1ffbbc857" size="48" mtime="1677089057"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="21fd51a9401e348d8281cb06e82bf9d3" size="61" mtime="1677089057"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:19 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:24 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package?view=info
@@ -1199,7 +893,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 6e5908f3-dc41-4cdd-a514-b99b4640e5b3
+      - fd504c28-10c2-4269-90cf-e66c07d6488d
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1222,10 +916,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="test_package" rev="58" vrev="58" srcmd5="1f939eb34ca2fca015459856a4038515" verifymd5="1f939eb34ca2fca015459856a4038515">
+        <sourceinfo package="test_package" rev="65" vrev="65" srcmd5="c832925a61302391edf832509e0eb195" verifymd5="c832925a61302391edf832509e0eb195">
           <error>bad build configuration, no build type defined or detected</error>
         </sourceinfo>
-  recorded_at: Thu, 03 Nov 2022 09:44:19 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:24 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package
@@ -1234,7 +928,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 6e5908f3-dc41-4cdd-a514-b99b4640e5b3
+      - fd504c28-10c2-4269-90cf-e66c07d6488d
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1257,12 +951,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="58" vrev="58" srcmd5="1f939eb34ca2fca015459856a4038515">
-          <entry name="_config" md5="979e1b425c373c02ed6cb4aa879c0a0f" size="60" mtime="1667468654"/>
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1666872407"/>
-          <entry name="somefile.txt" md5="3b6e6f4ce75dee69847100e0131e2e74" size="62" mtime="1667468654"/>
+        <directory name="test_package" rev="65" vrev="65" srcmd5="c832925a61302391edf832509e0eb195">
+          <entry name="_config" md5="989d47313b2bbb987e4a7ff1ffbbc857" size="48" mtime="1677089057"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="21fd51a9401e348d8281cb06e82bf9d3" size="61" mtime="1677089057"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:19 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:24 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:package_test_user/test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -1294,14 +988,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="840bc38611ce2c471024f4eeb73ab1ee">
+        <sourcediff key="4b5d45dc9b83c2d5d940780ad86d9b58">
           <old project="home:package_test_user" package="test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:package_test_user" package="test_package" rev="58" srcmd5="1f939eb34ca2fca015459856a4038515"/>
+          <new project="home:package_test_user" package="test_package" rev="65" srcmd5="c832925a61302391edf832509e0eb195"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 03 Nov 2022 09:44:19 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:25 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package
@@ -1310,7 +1004,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - '08cb5173-02dd-4b1d-912e-9d5482edc557'
+      - 5d862804-37c7-4898-bd4a-be71f3033efe
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1333,15 +1027,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="58" vrev="58" srcmd5="1f939eb34ca2fca015459856a4038515">
-          <entry name="_config" md5="979e1b425c373c02ed6cb4aa879c0a0f" size="60" mtime="1667468654"/>
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1666872407"/>
-          <entry name="somefile.txt" md5="3b6e6f4ce75dee69847100e0131e2e74" size="62" mtime="1667468654"/>
+        <directory name="test_package" rev="65" vrev="65" srcmd5="c832925a61302391edf832509e0eb195">
+          <entry name="_config" md5="989d47313b2bbb987e4a7ff1ffbbc857" size="48" mtime="1677089057"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="21fd51a9401e348d8281cb06e82bf9d3" size="61" mtime="1677089057"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:19 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:25 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package?expand=1&rev=58
+    uri: http://backend:5352/source/home:package_test_user/test_package?expand=1&rev=65
     body:
       encoding: US-ASCII
       string: ''
@@ -1368,58 +1062,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="58" vrev="58" srcmd5="1f939eb34ca2fca015459856a4038515">
-          <entry name="_config" md5="979e1b425c373c02ed6cb4aa879c0a0f" size="60" mtime="1667468654"/>
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1666872407"/>
-          <entry name="somefile.txt" md5="3b6e6f4ce75dee69847100e0131e2e74" size="62" mtime="1667468654"/>
+        <directory name="test_package" rev="65" vrev="65" srcmd5="c832925a61302391edf832509e0eb195">
+          <entry name="_config" md5="989d47313b2bbb987e4a7ff1ffbbc857" size="48" mtime="1677089057"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="21fd51a9401e348d8281cb06e82bf9d3" size="61" mtime="1677089057"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:19 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:25 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Request-Id:
-      - '08cb5173-02dd-4b1d-912e-9d5482edc557'
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '393'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="test_package" rev="58" vrev="58" srcmd5="1f939eb34ca2fca015459856a4038515">
-          <entry name="_config" md5="979e1b425c373c02ed6cb4aa879c0a0f" size="60" mtime="1667468654"/>
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1666872407"/>
-          <entry name="somefile.txt" md5="3b6e6f4ce75dee69847100e0131e2e74" size="62" mtime="1667468654"/>
-        </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:19 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package
+    uri: http://backend:5352/source/home:package_test_user/test_package/_history?deleted=1&meta=1&rev=65
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - '08cb5173-02dd-4b1d-912e-9d5482edc557'
+      - 5d862804-37c7-4898-bd4a-be71f3033efe
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1438,396 +1095,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '393'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="test_package" rev="58" vrev="58" srcmd5="1f939eb34ca2fca015459856a4038515">
-          <entry name="_config" md5="979e1b425c373c02ed6cb4aa879c0a0f" size="60" mtime="1667468654"/>
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1666872407"/>
-          <entry name="somefile.txt" md5="3b6e6f4ce75dee69847100e0131e2e74" size="62" mtime="1667468654"/>
-        </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:19 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package/_history
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '10725'
+      - '31'
     body:
       encoding: UTF-8
       string: |
         <revisionlist>
-          <revision rev="1" vrev="1">
-            <srcmd5>39430fe8eee11d74cd66e844e4647460</srcmd5>
-            <version>unknown</version>
-            <time>1666872405</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="2" vrev="2">
-            <srcmd5>369f1f23c6e11646161fe2e58127cc94</srcmd5>
-            <version>unknown</version>
-            <time>1666872405</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="3" vrev="3">
-            <srcmd5>e9c93f298abf3792c17a179e8472ef9f</srcmd5>
-            <version>unknown</version>
-            <time>1666872407</time>
-            <user>package_test_user</user>
-          </revision>
-          <revision rev="4" vrev="4">
-            <srcmd5>fe92ad389a77abc1c103e2b9abeb4d99</srcmd5>
-            <version>unknown</version>
-            <time>1667463244</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="5" vrev="5">
-            <srcmd5>c38595498e0e6cfcc304c9c0363c1476</srcmd5>
-            <version>unknown</version>
-            <time>1667463244</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="6" vrev="6">
-            <srcmd5>84ee2ec656c59bd2153d002321f4afed</srcmd5>
-            <version>unknown</version>
-            <time>1667464481</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="7" vrev="7">
-            <srcmd5>39185b1b7acbb1786bd3ab2a461ddb69</srcmd5>
-            <version>unknown</version>
-            <time>1667464481</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="8" vrev="8">
-            <srcmd5>f784cdc3453800dbf0347a0f80682de2</srcmd5>
-            <version>unknown</version>
-            <time>1667464736</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="9" vrev="9">
-            <srcmd5>b461ceaf1249dba9dfcb3c248e6be809</srcmd5>
-            <version>unknown</version>
-            <time>1667464736</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="10" vrev="10">
-            <srcmd5>d21b050db05f7a5c5ccaf6af362560b3</srcmd5>
-            <version>unknown</version>
-            <time>1667464744</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="11" vrev="11">
-            <srcmd5>6c635f1ad23df59a0d3da4effca55c71</srcmd5>
-            <version>unknown</version>
-            <time>1667464744</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="12" vrev="12">
-            <srcmd5>40e8fb03938d2be24413380673a7e494</srcmd5>
-            <version>unknown</version>
-            <time>1667464747</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="13" vrev="13">
-            <srcmd5>3baaad250de2dc0f0833d4a836972648</srcmd5>
-            <version>unknown</version>
-            <time>1667464747</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="14" vrev="14">
-            <srcmd5>3baaad250de2dc0f0833d4a836972648</srcmd5>
-            <version>unknown</version>
-            <time>1667464749</time>
-            <user>package_test_user</user>
-          </revision>
-          <revision rev="15" vrev="15">
-            <srcmd5>ba9b79ed65f5fbde153f78ffb08af146</srcmd5>
-            <version>unknown</version>
-            <time>1667464750</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="16" vrev="16">
-            <srcmd5>79762bab8a8fa6ec862b32f62cf72d21</srcmd5>
-            <version>unknown</version>
-            <time>1667464750</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="17" vrev="17">
-            <srcmd5>88366b20f7f01e5827dfd8091508fb25</srcmd5>
-            <version>unknown</version>
-            <time>1667464753</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="18" vrev="18">
-            <srcmd5>2436790b5946d1856306b2f0b2d1ab6f</srcmd5>
-            <version>unknown</version>
-            <time>1667464753</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="19" vrev="19">
-            <srcmd5>3e039aad3db23f9f4917e08eac60a922</srcmd5>
-            <version>unknown</version>
-            <time>1667464756</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="20" vrev="20">
-            <srcmd5>b9edb66d37ede13f625bdb4d688fe74b</srcmd5>
-            <version>unknown</version>
-            <time>1667464756</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="21" vrev="21">
-            <srcmd5>877721342ea4fa6a0c3cc3ccf5edb32f</srcmd5>
-            <version>unknown</version>
-            <time>1667464758</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="22" vrev="22">
-            <srcmd5>c12af4a22a92e27620ca9e743717bf04</srcmd5>
-            <version>unknown</version>
-            <time>1667464759</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="23" vrev="23">
-            <srcmd5>a9a24333f356400418c7d95da2c8be6f</srcmd5>
-            <version>unknown</version>
-            <time>1667464761</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="24" vrev="24">
-            <srcmd5>b0970bac3733ca0cdae917aad8bb79c7</srcmd5>
-            <version>unknown</version>
-            <time>1667464761</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="25" vrev="25">
-            <srcmd5>f2b4518bdfd16a84f51209ed78b5b8d1</srcmd5>
-            <version>unknown</version>
-            <time>1667464763</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="26" vrev="26">
-            <srcmd5>77238d237dbeac212945f06bc408917d</srcmd5>
-            <version>unknown</version>
-            <time>1667464763</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="27" vrev="27">
-            <srcmd5>39fa3baab4fe94f2caf25d450b0de8ed</srcmd5>
-            <version>unknown</version>
-            <time>1667464764</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="28" vrev="28">
-            <srcmd5>29698713fcf342ef8a376aba0146e61e</srcmd5>
-            <version>unknown</version>
-            <time>1667464764</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="29" vrev="29">
-            <srcmd5>0644c5bf6d37cc286692525419a61114</srcmd5>
-            <version>unknown</version>
-            <time>1667464767</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="30" vrev="30">
-            <srcmd5>ebe46e62b0cf0c963807e63d7d79485d</srcmd5>
-            <version>unknown</version>
-            <time>1667464767</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="31" vrev="31">
-            <srcmd5>da264a18d7117b5e853dab9f7339db08</srcmd5>
-            <version>unknown</version>
-            <time>1667464769</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="32" vrev="32">
-            <srcmd5>2a60f7a399bc383527fed10f88e493d7</srcmd5>
-            <version>unknown</version>
-            <time>1667464769</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="33" vrev="33">
-            <srcmd5>1930014cab69064a0384087ce2e0b649</srcmd5>
-            <version>unknown</version>
-            <time>1667464771</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="34" vrev="34">
-            <srcmd5>14a73a182d6dc32e8c6746b1a5f430b2</srcmd5>
-            <version>unknown</version>
-            <time>1667464771</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="35" vrev="35">
-            <srcmd5>8d36b298cd242ca4acf6f3857ea615d0</srcmd5>
-            <version>unknown</version>
-            <time>1667464774</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="36" vrev="36">
-            <srcmd5>757e5cf4a62cb7594cee98f44d5c5dfb</srcmd5>
-            <version>unknown</version>
-            <time>1667464774</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="37" vrev="37">
-            <srcmd5>c8218281e235eafe25a450a4af6795ea</srcmd5>
-            <version>unknown</version>
-            <time>1667464775</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="38" vrev="38">
-            <srcmd5>b34f256914adbd35d9416158188693ea</srcmd5>
-            <version>unknown</version>
-            <time>1667464775</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="39" vrev="39">
-            <srcmd5>866f12af510fe05a2aeb121833699dcd</srcmd5>
-            <version>unknown</version>
-            <time>1667464777</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="40" vrev="40">
-            <srcmd5>6b85a9444f69f8ade3246fd8f18c31a8</srcmd5>
-            <version>unknown</version>
-            <time>1667464777</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="41" vrev="41">
-            <srcmd5>3c730dc91073299ab81340b5c59b0cc3</srcmd5>
-            <version>unknown</version>
-            <time>1667464780</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="42" vrev="42">
-            <srcmd5>7cb8b74c1b67b7ab1c93ce7a7a2dbf72</srcmd5>
-            <version>unknown</version>
-            <time>1667464780</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="43" vrev="43">
-            <srcmd5>66fa604b63a4f143d1caed7c1fb7c12a</srcmd5>
-            <version>unknown</version>
-            <time>1667464782</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="44" vrev="44">
-            <srcmd5>80b9a02067224efd1d68aa9d79f14815</srcmd5>
-            <version>unknown</version>
-            <time>1667464782</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="45" vrev="45">
-            <srcmd5>02a2333bf072af09166c7e4eeeaa303d</srcmd5>
-            <version>unknown</version>
-            <time>1667464785</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="46" vrev="46">
-            <srcmd5>1a63fe0d41fe30b67d00493f1365da44</srcmd5>
-            <version>unknown</version>
-            <time>1667464785</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="47" vrev="47">
-            <srcmd5>735f8731e38f3c18bdaf5b34fa028ed8</srcmd5>
-            <version>unknown</version>
-            <time>1667464833</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="48" vrev="48">
-            <srcmd5>6af8bcd4b3c37ac1985609d7e2f141b2</srcmd5>
-            <version>unknown</version>
-            <time>1667464833</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="49" vrev="49">
-            <srcmd5>7e32b7d5850a80b1c460fa714ca5d4a5</srcmd5>
-            <version>unknown</version>
-            <time>1667464837</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="50" vrev="50">
-            <srcmd5>c80e563fdbc8e21508c8106b45be243a</srcmd5>
-            <version>unknown</version>
-            <time>1667464837</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="51" vrev="51">
-            <srcmd5>996c5eedf4e4f21229e7d8168695c8de</srcmd5>
-            <version>unknown</version>
-            <time>1667464840</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="52" vrev="52">
-            <srcmd5>055645f5c03a5a9675fd93f61eee3a2c</srcmd5>
-            <version>unknown</version>
-            <time>1667464840</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="53" vrev="53">
-            <srcmd5>0641c4fa40cc067d60f65fb905a63789</srcmd5>
-            <version>unknown</version>
-            <time>1667466962</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="54" vrev="54">
-            <srcmd5>c11f1fcb78d77216c74e9bf3a2c2c160</srcmd5>
-            <version>unknown</version>
-            <time>1667466962</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="55" vrev="55">
-            <srcmd5>c11f1fcb78d77216c74e9bf3a2c2c160</srcmd5>
-            <version>unknown</version>
-            <time>1667467792</time>
-            <user>package_test_user</user>
-          </revision>
-          <revision rev="56" vrev="56">
-            <srcmd5>65eba0f2c74b847bd64e354a3b6e21ce</srcmd5>
-            <version>unknown</version>
-            <time>1667468654</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="57" vrev="57">
-            <srcmd5>1f939eb34ca2fca015459856a4038515</srcmd5>
-            <version>unknown</version>
-            <time>1667468654</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="58" vrev="58">
-            <srcmd5>1f939eb34ca2fca015459856a4038515</srcmd5>
-            <version>unknown</version>
-            <time>1667468659</time>
-            <user>package_test_user</user>
-          </revision>
         </revisionlist>
-  recorded_at: Thu, 03 Nov 2022 09:44:20 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:25 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package
@@ -1836,7 +1110,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 2403354d-0775-4fa2-b0f4-a300b59e0a81
+      - 5d862804-37c7-4898-bd4a-be71f3033efe
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1859,12 +1133,120 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="58" vrev="58" srcmd5="1f939eb34ca2fca015459856a4038515">
-          <entry name="_config" md5="979e1b425c373c02ed6cb4aa879c0a0f" size="60" mtime="1667468654"/>
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1666872407"/>
-          <entry name="somefile.txt" md5="3b6e6f4ce75dee69847100e0131e2e74" size="62" mtime="1667468654"/>
+        <directory name="test_package" rev="65" vrev="65" srcmd5="c832925a61302391edf832509e0eb195">
+          <entry name="_config" md5="989d47313b2bbb987e4a7ff1ffbbc857" size="48" mtime="1677089057"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="21fd51a9401e348d8281cb06e82bf9d3" size="61" mtime="1677089057"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:20 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:25 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 5d862804-37c7-4898-bd4a-be71f3033efe
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '393'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test_package" rev="65" vrev="65" srcmd5="c832925a61302391edf832509e0eb195">
+          <entry name="_config" md5="989d47313b2bbb987e4a7ff1ffbbc857" size="48" mtime="1677089057"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="21fd51a9401e348d8281cb06e82bf9d3" size="61" mtime="1677089057"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:04:25 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package/_history?deleted=1&meta=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 5d862804-37c7-4898-bd4a-be71f3033efe
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Wed, 22 Feb 2023 18:04:25 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 78180faa-f785-4333-ae58-d9b2db52fce0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '393'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test_package" rev="65" vrev="65" srcmd5="c832925a61302391edf832509e0eb195">
+          <entry name="_config" md5="989d47313b2bbb987e4a7ff1ffbbc857" size="48" mtime="1677089057"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="21fd51a9401e348d8281cb06e82bf9d3" size="61" mtime="1677089057"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:04:25 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:package_test_user/_result?lastbuild=1&locallink=1&multibuild=1&package=test_package&view=status
@@ -1873,7 +1255,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 2403354d-0775-4fa2-b0f4-a300b59e0a81
+      - 78180faa-f785-4333-ae58-d9b2db52fce0
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1898,7 +1280,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:44:20 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:25 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package
@@ -1907,7 +1289,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 43290a55-be28-40b3-9767-0dc58fba7e2e
+      - adaa7f32-e89d-4623-b337-4072eff0cb50
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1930,12 +1312,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="58" vrev="58" srcmd5="1f939eb34ca2fca015459856a4038515">
-          <entry name="_config" md5="979e1b425c373c02ed6cb4aa879c0a0f" size="60" mtime="1667468654"/>
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1666872407"/>
-          <entry name="somefile.txt" md5="3b6e6f4ce75dee69847100e0131e2e74" size="62" mtime="1667468654"/>
+        <directory name="test_package" rev="65" vrev="65" srcmd5="c832925a61302391edf832509e0eb195">
+          <entry name="_config" md5="989d47313b2bbb987e4a7ff1ffbbc857" size="48" mtime="1677089057"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="21fd51a9401e348d8281cb06e82bf9d3" size="61" mtime="1677089057"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:20 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:25 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:package_test_user/_result?lastbuild=1&locallink=1&multibuild=1&package=test_package&view=status
@@ -1944,7 +1326,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 43290a55-be28-40b3-9767-0dc58fba7e2e
+      - adaa7f32-e89d-4623-b337-4072eff0cb50
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1969,7 +1351,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:44:20 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:25 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:package_test_user/_result?package=test_package&view=status
@@ -1978,7 +1360,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 4cf18ed9-3e41-434a-9f83-e8ffbf01aeb9
+      - 0e6ae5e0-81a6-415d-bd49-95da547a7bef
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -2003,5 +1385,5 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:44:20 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:25 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Packages/adding_an_invalid_file.yml
+++ b/src/api/spec/cassettes/Packages/adding_an_invalid_file.yml
@@ -39,16 +39,16 @@ http_interactions:
           <description></description>
           <person userid="package_test_user" role="maintainer"/>
         </project>
-  recorded_at: Fri, 25 Jun 2021 11:30:57 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:26 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=user_1
+    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=user_3
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>The Glory and the Dream</title>
-          <description>Quam rerum nulla quaerat.</description>
+          <title>The Other Side of Silence</title>
+          <description>Aut voluptatem ipsam et.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -69,21 +69,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '170'
+      - '171'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>The Glory and the Dream</title>
-          <description>Quam rerum nulla quaerat.</description>
+          <title>The Other Side of Silence</title>
+          <description>Aut voluptatem ipsam et.</description>
         </package>
-  recorded_at: Fri, 25 Jun 2021 11:30:57 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:26 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_config
     body:
       encoding: UTF-8
-      string: Totam omnis ipsum. Ea aut accusantium. Delectus placeat blanditiis.
+      string: Ut quia consequatur. Id aut commodi. Qui eos voluptas.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -103,25 +103,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1" vrev="1">
-          <srcmd5>a7feca4b99d529ab106b6666f98a5d5a</srcmd5>
+        <revision rev="66" vrev="66">
+          <srcmd5>f14b2f14bb60ca00cff8f2a2d761a622</srcmd5>
           <version>unknown</version>
-          <time>1624620657</time>
+          <time>1677089066</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Fri, 25 Jun 2021 11:30:57 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:26 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Velit doloremque sequi. Aspernatur in voluptatum. Odio aut non.
+      string: Atque voluptas ut. Veritatis et ullam. Amet animi tempore.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -141,19 +141,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="2" vrev="2">
-          <srcmd5>11bc7bc10a1ea1609de8a814bef6ef24</srcmd5>
+        <revision rev="67" vrev="67">
+          <srcmd5>f7dc60f56590fdec994cee94f8239cac</srcmd5>
           <version>unknown</version>
-          <time>1624620657</time>
+          <time>1677089066</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Fri, 25 Jun 2021 11:30:57 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:26 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/_meta?user=other_package_test_user
@@ -193,16 +193,16 @@ http_interactions:
           <description></description>
           <person userid="other_package_test_user" role="maintainer"/>
         </project>
-  recorded_at: Fri, 25 Jun 2021 11:30:57 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:26 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=user_2
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=user_4
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>The Stars' Tennis Balls</title>
-          <description>Unde sit et deleniti.</description>
+          <title>Have His Carcase</title>
+          <description>Facilis distinctio laboriosam et.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -223,22 +223,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '179'
+      - '184'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>The Stars' Tennis Balls</title>
-          <description>Unde sit et deleniti.</description>
+          <title>Have His Carcase</title>
+          <description>Facilis distinctio laboriosam et.</description>
         </package>
-  recorded_at: Fri, 25 Jun 2021 11:30:57 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:26 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_config
     body:
       encoding: UTF-8
-      string: Assumenda delectus reprehenderit. Necessitatibus ullam corporis. Nihil
-        accusamus aspernatur.
+      string: Maiores quam est. Est nostrum sunt. Et rem provident.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -258,25 +257,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1" vrev="1">
-          <srcmd5>5195c4c564cc151779614eebafb9d444</srcmd5>
+        <revision rev="59" vrev="59">
+          <srcmd5>8f6d1ac92032126ffe2772fa4d3b63ca</srcmd5>
           <version>unknown</version>
-          <time>1624620657</time>
+          <time>1677089066</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Fri, 25 Jun 2021 11:30:58 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:26 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Illo harum et. Et aspernatur non. Atque rerum maxime.
+      string: Vel fugit doloribus. Et nisi omnis. Labore omnis nesciunt.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -296,19 +295,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="2" vrev="2">
-          <srcmd5>33afbeb32473f90fd2963ecda85f70dd</srcmd5>
+        <revision rev="60" vrev="60">
+          <srcmd5>9cccfa3c8c3b1f88d6e8970ad4793e6e</srcmd5>
           <version>unknown</version>
-          <time>1624620658</time>
+          <time>1677089066</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Fri, 25 Jun 2021 11:30:58 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:26 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package
@@ -317,7 +316,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - d9041b07-894d-491e-ab84-7cca2ec140ab
+      - 47c60bbc-32db-481d-84be-8f69b8945ef7
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -336,18 +335,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '297'
+      - '393'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="2" vrev="2" srcmd5="11bc7bc10a1ea1609de8a814bef6ef24">
-          <entry name="_config" md5="ee4d854eb617fefa6fce3cd620641220" size="67" mtime="1624620657"/>
-          <entry name="somefile.txt" md5="10098b9f7eb377fbfabb0beca6501ab5" size="63" mtime="1624620657"/>
+        <directory name="test_package" rev="67" vrev="67" srcmd5="f7dc60f56590fdec994cee94f8239cac">
+          <entry name="_config" md5="740399b8340e8816139bc1a5373fe939" size="54" mtime="1677089066"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="e81b89fa51725f1cd7c05b0b162931e8" size="58" mtime="1677089066"/>
         </directory>
-  recorded_at: Fri, 25 Jun 2021 11:31:03 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:27 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package?expand=1&rev=2
+    uri: http://backend:5352/source/home:package_test_user/test_package?expand=1&rev=67
     body:
       encoding: US-ASCII
       string: ''
@@ -370,60 +370,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '297'
+      - '393'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="2" vrev="2" srcmd5="11bc7bc10a1ea1609de8a814bef6ef24">
-          <entry name="_config" md5="ee4d854eb617fefa6fce3cd620641220" size="67" mtime="1624620657"/>
-          <entry name="somefile.txt" md5="10098b9f7eb377fbfabb0beca6501ab5" size="63" mtime="1624620657"/>
+        <directory name="test_package" rev="67" vrev="67" srcmd5="f7dc60f56590fdec994cee94f8239cac">
+          <entry name="_config" md5="740399b8340e8816139bc1a5373fe939" size="54" mtime="1677089066"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="e81b89fa51725f1cd7c05b0b162931e8" size="58" mtime="1677089066"/>
         </directory>
-  recorded_at: Fri, 25 Jun 2021 11:31:03 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:27 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Request-Id:
-      - d9041b07-894d-491e-ab84-7cca2ec140ab
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '297'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="test_package" rev="2" vrev="2" srcmd5="11bc7bc10a1ea1609de8a814bef6ef24">
-          <entry name="_config" md5="ee4d854eb617fefa6fce3cd620641220" size="67" mtime="1624620657"/>
-          <entry name="somefile.txt" md5="10098b9f7eb377fbfabb0beca6501ab5" size="63" mtime="1624620657"/>
-        </directory>
-  recorded_at: Fri, 25 Jun 2021 11:31:03 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package
+    uri: http://backend:5352/source/home:package_test_user/test_package/_history?deleted=1&meta=1&rev=67
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - d9041b07-894d-491e-ab84-7cca2ec140ab
+      - 47c60bbc-32db-481d-84be-8f69b8945ef7
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -442,68 +407,167 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '297'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="test_package" rev="2" vrev="2" srcmd5="11bc7bc10a1ea1609de8a814bef6ef24">
-          <entry name="_config" md5="ee4d854eb617fefa6fce3cd620641220" size="67" mtime="1624620657"/>
-          <entry name="somefile.txt" md5="10098b9f7eb377fbfabb0beca6501ab5" size="63" mtime="1624620657"/>
-        </directory>
-  recorded_at: Fri, 25 Jun 2021 11:31:03 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package/_history
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '395'
+      - '31'
     body:
       encoding: UTF-8
       string: |
         <revisionlist>
-          <revision rev="1" vrev="1">
-            <srcmd5>a7feca4b99d529ab106b6666f98a5d5a</srcmd5>
-            <version>unknown</version>
-            <time>1624620657</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="2" vrev="2">
-            <srcmd5>11bc7bc10a1ea1609de8a814bef6ef24</srcmd5>
-            <version>unknown</version>
-            <time>1624620657</time>
-            <user>unknown</user>
-          </revision>
         </revisionlist>
-  recorded_at: Fri, 25 Jun 2021 11:31:04 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:27 GMT
 - request:
     method: get
-    uri: http://backend:5352/build/home:package_test_user/_result?package=test_package&view=status
+    uri: http://backend:5352/source/home:package_test_user/test_package
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - 9dedf2b1-f9f4-46d3-a842-a510ba208713
+      - 47c60bbc-32db-481d-84be-8f69b8945ef7
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '393'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test_package" rev="67" vrev="67" srcmd5="f7dc60f56590fdec994cee94f8239cac">
+          <entry name="_config" md5="740399b8340e8816139bc1a5373fe939" size="54" mtime="1677089066"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="e81b89fa51725f1cd7c05b0b162931e8" size="58" mtime="1677089066"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:04:27 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 47c60bbc-32db-481d-84be-8f69b8945ef7
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '393'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test_package" rev="67" vrev="67" srcmd5="f7dc60f56590fdec994cee94f8239cac">
+          <entry name="_config" md5="740399b8340e8816139bc1a5373fe939" size="54" mtime="1677089066"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="e81b89fa51725f1cd7c05b0b162931e8" size="58" mtime="1677089066"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:04:27 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package/_history?deleted=1&meta=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 47c60bbc-32db-481d-84be-8f69b8945ef7
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Wed, 22 Feb 2023 18:04:27 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - c72d3b35-5209-49c7-8175-0146b0760873
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '393'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test_package" rev="67" vrev="67" srcmd5="f7dc60f56590fdec994cee94f8239cac">
+          <entry name="_config" md5="740399b8340e8816139bc1a5373fe939" size="54" mtime="1677089066"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="e81b89fa51725f1cd7c05b0b162931e8" size="58" mtime="1677089066"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:04:27 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:package_test_user/_result?lastbuild=1&locallink=1&multibuild=1&package=test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - c72d3b35-5209-49c7-8175-0146b0760873
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -528,7 +592,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Fri, 25 Jun 2021 11:31:06 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:27 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package
@@ -537,7 +601,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 01064157-ecc8-4cbd-964f-e15bbd8a1031
+      - c4cc214c-1469-470b-af09-6d31f7bb0d70
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -556,15 +620,84 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '297'
+      - '393'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="2" vrev="2" srcmd5="11bc7bc10a1ea1609de8a814bef6ef24">
-          <entry name="_config" md5="ee4d854eb617fefa6fce3cd620641220" size="67" mtime="1624620657"/>
-          <entry name="somefile.txt" md5="10098b9f7eb377fbfabb0beca6501ab5" size="63" mtime="1624620657"/>
+        <directory name="test_package" rev="67" vrev="67" srcmd5="f7dc60f56590fdec994cee94f8239cac">
+          <entry name="_config" md5="740399b8340e8816139bc1a5373fe939" size="54" mtime="1677089066"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="e81b89fa51725f1cd7c05b0b162931e8" size="58" mtime="1677089066"/>
         </directory>
-  recorded_at: Fri, 25 Jun 2021 11:31:07 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:27 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:package_test_user/_result?lastbuild=1&locallink=1&multibuild=1&package=test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - c4cc214c-1469-470b-af09-6d31f7bb0d70
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 18:04:27 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:package_test_user/_result?package=test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 1167adb2-5308-4750-9902-fdb55ffaff74
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 18:04:27 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package
@@ -573,7 +706,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 8faa9157-1e0c-4177-94bc-787cbc9a0f51
+      - c126b72c-275f-4a90-b95c-51580ee348bc
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -592,15 +725,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '297'
+      - '393'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="2" vrev="2" srcmd5="11bc7bc10a1ea1609de8a814bef6ef24">
-          <entry name="_config" md5="ee4d854eb617fefa6fce3cd620641220" size="67" mtime="1624620657"/>
-          <entry name="somefile.txt" md5="10098b9f7eb377fbfabb0beca6501ab5" size="63" mtime="1624620657"/>
+        <directory name="test_package" rev="67" vrev="67" srcmd5="f7dc60f56590fdec994cee94f8239cac">
+          <entry name="_config" md5="740399b8340e8816139bc1a5373fe939" size="54" mtime="1677089066"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="e81b89fa51725f1cd7c05b0b162931e8" size="58" mtime="1677089066"/>
         </directory>
-  recorded_at: Fri, 25 Jun 2021 11:31:08 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:27 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package
@@ -609,7 +743,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 4e236226-7d91-49e2-860c-e6702e9e3254
+      - 3e545715-97d0-42fe-b5e4-b9223424e5da
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -628,15 +762,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '297'
+      - '393'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="2" vrev="2" srcmd5="11bc7bc10a1ea1609de8a814bef6ef24">
-          <entry name="_config" md5="ee4d854eb617fefa6fce3cd620641220" size="67" mtime="1624620657"/>
-          <entry name="somefile.txt" md5="10098b9f7eb377fbfabb0beca6501ab5" size="63" mtime="1624620657"/>
+        <directory name="test_package" rev="67" vrev="67" srcmd5="f7dc60f56590fdec994cee94f8239cac">
+          <entry name="_config" md5="740399b8340e8816139bc1a5373fe939" size="54" mtime="1677089066"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="e81b89fa51725f1cd7c05b0b162931e8" size="58" mtime="1677089066"/>
         </directory>
-  recorded_at: Fri, 25 Jun 2021 11:31:08 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:28 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package
@@ -645,7 +780,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 68f8a394-4afd-48da-af6e-6a8f3be5d241
+      - 659b3b71-1899-43fe-aa39-dc182b8d88a2
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -664,49 +799,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '297'
+      - '393'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="2" vrev="2" srcmd5="11bc7bc10a1ea1609de8a814bef6ef24">
-          <entry name="_config" md5="ee4d854eb617fefa6fce3cd620641220" size="67" mtime="1624620657"/>
-          <entry name="somefile.txt" md5="10098b9f7eb377fbfabb0beca6501ab5" size="63" mtime="1624620657"/>
+        <directory name="test_package" rev="67" vrev="67" srcmd5="f7dc60f56590fdec994cee94f8239cac">
+          <entry name="_config" md5="740399b8340e8816139bc1a5373fe939" size="54" mtime="1677089066"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="e81b89fa51725f1cd7c05b0b162931e8" size="58" mtime="1677089066"/>
         </directory>
-  recorded_at: Fri, 25 Jun 2021 11:31:08 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package?expand=1&rev=2
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '297'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="test_package" rev="2" vrev="2" srcmd5="11bc7bc10a1ea1609de8a814bef6ef24">
-          <entry name="_config" md5="ee4d854eb617fefa6fce3cd620641220" size="67" mtime="1624620657"/>
-          <entry name="somefile.txt" md5="10098b9f7eb377fbfabb0beca6501ab5" size="63" mtime="1624620657"/>
-        </directory>
-  recorded_at: Fri, 25 Jun 2021 11:31:08 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:28 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package
@@ -715,7 +817,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 68f8a394-4afd-48da-af6e-6a8f3be5d241
+      - bbe1edb7-b607-41c6-8c5a-5acc0b2ff7bb
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -734,15 +836,85 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '297'
+      - '393'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="2" vrev="2" srcmd5="11bc7bc10a1ea1609de8a814bef6ef24">
-          <entry name="_config" md5="ee4d854eb617fefa6fce3cd620641220" size="67" mtime="1624620657"/>
-          <entry name="somefile.txt" md5="10098b9f7eb377fbfabb0beca6501ab5" size="63" mtime="1624620657"/>
+        <directory name="test_package" rev="67" vrev="67" srcmd5="f7dc60f56590fdec994cee94f8239cac">
+          <entry name="_config" md5="740399b8340e8816139bc1a5373fe939" size="54" mtime="1677089066"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="e81b89fa51725f1cd7c05b0b162931e8" size="58" mtime="1677089066"/>
         </directory>
-  recorded_at: Fri, 25 Jun 2021 11:31:08 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:28 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package?expand=1&rev=67
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '393'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test_package" rev="67" vrev="67" srcmd5="f7dc60f56590fdec994cee94f8239cac">
+          <entry name="_config" md5="740399b8340e8816139bc1a5373fe939" size="54" mtime="1677089066"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="e81b89fa51725f1cd7c05b0b162931e8" size="58" mtime="1677089066"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:04:28 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package/_history?deleted=1&meta=1&rev=67
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - bbe1edb7-b607-41c6-8c5a-5acc0b2ff7bb
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Wed, 22 Feb 2023 18:04:28 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package
@@ -751,7 +923,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 68f8a394-4afd-48da-af6e-6a8f3be5d241
+      - bbe1edb7-b607-41c6-8c5a-5acc0b2ff7bb
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -770,13 +942,261 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '297'
+      - '393'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="2" vrev="2" srcmd5="11bc7bc10a1ea1609de8a814bef6ef24">
-          <entry name="_config" md5="ee4d854eb617fefa6fce3cd620641220" size="67" mtime="1624620657"/>
-          <entry name="somefile.txt" md5="10098b9f7eb377fbfabb0beca6501ab5" size="63" mtime="1624620657"/>
+        <directory name="test_package" rev="67" vrev="67" srcmd5="f7dc60f56590fdec994cee94f8239cac">
+          <entry name="_config" md5="740399b8340e8816139bc1a5373fe939" size="54" mtime="1677089066"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="e81b89fa51725f1cd7c05b0b162931e8" size="58" mtime="1677089066"/>
         </directory>
-  recorded_at: Fri, 25 Jun 2021 11:31:08 GMT
-recorded_with: VCR 6.0.0
+  recorded_at: Wed, 22 Feb 2023 18:04:28 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - bbe1edb7-b607-41c6-8c5a-5acc0b2ff7bb
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '393'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test_package" rev="67" vrev="67" srcmd5="f7dc60f56590fdec994cee94f8239cac">
+          <entry name="_config" md5="740399b8340e8816139bc1a5373fe939" size="54" mtime="1677089066"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="e81b89fa51725f1cd7c05b0b162931e8" size="58" mtime="1677089066"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:04:28 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package/_history?deleted=1&meta=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - bbe1edb7-b607-41c6-8c5a-5acc0b2ff7bb
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Wed, 22 Feb 2023 18:04:28 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - addb1205-af75-4c4b-839a-5440a81d464a
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '393'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test_package" rev="67" vrev="67" srcmd5="f7dc60f56590fdec994cee94f8239cac">
+          <entry name="_config" md5="740399b8340e8816139bc1a5373fe939" size="54" mtime="1677089066"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="e81b89fa51725f1cd7c05b0b162931e8" size="58" mtime="1677089066"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:04:29 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:package_test_user/_result?lastbuild=1&locallink=1&multibuild=1&package=test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - addb1205-af75-4c4b-839a-5440a81d464a
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 18:04:29 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - ecf7477c-e766-400a-9c0e-08b63fd194bf
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '393'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test_package" rev="67" vrev="67" srcmd5="f7dc60f56590fdec994cee94f8239cac">
+          <entry name="_config" md5="740399b8340e8816139bc1a5373fe939" size="54" mtime="1677089066"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="e81b89fa51725f1cd7c05b0b162931e8" size="58" mtime="1677089066"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:04:29 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:package_test_user/_result?lastbuild=1&locallink=1&multibuild=1&package=test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - ecf7477c-e766-400a-9c0e-08b63fd194bf
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 18:04:29 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:package_test_user/_result?package=test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - dcdf2742-3cd5-4b63-8cb3-c35afaeadc9b
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 18:04:29 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Packages/behaves_like_bootstrap_user_tab/group_roles/Add_an_existing_group.yml
+++ b/src/api/spec/cassettes/Packages/behaves_like_bootstrap_user_tab/group_roles/Add_an_existing_group.yml
@@ -39,7 +39,7 @@ http_interactions:
           <description></description>
           <person userid="package_test_user" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 15:55:23 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:05 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:user_tab_user/_meta?user=user_tab_user
@@ -79,16 +79,16 @@ http_interactions:
           <description></description>
           <person userid="user_tab_user" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 15:55:23 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:05 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_21
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_22
     body:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>Arms and the Man</title>
-          <description>Minus debitis praesentium illum.</description>
+          <title>Terrible Swift Sword</title>
+          <description>Et occaecati quidem deleniti.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,15 +109,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '172'
+      - '173'
     body:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>Arms and the Man</title>
-          <description>Minus debitis praesentium illum.</description>
+          <title>Terrible Swift Sword</title>
+          <description>Et occaecati quidem deleniti.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 15:55:23 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:05 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/_meta?user=other_user
@@ -157,16 +157,16 @@ http_interactions:
           <description></description>
           <person userid="other_user" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 15:55:23 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:06 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta?user=user_22
+    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta?user=user_23
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_user">
-          <title>To Sail Beyond the Sunset</title>
-          <description>Dolores corrupti id iusto.</description>
+          <title>The Moving Finger</title>
+          <description>Ea repellendus repellat officia.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -187,21 +187,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '173'
+      - '171'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_user">
-          <title>To Sail Beyond the Sunset</title>
-          <description>Dolores corrupti id iusto.</description>
+          <title>The Moving Finger</title>
+          <description>Ea repellendus repellat officia.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 15:55:23 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:06 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/branch_test_package/_config
     body:
       encoding: UTF-8
-      string: Recusandae accusamus qui. Soluta et repellendus. Minus maiores quia.
+      string: Aspernatur ut assumenda. Omnis pariatur consectetur. Velit ex eos.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -225,21 +225,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="43" vrev="43">
-          <srcmd5>75f379730eec80fdfd2d5956f603e12c</srcmd5>
+        <revision rev="25" vrev="25">
+          <srcmd5>cb86bd86084aea6cc4124818eb8d6763</srcmd5>
           <version>unknown</version>
-          <time>1658418923</time>
+          <time>1677089106</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 15:55:23 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:06 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/branch_test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Ea tenetur facere. Nobis rerum eum. Voluptatibus doloremque et.
+      string: Unde in corrupti. Modi soluta iusto. Molestias vero et.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -263,15 +263,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="44" vrev="44">
-          <srcmd5>27b332f35dc5a6959ff493f68ab86dc4</srcmd5>
+        <revision rev="26" vrev="26">
+          <srcmd5>62871b000d665a3798ec5e78d45c857a</srcmd5>
           <version>unknown</version>
-          <time>1658418923</time>
+          <time>1677089106</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 15:55:23 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:06 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -280,7 +280,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - e8473b32-f4ed-4406-a8e8-0e330e6c3d21
+      - 05f0c00c-52d3-4d42-bf6f-77a68448bbde
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -305,7 +305,7 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 15:55:24 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:07 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package?expand=1
@@ -337,7 +337,41 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 15:55:24 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:07 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_history?deleted=1&meta=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 05f0c00c-52d3-4d42-bf6f-77a68448bbde
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Wed, 22 Feb 2023 18:05:07 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -346,7 +380,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - e8473b32-f4ed-4406-a8e8-0e330e6c3d21
+      - 05f0c00c-52d3-4d42-bf6f-77a68448bbde
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -371,7 +405,7 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 15:55:24 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:07 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -380,7 +414,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - e8473b32-f4ed-4406-a8e8-0e330e6c3d21
+      - 05f0c00c-52d3-4d42-bf6f-77a68448bbde
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -405,16 +439,50 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 15:55:24 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:07 GMT
 - request:
     method: get
-    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - 44c83e94-c764-4a4b-8224-c9659826bc44
+      - 8ff23b5c-1a2a-4aa2-9a09-ea7d0e8e26e5
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:05:07 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:user_tab_user/_result?lastbuild=1&locallink=1&multibuild=1&package=group_test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 8ff23b5c-1a2a-4aa2-9a09-ea7d0e8e26e5
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -439,7 +507,109 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 21 Jul 2022 15:55:24 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:07 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - d3f698b0-a366-452f-b01e-4a49a3b58166
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:05:07 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:user_tab_user/_result?lastbuild=1&locallink=1&multibuild=1&package=group_test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - d3f698b0-a366-452f-b01e-4a49a3b58166
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 18:05:07 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - bea2f1b6-543b-458e-b99f-3d3b87b60b04
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 18:05:07 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_tab_user
@@ -447,8 +617,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>Arms and the Man</title>
-          <description>Minus debitis praesentium illum.</description>
+          <title>Terrible Swift Sword</title>
+          <description>Et occaecati quidem deleniti.</description>
           <person userid="user_tab_user" role="maintainer"/>
           <group groupid="existing_group" role="bugowner"/>
           <group groupid="existing_group" role="maintainer"/>
@@ -473,17 +643,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '382'
+      - '383'
     body:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>Arms and the Man</title>
-          <description>Minus debitis praesentium illum.</description>
+          <title>Terrible Swift Sword</title>
+          <description>Et occaecati quidem deleniti.</description>
           <person userid="user_tab_user" role="maintainer"/>
           <group groupid="existing_group" role="bugowner"/>
           <group groupid="existing_group" role="maintainer"/>
           <group groupid="other_group" role="maintainer"/>
         </package>
-  recorded_at: Thu, 21 Jul 2022 15:55:26 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:09 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Packages/behaves_like_bootstrap_user_tab/group_roles/Add_non_existent_group.yml
+++ b/src/api/spec/cassettes/Packages/behaves_like_bootstrap_user_tab/group_roles/Add_non_existent_group.yml
@@ -39,7 +39,7 @@ http_interactions:
           <description></description>
           <person userid="package_test_user" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 15:55:12 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:58 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:user_tab_user/_meta?user=user_tab_user
@@ -79,16 +79,16 @@ http_interactions:
           <description></description>
           <person userid="user_tab_user" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 15:55:12 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:58 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_15
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_18
     body:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>Vile Bodies</title>
-          <description>Eaque labore eum qui.</description>
+          <title>Of Mice and Men</title>
+          <description>Consequatur optio quia est.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,15 +109,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '156'
+      - '166'
     body:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>Vile Bodies</title>
-          <description>Eaque labore eum qui.</description>
+          <title>Of Mice and Men</title>
+          <description>Consequatur optio quia est.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 15:55:12 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:58 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/_meta?user=other_user
@@ -157,16 +157,16 @@ http_interactions:
           <description></description>
           <person userid="other_user" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 15:55:12 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:58 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta?user=user_16
+    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta?user=user_19
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_user">
-          <title>The Way Through the Woods</title>
-          <description>Enim qui iure sed.</description>
+          <title>In Dubious Battle</title>
+          <description>Autem repellat molestiae fugit.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -187,21 +187,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '165'
+      - '170'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_user">
-          <title>The Way Through the Woods</title>
-          <description>Enim qui iure sed.</description>
+          <title>In Dubious Battle</title>
+          <description>Autem repellat molestiae fugit.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 15:55:12 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:58 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/branch_test_package/_config
     body:
       encoding: UTF-8
-      string: Sed tenetur tempore. Beatae libero inventore. Quia rerum doloremque.
+      string: Provident accusamus officiis. Qui quibusdam voluptatem. Et sint ut.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -225,21 +225,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="37" vrev="37">
-          <srcmd5>c522a6998a1bd7ca28f106ff4b32bf5f</srcmd5>
+        <revision rev="21" vrev="21">
+          <srcmd5>4097e50e381cf52f3568cbdae54a39b2</srcmd5>
           <version>unknown</version>
-          <time>1658418912</time>
+          <time>1677089098</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 15:55:12 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:58 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/branch_test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Totam ut natus. Necessitatibus deleniti sed. Id quae quo.
+      string: Et eaque quisquam. Placeat non ex. Quisquam praesentium corporis.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -263,15 +263,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="38" vrev="38">
-          <srcmd5>1249677f5bf269d8a011f4ae3190bfac</srcmd5>
+        <revision rev="22" vrev="22">
+          <srcmd5>9a196023581dc7311e6b57c54b2d579b</srcmd5>
           <version>unknown</version>
-          <time>1658418912</time>
+          <time>1677089098</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 15:55:13 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:58 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -280,7 +280,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - fd4e8b01-1ea2-4ccd-8e9f-3fd4b3e2ec19
+      - f10d1ce0-5558-49c4-adc7-478a34415500
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -305,7 +305,7 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 15:55:13 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:59 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package?expand=1
@@ -337,7 +337,41 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 15:55:13 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:59 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_history?deleted=1&meta=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - f10d1ce0-5558-49c4-adc7-478a34415500
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Wed, 22 Feb 2023 18:04:59 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -346,7 +380,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - fd4e8b01-1ea2-4ccd-8e9f-3fd4b3e2ec19
+      - f10d1ce0-5558-49c4-adc7-478a34415500
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -371,7 +405,7 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 15:55:14 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:59 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -380,7 +414,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - fd4e8b01-1ea2-4ccd-8e9f-3fd4b3e2ec19
+      - f10d1ce0-5558-49c4-adc7-478a34415500
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -405,16 +439,50 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 15:55:14 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:59 GMT
 - request:
     method: get
-    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - dbf94621-42d7-4001-9a27-c630efb31fd6
+      - f343cea8-874c-4e36-bc99-bcd227e7b5b1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:04:59 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:user_tab_user/_result?lastbuild=1&locallink=1&multibuild=1&package=group_test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - f343cea8-874c-4e36-bc99-bcd227e7b5b1
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -439,5 +507,107 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 21 Jul 2022 15:55:14 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:59 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - f8b5b01b-a12f-4b39-93f9-211009eb174a
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:04:59 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:user_tab_user/_result?lastbuild=1&locallink=1&multibuild=1&package=group_test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - f8b5b01b-a12f-4b39-93f9-211009eb174a
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 18:04:59 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - ebaf6d95-e47d-4930-982d-dd0fc187798d
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 18:04:59 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Packages/behaves_like_bootstrap_user_tab/group_roles/Add_role_to_group.yml
+++ b/src/api/spec/cassettes/Packages/behaves_like_bootstrap_user_tab/group_roles/Add_role_to_group.yml
@@ -39,7 +39,7 @@ http_interactions:
           <description></description>
           <person userid="package_test_user" role="maintainer"/>
         </project>
-  recorded_at: Thu, 03 Nov 2022 09:44:49 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:user_tab_user/_meta?user=user_tab_user
@@ -79,16 +79,16 @@ http_interactions:
           <description></description>
           <person userid="user_tab_user" role="maintainer"/>
         </project>
-  recorded_at: Thu, 03 Nov 2022 09:44:49 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:49 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_30
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_14
     body:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>Françoise Sagan</title>
-          <description>Qui ipsum quae ullam.</description>
+          <title>An Instant In The Wind</title>
+          <description>Sint et et alias.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,12 +109,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '161'
+      - '163'
     body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        PHBhY2thZ2UgbmFtZT0iZ3JvdXBfdGVzdF9wYWNrYWdlIiBwcm9qZWN0PSJob21lOnVzZXJfdGFiX3VzZXIiPgogIDx0aXRsZT5GcmFuw6dvaXNlIFNhZ2FuPC90aXRsZT4KICA8ZGVzY3JpcHRpb24+UXVpIGlwc3VtIHF1YWUgdWxsYW0uPC9kZXNjcmlwdGlvbj4KPC9wYWNrYWdlPgo=
-  recorded_at: Thu, 03 Nov 2022 09:44:49 GMT
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>An Instant In The Wind</title>
+          <description>Sint et et alias.</description>
+        </package>
+  recorded_at: Wed, 22 Feb 2023 18:04:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/_meta?user=other_user
@@ -154,16 +157,16 @@ http_interactions:
           <description></description>
           <person userid="other_user" role="maintainer"/>
         </project>
-  recorded_at: Thu, 03 Nov 2022 09:44:49 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:49 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta?user=user_31
+    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta?user=user_15
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_user">
-          <title>The House of Mirth</title>
-          <description>Quia voluptatem omnis et.</description>
+          <title>Arms and the Man</title>
+          <description>Non et modi eum.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -184,21 +187,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '165'
+      - '154'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_user">
-          <title>The House of Mirth</title>
-          <description>Quia voluptatem omnis et.</description>
+          <title>Arms and the Man</title>
+          <description>Non et modi eum.</description>
         </package>
-  recorded_at: Thu, 03 Nov 2022 09:44:49 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/branch_test_package/_config
     body:
       encoding: UTF-8
-      string: Quas fuga mollitia. Sed officiis quia. Rerum eos ex.
+      string: Sit blanditiis ad. Debitis possimus blanditiis. Eveniet doloribus sed.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -222,22 +225,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="29" vrev="29">
-          <srcmd5>85759dd73a41f41983c076d658486831</srcmd5>
+        <revision rev="17" vrev="17">
+          <srcmd5>c2a99c706f2bc5d0990001162f58a77a</srcmd5>
           <version>unknown</version>
-          <time>1667468689</time>
+          <time>1677089089</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 03 Nov 2022 09:44:49 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/branch_test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Distinctio voluptatum sunt. Voluptatem rerum perferendis. Nam accusantium
-        cumque.
+      string: Perferendis nesciunt magni. Adipisci in tenetur. Optio sed assumenda.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -261,15 +263,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="30" vrev="30">
-          <srcmd5>b3b8effff7b99330fbd3420473f12e86</srcmd5>
+        <revision rev="18" vrev="18">
+          <srcmd5>67bd211998db1f3396748cf4ed90d301</srcmd5>
           <version>unknown</version>
-          <time>1667468689</time>
+          <time>1677089089</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 03 Nov 2022 09:44:49 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:49 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -278,7 +280,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 79568eda-d8cf-427d-a097-01983a3c3863
+      - f5a638df-3541-4263-a46d-76483bf6bfcf
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -303,7 +305,7 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:50 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:50 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package?expand=1
@@ -335,7 +337,41 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:50 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:50 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_history?deleted=1&meta=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - f5a638df-3541-4263-a46d-76483bf6bfcf
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Wed, 22 Feb 2023 18:04:50 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -344,7 +380,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 79568eda-d8cf-427d-a097-01983a3c3863
+      - f5a638df-3541-4263-a46d-76483bf6bfcf
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -369,7 +405,7 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:50 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:50 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -378,7 +414,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 79568eda-d8cf-427d-a097-01983a3c3863
+      - f5a638df-3541-4263-a46d-76483bf6bfcf
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -403,7 +439,7 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:50 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:50 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -412,7 +448,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - cf379063-8c8a-436d-a68c-f0e401b9d333
+      - 6bc53ed0-b62d-4ea8-b22c-c25d940787c7
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -437,7 +473,7 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:50 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:50 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:user_tab_user/_result?lastbuild=1&locallink=1&multibuild=1&package=group_test_package&view=status
@@ -446,7 +482,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - cf379063-8c8a-436d-a68c-f0e401b9d333
+      - 6bc53ed0-b62d-4ea8-b22c-c25d940787c7
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -471,7 +507,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:44:50 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:50 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -480,7 +516,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 9ce5f1b8-2a50-43d6-93bc-dc6c6b77349d
+      - 54134413-fe03-4a8b-936c-907d874985ba
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -505,7 +541,7 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:50 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:51 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:user_tab_user/_result?lastbuild=1&locallink=1&multibuild=1&package=group_test_package&view=status
@@ -514,7 +550,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 9ce5f1b8-2a50-43d6-93bc-dc6c6b77349d
+      - 54134413-fe03-4a8b-936c-907d874985ba
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -539,7 +575,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:44:50 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:51 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
@@ -548,7 +584,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - e7e86a8a-93a4-48df-bc9f-b53259dbf468
+      - 8de609db-ba27-4ab2-9498-c87f3c440e92
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -573,7 +609,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:44:50 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:51 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_tab_user
@@ -581,8 +617,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>Françoise Sagan</title>
-          <description>Qui ipsum quae ullam.</description>
+          <title>An Instant In The Wind</title>
+          <description>Sint et et alias.</description>
           <person userid="user_tab_user" role="maintainer"/>
           <group groupid="existing_group" role="bugowner"/>
           <group groupid="existing_group" role="maintainer"/>
@@ -607,12 +643,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '372'
+      - '374'
     body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        PHBhY2thZ2UgbmFtZT0iZ3JvdXBfdGVzdF9wYWNrYWdlIiBwcm9qZWN0PSJob21lOnVzZXJfdGFiX3VzZXIiPgogIDx0aXRsZT5GcmFuw6dvaXNlIFNhZ2FuPC90aXRsZT4KICA8ZGVzY3JpcHRpb24+UXVpIGlwc3VtIHF1YWUgdWxsYW0uPC9kZXNjcmlwdGlvbj4KICA8cGVyc29uIHVzZXJpZD0idXNlcl90YWJfdXNlciIgcm9sZT0ibWFpbnRhaW5lciIvPgogIDxncm91cCBncm91cGlkPSJleGlzdGluZ19ncm91cCIgcm9sZT0iYnVnb3duZXIiLz4KICA8Z3JvdXAgZ3JvdXBpZD0iZXhpc3RpbmdfZ3JvdXAiIHJvbGU9Im1haW50YWluZXIiLz4KICA8Z3JvdXAgZ3JvdXBpZD0iZXhpc3RpbmdfZ3JvdXAiIHJvbGU9InJldmlld2VyIi8+CjwvcGFja2FnZT4K
-  recorded_at: Thu, 03 Nov 2022 09:44:51 GMT
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>An Instant In The Wind</title>
+          <description>Sint et et alias.</description>
+          <person userid="user_tab_user" role="maintainer"/>
+          <group groupid="existing_group" role="bugowner"/>
+          <group groupid="existing_group" role="maintainer"/>
+          <group groupid="existing_group" role="reviewer"/>
+        </package>
+  recorded_at: Wed, 22 Feb 2023 18:04:51 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -621,7 +664,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - d0217552-91c9-44cb-99f5-474f1811c678
+      - 73d5d0ca-84c1-42a7-9273-c47ef1e3ecc3
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -646,7 +689,7 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:52 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:52 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package?expand=1
@@ -678,7 +721,41 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:52 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:52 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_history?deleted=1&meta=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 73d5d0ca-84c1-42a7-9273-c47ef1e3ecc3
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Wed, 22 Feb 2023 18:04:52 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -687,7 +764,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - d0217552-91c9-44cb-99f5-474f1811c678
+      - 73d5d0ca-84c1-42a7-9273-c47ef1e3ecc3
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -712,7 +789,7 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:52 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:52 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -721,7 +798,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - d0217552-91c9-44cb-99f5-474f1811c678
+      - 73d5d0ca-84c1-42a7-9273-c47ef1e3ecc3
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -746,7 +823,7 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:52 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:52 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -755,7 +832,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 6e9986c3-fdc8-495c-828b-1ebe266f7e75
+      - 640168a5-3693-4f6f-8d90-b0386f756603
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -780,7 +857,7 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:52 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:52 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:user_tab_user/_result?lastbuild=1&locallink=1&multibuild=1&package=group_test_package&view=status
@@ -789,7 +866,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 6e9986c3-fdc8-495c-828b-1ebe266f7e75
+      - 640168a5-3693-4f6f-8d90-b0386f756603
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -814,7 +891,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:44:52 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:52 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -823,7 +900,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 794db621-9b86-43f6-af91-bcc412f34b0e
+      - 40a8f67a-30f8-484c-9917-812ee581f59c
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -848,7 +925,7 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:52 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:52 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:user_tab_user/_result?lastbuild=1&locallink=1&multibuild=1&package=group_test_package&view=status
@@ -857,7 +934,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 794db621-9b86-43f6-af91-bcc412f34b0e
+      - 40a8f67a-30f8-484c-9917-812ee581f59c
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -882,7 +959,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:44:52 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:52 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
@@ -891,7 +968,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 292e34c1-6bc4-4397-a624-b379abfa8fe3
+      - 27fa4401-8efa-4078-a00d-2d411bf1fb7c
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -916,5 +993,5 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:44:52 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:53 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Packages/behaves_like_bootstrap_user_tab/group_roles/Remove_role_from_group.yml
+++ b/src/api/spec/cassettes/Packages/behaves_like_bootstrap_user_tab/group_roles/Remove_role_from_group.yml
@@ -39,7 +39,7 @@ http_interactions:
           <description></description>
           <person userid="package_test_user" role="maintainer"/>
         </project>
-  recorded_at: Thu, 03 Nov 2022 09:44:45 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:53 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:user_tab_user/_meta?user=user_tab_user
@@ -79,16 +79,16 @@ http_interactions:
           <description></description>
           <person userid="user_tab_user" role="maintainer"/>
         </project>
-  recorded_at: Thu, 03 Nov 2022 09:44:45 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:53 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_28
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_16
     body:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>Dance Dance Dance</title>
-          <description>Autem delectus facilis ipsa.</description>
+          <title>Things Fall Apart</title>
+          <description>Doloremque quidem ea at.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,15 +109,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '169'
+      - '165'
     body:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>Dance Dance Dance</title>
-          <description>Autem delectus facilis ipsa.</description>
+          <title>Things Fall Apart</title>
+          <description>Doloremque quidem ea at.</description>
         </package>
-  recorded_at: Thu, 03 Nov 2022 09:44:45 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:53 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/_meta?user=other_user
@@ -157,16 +157,16 @@ http_interactions:
           <description></description>
           <person userid="other_user" role="maintainer"/>
         </project>
-  recorded_at: Thu, 03 Nov 2022 09:44:45 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:53 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta?user=user_29
+    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta?user=user_17
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_user">
-          <title>The Violent Bear It Away</title>
-          <description>Maxime est aspernatur architecto.</description>
+          <title>Lilies of the Field</title>
+          <description>Nisi non beatae molestiae.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -187,22 +187,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '179'
+      - '167'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_user">
-          <title>The Violent Bear It Away</title>
-          <description>Maxime est aspernatur architecto.</description>
+          <title>Lilies of the Field</title>
+          <description>Nisi non beatae molestiae.</description>
         </package>
-  recorded_at: Thu, 03 Nov 2022 09:44:45 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:53 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/branch_test_package/_config
     body:
       encoding: UTF-8
-      string: Repudiandae earum eius. Possimus voluptatem velit. Voluptatem maiores
-        officiis.
+      string: Et ut sed. Maiores cumque dolor. Omnis sapiente hic.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -226,21 +225,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="27" vrev="27">
-          <srcmd5>25a75a86d3c01ac014f44a35eff9b8b1</srcmd5>
+        <revision rev="19" vrev="19">
+          <srcmd5>4c6ed4d737010ddf90cab6aa978a8358</srcmd5>
           <version>unknown</version>
-          <time>1667468685</time>
+          <time>1677089093</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 03 Nov 2022 09:44:45 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:53 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/branch_test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Qui repellendus id. Debitis aspernatur pariatur. Aut et alias.
+      string: Repellendus qui ut. Est minus assumenda. Eos deleniti quo.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -264,15 +263,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="28" vrev="28">
-          <srcmd5>dd065221e2aed5b51409368a1775c5dc</srcmd5>
+        <revision rev="20" vrev="20">
+          <srcmd5>37471a910f256b567c9aa1cde24bcb6d</srcmd5>
           <version>unknown</version>
-          <time>1667468685</time>
+          <time>1677089093</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 03 Nov 2022 09:44:45 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:53 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -281,7 +280,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 84883214-f006-401d-8013-621e2c144f2f
+      - e06842ed-5ccb-41d9-9159-70a006925765
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -306,7 +305,7 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:46 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:55 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package?expand=1
@@ -338,7 +337,41 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:46 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:55 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_history?deleted=1&meta=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - e06842ed-5ccb-41d9-9159-70a006925765
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Wed, 22 Feb 2023 18:04:55 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -347,7 +380,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 84883214-f006-401d-8013-621e2c144f2f
+      - e06842ed-5ccb-41d9-9159-70a006925765
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -372,7 +405,7 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:46 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:55 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -381,7 +414,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 84883214-f006-401d-8013-621e2c144f2f
+      - e06842ed-5ccb-41d9-9159-70a006925765
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -406,7 +439,7 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:46 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:55 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -415,7 +448,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 87c86fcb-dada-4ae0-9ee7-931783cf9bc8
+      - 990a289e-42d8-423b-9702-475c813d16d3
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -440,7 +473,7 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:46 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:55 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:user_tab_user/_result?lastbuild=1&locallink=1&multibuild=1&package=group_test_package&view=status
@@ -449,7 +482,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 87c86fcb-dada-4ae0-9ee7-931783cf9bc8
+      - 990a289e-42d8-423b-9702-475c813d16d3
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -474,7 +507,75 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:44:46 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:55 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 12f82f34-08b7-46eb-a467-60d77e882d3d
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:04:55 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:user_tab_user/_result?lastbuild=1&locallink=1&multibuild=1&package=group_test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 12f82f34-08b7-46eb-a467-60d77e882d3d
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 18:04:55 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
@@ -483,7 +584,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 47a51bf9-6a6b-408b-bb74-23114ccad299
+      - cb7f106b-3d64-4ae5-8b6f-7a1c5900d9a5
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -508,7 +609,91 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:44:46 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:55 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_tab_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>Things Fall Apart</title>
+          <description>Doloremque quidem ea at.</description>
+          <person userid="user_tab_user" role="maintainer"/>
+          <group groupid="existing_group" role="maintainer"/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '272'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>Things Fall Apart</title>
+          <description>Doloremque quidem ea at.</description>
+          <person userid="user_tab_user" role="maintainer"/>
+          <group groupid="existing_group" role="maintainer"/>
+        </package>
+  recorded_at: Wed, 22 Feb 2023 18:04:56 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_tab_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>Things Fall Apart</title>
+          <description>Doloremque quidem ea at.</description>
+          <person userid="user_tab_user" role="maintainer"/>
+          <group groupid="existing_group" role="maintainer"/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '272'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="group_test_package" project="home:user_tab_user">
+          <title>Things Fall Apart</title>
+          <description>Doloremque quidem ea at.</description>
+          <person userid="user_tab_user" role="maintainer"/>
+          <group groupid="existing_group" role="maintainer"/>
+        </package>
+  recorded_at: Wed, 22 Feb 2023 18:04:56 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -517,7 +702,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 6613d9a9-2c34-4cb2-b9f4-41f7b6ef86fa
+      - d6b37f83-6399-42b7-a2bf-33c433a07ef0
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -542,159 +727,7 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:46 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:user_tab_user/_result?lastbuild=1&locallink=1&multibuild=1&package=group_test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Request-Id:
-      - 6613d9a9-2c34-4cb2-b9f4-41f7b6ef86fa
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '55'
-    body:
-      encoding: UTF-8
-      string: '<resultlist state="00000000000000000000000000000000"/>
-
-'
-  recorded_at: Thu, 03 Nov 2022 09:44:46 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_tab_user
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="group_test_package" project="home:user_tab_user">
-          <title>Dance Dance Dance</title>
-          <description>Autem delectus facilis ipsa.</description>
-          <person userid="user_tab_user" role="maintainer"/>
-          <group groupid="existing_group" role="maintainer"/>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '276'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="group_test_package" project="home:user_tab_user">
-          <title>Dance Dance Dance</title>
-          <description>Autem delectus facilis ipsa.</description>
-          <person userid="user_tab_user" role="maintainer"/>
-          <group groupid="existing_group" role="maintainer"/>
-        </package>
-  recorded_at: Thu, 03 Nov 2022 09:44:47 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_tab_user
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="group_test_package" project="home:user_tab_user">
-          <title>Dance Dance Dance</title>
-          <description>Autem delectus facilis ipsa.</description>
-          <person userid="user_tab_user" role="maintainer"/>
-          <group groupid="existing_group" role="maintainer"/>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '276'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="group_test_package" project="home:user_tab_user">
-          <title>Dance Dance Dance</title>
-          <description>Autem delectus facilis ipsa.</description>
-          <person userid="user_tab_user" role="maintainer"/>
-          <group groupid="existing_group" role="maintainer"/>
-        </package>
-  recorded_at: Thu, 03 Nov 2022 09:44:47 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Request-Id:
-      - fb58e646-bee2-4081-8b70-e7f8e21b59fd
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '93'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
-        </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:48 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:57 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package?expand=1
@@ -726,7 +759,41 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:48 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:57 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_history?deleted=1&meta=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - d6b37f83-6399-42b7-a2bf-33c433a07ef0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Wed, 22 Feb 2023 18:04:57 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -735,7 +802,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - fb58e646-bee2-4081-8b70-e7f8e21b59fd
+      - d6b37f83-6399-42b7-a2bf-33c433a07ef0
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -760,7 +827,7 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:48 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:57 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -769,7 +836,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - fb58e646-bee2-4081-8b70-e7f8e21b59fd
+      - d6b37f83-6399-42b7-a2bf-33c433a07ef0
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -794,7 +861,7 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:48 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:57 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -803,7 +870,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 29a3c136-5438-4d54-899d-d5fb744a9413
+      - '06296dd8-a63c-486d-a20c-c88a912a062e'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -828,7 +895,7 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:48 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:57 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:user_tab_user/_result?lastbuild=1&locallink=1&multibuild=1&package=group_test_package&view=status
@@ -837,7 +904,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 29a3c136-5438-4d54-899d-d5fb744a9413
+      - '06296dd8-a63c-486d-a20c-c88a912a062e'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -862,7 +929,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:44:48 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:57 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -871,7 +938,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - c9cc7311-7ac4-44cf-b56e-1bf7a5689382
+      - e153497c-d4d3-409d-8fe4-2ccc73ec801a
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -896,7 +963,7 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:48 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:57 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:user_tab_user/_result?lastbuild=1&locallink=1&multibuild=1&package=group_test_package&view=status
@@ -905,7 +972,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - c9cc7311-7ac4-44cf-b56e-1bf7a5689382
+      - e153497c-d4d3-409d-8fe4-2ccc73ec801a
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -930,7 +997,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:44:48 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:57 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
@@ -939,7 +1006,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 3057d038-abee-4b89-9515-a222689e0c22
+      - 5c6ea58f-207d-45e4-8832-5a489f14d101
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -964,5 +1031,5 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:44:48 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:57 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Packages/behaves_like_bootstrap_user_tab/group_roles/Viewing_group_roles.yml
+++ b/src/api/spec/cassettes/Packages/behaves_like_bootstrap_user_tab/group_roles/Viewing_group_roles.yml
@@ -39,7 +39,7 @@ http_interactions:
           <description></description>
           <person userid="package_test_user" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 15:55:21 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:02 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:user_tab_user/_meta?user=user_tab_user
@@ -79,16 +79,16 @@ http_interactions:
           <description></description>
           <person userid="user_tab_user" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 15:55:21 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:03 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_19
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_20
     body:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>Alone on a Wide, Wide Sea</title>
-          <description>Nam quam fugit veniam.</description>
+          <title>This Lime Tree Bower</title>
+          <description>Est voluptatem ex ipsam.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,15 +109,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '168'
     body:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>Alone on a Wide, Wide Sea</title>
-          <description>Nam quam fugit veniam.</description>
+          <title>This Lime Tree Bower</title>
+          <description>Est voluptatem ex ipsam.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 15:55:21 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:03 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/_meta?user=other_user
@@ -157,16 +157,16 @@ http_interactions:
           <description></description>
           <person userid="other_user" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 15:55:21 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:03 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta?user=user_20
+    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta?user=user_21
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_user">
-          <title>A Glass of Blessings</title>
-          <description>In voluptatum sed maxime.</description>
+          <title>The Stars' Tennis Balls</title>
+          <description>Odio fuga porro corporis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -187,21 +187,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '170'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_user">
-          <title>A Glass of Blessings</title>
-          <description>In voluptatum sed maxime.</description>
+          <title>The Stars' Tennis Balls</title>
+          <description>Odio fuga porro corporis.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 15:55:21 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:03 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/branch_test_package/_config
     body:
       encoding: UTF-8
-      string: Eveniet atque quas. Ducimus quasi ut. Nemo sit quis.
+      string: Nihil officia modi. Veniam assumenda ex. Sint aut porro.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -225,21 +225,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="41" vrev="41">
-          <srcmd5>c11359610ed0d9e7782d44f49d418000</srcmd5>
+        <revision rev="23" vrev="23">
+          <srcmd5>554bb6e120125f4ce2312d4d4bcc66ea</srcmd5>
           <version>unknown</version>
-          <time>1658418921</time>
+          <time>1677089103</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 15:55:21 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:03 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/branch_test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Ea quo a. Exercitationem quia provident. Non quis qui.
+      string: Ipsam quo voluptas. Facilis quibusdam excepturi. Tempore vel consequatur.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -263,15 +263,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="42" vrev="42">
-          <srcmd5>59b3d2d50c64af72362c28d4d20962e6</srcmd5>
+        <revision rev="24" vrev="24">
+          <srcmd5>b2449002e1dda17eee07f0f85982dc69</srcmd5>
           <version>unknown</version>
-          <time>1658418921</time>
+          <time>1677089103</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 15:55:21 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:03 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -280,7 +280,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 5f225c84-98e4-475d-8722-fcc7e878fc6c
+      - 3364cfec-b3e1-49cd-b3ba-a19b58d43e1c
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -305,7 +305,7 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 15:55:22 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:04 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package?expand=1
@@ -337,7 +337,41 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 15:55:22 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:04 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_history?deleted=1&meta=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 3364cfec-b3e1-49cd-b3ba-a19b58d43e1c
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Wed, 22 Feb 2023 18:05:04 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -346,7 +380,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 5f225c84-98e4-475d-8722-fcc7e878fc6c
+      - 3364cfec-b3e1-49cd-b3ba-a19b58d43e1c
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -371,7 +405,7 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 15:55:22 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:04 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -380,7 +414,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 5f225c84-98e4-475d-8722-fcc7e878fc6c
+      - 3364cfec-b3e1-49cd-b3ba-a19b58d43e1c
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -405,16 +439,50 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 15:55:22 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:04 GMT
 - request:
     method: get
-    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - 32e8da8f-cecf-48de-a070-711bcf256dc8
+      - bb6deace-d20a-483b-8330-f774c31871ab
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:05:04 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:user_tab_user/_result?lastbuild=1&locallink=1&multibuild=1&package=group_test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - bb6deace-d20a-483b-8330-f774c31871ab
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -439,5 +507,107 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 21 Jul 2022 15:55:22 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:04 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - fd9d3309-e6d9-4c71-b002-11c36cfcaf40
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:05:04 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:user_tab_user/_result?lastbuild=1&locallink=1&multibuild=1&package=group_test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - fd9d3309-e6d9-4c71-b002-11c36cfcaf40
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 18:05:04 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - c0a27483-6b74-43f5-98e9-41d9aa00be8f
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 18:05:04 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Packages/behaves_like_bootstrap_user_tab/user_roles/Add_an_existing_user.yml
+++ b/src/api/spec/cassettes/Packages/behaves_like_bootstrap_user_tab/user_roles/Add_an_existing_user.yml
@@ -39,7 +39,7 @@ http_interactions:
           <description></description>
           <person userid="package_test_user" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 15:54:56 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:27 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:user_tab_user/_meta?user=user_tab_user
@@ -79,16 +79,16 @@ http_interactions:
           <description></description>
           <person userid="user_tab_user" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 15:54:56 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:27 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_7
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_30
     body:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>All Passion Spent</title>
-          <description>Animi blanditiis sed porro.</description>
+          <title>The Soldier's Art</title>
+          <description>Qui et est et.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,15 +109,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '168'
+      - '155'
     body:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>All Passion Spent</title>
-          <description>Animi blanditiis sed porro.</description>
+          <title>The Soldier's Art</title>
+          <description>Qui et est et.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 15:54:56 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:27 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/_meta?user=other_user
@@ -157,16 +157,16 @@ http_interactions:
           <description></description>
           <person userid="other_user" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 15:54:56 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:27 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta?user=user_8
+    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta?user=user_31
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_user">
-          <title>Jesting Pilate</title>
-          <description>Et sequi ea ipsam.</description>
+          <title>The Way Through the Woods</title>
+          <description>Sit enim reiciendis molestiae.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -187,21 +187,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '154'
+      - '177'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_user">
-          <title>Jesting Pilate</title>
-          <description>Et sequi ea ipsam.</description>
+          <title>The Way Through the Woods</title>
+          <description>Sit enim reiciendis molestiae.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 15:54:56 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:27 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/branch_test_package/_config
     body:
       encoding: UTF-8
-      string: Ad possimus qui. Quibusdam ut repellendus. Dolore quam ea.
+      string: Reiciendis corporis sint. Quae cumque sit. Animi qui est.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -225,21 +225,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="29" vrev="29">
-          <srcmd5>3b2998e421c36b612e22051d4caec659</srcmd5>
+        <revision rev="33" vrev="33">
+          <srcmd5>a6028c1d0d8068d24f54964a8cee5c7e</srcmd5>
           <version>unknown</version>
-          <time>1658418896</time>
+          <time>1677089127</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 15:54:56 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:27 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/branch_test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Quis fugiat est. Quis voluptatem amet. Omnis aperiam ea.
+      string: Ullam quibusdam veniam. Necessitatibus quae voluptatem. Illo nihil assumenda.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -263,15 +263,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="30" vrev="30">
-          <srcmd5>1bc121a06957787f60b8d802d1329761</srcmd5>
+        <revision rev="34" vrev="34">
+          <srcmd5>561c5bbfefadd6291c1eed2ee5401ecd</srcmd5>
           <version>unknown</version>
-          <time>1658418896</time>
+          <time>1677089127</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 15:54:56 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:27 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -280,7 +280,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - dc65e713-dc58-4834-9a5e-6d41bcf02943
+      - 21ed27cd-f6a4-40d7-8537-ae584f7872a9
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -305,7 +305,7 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 15:54:57 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:28 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package?expand=1
@@ -337,7 +337,41 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 15:54:57 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:28 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_history?deleted=1&meta=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 21ed27cd-f6a4-40d7-8537-ae584f7872a9
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Wed, 22 Feb 2023 18:05:28 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -346,7 +380,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - dc65e713-dc58-4834-9a5e-6d41bcf02943
+      - 21ed27cd-f6a4-40d7-8537-ae584f7872a9
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -371,7 +405,7 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 15:54:57 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:28 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -380,7 +414,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - dc65e713-dc58-4834-9a5e-6d41bcf02943
+      - 21ed27cd-f6a4-40d7-8537-ae584f7872a9
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -405,16 +439,50 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 15:54:57 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:28 GMT
 - request:
     method: get
-    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - 102c9916-817a-4038-b62d-ad53609dfe99
+      - 9c1867c0-b73c-480c-ac44-3484fc5d8c9f
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:05:29 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:user_tab_user/_result?lastbuild=1&locallink=1&multibuild=1&package=group_test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 9c1867c0-b73c-480c-ac44-3484fc5d8c9f
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -439,7 +507,109 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 21 Jul 2022 15:54:57 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:29 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - '04150872-c7b3-4c8e-a9c0-ea2fee6b5bb0'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:05:29 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:user_tab_user/_result?lastbuild=1&locallink=1&multibuild=1&package=group_test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - '04150872-c7b3-4c8e-a9c0-ea2fee6b5bb0'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 18:05:29 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - b0b69cc7-172e-4743-a129-c1cb486ce006
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 18:05:29 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_tab_user
@@ -447,8 +617,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>All Passion Spent</title>
-          <description>Animi blanditiis sed porro.</description>
+          <title>The Soldier's Art</title>
+          <description>Qui et est et.</description>
           <person userid="user_tab_user" role="bugowner"/>
           <person userid="other_user" role="maintainer"/>
           <person userid="user_tab_user" role="maintainer"/>
@@ -473,17 +643,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '369'
+      - '356'
     body:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>All Passion Spent</title>
-          <description>Animi blanditiis sed porro.</description>
+          <title>The Soldier's Art</title>
+          <description>Qui et est et.</description>
           <person userid="user_tab_user" role="bugowner"/>
           <person userid="other_user" role="maintainer"/>
           <person userid="user_tab_user" role="maintainer"/>
           <person userid="reader_user" role="reader"/>
         </package>
-  recorded_at: Thu, 21 Jul 2022 15:54:59 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:31 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Packages/behaves_like_bootstrap_user_tab/user_roles/Add_non_existent_user.yml
+++ b/src/api/spec/cassettes/Packages/behaves_like_bootstrap_user_tab/user_roles/Add_non_existent_user.yml
@@ -39,7 +39,7 @@ http_interactions:
           <description></description>
           <person userid="package_test_user" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 15:54:33 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:22 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:user_tab_user/_meta?user=user_tab_user
@@ -79,16 +79,16 @@ http_interactions:
           <description></description>
           <person userid="user_tab_user" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 15:54:33 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:22 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_1
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_28
     body:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>O Pioneers!</title>
-          <description>Numquam doloribus ratione est.</description>
+          <title>To Your Scattered Bodies Go</title>
+          <description>Impedit voluptas rerum reprehenderit.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,15 +109,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '165'
+      - '188'
     body:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>O Pioneers!</title>
-          <description>Numquam doloribus ratione est.</description>
+          <title>To Your Scattered Bodies Go</title>
+          <description>Impedit voluptas rerum reprehenderit.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 15:54:33 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:22 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/_meta?user=other_user
@@ -157,16 +157,16 @@ http_interactions:
           <description></description>
           <person userid="other_user" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 15:54:34 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:22 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta?user=user_2
+    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta?user=user_29
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_user">
-          <title>In a Glass Darkly</title>
-          <description>Officiis voluptatem dolorem dolorum.</description>
+          <title>If Not Now, When?</title>
+          <description>Velit molestiae reprehenderit consequatur.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -187,21 +187,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '175'
+      - '181'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_user">
-          <title>In a Glass Darkly</title>
-          <description>Officiis voluptatem dolorem dolorum.</description>
+          <title>If Not Now, When?</title>
+          <description>Velit molestiae reprehenderit consequatur.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 15:54:34 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:22 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/branch_test_package/_config
     body:
       encoding: UTF-8
-      string: Excepturi quam reprehenderit. Ad eaque vero. Temporibus aut et.
+      string: Non voluptatem minus. Facere doloremque qui. Ad quis voluptatem.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -225,21 +225,22 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="23" vrev="23">
-          <srcmd5>26e5bb7abb7c587132f1f88c41a04ef4</srcmd5>
+        <revision rev="31" vrev="31">
+          <srcmd5>19282f8cf10aed19f9282eeb491466c6</srcmd5>
           <version>unknown</version>
-          <time>1658418874</time>
+          <time>1677089122</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 15:54:34 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:22 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/branch_test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Commodi est facilis. Nisi in at. Alias a praesentium.
+      string: Doloribus vel quibusdam. Occaecati suscipit assumenda. Voluptatem eos
+        voluptate.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -263,15 +264,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="24" vrev="24">
-          <srcmd5>42880cbc4bda0875db3718bc25c3f340</srcmd5>
+        <revision rev="32" vrev="32">
+          <srcmd5>1c731f0934397a2f09fc69ecba42d588</srcmd5>
           <version>unknown</version>
-          <time>1658418874</time>
+          <time>1677089122</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 15:54:34 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:22 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -280,7 +281,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - d627eeee-9800-4506-9918-6947b11ae2c5
+      - e1e55cb0-92e5-4665-a51a-06b3a81bf59c
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -305,7 +306,7 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 15:54:43 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:24 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package?expand=1
@@ -337,7 +338,41 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 15:54:43 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:24 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_history?deleted=1&meta=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - e1e55cb0-92e5-4665-a51a-06b3a81bf59c
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Wed, 22 Feb 2023 18:05:24 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -346,7 +381,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - d627eeee-9800-4506-9918-6947b11ae2c5
+      - e1e55cb0-92e5-4665-a51a-06b3a81bf59c
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -371,7 +406,7 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 15:54:43 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:24 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -380,7 +415,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - d627eeee-9800-4506-9918-6947b11ae2c5
+      - e1e55cb0-92e5-4665-a51a-06b3a81bf59c
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -405,16 +440,50 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 15:54:43 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:24 GMT
 - request:
     method: get
-    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - b37ebf3b-65fe-4a7a-a638-7f3be3cb9e7e
+      - 981f700f-3d44-4384-8a7d-7d5f3a8e2fa4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:05:24 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:user_tab_user/_result?lastbuild=1&locallink=1&multibuild=1&package=group_test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 981f700f-3d44-4384-8a7d-7d5f3a8e2fa4
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -439,5 +508,107 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 21 Jul 2022 15:54:43 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:24 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 721037cf-52be-4d48-9df4-d8cb28180671
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:05:24 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:user_tab_user/_result?lastbuild=1&locallink=1&multibuild=1&package=group_test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 721037cf-52be-4d48-9df4-d8cb28180671
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 18:05:24 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 1124783e-8b31-4bf7-a173-43bb187e1658
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 18:05:24 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Packages/behaves_like_bootstrap_user_tab/user_roles/Add_role_to_user.yml
+++ b/src/api/spec/cassettes/Packages/behaves_like_bootstrap_user_tab/user_roles/Add_role_to_user.yml
@@ -39,7 +39,7 @@ http_interactions:
           <description></description>
           <person userid="package_test_user" role="maintainer"/>
         </project>
-  recorded_at: Thu, 03 Nov 2022 09:44:34 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:13 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:user_tab_user/_meta?user=user_tab_user
@@ -79,16 +79,16 @@ http_interactions:
           <description></description>
           <person userid="user_tab_user" role="maintainer"/>
         </project>
-  recorded_at: Thu, 03 Nov 2022 09:44:34 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:13 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_20
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_24
     body:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>Ego Dominus Tuus</title>
-          <description>Iure quo velit quos.</description>
+          <title>If I Forget Thee Jerusalem</title>
+          <description>Velit tempora nulla eligendi.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,15 +109,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '160'
+      - '179'
     body:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>Ego Dominus Tuus</title>
-          <description>Iure quo velit quos.</description>
+          <title>If I Forget Thee Jerusalem</title>
+          <description>Velit tempora nulla eligendi.</description>
         </package>
-  recorded_at: Thu, 03 Nov 2022 09:44:34 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:13 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/_meta?user=other_user
@@ -157,16 +157,16 @@ http_interactions:
           <description></description>
           <person userid="other_user" role="maintainer"/>
         </project>
-  recorded_at: Thu, 03 Nov 2022 09:44:34 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:13 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta?user=user_21
+    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta?user=user_25
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_user">
-          <title>Gone with the Wind</title>
-          <description>Quis illo enim sint.</description>
+          <title>I Will Fear No Evil</title>
+          <description>Vitae quidem distinctio velit.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -187,21 +187,22 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '160'
+      - '171'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_user">
-          <title>Gone with the Wind</title>
-          <description>Quis illo enim sint.</description>
+          <title>I Will Fear No Evil</title>
+          <description>Vitae quidem distinctio velit.</description>
         </package>
-  recorded_at: Thu, 03 Nov 2022 09:44:34 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:13 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/branch_test_package/_config
     body:
       encoding: UTF-8
-      string: Est voluptatum voluptatem. Ut saepe ab. Et nam sed.
+      string: Velit dignissimos assumenda. Accusamus voluptatibus molestiae. Qui adipisci
+        at.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -225,21 +226,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="23" vrev="23">
-          <srcmd5>6be30ff05e9eb55ac3e0cfa063b0feda</srcmd5>
+        <revision rev="27" vrev="27">
+          <srcmd5>bcb3955fc5fee25f91e9d085ba165672</srcmd5>
           <version>unknown</version>
-          <time>1667468674</time>
+          <time>1677089113</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 03 Nov 2022 09:44:34 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:13 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/branch_test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Dicta libero doloremque. Velit incidunt nam. Blanditiis in tempore.
+      string: Doloremque molestiae unde. Corrupti ipsum maiores. Dolores eaque a.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -263,15 +264,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="24" vrev="24">
-          <srcmd5>5a59607c346913eaab79a66dcdbc4eaa</srcmd5>
+        <revision rev="28" vrev="28">
+          <srcmd5>1bd53b650b696f8aa1a1e2c93c39c9fc</srcmd5>
           <version>unknown</version>
-          <time>1667468674</time>
+          <time>1677089113</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 03 Nov 2022 09:44:35 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:13 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -280,7 +281,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - b1d0856b-a32b-4161-9531-b2b6fb99d004
+      - d2646ea5-8307-480c-8a7d-bf8e6dc95379
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -305,7 +306,7 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:35 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:14 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package?expand=1
@@ -337,7 +338,41 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:35 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:14 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_history?deleted=1&meta=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - d2646ea5-8307-480c-8a7d-bf8e6dc95379
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Wed, 22 Feb 2023 18:05:14 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -346,7 +381,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - b1d0856b-a32b-4161-9531-b2b6fb99d004
+      - d2646ea5-8307-480c-8a7d-bf8e6dc95379
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -371,7 +406,7 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:35 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:14 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -380,7 +415,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - b1d0856b-a32b-4161-9531-b2b6fb99d004
+      - d2646ea5-8307-480c-8a7d-bf8e6dc95379
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -405,7 +440,7 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:35 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:14 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -414,7 +449,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 105d17c8-a3d9-419e-ac61-7e09785dafb7
+      - bd18e1da-b14f-48f3-839b-48e9e515c91d
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -439,7 +474,7 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:36 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:15 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:user_tab_user/_result?lastbuild=1&locallink=1&multibuild=1&package=group_test_package&view=status
@@ -448,7 +483,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 105d17c8-a3d9-419e-ac61-7e09785dafb7
+      - bd18e1da-b14f-48f3-839b-48e9e515c91d
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -473,7 +508,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:44:36 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:15 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -482,7 +517,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 7ed9bbe7-738c-458f-8624-ef099c112af7
+      - 15339851-bfb5-4643-94ba-f80192c24ba3
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -507,7 +542,7 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:36 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:15 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:user_tab_user/_result?lastbuild=1&locallink=1&multibuild=1&package=group_test_package&view=status
@@ -516,7 +551,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 7ed9bbe7-738c-458f-8624-ef099c112af7
+      - 15339851-bfb5-4643-94ba-f80192c24ba3
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -541,7 +576,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:44:36 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:15 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
@@ -550,7 +585,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 46b6422c-631e-4a0c-ba77-4e80ba6ebf38
+      - cbf833af-2e80-4ffd-96eb-946bc392ee4d
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -575,7 +610,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:44:36 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:15 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_tab_user
@@ -583,8 +618,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>Ego Dominus Tuus</title>
-          <description>Iure quo velit quos.</description>
+          <title>If I Forget Thee Jerusalem</title>
+          <description>Velit tempora nulla eligendi.</description>
           <person userid="user_tab_user" role="bugowner"/>
           <person userid="user_tab_user" role="maintainer"/>
           <person userid="reader_user" role="reader"/>
@@ -609,19 +644,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '362'
+      - '381'
     body:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>Ego Dominus Tuus</title>
-          <description>Iure quo velit quos.</description>
+          <title>If I Forget Thee Jerusalem</title>
+          <description>Velit tempora nulla eligendi.</description>
           <person userid="user_tab_user" role="bugowner"/>
           <person userid="user_tab_user" role="maintainer"/>
           <person userid="reader_user" role="reader"/>
           <person userid="user_tab_user" role="reviewer"/>
         </package>
-  recorded_at: Thu, 03 Nov 2022 09:44:37 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:15 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -630,7 +665,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 57982dfd-bf81-462b-8515-3c343de86864
+      - 8359ac77-da6d-4165-91af-4e4f05227ff6
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -655,7 +690,7 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:38 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:16 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package?expand=1
@@ -687,7 +722,41 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:38 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:16 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_history?deleted=1&meta=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 8359ac77-da6d-4165-91af-4e4f05227ff6
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Wed, 22 Feb 2023 18:05:16 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -696,7 +765,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 57982dfd-bf81-462b-8515-3c343de86864
+      - 8359ac77-da6d-4165-91af-4e4f05227ff6
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -721,7 +790,7 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:38 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:16 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -730,7 +799,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 57982dfd-bf81-462b-8515-3c343de86864
+      - 8359ac77-da6d-4165-91af-4e4f05227ff6
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -755,7 +824,7 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:38 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:16 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -764,7 +833,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 443b08a8-61ac-46c7-97a1-26d8f38f0bb0
+      - 183c23e2-2c69-4081-9216-f8fd26b350a5
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -789,7 +858,7 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:38 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:16 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:user_tab_user/_result?lastbuild=1&locallink=1&multibuild=1&package=group_test_package&view=status
@@ -798,7 +867,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 443b08a8-61ac-46c7-97a1-26d8f38f0bb0
+      - 183c23e2-2c69-4081-9216-f8fd26b350a5
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -823,7 +892,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:44:38 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:16 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -832,7 +901,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 6256df54-a148-4196-9601-b1029056166a
+      - a4a54ab6-b8cf-4bae-b954-6d82b63b9ae1
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -857,7 +926,7 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:38 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:16 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:user_tab_user/_result?lastbuild=1&locallink=1&multibuild=1&package=group_test_package&view=status
@@ -866,7 +935,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 6256df54-a148-4196-9601-b1029056166a
+      - a4a54ab6-b8cf-4bae-b954-6d82b63b9ae1
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -891,7 +960,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:44:38 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:16 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
@@ -900,7 +969,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 256d41cb-e6a2-4314-9b41-567ef968fd87
+      - f4fa1a52-be9b-4052-b90f-9c5bdc142b69
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -925,5 +994,5 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:44:38 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:17 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Packages/behaves_like_bootstrap_user_tab/user_roles/Remove_role_from_user.yml
+++ b/src/api/spec/cassettes/Packages/behaves_like_bootstrap_user_tab/user_roles/Remove_role_from_user.yml
@@ -39,7 +39,7 @@ http_interactions:
           <description></description>
           <person userid="package_test_user" role="maintainer"/>
         </project>
-  recorded_at: Thu, 03 Nov 2022 09:44:39 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:37 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:user_tab_user/_meta?user=user_tab_user
@@ -79,16 +79,16 @@ http_interactions:
           <description></description>
           <person userid="user_tab_user" role="maintainer"/>
         </project>
-  recorded_at: Thu, 03 Nov 2022 09:44:39 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:37 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_22
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_34
     body:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>The Stars' Tennis Balls</title>
-          <description>Praesentium ea doloribus quam.</description>
+          <title>Waiting for the Barbarians</title>
+          <description>Tempore dolor mollitia assumenda.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,15 +109,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '177'
+      - '183'
     body:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>The Stars' Tennis Balls</title>
-          <description>Praesentium ea doloribus quam.</description>
+          <title>Waiting for the Barbarians</title>
+          <description>Tempore dolor mollitia assumenda.</description>
         </package>
-  recorded_at: Thu, 03 Nov 2022 09:44:39 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:37 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/_meta?user=other_user
@@ -157,16 +157,16 @@ http_interactions:
           <description></description>
           <person userid="other_user" role="maintainer"/>
         </project>
-  recorded_at: Thu, 03 Nov 2022 09:44:39 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:37 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta?user=user_23
+    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta?user=user_35
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_user">
-          <title>All the King's Men</title>
-          <description>Consequatur eligendi tenetur odio.</description>
+          <title>Everything is Illuminated</title>
+          <description>Est officiis quisquam atque.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -187,21 +187,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '174'
+      - '175'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_user">
-          <title>All the King's Men</title>
-          <description>Consequatur eligendi tenetur odio.</description>
+          <title>Everything is Illuminated</title>
+          <description>Est officiis quisquam atque.</description>
         </package>
-  recorded_at: Thu, 03 Nov 2022 09:44:39 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:37 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/branch_test_package/_config
     body:
       encoding: UTF-8
-      string: Nisi qui est. Quam itaque omnis. Error rerum repellat.
+      string: Et aut et. Alias totam officiis. Aut fuga in.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -225,21 +225,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="25" vrev="25">
-          <srcmd5>ff5297e4575434b060953d192909c13c</srcmd5>
+        <revision rev="37" vrev="37">
+          <srcmd5>800ae651308b02c6de3576f3211ffe2e</srcmd5>
           <version>unknown</version>
-          <time>1667468679</time>
+          <time>1677089137</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 03 Nov 2022 09:44:39 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:37 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/branch_test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Rerum ullam odio. Quia amet aut. Voluptatem beatae cum.
+      string: In nulla voluptate. Veniam enim quia. Nihil aspernatur aut.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -263,15 +263,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="26" vrev="26">
-          <srcmd5>a232aa6d174d95f898a24824640b2bda</srcmd5>
+        <revision rev="38" vrev="38">
+          <srcmd5>0a0ba0b150636ad606fd07d6207b4e71</srcmd5>
           <version>unknown</version>
-          <time>1667468679</time>
+          <time>1677089137</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 03 Nov 2022 09:44:39 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:37 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -280,7 +280,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - a4cc4d66-826b-482e-980f-d50210eba747
+      - d3bef551-08ed-493e-aa00-55e5b23c0896
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -305,7 +305,7 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:40 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:39 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package?expand=1
@@ -337,7 +337,41 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:40 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:39 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_history?deleted=1&meta=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - d3bef551-08ed-493e-aa00-55e5b23c0896
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Wed, 22 Feb 2023 18:05:39 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -346,7 +380,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - a4cc4d66-826b-482e-980f-d50210eba747
+      - d3bef551-08ed-493e-aa00-55e5b23c0896
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -371,7 +405,7 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:40 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:39 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -380,7 +414,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - a4cc4d66-826b-482e-980f-d50210eba747
+      - d3bef551-08ed-493e-aa00-55e5b23c0896
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -405,7 +439,7 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:40 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:39 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -414,7 +448,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 903b2ec0-5c63-40a5-92a6-ea763ed71b64
+      - dd66c2cc-4c47-49b8-92bd-e8f1bdd799e3
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -439,7 +473,7 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:40 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:39 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:user_tab_user/_result?lastbuild=1&locallink=1&multibuild=1&package=group_test_package&view=status
@@ -448,7 +482,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 903b2ec0-5c63-40a5-92a6-ea763ed71b64
+      - dd66c2cc-4c47-49b8-92bd-e8f1bdd799e3
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -473,7 +507,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:44:40 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:39 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -482,7 +516,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 430373f9-0faf-4190-b5ea-f2e4ae2ecc33
+      - 83041206-d4f9-48d0-904f-f16c8a79bbc8
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -507,7 +541,7 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:40 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:39 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:user_tab_user/_result?lastbuild=1&locallink=1&multibuild=1&package=group_test_package&view=status
@@ -516,7 +550,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 430373f9-0faf-4190-b5ea-f2e4ae2ecc33
+      - 83041206-d4f9-48d0-904f-f16c8a79bbc8
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -541,7 +575,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:44:40 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:39 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
@@ -550,7 +584,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - b6be982e-b05e-4a40-a7ed-45f2153df468
+      - da79d72e-75b6-4890-9815-ce0a639a43dc
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -575,7 +609,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:44:40 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:39 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_tab_user
@@ -583,8 +617,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>The Stars' Tennis Balls</title>
-          <description>Praesentium ea doloribus quam.</description>
+          <title>Waiting for the Barbarians</title>
+          <description>Tempore dolor mollitia assumenda.</description>
           <person userid="user_tab_user" role="maintainer"/>
           <person userid="reader_user" role="reader"/>
         </package>
@@ -607,17 +641,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '277'
+      - '283'
     body:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>The Stars' Tennis Balls</title>
-          <description>Praesentium ea doloribus quam.</description>
+          <title>Waiting for the Barbarians</title>
+          <description>Tempore dolor mollitia assumenda.</description>
           <person userid="user_tab_user" role="maintainer"/>
           <person userid="reader_user" role="reader"/>
         </package>
-  recorded_at: Thu, 03 Nov 2022 09:44:41 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:40 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_tab_user
@@ -625,8 +659,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>The Stars' Tennis Balls</title>
-          <description>Praesentium ea doloribus quam.</description>
+          <title>Waiting for the Barbarians</title>
+          <description>Tempore dolor mollitia assumenda.</description>
           <person userid="user_tab_user" role="maintainer"/>
           <person userid="reader_user" role="reader"/>
         </package>
@@ -649,17 +683,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '277'
+      - '283'
     body:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>The Stars' Tennis Balls</title>
-          <description>Praesentium ea doloribus quam.</description>
+          <title>Waiting for the Barbarians</title>
+          <description>Tempore dolor mollitia assumenda.</description>
           <person userid="user_tab_user" role="maintainer"/>
           <person userid="reader_user" role="reader"/>
         </package>
-  recorded_at: Thu, 03 Nov 2022 09:44:41 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:40 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -668,7 +702,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - a960bd99-c81f-458f-89b3-fc247c381d2b
+      - 32bd4533-4633-4bbb-ba7a-24db514f4322
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -693,7 +727,7 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:42 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:41 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package?expand=1
@@ -725,7 +759,41 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:42 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:41 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_history?deleted=1&meta=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 32bd4533-4633-4bbb-ba7a-24db514f4322
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Wed, 22 Feb 2023 18:05:41 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -734,7 +802,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - a960bd99-c81f-458f-89b3-fc247c381d2b
+      - 32bd4533-4633-4bbb-ba7a-24db514f4322
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -759,7 +827,7 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:42 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:41 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -768,7 +836,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - a960bd99-c81f-458f-89b3-fc247c381d2b
+      - 32bd4533-4633-4bbb-ba7a-24db514f4322
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -793,7 +861,7 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:42 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:41 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -802,7 +870,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 8e28be45-c936-49bb-a6d1-c6682a0fc8af
+      - 013a38fb-fd8e-43dc-9a04-779d2d5ae0e6
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -827,7 +895,7 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:42 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:41 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:user_tab_user/_result?lastbuild=1&locallink=1&multibuild=1&package=group_test_package&view=status
@@ -836,7 +904,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 8e28be45-c936-49bb-a6d1-c6682a0fc8af
+      - 013a38fb-fd8e-43dc-9a04-779d2d5ae0e6
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -861,7 +929,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:44:42 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:41 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -870,7 +938,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 7d1a8e08-2893-4845-ab41-4143c152e8b1
+      - 34456319-bb8b-482f-a4c0-b7bd6a728e21
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -895,7 +963,7 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:42 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:41 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:user_tab_user/_result?lastbuild=1&locallink=1&multibuild=1&package=group_test_package&view=status
@@ -904,7 +972,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 7d1a8e08-2893-4845-ab41-4143c152e8b1
+      - 34456319-bb8b-482f-a4c0-b7bd6a728e21
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -929,7 +997,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:44:42 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:41 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
@@ -938,7 +1006,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - bf4b0a25-63ae-47ca-a61b-18e2f16c2418
+      - 2b38014c-c175-4394-b669-ce0c1d4df9ab
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -963,5 +1031,5 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:44:42 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:41 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Packages/behaves_like_bootstrap_user_tab/user_roles/Remove_user_from_package_/_project.yml
+++ b/src/api/spec/cassettes/Packages/behaves_like_bootstrap_user_tab/user_roles/Remove_user_from_package_/_project.yml
@@ -39,7 +39,7 @@ http_interactions:
           <description></description>
           <person userid="package_test_user" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 15:54:47 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:17 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:user_tab_user/_meta?user=user_tab_user
@@ -79,16 +79,16 @@ http_interactions:
           <description></description>
           <person userid="user_tab_user" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 15:54:47 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:17 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_3
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_26
     body:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>The Little Foxes</title>
-          <description>Aut enim molestiae odio.</description>
+          <title>The Heart Is a Lonely Hunter</title>
+          <description>Aut necessitatibus dolor soluta.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,15 +109,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '164'
+      - '184'
     body:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>The Little Foxes</title>
-          <description>Aut enim molestiae odio.</description>
+          <title>The Heart Is a Lonely Hunter</title>
+          <description>Aut necessitatibus dolor soluta.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 15:54:47 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:17 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/_meta?user=other_user
@@ -157,16 +157,16 @@ http_interactions:
           <description></description>
           <person userid="other_user" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 15:54:47 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:18 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta?user=user_4
+    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta?user=user_27
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_user">
-          <title>Consider Phlebas</title>
-          <description>Qui sunt illo porro.</description>
+          <title>Recalled to Life</title>
+          <description>Quae expedita ipsam assumenda.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -187,21 +187,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '158'
+      - '168'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_user">
-          <title>Consider Phlebas</title>
-          <description>Qui sunt illo porro.</description>
+          <title>Recalled to Life</title>
+          <description>Quae expedita ipsam assumenda.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 15:54:48 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:18 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/branch_test_package/_config
     body:
       encoding: UTF-8
-      string: Impedit omnis est. Qui labore laborum. Rerum nihil repellendus.
+      string: Ullam enim ipsum. Nesciunt est nobis. Iste repellat cum.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -225,21 +225,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="25" vrev="25">
-          <srcmd5>bcccc5d7fc2000b86ecfb0178c3e3946</srcmd5>
+        <revision rev="29" vrev="29">
+          <srcmd5>62501d94d0adddb57314ea1a933b781e</srcmd5>
           <version>unknown</version>
-          <time>1658418888</time>
+          <time>1677089118</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 15:54:48 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:18 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/branch_test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Voluptatem accusantium odio. Nam autem ad. Aut placeat ipsum.
+      string: Dicta repellendus et. Eos quisquam assumenda. Quia consequuntur ducimus.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -263,15 +263,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="26" vrev="26">
-          <srcmd5>b06cac42e61303834d0d2664c53ec1ab</srcmd5>
+        <revision rev="30" vrev="30">
+          <srcmd5>f58da26a50143789bb9499d07e2b2877</srcmd5>
           <version>unknown</version>
-          <time>1658418888</time>
+          <time>1677089118</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 15:54:48 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:18 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -280,7 +280,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 87d470e7-f7d7-406b-9b1f-95f19423e526
+      - f734fbac-ad85-4e53-a1a9-d75d31ca15db
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -305,7 +305,7 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 15:54:49 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:19 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package?expand=1
@@ -337,7 +337,41 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 15:54:49 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:19 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_history?deleted=1&meta=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - f734fbac-ad85-4e53-a1a9-d75d31ca15db
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Wed, 22 Feb 2023 18:05:19 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -346,7 +380,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 87d470e7-f7d7-406b-9b1f-95f19423e526
+      - f734fbac-ad85-4e53-a1a9-d75d31ca15db
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -371,7 +405,7 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 15:54:49 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:19 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -380,7 +414,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 87d470e7-f7d7-406b-9b1f-95f19423e526
+      - f734fbac-ad85-4e53-a1a9-d75d31ca15db
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -405,16 +439,50 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 15:54:49 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:19 GMT
 - request:
     method: get
-    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - 93ec70c4-7e80-47b3-be5f-b668bbbd4d10
+      - 934744f6-a31d-41f2-93b0-d8c3f9bab8c8
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:05:19 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:user_tab_user/_result?lastbuild=1&locallink=1&multibuild=1&package=group_test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 934744f6-a31d-41f2-93b0-d8c3f9bab8c8
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -439,7 +507,109 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 21 Jul 2022 15:54:49 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:19 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 1feb1e32-05da-4030-b0bc-771b8b589329
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:05:19 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:user_tab_user/_result?lastbuild=1&locallink=1&multibuild=1&package=group_test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 1feb1e32-05da-4030-b0bc-771b8b589329
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 18:05:19 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 849d8aa8-92d8-4c30-a070-2fe34759e0dc
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 18:05:19 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_tab_user
@@ -447,8 +617,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>The Little Foxes</title>
-          <description>Aut enim molestiae odio.</description>
+          <title>The Heart Is a Lonely Hunter</title>
+          <description>Aut necessitatibus dolor soluta.</description>
           <person userid="user_tab_user" role="bugowner"/>
           <person userid="user_tab_user" role="maintainer"/>
         </package>
@@ -471,17 +641,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '268'
+      - '288'
     body:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>The Little Foxes</title>
-          <description>Aut enim molestiae odio.</description>
+          <title>The Heart Is a Lonely Hunter</title>
+          <description>Aut necessitatibus dolor soluta.</description>
           <person userid="user_tab_user" role="bugowner"/>
           <person userid="user_tab_user" role="maintainer"/>
         </package>
-  recorded_at: Thu, 21 Jul 2022 15:54:51 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:21 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_tab_user
@@ -489,8 +659,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>The Little Foxes</title>
-          <description>Aut enim molestiae odio.</description>
+          <title>The Heart Is a Lonely Hunter</title>
+          <description>Aut necessitatibus dolor soluta.</description>
           <person userid="user_tab_user" role="bugowner"/>
           <person userid="user_tab_user" role="maintainer"/>
         </package>
@@ -513,15 +683,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '268'
+      - '288'
     body:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>The Little Foxes</title>
-          <description>Aut enim molestiae odio.</description>
+          <title>The Heart Is a Lonely Hunter</title>
+          <description>Aut necessitatibus dolor soluta.</description>
           <person userid="user_tab_user" role="bugowner"/>
           <person userid="user_tab_user" role="maintainer"/>
         </package>
-  recorded_at: Thu, 21 Jul 2022 15:54:51 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:21 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Packages/behaves_like_bootstrap_user_tab/user_roles/Viewing_user_roles.yml
+++ b/src/api/spec/cassettes/Packages/behaves_like_bootstrap_user_tab/user_roles/Viewing_user_roles.yml
@@ -39,7 +39,7 @@ http_interactions:
           <description></description>
           <person userid="package_test_user" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 15:55:02 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:34 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:user_tab_user/_meta?user=user_tab_user
@@ -79,16 +79,16 @@ http_interactions:
           <description></description>
           <person userid="user_tab_user" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 15:55:02 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:34 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_9
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_meta?user=user_32
     body:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>The Wives of Bath</title>
-          <description>Provident dolor cupiditate id.</description>
+          <title>Shall not Perish</title>
+          <description>Non laboriosam et iste.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,15 +109,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '163'
     body:
       encoding: UTF-8
       string: |
         <package name="group_test_package" project="home:user_tab_user">
-          <title>The Wives of Bath</title>
-          <description>Provident dolor cupiditate id.</description>
+          <title>Shall not Perish</title>
+          <description>Non laboriosam et iste.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 15:55:02 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:34 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/_meta?user=other_user
@@ -157,16 +157,16 @@ http_interactions:
           <description></description>
           <person userid="other_user" role="maintainer"/>
         </project>
-  recorded_at: Thu, 21 Jul 2022 15:55:02 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:34 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta?user=user_10
+    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta?user=user_33
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_user">
-          <title>Recalled to Life</title>
-          <description>Est sequi ut quia.</description>
+          <title>Vanity Fair</title>
+          <description>Ipsum tempore autem culpa.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -187,21 +187,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '156'
+      - '159'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_user">
-          <title>Recalled to Life</title>
-          <description>Est sequi ut quia.</description>
+          <title>Vanity Fair</title>
+          <description>Ipsum tempore autem culpa.</description>
         </package>
-  recorded_at: Thu, 21 Jul 2022 15:55:02 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:34 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/branch_test_package/_config
     body:
       encoding: UTF-8
-      string: Laborum odio molestiae. Ullam sit quaerat. Sed aliquam blanditiis.
+      string: Facilis maiores impedit. Ipsum et nulla. Maxime aut sapiente.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -225,21 +225,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="31" vrev="31">
-          <srcmd5>b11a5e8ebcd227882369ca4010198e82</srcmd5>
+        <revision rev="35" vrev="35">
+          <srcmd5>fa14f288582030c5036abf9dbb47f866</srcmd5>
           <version>unknown</version>
-          <time>1658418902</time>
+          <time>1677089134</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 15:55:02 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:34 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/branch_test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Vero beatae id. Incidunt quas beatae. Saepe unde aut.
+      string: Sapiente ratione facere. Vitae cum distinctio. Quae assumenda hic.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -263,15 +263,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="32" vrev="32">
-          <srcmd5>39533c26c6a0cc2b2792d3ca0130df58</srcmd5>
+        <revision rev="36" vrev="36">
+          <srcmd5>82698b5eed9b58c8c887c2ca132c0780</srcmd5>
           <version>unknown</version>
-          <time>1658418902</time>
+          <time>1677089134</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 21 Jul 2022 15:55:02 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:34 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -280,7 +280,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 2611db34-d3ae-4b0e-b235-6286ce92f9b8
+      - 89f5e02d-c1a3-45fd-bb9e-d2f9103b0774
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -305,7 +305,7 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 15:55:03 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:36 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package?expand=1
@@ -337,7 +337,41 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 15:55:03 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:36 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package/_history?deleted=1&meta=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 89f5e02d-c1a3-45fd-bb9e-d2f9103b0774
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Wed, 22 Feb 2023 18:05:36 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -346,7 +380,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 2611db34-d3ae-4b0e-b235-6286ce92f9b8
+      - 89f5e02d-c1a3-45fd-bb9e-d2f9103b0774
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -371,7 +405,7 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 15:55:03 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:36 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:user_tab_user/group_test_package
@@ -380,7 +414,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 2611db34-d3ae-4b0e-b235-6286ce92f9b8
+      - 89f5e02d-c1a3-45fd-bb9e-d2f9103b0774
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -405,16 +439,50 @@ http_interactions:
       string: |
         <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 21 Jul 2022 15:55:03 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:36 GMT
 - request:
     method: get
-    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - 69c305ee-3ed6-4410-a14a-078ffc8a8da2
+      - 55865762-6119-4e9c-8dab-413cb8ab545f
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:05:36 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:user_tab_user/_result?lastbuild=1&locallink=1&multibuild=1&package=group_test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 55865762-6119-4e9c-8dab-413cb8ab545f
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -439,5 +507,107 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 21 Jul 2022 15:55:04 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:36 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:user_tab_user/group_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 67ec5863-b83d-4029-a82b-daf370199f35
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '93'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="group_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:05:36 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:user_tab_user/_result?lastbuild=1&locallink=1&multibuild=1&package=group_test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 67ec5863-b83d-4029-a82b-daf370199f35
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 18:05:36 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:user_tab_user/_result?package=group_test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - b0c1b27a-490f-497f-aa77-20eb7c966dd4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 18:05:36 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Packages/branching_a_package_from_another_users_project/with_AutoCleanup.yml
+++ b/src/api/spec/cassettes/Packages/branching_a_package_from_another_users_project/with_AutoCleanup.yml
@@ -39,16 +39,16 @@ http_interactions:
           <description></description>
           <person userid="package_test_user" role="maintainer"/>
         </project>
-  recorded_at: Thu, 03 Nov 2022 09:44:26 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:46 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=user_9
+    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=user_38
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>Mother Night</title>
-          <description>Quisquam optio quo facere.</description>
+          <title>An Instant In The Wind</title>
+          <description>Sint dolor maxime amet.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -69,21 +69,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '160'
+      - '167'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>Mother Night</title>
-          <description>Quisquam optio quo facere.</description>
+          <title>An Instant In The Wind</title>
+          <description>Sint dolor maxime amet.</description>
         </package>
-  recorded_at: Thu, 03 Nov 2022 09:44:26 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:46 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_config
     body:
       encoding: UTF-8
-      string: Sit et sed. Expedita consequuntur qui. Eos perspiciatis eos.
+      string: Qui dolore quia. Ut et facere. Tempora officiis rem.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -107,21 +107,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="61" vrev="61">
-          <srcmd5>36764a3550cde304eb2dd39c2f230fd9</srcmd5>
+        <revision rev="76" vrev="76">
+          <srcmd5>8f74fc59ac65d1d906cf6b889b1236a9</srcmd5>
           <version>unknown</version>
-          <time>1667468666</time>
+          <time>1677089146</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 03 Nov 2022 09:44:26 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:46 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Quia deserunt modi. Illum et vel. Dolorum dolore esse.
+      string: Ipsam quia mollitia. Non recusandae quam. Est blanditiis illum.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -145,15 +145,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="62" vrev="62">
-          <srcmd5>2fcfa49dc0b011c276200e205760c94a</srcmd5>
+        <revision rev="77" vrev="77">
+          <srcmd5>af1192c3ee46268e495ba28b3f3b81d9</srcmd5>
           <version>unknown</version>
-          <time>1667468666</time>
+          <time>1677089146</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 03 Nov 2022 09:44:26 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:46 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/_meta?user=other_package_test_user
@@ -193,16 +193,16 @@ http_interactions:
           <description></description>
           <person userid="other_package_test_user" role="maintainer"/>
         </project>
-  recorded_at: Thu, 03 Nov 2022 09:44:26 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:46 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=user_10
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=user_39
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>The House of Mirth</title>
-          <description>Molestiae sed sapiente est.</description>
+          <title>Such, Such Were the Joys</title>
+          <description>Quos vitae officiis voluptatem.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -223,21 +223,22 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '180'
+      - '190'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>The House of Mirth</title>
-          <description>Molestiae sed sapiente est.</description>
+          <title>Such, Such Were the Joys</title>
+          <description>Quos vitae officiis voluptatem.</description>
         </package>
-  recorded_at: Thu, 03 Nov 2022 09:44:26 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:46 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_config
     body:
       encoding: UTF-8
-      string: Sit culpa rerum. Architecto expedita assumenda. Voluptas voluptas sint.
+      string: Quisquam ut repellendus. Amet expedita dolores. Dolorum necessitatibus
+        in.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -261,21 +262,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="55" vrev="55">
-          <srcmd5>998e1b7b69306b798845c0f5360b121b</srcmd5>
+        <revision rev="69" vrev="69">
+          <srcmd5>1dea72c1cda929d15315dae6f484f8f6</srcmd5>
           <version>unknown</version>
-          <time>1667468666</time>
+          <time>1677089146</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 03 Nov 2022 09:44:26 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:46 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Quod earum dolor. Odio debitis nobis. Iusto ipsam sapiente.
+      string: Voluptatem quam quae. Voluptas labore tempora. Et est ratione.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -299,15 +300,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="56" vrev="56">
-          <srcmd5>e63b44ee4c954030cc0e54aca9d278ce</srcmd5>
+        <revision rev="70" vrev="70">
+          <srcmd5>01fb92edcefa818ecae2e9227fcd0ca7</srcmd5>
           <version>unknown</version>
-          <time>1667468666</time>
+          <time>1677089146</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 03 Nov 2022 09:44:26 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:46 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package
@@ -316,7 +317,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - a63fd722-efd2-474a-bcd5-1560854ebc9f
+      - ba75a824-61aa-4114-9dd8-97a3cf9d707f
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -339,14 +340,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="56" vrev="56" srcmd5="e63b44ee4c954030cc0e54aca9d278ce">
-          <entry name="_config" md5="100cf0b1efcaa7cc12f7efe32984843e" size="71" mtime="1667468666"/>
-          <entry name="somefile.txt" md5="d7564485f8f64b60b4b93df5fe1af78c" size="59" mtime="1667468666"/>
+        <directory name="branch_test_package" rev="70" vrev="70" srcmd5="01fb92edcefa818ecae2e9227fcd0ca7">
+          <entry name="_config" md5="41786a0eaafbfa610b014099c992fc2b" size="74" mtime="1677089146"/>
+          <entry name="somefile.txt" md5="451d884d414b8551362859a38910fad2" size="62" mtime="1677089146"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:27 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:47 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package?expand=1&rev=56
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package?expand=1&rev=70
     body:
       encoding: US-ASCII
       string: ''
@@ -373,18 +374,20 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="56" vrev="56" srcmd5="e63b44ee4c954030cc0e54aca9d278ce">
-          <entry name="_config" md5="100cf0b1efcaa7cc12f7efe32984843e" size="71" mtime="1667468666"/>
-          <entry name="somefile.txt" md5="d7564485f8f64b60b4b93df5fe1af78c" size="59" mtime="1667468666"/>
+        <directory name="branch_test_package" rev="70" vrev="70" srcmd5="01fb92edcefa818ecae2e9227fcd0ca7">
+          <entry name="_config" md5="41786a0eaafbfa610b014099c992fc2b" size="74" mtime="1677089146"/>
+          <entry name="somefile.txt" md5="451d884d414b8551362859a38910fad2" size="62" mtime="1677089146"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:27 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:47 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_history
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_history?deleted=1&meta=1&rev=70
     body:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - ba75a824-61aa-4114-9dd8-97a3cf9d707f
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -403,349 +406,47 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '10317'
+      - '31'
     body:
       encoding: UTF-8
       string: |
         <revisionlist>
-          <revision rev="1" vrev="1">
-            <srcmd5>cf06b5b0511092db4a9e45a3b5042f99</srcmd5>
-            <version>unknown</version>
-            <time>1666872405</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="2" vrev="2">
-            <srcmd5>c06e450cdd3978970fac916f02c7dd7d</srcmd5>
-            <version>unknown</version>
-            <time>1666872405</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="3" vrev="3">
-            <srcmd5>3ce56f10e21ef5167a683b9581f11ac7</srcmd5>
-            <version>unknown</version>
-            <time>1667463244</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="4" vrev="4">
-            <srcmd5>9088839a004375dccee13c17a953326e</srcmd5>
-            <version>unknown</version>
-            <time>1667463244</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="5" vrev="5">
-            <srcmd5>2d9649d14cb59e3d031b7e95ea964e77</srcmd5>
-            <version>unknown</version>
-            <time>1667464482</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="6" vrev="6">
-            <srcmd5>2b44424f02eef718ecdf50691ec9f31f</srcmd5>
-            <version>unknown</version>
-            <time>1667464482</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="7" vrev="7">
-            <srcmd5>0d4dfbe39c39985f60f5ce4682d11903</srcmd5>
-            <version>unknown</version>
-            <time>1667464736</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="8" vrev="8">
-            <srcmd5>de5cca154f328a14a685435e3eb406ba</srcmd5>
-            <version>unknown</version>
-            <time>1667464736</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="9" vrev="9">
-            <srcmd5>a547f7991e24a80953ad2fc1c10e30ad</srcmd5>
-            <version>unknown</version>
-            <time>1667464744</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="10" vrev="10">
-            <srcmd5>a2f7f9be6efb7827bf9b54d716babbe0</srcmd5>
-            <version>unknown</version>
-            <time>1667464744</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="11" vrev="11">
-            <srcmd5>bfa6dda3dbfb0aa5e57de73df0ca59b4</srcmd5>
-            <version>unknown</version>
-            <time>1667464747</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="12" vrev="12">
-            <srcmd5>21026f5fb7e2f62f329d47c3cbe74691</srcmd5>
-            <version>unknown</version>
-            <time>1667464747</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="13" vrev="13">
-            <srcmd5>3414997a2a511588aaec15766e6d37cb</srcmd5>
-            <version>unknown</version>
-            <time>1667464750</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="14" vrev="14">
-            <srcmd5>5a72a15a0324b55af3f44d14007e79c2</srcmd5>
-            <version>unknown</version>
-            <time>1667464750</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="15" vrev="15">
-            <srcmd5>6150e6991dfa10c2adbd802b55d994d9</srcmd5>
-            <version>unknown</version>
-            <time>1667464753</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="16" vrev="16">
-            <srcmd5>c91330229762bb40b2b1e60879fbb95c</srcmd5>
-            <version>unknown</version>
-            <time>1667464753</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="17" vrev="17">
-            <srcmd5>e23c5bc5023b95407f25da0fd943eca6</srcmd5>
-            <version>unknown</version>
-            <time>1667464756</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="18" vrev="18">
-            <srcmd5>c28468d04c555f6eb172de224be0d4bb</srcmd5>
-            <version>unknown</version>
-            <time>1667464756</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="19" vrev="19">
-            <srcmd5>4c7cfd5d542cf79ffee9c5c91fe4f4f3</srcmd5>
-            <version>unknown</version>
-            <time>1667464761</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="20" vrev="20">
-            <srcmd5>14ed5559f599793371b799ade3b9eb81</srcmd5>
-            <version>unknown</version>
-            <time>1667464761</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="21" vrev="21">
-            <srcmd5>50e01ec85f591a87d22e038cf7cddeb2</srcmd5>
-            <version>unknown</version>
-            <time>1667464763</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="22" vrev="22">
-            <srcmd5>e46fb9c10f12712a0baaa1d1ae072adb</srcmd5>
-            <version>unknown</version>
-            <time>1667464763</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="23" vrev="23">
-            <srcmd5>a88bbcd2d335d99d1e673157ef6fec8f</srcmd5>
-            <version>unknown</version>
-            <time>1667464764</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="24" vrev="24">
-            <srcmd5>1bcbff5aef0c3b0ff2d606e2386b4484</srcmd5>
-            <version>unknown</version>
-            <time>1667464764</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="25" vrev="25">
-            <srcmd5>2290c0a92f335e91686e2ad77276f43c</srcmd5>
-            <version>unknown</version>
-            <time>1667464767</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="26" vrev="26">
-            <srcmd5>93243ff52cd6b70bf54cbdb782fcd027</srcmd5>
-            <version>unknown</version>
-            <time>1667464767</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="27" vrev="27">
-            <srcmd5>7729a462583b22277b2acd2b872b8eec</srcmd5>
-            <version>unknown</version>
-            <time>1667464769</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="28" vrev="28">
-            <srcmd5>38795844f7c2ad248adb727b687bb50a</srcmd5>
-            <version>unknown</version>
-            <time>1667464769</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="29" vrev="29">
-            <srcmd5>e483b9b8258489f719ef55eab5bb7789</srcmd5>
-            <version>unknown</version>
-            <time>1667464772</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="30" vrev="30">
-            <srcmd5>5dcdb4d92cea3ce49f0a01c9f38299f0</srcmd5>
-            <version>unknown</version>
-            <time>1667464772</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="31" vrev="31">
-            <srcmd5>ccfeda81520d0503a80f9c2329c5df57</srcmd5>
-            <version>unknown</version>
-            <time>1667464774</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="32" vrev="32">
-            <srcmd5>36d3cf2ba23d969411670c61550de093</srcmd5>
-            <version>unknown</version>
-            <time>1667464774</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="33" vrev="33">
-            <srcmd5>7d1a7e43c1fa21ee3559f0dc99056f5f</srcmd5>
-            <version>unknown</version>
-            <time>1667464776</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="34" vrev="34">
-            <srcmd5>a30ae743f8f081a3ee1d323830c77fd9</srcmd5>
-            <version>unknown</version>
-            <time>1667464776</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="35" vrev="35">
-            <srcmd5>585d8c0b56dfc1f82d15d6f306940e75</srcmd5>
-            <version>unknown</version>
-            <time>1667464777</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="36" vrev="36">
-            <srcmd5>3348f383bc1de16d2e20eb9668831ebc</srcmd5>
-            <version>unknown</version>
-            <time>1667464777</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="37" vrev="37">
-            <srcmd5>b71f410e0ec4266893b05277969058ba</srcmd5>
-            <version>unknown</version>
-            <time>1667464780</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="38" vrev="38">
-            <srcmd5>4649c3e349ad351245a481f7d38701f7</srcmd5>
-            <version>unknown</version>
-            <time>1667464780</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="39" vrev="39">
-            <srcmd5>936cdd189460d1159f1edc579d0a4673</srcmd5>
-            <version>unknown</version>
-            <time>1667464783</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="40" vrev="40">
-            <srcmd5>aa29fc9918862a90eb0049be78f1853f</srcmd5>
-            <version>unknown</version>
-            <time>1667464783</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="41" vrev="41">
-            <srcmd5>2c39f6340a743a2e8c35d9ab3fba3f41</srcmd5>
-            <version>unknown</version>
-            <time>1667464785</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="42" vrev="42">
-            <srcmd5>231ffb70982aec45d15c5c4382c31eab</srcmd5>
-            <version>unknown</version>
-            <time>1667464785</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="43" vrev="43">
-            <srcmd5>bdad0641e2d676ad5aac95d648c7e6c8</srcmd5>
-            <version>unknown</version>
-            <time>1667464833</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="44" vrev="44">
-            <srcmd5>0f369e3902648d1e970f3b70755625bf</srcmd5>
-            <version>unknown</version>
-            <time>1667464833</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="45" vrev="45">
-            <srcmd5>ee99de7b9347e8d43aaa23fa18c914bf</srcmd5>
-            <version>unknown</version>
-            <time>1667464837</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="46" vrev="46">
-            <srcmd5>9ed547bfae8d72c544a2bc5ca925106f</srcmd5>
-            <version>unknown</version>
-            <time>1667464837</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="47" vrev="47">
-            <srcmd5>c440ed85bde55fb02285e3999c785821</srcmd5>
-            <version>unknown</version>
-            <time>1667464840</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="48" vrev="48">
-            <srcmd5>a2d8f9a492315cd19b850c060446db8b</srcmd5>
-            <version>unknown</version>
-            <time>1667464840</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="49" vrev="49">
-            <srcmd5>54dbf92618536724106b31f333a0d886</srcmd5>
-            <version>unknown</version>
-            <time>1667466962</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="50" vrev="50">
-            <srcmd5>1d645f8f21b915b63635838cdbe15235</srcmd5>
-            <version>unknown</version>
-            <time>1667466962</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="51" vrev="51">
-            <srcmd5>2f00c05340e4eba7a824b06df8f13e5a</srcmd5>
-            <version>unknown</version>
-            <time>1667468655</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="52" vrev="52">
-            <srcmd5>a6c88fe740d6dab660a1befa5a1f7ebb</srcmd5>
-            <version>unknown</version>
-            <time>1667468655</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="53" vrev="53">
-            <srcmd5>a562b526752af1ba13a4ecb7e4d34c9b</srcmd5>
-            <version>unknown</version>
-            <time>1667468662</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="54" vrev="54">
-            <srcmd5>12afe53f943e7943dbfd137174f0561d</srcmd5>
-            <version>unknown</version>
-            <time>1667468662</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="55" vrev="55">
-            <srcmd5>998e1b7b69306b798845c0f5360b121b</srcmd5>
-            <version>unknown</version>
-            <time>1667468666</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="56" vrev="56">
-            <srcmd5>e63b44ee4c954030cc0e54aca9d278ce</srcmd5>
-            <version>unknown</version>
-            <time>1667468666</time>
-            <user>unknown</user>
-          </revision>
         </revisionlist>
-  recorded_at: Thu, 03 Nov 2022 09:44:27 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:47 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_history?deleted=1&meta=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - ba75a824-61aa-4114-9dd8-97a3cf9d707f
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Wed, 22 Feb 2023 18:05:47 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package
@@ -754,7 +455,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 9c34c630-bb99-46e0-8c1d-fc546457f891
+      - d9a5cd0e-9c91-4805-9953-b94eda862596
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -777,11 +478,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="56" vrev="56" srcmd5="e63b44ee4c954030cc0e54aca9d278ce">
-          <entry name="_config" md5="100cf0b1efcaa7cc12f7efe32984843e" size="71" mtime="1667468666"/>
-          <entry name="somefile.txt" md5="d7564485f8f64b60b4b93df5fe1af78c" size="59" mtime="1667468666"/>
+        <directory name="branch_test_package" rev="70" vrev="70" srcmd5="01fb92edcefa818ecae2e9227fcd0ca7">
+          <entry name="_config" md5="41786a0eaafbfa610b014099c992fc2b" size="74" mtime="1677089146"/>
+          <entry name="somefile.txt" md5="451d884d414b8551362859a38910fad2" size="62" mtime="1677089146"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:27 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:48 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:other_package_test_user/_result?lastbuild=1&locallink=1&multibuild=1&package=branch_test_package&view=status
@@ -790,7 +491,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 9c34c630-bb99-46e0-8c1d-fc546457f891
+      - d9a5cd0e-9c91-4805-9953-b94eda862596
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -815,7 +516,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:44:27 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:48 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package
@@ -824,7 +525,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 13d09060-6196-42c6-a4cb-7ba1ec4069d7
+      - 7fad288b-90b8-408a-bd31-470eaed8fafd
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -847,11 +548,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="56" vrev="56" srcmd5="e63b44ee4c954030cc0e54aca9d278ce">
-          <entry name="_config" md5="100cf0b1efcaa7cc12f7efe32984843e" size="71" mtime="1667468666"/>
-          <entry name="somefile.txt" md5="d7564485f8f64b60b4b93df5fe1af78c" size="59" mtime="1667468666"/>
+        <directory name="branch_test_package" rev="70" vrev="70" srcmd5="01fb92edcefa818ecae2e9227fcd0ca7">
+          <entry name="_config" md5="41786a0eaafbfa610b014099c992fc2b" size="74" mtime="1677089146"/>
+          <entry name="somefile.txt" md5="451d884d414b8551362859a38910fad2" size="62" mtime="1677089146"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:27 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:48 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:other_package_test_user/_result?lastbuild=1&locallink=1&multibuild=1&package=branch_test_package&view=status
@@ -860,7 +561,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 13d09060-6196-42c6-a4cb-7ba1ec4069d7
+      - 7fad288b-90b8-408a-bd31-470eaed8fafd
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -885,7 +586,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:44:28 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:48 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:other_package_test_user/_result?package=branch_test_package&view=status
@@ -894,7 +595,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 55a44a84-735c-45c1-9d59-9fe088fd082a
+      - 65a08e3e-2091-4098-a9c3-b8daf3bcd36f
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -919,7 +620,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:44:28 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:48 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package
@@ -928,7 +629,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 91eac030-e991-473d-a706-1759910f4832
+      - 86207be6-fa76-4235-bac9-062e9206a348
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -951,11 +652,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="56" vrev="56" srcmd5="e63b44ee4c954030cc0e54aca9d278ce">
-          <entry name="_config" md5="100cf0b1efcaa7cc12f7efe32984843e" size="71" mtime="1667468666"/>
-          <entry name="somefile.txt" md5="d7564485f8f64b60b4b93df5fe1af78c" size="59" mtime="1667468666"/>
+        <directory name="branch_test_package" rev="70" vrev="70" srcmd5="01fb92edcefa818ecae2e9227fcd0ca7">
+          <entry name="_config" md5="41786a0eaafbfa610b014099c992fc2b" size="74" mtime="1677089146"/>
+          <entry name="somefile.txt" md5="451d884d414b8551362859a38910fad2" size="62" mtime="1677089146"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:28 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:48 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22branch_test_package%22%20and%20linkinfo/@project=%22home:other_package_test_user%22%20and%20@project=%22home:other_package_test_user%22)
@@ -989,7 +690,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 03 Nov 2022 09:44:28 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:48 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/_meta?user=package_test_user
@@ -1003,7 +704,7 @@ http_interactions:
         </project>
     headers:
       X-Request-Id:
-      - c162e6de-32a7-4cd5-8915-eda0e0a910aa
+      - 044ca573-0450-4539-9881-d355cbb6dcaa
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1031,7 +732,7 @@ http_interactions:
           <description>This project was created for package branch_test_package via attribute OBS:Maintained</description>
           <person userid="package_test_user" role="maintainer"/>
         </project>
-  recorded_at: Thu, 03 Nov 2022 09:44:28 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:48 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/_project/_attribute?meta=1&user=package_test_user
@@ -1040,12 +741,12 @@ http_interactions:
       string: |
         <attributes>
           <attribute name="AutoCleanup" namespace="OBS">
-            <value>2022-11-17 09:44:28 +0000</value>
+            <value>2023-03-08 18:05:48 +0000</value>
           </attribute>
         </attributes>
     headers:
       X-Request-Id:
-      - c162e6de-32a7-4cd5-8915-eda0e0a910aa
+      - 044ca573-0450-4539-9881-d355cbb6dcaa
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1069,13 +770,13 @@ http_interactions:
       encoding: UTF-8
       string: |
         <revision rev="9">
-          <srcmd5>caa332f79116340a601065bd9a6653c8</srcmd5>
-          <time>1667468668</time>
+          <srcmd5>7c7e06c5c6e2477a7fcac257d887de60</srcmd5>
+          <time>1677089148</time>
           <user>package_test_user</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 03 Nov 2022 09:44:28 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:48 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package/_meta?user=package_test_user
@@ -1083,8 +784,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:package_test_user:branches:home:other_package_test_user">
-          <title>The House of Mirth</title>
-          <description>Molestiae sed sapiente est.</description>
+          <title>Such, Such Were the Joys</title>
+          <description>Quos vitae officiis voluptatem.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1105,15 +806,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '212'
+      - '222'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:package_test_user:branches:home:other_package_test_user">
-          <title>The House of Mirth</title>
-          <description>Molestiae sed sapiente est.</description>
+          <title>Such, Such Were the Joys</title>
+          <description>Quos vitae officiis voluptatem.</description>
         </package>
-  recorded_at: Thu, 03 Nov 2022 09:44:28 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:48 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package?cmd=branch&noservice=1&opackage=branch_test_package&oproject=home:other_package_test_user&user=package_test_user
@@ -1145,15 +846,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="6" vrev="6">
-          <srcmd5>b9418a880c75f8ae8f7f4382866005f1</srcmd5>
+        <revision rev="4" vrev="4">
+          <srcmd5>39feb5501469a1224ca17c723eaa3e0e</srcmd5>
           <version>unknown</version>
-          <time>1667468668</time>
+          <time>1677089148</time>
           <user>package_test_user</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 03 Nov 2022 09:44:28 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:48 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package/_meta?user=package_test_user
@@ -1161,8 +862,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:package_test_user:branches:home:other_package_test_user">
-          <title>The House of Mirth</title>
-          <description>Molestiae sed sapiente est.</description>
+          <title>Such, Such Were the Joys</title>
+          <description>Quos vitae officiis voluptatem.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1183,15 +884,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '212'
+      - '222'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:package_test_user:branches:home:other_package_test_user">
-          <title>The House of Mirth</title>
-          <description>Molestiae sed sapiente est.</description>
+          <title>Such, Such Were the Joys</title>
+          <description>Quos vitae officiis voluptatem.</description>
         </package>
-  recorded_at: Thu, 03 Nov 2022 09:44:28 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:48 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package
@@ -1221,13 +922,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="6" vrev="6" srcmd5="b9418a880c75f8ae8f7f4382866005f1">
-          <linkinfo project="home:other_package_test_user" package="branch_test_package" srcmd5="e63b44ee4c954030cc0e54aca9d278ce" baserev="e63b44ee4c954030cc0e54aca9d278ce" xsrcmd5="0c2cc8bc3460cb7fb0258e616a80bb69" lsrcmd5="b9418a880c75f8ae8f7f4382866005f1"/>
-          <entry name="_config" md5="100cf0b1efcaa7cc12f7efe32984843e" size="71" mtime="1667468666"/>
-          <entry name="_link" md5="16b7079f7e5f4a611ec88f15644efc04" size="136" mtime="1667468668"/>
-          <entry name="somefile.txt" md5="d7564485f8f64b60b4b93df5fe1af78c" size="59" mtime="1667468666"/>
+        <directory name="branch_test_package" rev="4" vrev="4" srcmd5="39feb5501469a1224ca17c723eaa3e0e">
+          <linkinfo project="home:other_package_test_user" package="branch_test_package" srcmd5="01fb92edcefa818ecae2e9227fcd0ca7" baserev="01fb92edcefa818ecae2e9227fcd0ca7" xsrcmd5="e8386b6f256c1108bd16d8e30eef9b1e" lsrcmd5="39feb5501469a1224ca17c723eaa3e0e"/>
+          <entry name="_config" md5="41786a0eaafbfa610b014099c992fc2b" size="74" mtime="1677089146"/>
+          <entry name="_link" md5="772fdd2e0db4dbe3eda4a65b6abce61d" size="136" mtime="1677089148"/>
+          <entry name="somefile.txt" md5="451d884d414b8551362859a38910fad2" size="62" mtime="1677089146"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:28 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:48 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package?view=info
@@ -1236,7 +937,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - c162e6de-32a7-4cd5-8915-eda0e0a910aa
+      - 044ca573-0450-4539-9881-d355cbb6dcaa
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1259,11 +960,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="branch_test_package" rev="6" vrev="62" srcmd5="0c2cc8bc3460cb7fb0258e616a80bb69" lsrcmd5="b9418a880c75f8ae8f7f4382866005f1" verifymd5="e63b44ee4c954030cc0e54aca9d278ce">
+        <sourceinfo package="branch_test_package" rev="4" vrev="74" srcmd5="e8386b6f256c1108bd16d8e30eef9b1e" lsrcmd5="39feb5501469a1224ca17c723eaa3e0e" verifymd5="01fb92edcefa818ecae2e9227fcd0ca7">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="home:other_package_test_user" package="branch_test_package"/>
         </sourceinfo>
-  recorded_at: Thu, 03 Nov 2022 09:44:28 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:48 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package
@@ -1272,7 +973,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - c162e6de-32a7-4cd5-8915-eda0e0a910aa
+      - 044ca573-0450-4539-9881-d355cbb6dcaa
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1295,13 +996,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="6" vrev="6" srcmd5="b9418a880c75f8ae8f7f4382866005f1">
-          <linkinfo project="home:other_package_test_user" package="branch_test_package" srcmd5="e63b44ee4c954030cc0e54aca9d278ce" baserev="e63b44ee4c954030cc0e54aca9d278ce" xsrcmd5="0c2cc8bc3460cb7fb0258e616a80bb69" lsrcmd5="b9418a880c75f8ae8f7f4382866005f1"/>
-          <entry name="_config" md5="100cf0b1efcaa7cc12f7efe32984843e" size="71" mtime="1667468666"/>
-          <entry name="_link" md5="16b7079f7e5f4a611ec88f15644efc04" size="136" mtime="1667468668"/>
-          <entry name="somefile.txt" md5="d7564485f8f64b60b4b93df5fe1af78c" size="59" mtime="1667468666"/>
+        <directory name="branch_test_package" rev="4" vrev="4" srcmd5="39feb5501469a1224ca17c723eaa3e0e">
+          <linkinfo project="home:other_package_test_user" package="branch_test_package" srcmd5="01fb92edcefa818ecae2e9227fcd0ca7" baserev="01fb92edcefa818ecae2e9227fcd0ca7" xsrcmd5="e8386b6f256c1108bd16d8e30eef9b1e" lsrcmd5="39feb5501469a1224ca17c723eaa3e0e"/>
+          <entry name="_config" md5="41786a0eaafbfa610b014099c992fc2b" size="74" mtime="1677089146"/>
+          <entry name="_link" md5="772fdd2e0db4dbe3eda4a65b6abce61d" size="136" mtime="1677089148"/>
+          <entry name="somefile.txt" md5="451d884d414b8551362859a38910fad2" size="62" mtime="1677089146"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:28 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:48 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -1333,14 +1034,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="c7985c5bf2ea2490eec8984637ade53f">
+        <sourcediff key="89694a9a4abe1ef631f64743505ec792">
           <old project="home:package_test_user:branches:home:other_package_test_user" package="branch_test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:package_test_user:branches:home:other_package_test_user" package="branch_test_package" rev="6" srcmd5="b9418a880c75f8ae8f7f4382866005f1"/>
+          <new project="home:package_test_user:branches:home:other_package_test_user" package="branch_test_package" rev="4" srcmd5="39feb5501469a1224ca17c723eaa3e0e"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 03 Nov 2022 09:44:28 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:48 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -1372,12 +1073,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="7de680ed95959b87be53251d24360fb6">
-          <old project="home:other_package_test_user" package="branch_test_package" rev="e63b44ee4c954030cc0e54aca9d278ce" srcmd5="e63b44ee4c954030cc0e54aca9d278ce"/>
-          <new project="home:package_test_user:branches:home:other_package_test_user" package="branch_test_package" rev="0c2cc8bc3460cb7fb0258e616a80bb69" srcmd5="0c2cc8bc3460cb7fb0258e616a80bb69"/>
+        <sourcediff key="9228e94c4ddb1859fe0d3d680f032d8e">
+          <old project="home:other_package_test_user" package="branch_test_package" rev="01fb92edcefa818ecae2e9227fcd0ca7" srcmd5="01fb92edcefa818ecae2e9227fcd0ca7"/>
+          <new project="home:package_test_user:branches:home:other_package_test_user" package="branch_test_package" rev="e8386b6f256c1108bd16d8e30eef9b1e" srcmd5="e8386b6f256c1108bd16d8e30eef9b1e"/>
           <files/>
         </sourcediff>
-  recorded_at: Thu, 03 Nov 2022 09:44:28 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/_meta?user=package_test_user
@@ -1394,7 +1095,7 @@ http_interactions:
         </project>
     headers:
       X-Request-Id:
-      - c162e6de-32a7-4cd5-8915-eda0e0a910aa
+      - 044ca573-0450-4539-9881-d355cbb6dcaa
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1425,7 +1126,7 @@ http_interactions:
             <disable/>
           </publish>
         </project>
-  recorded_at: Thu, 03 Nov 2022 09:44:28 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:49 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package?view=info
@@ -1434,7 +1135,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 98b5bcbf-8e74-4652-b060-6f59c283912d
+      - 6e2cc086-9586-4da0-b78e-975368bfdba2
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1457,10 +1158,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="branch_test_package" rev="56" vrev="56" srcmd5="e63b44ee4c954030cc0e54aca9d278ce" verifymd5="e63b44ee4c954030cc0e54aca9d278ce">
+        <sourceinfo package="branch_test_package" rev="70" vrev="70" srcmd5="01fb92edcefa818ecae2e9227fcd0ca7" verifymd5="01fb92edcefa818ecae2e9227fcd0ca7">
           <error>bad build configuration, no build type defined or detected</error>
         </sourceinfo>
-  recorded_at: Thu, 03 Nov 2022 09:44:29 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:49 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package
@@ -1469,7 +1170,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 98b5bcbf-8e74-4652-b060-6f59c283912d
+      - 6e2cc086-9586-4da0-b78e-975368bfdba2
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1492,11 +1193,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="56" vrev="56" srcmd5="e63b44ee4c954030cc0e54aca9d278ce">
-          <entry name="_config" md5="100cf0b1efcaa7cc12f7efe32984843e" size="71" mtime="1667468666"/>
-          <entry name="somefile.txt" md5="d7564485f8f64b60b4b93df5fe1af78c" size="59" mtime="1667468666"/>
+        <directory name="branch_test_package" rev="70" vrev="70" srcmd5="01fb92edcefa818ecae2e9227fcd0ca7">
+          <entry name="_config" md5="41786a0eaafbfa610b014099c992fc2b" size="74" mtime="1677089146"/>
+          <entry name="somefile.txt" md5="451d884d414b8551362859a38910fad2" size="62" mtime="1677089146"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:29 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:49 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -1528,14 +1229,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="848d54661d7629385743760f96564466">
+        <sourcediff key="7a9b360fb9dbff828f9d25109dab6565">
           <old project="home:other_package_test_user" package="branch_test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:other_package_test_user" package="branch_test_package" rev="56" srcmd5="e63b44ee4c954030cc0e54aca9d278ce"/>
+          <new project="home:other_package_test_user" package="branch_test_package" rev="70" srcmd5="01fb92edcefa818ecae2e9227fcd0ca7"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 03 Nov 2022 09:44:29 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:49 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package
@@ -1544,7 +1245,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 98b5bcbf-8e74-4652-b060-6f59c283912d
+      - 6e2cc086-9586-4da0-b78e-975368bfdba2
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1567,16 +1268,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="6" vrev="6" srcmd5="b9418a880c75f8ae8f7f4382866005f1">
-          <linkinfo project="home:other_package_test_user" package="branch_test_package" srcmd5="e63b44ee4c954030cc0e54aca9d278ce" baserev="e63b44ee4c954030cc0e54aca9d278ce" xsrcmd5="0c2cc8bc3460cb7fb0258e616a80bb69" lsrcmd5="b9418a880c75f8ae8f7f4382866005f1"/>
-          <entry name="_config" md5="100cf0b1efcaa7cc12f7efe32984843e" size="71" mtime="1667468666"/>
-          <entry name="_link" md5="16b7079f7e5f4a611ec88f15644efc04" size="136" mtime="1667468668"/>
-          <entry name="somefile.txt" md5="d7564485f8f64b60b4b93df5fe1af78c" size="59" mtime="1667468666"/>
+        <directory name="branch_test_package" rev="4" vrev="4" srcmd5="39feb5501469a1224ca17c723eaa3e0e">
+          <linkinfo project="home:other_package_test_user" package="branch_test_package" srcmd5="01fb92edcefa818ecae2e9227fcd0ca7" baserev="01fb92edcefa818ecae2e9227fcd0ca7" xsrcmd5="e8386b6f256c1108bd16d8e30eef9b1e" lsrcmd5="39feb5501469a1224ca17c723eaa3e0e"/>
+          <entry name="_config" md5="41786a0eaafbfa610b014099c992fc2b" size="74" mtime="1677089146"/>
+          <entry name="_link" md5="772fdd2e0db4dbe3eda4a65b6abce61d" size="136" mtime="1677089148"/>
+          <entry name="somefile.txt" md5="451d884d414b8551362859a38910fad2" size="62" mtime="1677089146"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:29 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:49 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package?expand=1&rev=6
+    uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package?expand=1&rev=4
     body:
       encoding: US-ASCII
       string: ''
@@ -1603,21 +1304,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="0c2cc8bc3460cb7fb0258e616a80bb69" vrev="62" srcmd5="0c2cc8bc3460cb7fb0258e616a80bb69">
-          <linkinfo project="home:other_package_test_user" package="branch_test_package" srcmd5="e63b44ee4c954030cc0e54aca9d278ce" baserev="e63b44ee4c954030cc0e54aca9d278ce" lsrcmd5="b9418a880c75f8ae8f7f4382866005f1"/>
-          <entry name="_config" md5="100cf0b1efcaa7cc12f7efe32984843e" size="71" mtime="1667468666"/>
-          <entry name="somefile.txt" md5="d7564485f8f64b60b4b93df5fe1af78c" size="59" mtime="1667468666"/>
+        <directory name="branch_test_package" rev="e8386b6f256c1108bd16d8e30eef9b1e" vrev="74" srcmd5="e8386b6f256c1108bd16d8e30eef9b1e">
+          <linkinfo project="home:other_package_test_user" package="branch_test_package" srcmd5="01fb92edcefa818ecae2e9227fcd0ca7" baserev="01fb92edcefa818ecae2e9227fcd0ca7" lsrcmd5="39feb5501469a1224ca17c723eaa3e0e"/>
+          <entry name="_config" md5="41786a0eaafbfa610b014099c992fc2b" size="74" mtime="1677089146"/>
+          <entry name="somefile.txt" md5="451d884d414b8551362859a38910fad2" size="62" mtime="1677089146"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:29 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:49 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package
+    uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package/_history?deleted=1&meta=1&rev=4
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - 98b5bcbf-8e74-4652-b060-6f59c283912d
+      - 6e2cc086-9586-4da0-b78e-975368bfdba2
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1636,123 +1337,123 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '651'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="branch_test_package" rev="6" vrev="6" srcmd5="b9418a880c75f8ae8f7f4382866005f1">
-          <linkinfo project="home:other_package_test_user" package="branch_test_package" srcmd5="e63b44ee4c954030cc0e54aca9d278ce" baserev="e63b44ee4c954030cc0e54aca9d278ce" xsrcmd5="0c2cc8bc3460cb7fb0258e616a80bb69" lsrcmd5="b9418a880c75f8ae8f7f4382866005f1"/>
-          <entry name="_config" md5="100cf0b1efcaa7cc12f7efe32984843e" size="71" mtime="1667468666"/>
-          <entry name="_link" md5="16b7079f7e5f4a611ec88f15644efc04" size="136" mtime="1667468668"/>
-          <entry name="somefile.txt" md5="d7564485f8f64b60b4b93df5fe1af78c" size="59" mtime="1667468666"/>
-        </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:29 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Request-Id:
-      - 98b5bcbf-8e74-4652-b060-6f59c283912d
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '651'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="branch_test_package" rev="6" vrev="6" srcmd5="b9418a880c75f8ae8f7f4382866005f1">
-          <linkinfo project="home:other_package_test_user" package="branch_test_package" srcmd5="e63b44ee4c954030cc0e54aca9d278ce" baserev="e63b44ee4c954030cc0e54aca9d278ce" xsrcmd5="0c2cc8bc3460cb7fb0258e616a80bb69" lsrcmd5="b9418a880c75f8ae8f7f4382866005f1"/>
-          <entry name="_config" md5="100cf0b1efcaa7cc12f7efe32984843e" size="71" mtime="1667468666"/>
-          <entry name="_link" md5="16b7079f7e5f4a611ec88f15644efc04" size="136" mtime="1667468668"/>
-          <entry name="somefile.txt" md5="d7564485f8f64b60b4b93df5fe1af78c" size="59" mtime="1667468666"/>
-        </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:29 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package/_history
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '1183'
+      - '31'
     body:
       encoding: UTF-8
       string: |
         <revisionlist>
-          <revision rev="1" vrev="1">
-            <srcmd5>6ba8fed4618636dd5a78a718cbade2c6</srcmd5>
-            <version>unknown</version>
-            <time>1667464835</time>
-            <user>package_test_user</user>
-          </revision>
-          <revision rev="2" vrev="2">
-            <srcmd5>ba7a46d20d0dbd01668ae6e13a644909</srcmd5>
-            <version>unknown</version>
-            <time>1667464838</time>
-            <user>package_test_user</user>
-          </revision>
-          <revision rev="3" vrev="3">
-            <srcmd5>1b07a884868c4aacc583d54a5d0dec26</srcmd5>
-            <version>unknown</version>
-            <time>1667467815</time>
-            <user>package_test_user</user>
-          </revision>
-          <revision rev="4" vrev="4">
-            <srcmd5>1b07a884868c4aacc583d54a5d0dec26</srcmd5>
-            <version>unknown</version>
-            <time>1667467818</time>
-            <user>package_test_user</user>
-          </revision>
-          <revision rev="5" vrev="5">
-            <srcmd5>49ca443d76fd1f58db5cd05eea6175af</srcmd5>
-            <version>unknown</version>
-            <time>1667468664</time>
-            <user>package_test_user</user>
-          </revision>
-          <revision rev="6" vrev="6">
-            <srcmd5>b9418a880c75f8ae8f7f4382866005f1</srcmd5>
-            <version>unknown</version>
-            <time>1667468668</time>
-            <user>package_test_user</user>
-          </revision>
         </revisionlist>
-  recorded_at: Thu, 03 Nov 2022 09:44:29 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:49 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 6e2cc086-9586-4da0-b78e-975368bfdba2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '651'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="branch_test_package" rev="4" vrev="4" srcmd5="39feb5501469a1224ca17c723eaa3e0e">
+          <linkinfo project="home:other_package_test_user" package="branch_test_package" srcmd5="01fb92edcefa818ecae2e9227fcd0ca7" baserev="01fb92edcefa818ecae2e9227fcd0ca7" xsrcmd5="e8386b6f256c1108bd16d8e30eef9b1e" lsrcmd5="39feb5501469a1224ca17c723eaa3e0e"/>
+          <entry name="_config" md5="41786a0eaafbfa610b014099c992fc2b" size="74" mtime="1677089146"/>
+          <entry name="_link" md5="772fdd2e0db4dbe3eda4a65b6abce61d" size="136" mtime="1677089148"/>
+          <entry name="somefile.txt" md5="451d884d414b8551362859a38910fad2" size="62" mtime="1677089146"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:05:49 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 6e2cc086-9586-4da0-b78e-975368bfdba2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '651'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="branch_test_package" rev="4" vrev="4" srcmd5="39feb5501469a1224ca17c723eaa3e0e">
+          <linkinfo project="home:other_package_test_user" package="branch_test_package" srcmd5="01fb92edcefa818ecae2e9227fcd0ca7" baserev="01fb92edcefa818ecae2e9227fcd0ca7" xsrcmd5="e8386b6f256c1108bd16d8e30eef9b1e" lsrcmd5="39feb5501469a1224ca17c723eaa3e0e"/>
+          <entry name="_config" md5="41786a0eaafbfa610b014099c992fc2b" size="74" mtime="1677089146"/>
+          <entry name="_link" md5="772fdd2e0db4dbe3eda4a65b6abce61d" size="136" mtime="1677089148"/>
+          <entry name="somefile.txt" md5="451d884d414b8551362859a38910fad2" size="62" mtime="1677089146"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:05:49 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package/_history?deleted=1&meta=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 6e2cc086-9586-4da0-b78e-975368bfdba2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Wed, 22 Feb 2023 18:05:49 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:package_test_user:branches:home:other_package_test_user/_result?lastbuild=1&locallink=1&multibuild=1&package=branch_test_package&view=status
@@ -1761,7 +1462,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 19babf08-087c-4900-ac98-b6614fceba90
+      - a1f5aa6a-8265-4e42-937b-a100f65287c9
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1786,7 +1487,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:44:29 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:49 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:package_test_user:branches:home:other_package_test_user/_result?lastbuild=1&locallink=1&multibuild=1&package=branch_test_package&view=status
@@ -1795,7 +1496,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - fa6a2558-b8e3-4772-926f-91135dcde3f2
+      - ce85a8e6-eb94-4af9-9296-6331a3a32c53
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1820,7 +1521,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:44:29 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:49 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:package_test_user:branches:home:other_package_test_user/_result?package=branch_test_package&view=status
@@ -1829,7 +1530,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - de8c6d2d-2f9d-4b35-978f-153d98d95495
+      - 4548739d-0aa3-49cd-a702-1a4b75090d54
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1854,5 +1555,5 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:44:29 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:49 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Packages/branching_a_package_from_another_users_project/without_AutoCleanup.yml
+++ b/src/api/spec/cassettes/Packages/branching_a_package_from_another_users_project/without_AutoCleanup.yml
@@ -39,16 +39,16 @@ http_interactions:
           <description></description>
           <person userid="package_test_user" role="maintainer"/>
         </project>
-  recorded_at: Thu, 03 Nov 2022 09:44:22 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:42 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=user_7
+    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=user_36
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>The Last Temptation</title>
-          <description>Quis corrupti odio voluptatibus.</description>
+          <title>Wildfire at Midnight</title>
+          <description>Ea dolor cumque dicta.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -69,21 +69,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '173'
+      - '164'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>The Last Temptation</title>
-          <description>Quis corrupti odio voluptatibus.</description>
+          <title>Wildfire at Midnight</title>
+          <description>Ea dolor cumque dicta.</description>
         </package>
-  recorded_at: Thu, 03 Nov 2022 09:44:22 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:42 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_config
     body:
       encoding: UTF-8
-      string: Voluptas quia iusto. Amet sit voluptas. Dolores sequi totam.
+      string: Quibusdam enim ratione. Aut cumque est. Et necessitatibus earum.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -107,21 +107,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="59" vrev="59">
-          <srcmd5>65aff4b2f0c39844b5a507b6ee8ac76b</srcmd5>
+        <revision rev="74" vrev="74">
+          <srcmd5>55d7ca01c220afbacd4b15bb2fae1f9e</srcmd5>
           <version>unknown</version>
-          <time>1667468662</time>
+          <time>1677089142</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 03 Nov 2022 09:44:22 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:42 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Eos rerum dolores. Quis quae molestiae. Modi ab assumenda.
+      string: Sit saepe totam. Explicabo non modi. Aliquid sit voluptatum.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -145,15 +145,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="60" vrev="60">
-          <srcmd5>d8e4b959841c2f46207746c6a4af9313</srcmd5>
+        <revision rev="75" vrev="75">
+          <srcmd5>430295eea88c19cd7d2b946aba49863d</srcmd5>
           <version>unknown</version>
-          <time>1667468662</time>
+          <time>1677089142</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 03 Nov 2022 09:44:22 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:42 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/_meta?user=other_package_test_user
@@ -193,16 +193,16 @@ http_interactions:
           <description></description>
           <person userid="other_package_test_user" role="maintainer"/>
         </project>
-  recorded_at: Thu, 03 Nov 2022 09:44:22 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:42 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=user_8
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=user_37
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>Consider Phlebas</title>
-          <description>Aut est molestiae officiis.</description>
+          <title>Unweaving the Rainbow</title>
+          <description>Veniam quia architecto odit.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -223,21 +223,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '178'
+      - '184'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>Consider Phlebas</title>
-          <description>Aut est molestiae officiis.</description>
+          <title>Unweaving the Rainbow</title>
+          <description>Veniam quia architecto odit.</description>
         </package>
-  recorded_at: Thu, 03 Nov 2022 09:44:22 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:42 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_config
     body:
       encoding: UTF-8
-      string: Neque ipsam atque. Ut sed non. Quia sapiente voluptas.
+      string: Consequatur iure veniam. Rerum incidunt eaque. Voluptas fuga omnis.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -261,21 +261,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="53" vrev="53">
-          <srcmd5>a562b526752af1ba13a4ecb7e4d34c9b</srcmd5>
+        <revision rev="67" vrev="67">
+          <srcmd5>5682ed1c49b11de598f075eb06bafe22</srcmd5>
           <version>unknown</version>
-          <time>1667468662</time>
+          <time>1677089142</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 03 Nov 2022 09:44:22 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:42 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Mollitia sit et. Odio vitae quisquam. Repellat ut tenetur.
+      string: Debitis aut quod. Veniam reprehenderit aspernatur. Delectus at ut.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -299,15 +299,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="54" vrev="54">
-          <srcmd5>12afe53f943e7943dbfd137174f0561d</srcmd5>
+        <revision rev="68" vrev="68">
+          <srcmd5>1c55c3a91975023ec64ea99c865a0c7a</srcmd5>
           <version>unknown</version>
-          <time>1667468662</time>
+          <time>1677089142</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 03 Nov 2022 09:44:22 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:42 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package
@@ -316,7 +316,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 7d506b17-83da-4c10-b058-7ef204d7a043
+      - 5dd25bdf-ddba-47c6-9e73-fa6be32f073a
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -339,14 +339,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="54" vrev="54" srcmd5="12afe53f943e7943dbfd137174f0561d">
-          <entry name="_config" md5="d1f5cf04283b0b567db10245458d7536" size="54" mtime="1667468662"/>
-          <entry name="somefile.txt" md5="96173f3df334668b8fe4503be2d820ac" size="58" mtime="1667468662"/>
+        <directory name="branch_test_package" rev="68" vrev="68" srcmd5="1c55c3a91975023ec64ea99c865a0c7a">
+          <entry name="_config" md5="5f637fe218fc5f364b1e9c0e55660d18" size="67" mtime="1677089142"/>
+          <entry name="somefile.txt" md5="b5cde3f96fdd0af70d52737bded0baad" size="66" mtime="1677089142"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:23 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:43 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package?expand=1&rev=54
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package?expand=1&rev=68
     body:
       encoding: US-ASCII
       string: ''
@@ -373,18 +373,20 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="54" vrev="54" srcmd5="12afe53f943e7943dbfd137174f0561d">
-          <entry name="_config" md5="d1f5cf04283b0b567db10245458d7536" size="54" mtime="1667468662"/>
-          <entry name="somefile.txt" md5="96173f3df334668b8fe4503be2d820ac" size="58" mtime="1667468662"/>
+        <directory name="branch_test_package" rev="68" vrev="68" srcmd5="1c55c3a91975023ec64ea99c865a0c7a">
+          <entry name="_config" md5="5f637fe218fc5f364b1e9c0e55660d18" size="67" mtime="1677089142"/>
+          <entry name="somefile.txt" md5="b5cde3f96fdd0af70d52737bded0baad" size="66" mtime="1677089142"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:23 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:43 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_history
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_history?deleted=1&meta=1&rev=68
     body:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - 5dd25bdf-ddba-47c6-9e73-fa6be32f073a
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -403,337 +405,47 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '9949'
+      - '31'
     body:
       encoding: UTF-8
       string: |
         <revisionlist>
-          <revision rev="1" vrev="1">
-            <srcmd5>cf06b5b0511092db4a9e45a3b5042f99</srcmd5>
-            <version>unknown</version>
-            <time>1666872405</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="2" vrev="2">
-            <srcmd5>c06e450cdd3978970fac916f02c7dd7d</srcmd5>
-            <version>unknown</version>
-            <time>1666872405</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="3" vrev="3">
-            <srcmd5>3ce56f10e21ef5167a683b9581f11ac7</srcmd5>
-            <version>unknown</version>
-            <time>1667463244</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="4" vrev="4">
-            <srcmd5>9088839a004375dccee13c17a953326e</srcmd5>
-            <version>unknown</version>
-            <time>1667463244</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="5" vrev="5">
-            <srcmd5>2d9649d14cb59e3d031b7e95ea964e77</srcmd5>
-            <version>unknown</version>
-            <time>1667464482</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="6" vrev="6">
-            <srcmd5>2b44424f02eef718ecdf50691ec9f31f</srcmd5>
-            <version>unknown</version>
-            <time>1667464482</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="7" vrev="7">
-            <srcmd5>0d4dfbe39c39985f60f5ce4682d11903</srcmd5>
-            <version>unknown</version>
-            <time>1667464736</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="8" vrev="8">
-            <srcmd5>de5cca154f328a14a685435e3eb406ba</srcmd5>
-            <version>unknown</version>
-            <time>1667464736</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="9" vrev="9">
-            <srcmd5>a547f7991e24a80953ad2fc1c10e30ad</srcmd5>
-            <version>unknown</version>
-            <time>1667464744</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="10" vrev="10">
-            <srcmd5>a2f7f9be6efb7827bf9b54d716babbe0</srcmd5>
-            <version>unknown</version>
-            <time>1667464744</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="11" vrev="11">
-            <srcmd5>bfa6dda3dbfb0aa5e57de73df0ca59b4</srcmd5>
-            <version>unknown</version>
-            <time>1667464747</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="12" vrev="12">
-            <srcmd5>21026f5fb7e2f62f329d47c3cbe74691</srcmd5>
-            <version>unknown</version>
-            <time>1667464747</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="13" vrev="13">
-            <srcmd5>3414997a2a511588aaec15766e6d37cb</srcmd5>
-            <version>unknown</version>
-            <time>1667464750</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="14" vrev="14">
-            <srcmd5>5a72a15a0324b55af3f44d14007e79c2</srcmd5>
-            <version>unknown</version>
-            <time>1667464750</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="15" vrev="15">
-            <srcmd5>6150e6991dfa10c2adbd802b55d994d9</srcmd5>
-            <version>unknown</version>
-            <time>1667464753</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="16" vrev="16">
-            <srcmd5>c91330229762bb40b2b1e60879fbb95c</srcmd5>
-            <version>unknown</version>
-            <time>1667464753</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="17" vrev="17">
-            <srcmd5>e23c5bc5023b95407f25da0fd943eca6</srcmd5>
-            <version>unknown</version>
-            <time>1667464756</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="18" vrev="18">
-            <srcmd5>c28468d04c555f6eb172de224be0d4bb</srcmd5>
-            <version>unknown</version>
-            <time>1667464756</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="19" vrev="19">
-            <srcmd5>4c7cfd5d542cf79ffee9c5c91fe4f4f3</srcmd5>
-            <version>unknown</version>
-            <time>1667464761</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="20" vrev="20">
-            <srcmd5>14ed5559f599793371b799ade3b9eb81</srcmd5>
-            <version>unknown</version>
-            <time>1667464761</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="21" vrev="21">
-            <srcmd5>50e01ec85f591a87d22e038cf7cddeb2</srcmd5>
-            <version>unknown</version>
-            <time>1667464763</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="22" vrev="22">
-            <srcmd5>e46fb9c10f12712a0baaa1d1ae072adb</srcmd5>
-            <version>unknown</version>
-            <time>1667464763</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="23" vrev="23">
-            <srcmd5>a88bbcd2d335d99d1e673157ef6fec8f</srcmd5>
-            <version>unknown</version>
-            <time>1667464764</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="24" vrev="24">
-            <srcmd5>1bcbff5aef0c3b0ff2d606e2386b4484</srcmd5>
-            <version>unknown</version>
-            <time>1667464764</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="25" vrev="25">
-            <srcmd5>2290c0a92f335e91686e2ad77276f43c</srcmd5>
-            <version>unknown</version>
-            <time>1667464767</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="26" vrev="26">
-            <srcmd5>93243ff52cd6b70bf54cbdb782fcd027</srcmd5>
-            <version>unknown</version>
-            <time>1667464767</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="27" vrev="27">
-            <srcmd5>7729a462583b22277b2acd2b872b8eec</srcmd5>
-            <version>unknown</version>
-            <time>1667464769</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="28" vrev="28">
-            <srcmd5>38795844f7c2ad248adb727b687bb50a</srcmd5>
-            <version>unknown</version>
-            <time>1667464769</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="29" vrev="29">
-            <srcmd5>e483b9b8258489f719ef55eab5bb7789</srcmd5>
-            <version>unknown</version>
-            <time>1667464772</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="30" vrev="30">
-            <srcmd5>5dcdb4d92cea3ce49f0a01c9f38299f0</srcmd5>
-            <version>unknown</version>
-            <time>1667464772</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="31" vrev="31">
-            <srcmd5>ccfeda81520d0503a80f9c2329c5df57</srcmd5>
-            <version>unknown</version>
-            <time>1667464774</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="32" vrev="32">
-            <srcmd5>36d3cf2ba23d969411670c61550de093</srcmd5>
-            <version>unknown</version>
-            <time>1667464774</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="33" vrev="33">
-            <srcmd5>7d1a7e43c1fa21ee3559f0dc99056f5f</srcmd5>
-            <version>unknown</version>
-            <time>1667464776</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="34" vrev="34">
-            <srcmd5>a30ae743f8f081a3ee1d323830c77fd9</srcmd5>
-            <version>unknown</version>
-            <time>1667464776</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="35" vrev="35">
-            <srcmd5>585d8c0b56dfc1f82d15d6f306940e75</srcmd5>
-            <version>unknown</version>
-            <time>1667464777</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="36" vrev="36">
-            <srcmd5>3348f383bc1de16d2e20eb9668831ebc</srcmd5>
-            <version>unknown</version>
-            <time>1667464777</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="37" vrev="37">
-            <srcmd5>b71f410e0ec4266893b05277969058ba</srcmd5>
-            <version>unknown</version>
-            <time>1667464780</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="38" vrev="38">
-            <srcmd5>4649c3e349ad351245a481f7d38701f7</srcmd5>
-            <version>unknown</version>
-            <time>1667464780</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="39" vrev="39">
-            <srcmd5>936cdd189460d1159f1edc579d0a4673</srcmd5>
-            <version>unknown</version>
-            <time>1667464783</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="40" vrev="40">
-            <srcmd5>aa29fc9918862a90eb0049be78f1853f</srcmd5>
-            <version>unknown</version>
-            <time>1667464783</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="41" vrev="41">
-            <srcmd5>2c39f6340a743a2e8c35d9ab3fba3f41</srcmd5>
-            <version>unknown</version>
-            <time>1667464785</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="42" vrev="42">
-            <srcmd5>231ffb70982aec45d15c5c4382c31eab</srcmd5>
-            <version>unknown</version>
-            <time>1667464785</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="43" vrev="43">
-            <srcmd5>bdad0641e2d676ad5aac95d648c7e6c8</srcmd5>
-            <version>unknown</version>
-            <time>1667464833</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="44" vrev="44">
-            <srcmd5>0f369e3902648d1e970f3b70755625bf</srcmd5>
-            <version>unknown</version>
-            <time>1667464833</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="45" vrev="45">
-            <srcmd5>ee99de7b9347e8d43aaa23fa18c914bf</srcmd5>
-            <version>unknown</version>
-            <time>1667464837</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="46" vrev="46">
-            <srcmd5>9ed547bfae8d72c544a2bc5ca925106f</srcmd5>
-            <version>unknown</version>
-            <time>1667464837</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="47" vrev="47">
-            <srcmd5>c440ed85bde55fb02285e3999c785821</srcmd5>
-            <version>unknown</version>
-            <time>1667464840</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="48" vrev="48">
-            <srcmd5>a2d8f9a492315cd19b850c060446db8b</srcmd5>
-            <version>unknown</version>
-            <time>1667464840</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="49" vrev="49">
-            <srcmd5>54dbf92618536724106b31f333a0d886</srcmd5>
-            <version>unknown</version>
-            <time>1667466962</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="50" vrev="50">
-            <srcmd5>1d645f8f21b915b63635838cdbe15235</srcmd5>
-            <version>unknown</version>
-            <time>1667466962</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="51" vrev="51">
-            <srcmd5>2f00c05340e4eba7a824b06df8f13e5a</srcmd5>
-            <version>unknown</version>
-            <time>1667468655</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="52" vrev="52">
-            <srcmd5>a6c88fe740d6dab660a1befa5a1f7ebb</srcmd5>
-            <version>unknown</version>
-            <time>1667468655</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="53" vrev="53">
-            <srcmd5>a562b526752af1ba13a4ecb7e4d34c9b</srcmd5>
-            <version>unknown</version>
-            <time>1667468662</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="54" vrev="54">
-            <srcmd5>12afe53f943e7943dbfd137174f0561d</srcmd5>
-            <version>unknown</version>
-            <time>1667468662</time>
-            <user>unknown</user>
-          </revision>
         </revisionlist>
-  recorded_at: Thu, 03 Nov 2022 09:44:24 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:43 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_history?deleted=1&meta=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 5dd25bdf-ddba-47c6-9e73-fa6be32f073a
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Wed, 22 Feb 2023 18:05:43 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package
@@ -742,7 +454,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - b8e939bd-5fb0-4fd6-b3d9-0ba237dc98bc
+      - 987f24a3-07e4-4ec1-9f34-1b66b50defbd
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -765,11 +477,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="54" vrev="54" srcmd5="12afe53f943e7943dbfd137174f0561d">
-          <entry name="_config" md5="d1f5cf04283b0b567db10245458d7536" size="54" mtime="1667468662"/>
-          <entry name="somefile.txt" md5="96173f3df334668b8fe4503be2d820ac" size="58" mtime="1667468662"/>
+        <directory name="branch_test_package" rev="68" vrev="68" srcmd5="1c55c3a91975023ec64ea99c865a0c7a">
+          <entry name="_config" md5="5f637fe218fc5f364b1e9c0e55660d18" size="67" mtime="1677089142"/>
+          <entry name="somefile.txt" md5="b5cde3f96fdd0af70d52737bded0baad" size="66" mtime="1677089142"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:24 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:44 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:other_package_test_user/_result?lastbuild=1&locallink=1&multibuild=1&package=branch_test_package&view=status
@@ -778,7 +490,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - b8e939bd-5fb0-4fd6-b3d9-0ba237dc98bc
+      - 987f24a3-07e4-4ec1-9f34-1b66b50defbd
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -803,7 +515,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:44:24 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:44 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package
@@ -812,7 +524,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - fb3f711d-8771-4f71-8b67-f7f1ea913846
+      - caf362ca-329f-47f9-81ee-67f78ab85a68
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -835,11 +547,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="54" vrev="54" srcmd5="12afe53f943e7943dbfd137174f0561d">
-          <entry name="_config" md5="d1f5cf04283b0b567db10245458d7536" size="54" mtime="1667468662"/>
-          <entry name="somefile.txt" md5="96173f3df334668b8fe4503be2d820ac" size="58" mtime="1667468662"/>
+        <directory name="branch_test_package" rev="68" vrev="68" srcmd5="1c55c3a91975023ec64ea99c865a0c7a">
+          <entry name="_config" md5="5f637fe218fc5f364b1e9c0e55660d18" size="67" mtime="1677089142"/>
+          <entry name="somefile.txt" md5="b5cde3f96fdd0af70d52737bded0baad" size="66" mtime="1677089142"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:24 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:44 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:other_package_test_user/_result?lastbuild=1&locallink=1&multibuild=1&package=branch_test_package&view=status
@@ -848,7 +560,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - fb3f711d-8771-4f71-8b67-f7f1ea913846
+      - caf362ca-329f-47f9-81ee-67f78ab85a68
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -873,7 +585,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:44:24 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:44 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:other_package_test_user/_result?package=branch_test_package&view=status
@@ -882,7 +594,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - eb975d5e-8cbc-4be3-ad76-011fb0f1b2f1
+      - 3ddb5c19-30dd-4f77-97d4-67e896bcabe7
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -907,7 +619,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:44:24 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:44 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package
@@ -916,7 +628,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 8cd455dc-5dbb-4f19-83af-729beb37d4ad
+      - fdbe8f59-9fbb-4617-ab74-32eee0e1d83a
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -939,11 +651,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="54" vrev="54" srcmd5="12afe53f943e7943dbfd137174f0561d">
-          <entry name="_config" md5="d1f5cf04283b0b567db10245458d7536" size="54" mtime="1667468662"/>
-          <entry name="somefile.txt" md5="96173f3df334668b8fe4503be2d820ac" size="58" mtime="1667468662"/>
+        <directory name="branch_test_package" rev="68" vrev="68" srcmd5="1c55c3a91975023ec64ea99c865a0c7a">
+          <entry name="_config" md5="5f637fe218fc5f364b1e9c0e55660d18" size="67" mtime="1677089142"/>
+          <entry name="somefile.txt" md5="b5cde3f96fdd0af70d52737bded0baad" size="66" mtime="1677089142"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:24 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:44 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22branch_test_package%22%20and%20linkinfo/@project=%22home:other_package_test_user%22%20and%20@project=%22home:other_package_test_user%22)
@@ -977,7 +689,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Thu, 03 Nov 2022 09:44:24 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:44 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/_meta?user=package_test_user
@@ -991,7 +703,7 @@ http_interactions:
         </project>
     headers:
       X-Request-Id:
-      - 50d0a1d0-1b33-4fb2-a81a-d0565226661d
+      - 3c2fddd5-4c57-4592-b30c-9b8a5a9be75c
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1019,7 +731,7 @@ http_interactions:
           <description>This project was created for package branch_test_package via attribute OBS:Maintained</description>
           <person userid="package_test_user" role="maintainer"/>
         </project>
-  recorded_at: Thu, 03 Nov 2022 09:44:24 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:44 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package/_meta?user=package_test_user
@@ -1027,8 +739,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:package_test_user:branches:home:other_package_test_user">
-          <title>Consider Phlebas</title>
-          <description>Aut est molestiae officiis.</description>
+          <title>Unweaving the Rainbow</title>
+          <description>Veniam quia architecto odit.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1049,15 +761,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '210'
+      - '216'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:package_test_user:branches:home:other_package_test_user">
-          <title>Consider Phlebas</title>
-          <description>Aut est molestiae officiis.</description>
+          <title>Unweaving the Rainbow</title>
+          <description>Veniam quia architecto odit.</description>
         </package>
-  recorded_at: Thu, 03 Nov 2022 09:44:24 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:44 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package?cmd=branch&noservice=1&opackage=branch_test_package&oproject=home:other_package_test_user&user=package_test_user
@@ -1089,15 +801,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="5" vrev="5">
-          <srcmd5>49ca443d76fd1f58db5cd05eea6175af</srcmd5>
+        <revision rev="3" vrev="3">
+          <srcmd5>0ca7ae4a6b97b6815357b99a81f28b6b</srcmd5>
           <version>unknown</version>
-          <time>1667468664</time>
+          <time>1677089144</time>
           <user>package_test_user</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 03 Nov 2022 09:44:24 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:44 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package/_meta?user=package_test_user
@@ -1105,8 +817,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:package_test_user:branches:home:other_package_test_user">
-          <title>Consider Phlebas</title>
-          <description>Aut est molestiae officiis.</description>
+          <title>Unweaving the Rainbow</title>
+          <description>Veniam quia architecto odit.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1127,15 +839,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '210'
+      - '216'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:package_test_user:branches:home:other_package_test_user">
-          <title>Consider Phlebas</title>
-          <description>Aut est molestiae officiis.</description>
+          <title>Unweaving the Rainbow</title>
+          <description>Veniam quia architecto odit.</description>
         </package>
-  recorded_at: Thu, 03 Nov 2022 09:44:24 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:45 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package
@@ -1165,13 +877,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="5" vrev="5" srcmd5="49ca443d76fd1f58db5cd05eea6175af">
-          <linkinfo project="home:other_package_test_user" package="branch_test_package" srcmd5="12afe53f943e7943dbfd137174f0561d" baserev="12afe53f943e7943dbfd137174f0561d" xsrcmd5="207a9c38697f8240df18b2c9a5e8bcae" lsrcmd5="49ca443d76fd1f58db5cd05eea6175af"/>
-          <entry name="_config" md5="d1f5cf04283b0b567db10245458d7536" size="54" mtime="1667468662"/>
-          <entry name="_link" md5="5341bda4583a0c7513fc053e5db97efd" size="136" mtime="1667468664"/>
-          <entry name="somefile.txt" md5="96173f3df334668b8fe4503be2d820ac" size="58" mtime="1667468662"/>
+        <directory name="branch_test_package" rev="3" vrev="3" srcmd5="0ca7ae4a6b97b6815357b99a81f28b6b">
+          <linkinfo project="home:other_package_test_user" package="branch_test_package" srcmd5="1c55c3a91975023ec64ea99c865a0c7a" baserev="1c55c3a91975023ec64ea99c865a0c7a" xsrcmd5="bb9b60b169c2f2e6d0fbccb18417e34b" lsrcmd5="0ca7ae4a6b97b6815357b99a81f28b6b"/>
+          <entry name="_config" md5="5f637fe218fc5f364b1e9c0e55660d18" size="67" mtime="1677089142"/>
+          <entry name="_link" md5="f7beeba40e8d9a60fc1b6182b90b4d3d" size="136" mtime="1677089144"/>
+          <entry name="somefile.txt" md5="b5cde3f96fdd0af70d52737bded0baad" size="66" mtime="1677089142"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:24 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:45 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package?view=info
@@ -1180,7 +892,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 50d0a1d0-1b33-4fb2-a81a-d0565226661d
+      - 3c2fddd5-4c57-4592-b30c-9b8a5a9be75c
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1203,11 +915,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="branch_test_package" rev="5" vrev="59" srcmd5="207a9c38697f8240df18b2c9a5e8bcae" lsrcmd5="49ca443d76fd1f58db5cd05eea6175af" verifymd5="12afe53f943e7943dbfd137174f0561d">
+        <sourceinfo package="branch_test_package" rev="3" vrev="71" srcmd5="bb9b60b169c2f2e6d0fbccb18417e34b" lsrcmd5="0ca7ae4a6b97b6815357b99a81f28b6b" verifymd5="1c55c3a91975023ec64ea99c865a0c7a">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="home:other_package_test_user" package="branch_test_package"/>
         </sourceinfo>
-  recorded_at: Thu, 03 Nov 2022 09:44:24 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:45 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package
@@ -1216,7 +928,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 50d0a1d0-1b33-4fb2-a81a-d0565226661d
+      - 3c2fddd5-4c57-4592-b30c-9b8a5a9be75c
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1239,13 +951,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="5" vrev="5" srcmd5="49ca443d76fd1f58db5cd05eea6175af">
-          <linkinfo project="home:other_package_test_user" package="branch_test_package" srcmd5="12afe53f943e7943dbfd137174f0561d" baserev="12afe53f943e7943dbfd137174f0561d" xsrcmd5="207a9c38697f8240df18b2c9a5e8bcae" lsrcmd5="49ca443d76fd1f58db5cd05eea6175af"/>
-          <entry name="_config" md5="d1f5cf04283b0b567db10245458d7536" size="54" mtime="1667468662"/>
-          <entry name="_link" md5="5341bda4583a0c7513fc053e5db97efd" size="136" mtime="1667468664"/>
-          <entry name="somefile.txt" md5="96173f3df334668b8fe4503be2d820ac" size="58" mtime="1667468662"/>
+        <directory name="branch_test_package" rev="3" vrev="3" srcmd5="0ca7ae4a6b97b6815357b99a81f28b6b">
+          <linkinfo project="home:other_package_test_user" package="branch_test_package" srcmd5="1c55c3a91975023ec64ea99c865a0c7a" baserev="1c55c3a91975023ec64ea99c865a0c7a" xsrcmd5="bb9b60b169c2f2e6d0fbccb18417e34b" lsrcmd5="0ca7ae4a6b97b6815357b99a81f28b6b"/>
+          <entry name="_config" md5="5f637fe218fc5f364b1e9c0e55660d18" size="67" mtime="1677089142"/>
+          <entry name="_link" md5="f7beeba40e8d9a60fc1b6182b90b4d3d" size="136" mtime="1677089144"/>
+          <entry name="somefile.txt" md5="b5cde3f96fdd0af70d52737bded0baad" size="66" mtime="1677089142"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:25 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:45 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -1277,14 +989,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="8eb8c8dac6b7301d492cb11d8014c39d">
+        <sourcediff key="ee2b58cab519cda9b0e60e03d366b1b7">
           <old project="home:package_test_user:branches:home:other_package_test_user" package="branch_test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:package_test_user:branches:home:other_package_test_user" package="branch_test_package" rev="5" srcmd5="49ca443d76fd1f58db5cd05eea6175af"/>
+          <new project="home:package_test_user:branches:home:other_package_test_user" package="branch_test_package" rev="3" srcmd5="0ca7ae4a6b97b6815357b99a81f28b6b"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 03 Nov 2022 09:44:25 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:45 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -1316,12 +1028,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="1b59df0aaf1a9a8f386ced682566d467">
-          <old project="home:other_package_test_user" package="branch_test_package" rev="12afe53f943e7943dbfd137174f0561d" srcmd5="12afe53f943e7943dbfd137174f0561d"/>
-          <new project="home:package_test_user:branches:home:other_package_test_user" package="branch_test_package" rev="207a9c38697f8240df18b2c9a5e8bcae" srcmd5="207a9c38697f8240df18b2c9a5e8bcae"/>
+        <sourcediff key="78a06ee27b8d62baf1b19381fcc65579">
+          <old project="home:other_package_test_user" package="branch_test_package" rev="1c55c3a91975023ec64ea99c865a0c7a" srcmd5="1c55c3a91975023ec64ea99c865a0c7a"/>
+          <new project="home:package_test_user:branches:home:other_package_test_user" package="branch_test_package" rev="bb9b60b169c2f2e6d0fbccb18417e34b" srcmd5="bb9b60b169c2f2e6d0fbccb18417e34b"/>
           <files/>
         </sourcediff>
-  recorded_at: Thu, 03 Nov 2022 09:44:25 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:45 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/_meta?user=package_test_user
@@ -1338,7 +1050,7 @@ http_interactions:
         </project>
     headers:
       X-Request-Id:
-      - 50d0a1d0-1b33-4fb2-a81a-d0565226661d
+      - 3c2fddd5-4c57-4592-b30c-9b8a5a9be75c
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1369,7 +1081,7 @@ http_interactions:
             <disable/>
           </publish>
         </project>
-  recorded_at: Thu, 03 Nov 2022 09:44:25 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:45 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package?view=info
@@ -1378,7 +1090,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 231fb759-7c85-4c89-ae50-1cff5cedf2c4
+      - a434a3f5-1bb0-4445-bdd2-5cc6ea03ed75
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1401,10 +1113,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="branch_test_package" rev="54" vrev="54" srcmd5="12afe53f943e7943dbfd137174f0561d" verifymd5="12afe53f943e7943dbfd137174f0561d">
+        <sourceinfo package="branch_test_package" rev="68" vrev="68" srcmd5="1c55c3a91975023ec64ea99c865a0c7a" verifymd5="1c55c3a91975023ec64ea99c865a0c7a">
           <error>bad build configuration, no build type defined or detected</error>
         </sourceinfo>
-  recorded_at: Thu, 03 Nov 2022 09:44:25 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:45 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package
@@ -1413,7 +1125,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 231fb759-7c85-4c89-ae50-1cff5cedf2c4
+      - a434a3f5-1bb0-4445-bdd2-5cc6ea03ed75
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1436,11 +1148,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="54" vrev="54" srcmd5="12afe53f943e7943dbfd137174f0561d">
-          <entry name="_config" md5="d1f5cf04283b0b567db10245458d7536" size="54" mtime="1667468662"/>
-          <entry name="somefile.txt" md5="96173f3df334668b8fe4503be2d820ac" size="58" mtime="1667468662"/>
+        <directory name="branch_test_package" rev="68" vrev="68" srcmd5="1c55c3a91975023ec64ea99c865a0c7a">
+          <entry name="_config" md5="5f637fe218fc5f364b1e9c0e55660d18" size="67" mtime="1677089142"/>
+          <entry name="somefile.txt" md5="b5cde3f96fdd0af70d52737bded0baad" size="66" mtime="1677089142"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:25 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:45 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -1472,14 +1184,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="4a8078d8378000c6129e16de71656deb">
+        <sourcediff key="d47225b6db9aa575f229bdd996da5c9f">
           <old project="home:other_package_test_user" package="branch_test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:other_package_test_user" package="branch_test_package" rev="54" srcmd5="12afe53f943e7943dbfd137174f0561d"/>
+          <new project="home:other_package_test_user" package="branch_test_package" rev="68" srcmd5="1c55c3a91975023ec64ea99c865a0c7a"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 03 Nov 2022 09:44:25 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:45 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package
@@ -1488,7 +1200,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 231fb759-7c85-4c89-ae50-1cff5cedf2c4
+      - a434a3f5-1bb0-4445-bdd2-5cc6ea03ed75
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1511,16 +1223,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="5" vrev="5" srcmd5="49ca443d76fd1f58db5cd05eea6175af">
-          <linkinfo project="home:other_package_test_user" package="branch_test_package" srcmd5="12afe53f943e7943dbfd137174f0561d" baserev="12afe53f943e7943dbfd137174f0561d" xsrcmd5="207a9c38697f8240df18b2c9a5e8bcae" lsrcmd5="49ca443d76fd1f58db5cd05eea6175af"/>
-          <entry name="_config" md5="d1f5cf04283b0b567db10245458d7536" size="54" mtime="1667468662"/>
-          <entry name="_link" md5="5341bda4583a0c7513fc053e5db97efd" size="136" mtime="1667468664"/>
-          <entry name="somefile.txt" md5="96173f3df334668b8fe4503be2d820ac" size="58" mtime="1667468662"/>
+        <directory name="branch_test_package" rev="3" vrev="3" srcmd5="0ca7ae4a6b97b6815357b99a81f28b6b">
+          <linkinfo project="home:other_package_test_user" package="branch_test_package" srcmd5="1c55c3a91975023ec64ea99c865a0c7a" baserev="1c55c3a91975023ec64ea99c865a0c7a" xsrcmd5="bb9b60b169c2f2e6d0fbccb18417e34b" lsrcmd5="0ca7ae4a6b97b6815357b99a81f28b6b"/>
+          <entry name="_config" md5="5f637fe218fc5f364b1e9c0e55660d18" size="67" mtime="1677089142"/>
+          <entry name="_link" md5="f7beeba40e8d9a60fc1b6182b90b4d3d" size="136" mtime="1677089144"/>
+          <entry name="somefile.txt" md5="b5cde3f96fdd0af70d52737bded0baad" size="66" mtime="1677089142"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:25 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:45 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package?expand=1&rev=5
+    uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package?expand=1&rev=3
     body:
       encoding: US-ASCII
       string: ''
@@ -1547,21 +1259,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="207a9c38697f8240df18b2c9a5e8bcae" vrev="59" srcmd5="207a9c38697f8240df18b2c9a5e8bcae">
-          <linkinfo project="home:other_package_test_user" package="branch_test_package" srcmd5="12afe53f943e7943dbfd137174f0561d" baserev="12afe53f943e7943dbfd137174f0561d" lsrcmd5="49ca443d76fd1f58db5cd05eea6175af"/>
-          <entry name="_config" md5="d1f5cf04283b0b567db10245458d7536" size="54" mtime="1667468662"/>
-          <entry name="somefile.txt" md5="96173f3df334668b8fe4503be2d820ac" size="58" mtime="1667468662"/>
+        <directory name="branch_test_package" rev="bb9b60b169c2f2e6d0fbccb18417e34b" vrev="71" srcmd5="bb9b60b169c2f2e6d0fbccb18417e34b">
+          <linkinfo project="home:other_package_test_user" package="branch_test_package" srcmd5="1c55c3a91975023ec64ea99c865a0c7a" baserev="1c55c3a91975023ec64ea99c865a0c7a" lsrcmd5="0ca7ae4a6b97b6815357b99a81f28b6b"/>
+          <entry name="_config" md5="5f637fe218fc5f364b1e9c0e55660d18" size="67" mtime="1677089142"/>
+          <entry name="somefile.txt" md5="b5cde3f96fdd0af70d52737bded0baad" size="66" mtime="1677089142"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:25 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:45 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package
+    uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package/_history?deleted=1&meta=1&rev=3
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - 231fb759-7c85-4c89-ae50-1cff5cedf2c4
+      - a434a3f5-1bb0-4445-bdd2-5cc6ea03ed75
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1580,117 +1292,123 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '651'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="branch_test_package" rev="5" vrev="5" srcmd5="49ca443d76fd1f58db5cd05eea6175af">
-          <linkinfo project="home:other_package_test_user" package="branch_test_package" srcmd5="12afe53f943e7943dbfd137174f0561d" baserev="12afe53f943e7943dbfd137174f0561d" xsrcmd5="207a9c38697f8240df18b2c9a5e8bcae" lsrcmd5="49ca443d76fd1f58db5cd05eea6175af"/>
-          <entry name="_config" md5="d1f5cf04283b0b567db10245458d7536" size="54" mtime="1667468662"/>
-          <entry name="_link" md5="5341bda4583a0c7513fc053e5db97efd" size="136" mtime="1667468664"/>
-          <entry name="somefile.txt" md5="96173f3df334668b8fe4503be2d820ac" size="58" mtime="1667468662"/>
-        </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:25 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Request-Id:
-      - 231fb759-7c85-4c89-ae50-1cff5cedf2c4
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '651'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="branch_test_package" rev="5" vrev="5" srcmd5="49ca443d76fd1f58db5cd05eea6175af">
-          <linkinfo project="home:other_package_test_user" package="branch_test_package" srcmd5="12afe53f943e7943dbfd137174f0561d" baserev="12afe53f943e7943dbfd137174f0561d" xsrcmd5="207a9c38697f8240df18b2c9a5e8bcae" lsrcmd5="49ca443d76fd1f58db5cd05eea6175af"/>
-          <entry name="_config" md5="d1f5cf04283b0b567db10245458d7536" size="54" mtime="1667468662"/>
-          <entry name="_link" md5="5341bda4583a0c7513fc053e5db97efd" size="136" mtime="1667468664"/>
-          <entry name="somefile.txt" md5="96173f3df334668b8fe4503be2d820ac" size="58" mtime="1667468662"/>
-        </directory>
-  recorded_at: Thu, 03 Nov 2022 09:44:25 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package/_history
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '991'
+      - '31'
     body:
       encoding: UTF-8
       string: |
         <revisionlist>
-          <revision rev="1" vrev="1">
-            <srcmd5>6ba8fed4618636dd5a78a718cbade2c6</srcmd5>
-            <version>unknown</version>
-            <time>1667464835</time>
-            <user>package_test_user</user>
-          </revision>
-          <revision rev="2" vrev="2">
-            <srcmd5>ba7a46d20d0dbd01668ae6e13a644909</srcmd5>
-            <version>unknown</version>
-            <time>1667464838</time>
-            <user>package_test_user</user>
-          </revision>
-          <revision rev="3" vrev="3">
-            <srcmd5>1b07a884868c4aacc583d54a5d0dec26</srcmd5>
-            <version>unknown</version>
-            <time>1667467815</time>
-            <user>package_test_user</user>
-          </revision>
-          <revision rev="4" vrev="4">
-            <srcmd5>1b07a884868c4aacc583d54a5d0dec26</srcmd5>
-            <version>unknown</version>
-            <time>1667467818</time>
-            <user>package_test_user</user>
-          </revision>
-          <revision rev="5" vrev="5">
-            <srcmd5>49ca443d76fd1f58db5cd05eea6175af</srcmd5>
-            <version>unknown</version>
-            <time>1667468664</time>
-            <user>package_test_user</user>
-          </revision>
         </revisionlist>
-  recorded_at: Thu, 03 Nov 2022 09:44:25 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:45 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - a434a3f5-1bb0-4445-bdd2-5cc6ea03ed75
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '651'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="branch_test_package" rev="3" vrev="3" srcmd5="0ca7ae4a6b97b6815357b99a81f28b6b">
+          <linkinfo project="home:other_package_test_user" package="branch_test_package" srcmd5="1c55c3a91975023ec64ea99c865a0c7a" baserev="1c55c3a91975023ec64ea99c865a0c7a" xsrcmd5="bb9b60b169c2f2e6d0fbccb18417e34b" lsrcmd5="0ca7ae4a6b97b6815357b99a81f28b6b"/>
+          <entry name="_config" md5="5f637fe218fc5f364b1e9c0e55660d18" size="67" mtime="1677089142"/>
+          <entry name="_link" md5="f7beeba40e8d9a60fc1b6182b90b4d3d" size="136" mtime="1677089144"/>
+          <entry name="somefile.txt" md5="b5cde3f96fdd0af70d52737bded0baad" size="66" mtime="1677089142"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:05:45 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - a434a3f5-1bb0-4445-bdd2-5cc6ea03ed75
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '651'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="branch_test_package" rev="3" vrev="3" srcmd5="0ca7ae4a6b97b6815357b99a81f28b6b">
+          <linkinfo project="home:other_package_test_user" package="branch_test_package" srcmd5="1c55c3a91975023ec64ea99c865a0c7a" baserev="1c55c3a91975023ec64ea99c865a0c7a" xsrcmd5="bb9b60b169c2f2e6d0fbccb18417e34b" lsrcmd5="0ca7ae4a6b97b6815357b99a81f28b6b"/>
+          <entry name="_config" md5="5f637fe218fc5f364b1e9c0e55660d18" size="67" mtime="1677089142"/>
+          <entry name="_link" md5="f7beeba40e8d9a60fc1b6182b90b4d3d" size="136" mtime="1677089144"/>
+          <entry name="somefile.txt" md5="b5cde3f96fdd0af70d52737bded0baad" size="66" mtime="1677089142"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:05:45 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user:branches:home:other_package_test_user/branch_test_package/_history?deleted=1&meta=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - a434a3f5-1bb0-4445-bdd2-5cc6ea03ed75
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Wed, 22 Feb 2023 18:05:45 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:package_test_user:branches:home:other_package_test_user/_result?lastbuild=1&locallink=1&multibuild=1&package=branch_test_package&view=status
@@ -1699,7 +1417,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 4dc910ff-2fd5-4671-8fc7-2968012c2120
+      - c82a8345-2353-4090-bac3-ee16a300c978
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1724,7 +1442,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:44:25 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:45 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:package_test_user:branches:home:other_package_test_user/_result?lastbuild=1&locallink=1&multibuild=1&package=branch_test_package&view=status
@@ -1733,7 +1451,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 510c0a71-bce7-4d5a-bdb2-4f03d702c4fb
+      - '08f262a2-339e-44e8-b7a9-6d8f229bcc7b'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1758,7 +1476,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:44:25 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:45 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:package_test_user:branches:home:other_package_test_user/_result?package=branch_test_package&view=status
@@ -1767,7 +1485,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 3779596b-acea-4b9a-b08c-30d4c6cd04cf
+      - 5f08e2db-18b1-460b-9863-498b2fcab10e
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1792,5 +1510,5 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:44:25 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:45 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Packages/changing_the_package_s_devel_project.yml
+++ b/src/api/spec/cassettes/Packages/changing_the_package_s_devel_project.yml
@@ -1,14 +1,17 @@
 ---
 http_interactions:
 - request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/develpackage
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/_meta?user=package_test_user
     body:
-      encoding: US-ASCII
-      string: ''
+      encoding: UTF-8
+      string: |
+        <project name="home:package_test_user">
+          <title/>
+          <description/>
+          <person userid="package_test_user" role="maintainer"/>
+        </project>
     headers:
-      X-Request-Id:
-      - 47ba5b8c-01b0-4bfb-9e49-cd7a3edeb239
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -17,8 +20,8 @@ http_interactions:
       - Ruby
   response:
     status:
-      code: 404
-      message: project 'home package_test_user' does not exist
+      code: 200
+      message: OK
     headers:
       Content-Type:
       - text/xml
@@ -27,15 +30,359 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '172'
+      - '156'
     body:
       encoding: UTF-8
       string: |
-        <status code="404">
-          <summary>project 'home:package_test_user' does not exist</summary>
-          <details>404 project 'home:package_test_user' does not exist</details>
-        </status>
-  recorded_at: Thu, 14 Oct 2021 09:19:55 GMT
+        <project name="home:package_test_user">
+          <title></title>
+          <description></description>
+          <person userid="package_test_user" role="maintainer"/>
+        </project>
+  recorded_at: Wed, 22 Feb 2023 18:04:29 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=user_5
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:package_test_user">
+          <title>The Waste Land</title>
+          <description>Consequatur iste deserunt ratione.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '170'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:package_test_user">
+          <title>The Waste Land</title>
+          <description>Consequatur iste deserunt ratione.</description>
+        </package>
+  recorded_at: Wed, 22 Feb 2023 18:04:29 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/test_package/_config
+    body:
+      encoding: UTF-8
+      string: Error quisquam et. Id voluptatibus beatae. Quia qui nam.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="68" vrev="68">
+          <srcmd5>8211299191a40f82b6b61ccf3a532b63</srcmd5>
+          <version>unknown</version>
+          <time>1677089069</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 22 Feb 2023 18:04:29 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/test_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Et blanditiis voluptatibus. Accusamus voluptas dolores. Commodi aut
+        quia.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="69" vrev="69">
+          <srcmd5>4c8401ecbe8f097246b7ce766d6cdf2d</srcmd5>
+          <version>unknown</version>
+          <time>1677089069</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 22 Feb 2023 18:04:29 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_package_test_user/_meta?user=other_package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:other_package_test_user">
+          <title/>
+          <description/>
+          <person userid="other_package_test_user" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '168'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:other_package_test_user">
+          <title></title>
+          <description></description>
+          <person userid="other_package_test_user" role="maintainer"/>
+        </project>
+  recorded_at: Wed, 22 Feb 2023 18:04:29 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=user_6
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_package_test_user">
+          <title>Tiger! Tiger!</title>
+          <description>Accusamus qui debitis rerum.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '176'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_package_test_user">
+          <title>Tiger! Tiger!</title>
+          <description>Accusamus qui debitis rerum.</description>
+        </package>
+  recorded_at: Wed, 22 Feb 2023 18:04:29 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_config
+    body:
+      encoding: UTF-8
+      string: Ad autem occaecati. Voluptatem nemo magni. Et impedit consequatur.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="61" vrev="61">
+          <srcmd5>98521bfec3c1df2cae8fcae3f793a4e0</srcmd5>
+          <version>unknown</version>
+          <time>1677089069</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 22 Feb 2023 18:04:29 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Molestias aliquam odit. Hic aperiam inventore. Sed occaecati distinctio.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="62" vrev="62">
+          <srcmd5>821f9b1ea0a8b6a40ce7cb93d430f7c5</srcmd5>
+          <version>unknown</version>
+          <time>1677089069</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 22 Feb 2023 18:04:29 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/develpackage/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="develpackage" project="home:package_test_user">
+          <title>The Far-Distant Oxus</title>
+          <description>Ut eius doloremque laborum.</description>
+          <devel project="home:other_package_test_user" package="branch_test_package"/>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '249'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="develpackage" project="home:package_test_user">
+          <title>The Far-Distant Oxus</title>
+          <description>Ut eius doloremque laborum.</description>
+          <devel project="home:other_package_test_user" package="branch_test_package"/>
+        </package>
+  recorded_at: Wed, 22 Feb 2023 18:04:30 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/develpackage
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 4b9c3290-a2e1-4cdd-9312-8accef27d001
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '87'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="develpackage" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:04:30 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/develpackage?expand=1
@@ -51,8 +398,8 @@ http_interactions:
       - Ruby
   response:
     status:
-      code: 404
-      message: project 'home package_test_user' does not exist
+      code: 200
+      message: OK
     headers:
       Content-Type:
       - text/xml
@@ -61,15 +408,47 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '172'
+      - '87'
     body:
       encoding: UTF-8
       string: |
-        <status code="404">
-          <summary>project 'home:package_test_user' does not exist</summary>
-          <details>404 project 'home:package_test_user' does not exist</details>
-        </status>
-  recorded_at: Thu, 14 Oct 2021 09:19:55 GMT
+        <directory name="develpackage" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:04:30 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/develpackage/_history?deleted=1&meta=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 4b9c3290-a2e1-4cdd-9312-8accef27d001
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Wed, 22 Feb 2023 18:04:30 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/develpackage
@@ -78,7 +457,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 47ba5b8c-01b0-4bfb-9e49-cd7a3edeb239
+      - 4b9c3290-a2e1-4cdd-9312-8accef27d001
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -87,8 +466,8 @@ http_interactions:
       - Ruby
   response:
     status:
-      code: 404
-      message: project 'home package_test_user' does not exist
+      code: 200
+      message: OK
     headers:
       Content-Type:
       - text/xml
@@ -97,49 +476,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '172'
+      - '87'
     body:
       encoding: UTF-8
       string: |
-        <status code="404">
-          <summary>project 'home:package_test_user' does not exist</summary>
-          <details>404 project 'home:package_test_user' does not exist</details>
-        </status>
-  recorded_at: Thu, 14 Oct 2021 09:19:55 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/develpackage?expand=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 404
-      message: project 'home package_test_user' does not exist
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '172'
-    body:
-      encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:package_test_user' does not exist</summary>
-          <details>404 project 'home:package_test_user' does not exist</details>
-        </status>
-  recorded_at: Thu, 14 Oct 2021 09:19:55 GMT
+        <directory name="develpackage" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:04:30 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/develpackage
@@ -148,7 +491,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 47ba5b8c-01b0-4bfb-9e49-cd7a3edeb239
+      - 4b9c3290-a2e1-4cdd-9312-8accef27d001
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -157,8 +500,8 @@ http_interactions:
       - Ruby
   response:
     status:
-      code: 404
-      message: project 'home package_test_user' does not exist
+      code: 200
+      message: OK
     headers:
       Content-Type:
       - text/xml
@@ -167,15 +510,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '172'
+      - '87'
     body:
       encoding: UTF-8
       string: |
-        <status code="404">
-          <summary>project 'home:package_test_user' does not exist</summary>
-          <details>404 project 'home:package_test_user' does not exist</details>
-        </status>
-  recorded_at: Thu, 14 Oct 2021 09:19:55 GMT
+        <directory name="develpackage" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:04:30 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/develpackage
@@ -184,7 +525,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 47ba5b8c-01b0-4bfb-9e49-cd7a3edeb239
+      - f89ff338-4fbf-4761-b8cd-0ff46c4270ad
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -193,8 +534,8 @@ http_interactions:
       - Ruby
   response:
     status:
-      code: 404
-      message: project 'home package_test_user' does not exist
+      code: 200
+      message: OK
     headers:
       Content-Type:
       - text/xml
@@ -203,15 +544,115 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '172'
+      - '87'
     body:
       encoding: UTF-8
       string: |
-        <status code="404">
-          <summary>project 'home:package_test_user' does not exist</summary>
-          <details>404 project 'home:package_test_user' does not exist</details>
-        </status>
-  recorded_at: Thu, 14 Oct 2021 09:19:55 GMT
+        <directory name="develpackage" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:04:31 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:package_test_user/_result?lastbuild=1&locallink=1&multibuild=1&package=develpackage&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - f89ff338-4fbf-4761-b8cd-0ff46c4270ad
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 18:04:31 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/develpackage
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 40f5562d-ff1c-432e-88b7-310a886b7d61
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '87'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="develpackage" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:04:31 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:package_test_user/_result?lastbuild=1&locallink=1&multibuild=1&package=develpackage&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 40f5562d-ff1c-432e-88b7-310a886b7d61
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 18:04:31 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:package_test_user/_result?package=develpackage&view=status
@@ -220,7 +661,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - e387bc96-f7eb-4dec-94f6-f0596492424c
+      - b2087019-f0b3-4106-8e80-f63b411aa5e0
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -229,8 +670,8 @@ http_interactions:
       - Ruby
   response:
     status:
-      code: 404
-      message: project 'home package_test_user' does not exist
+      code: 200
+      message: OK
     headers:
       Content-Type:
       - text/xml
@@ -239,24 +680,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '172'
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 18:04:31 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_1/_meta?user=package_test_user
     body:
       encoding: UTF-8
       string: |
-        <status code="404">
-          <summary>project 'home:package_test_user' does not exist</summary>
-          <details>404 project 'home:package_test_user' does not exist</details>
-        </status>
-  recorded_at: Thu, 14 Oct 2021 09:19:55 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/project_1/develpackage
-    body:
-      encoding: US-ASCII
-      string: ''
+        <project name="project_1">
+          <title>Precious Bane</title>
+          <description/>
+        </project>
     headers:
-      X-Request-Id:
-      - 15746023-7354-4228-8eeb-50188bdc37cc
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -265,8 +706,46 @@ http_interactions:
       - Ruby
   response:
     status:
-      code: 404
-      message: project 'project_1' does not exist
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '99'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_1">
+          <title>Precious Bane</title>
+          <description></description>
+        </project>
+  recorded_at: Wed, 22 Feb 2023 18:04:31 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_1/develpackage/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="develpackage" project="project_1">
+          <title>All Passion Spent</title>
+          <description>Facere modi iste ut.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
     headers:
       Content-Type:
       - text/xml
@@ -279,11 +758,83 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <status code="404">
-          <summary>project 'project_1' does not exist</summary>
-          <details>404 project 'project_1' does not exist</details>
-        </status>
-  recorded_at: Thu, 14 Oct 2021 09:19:56 GMT
+        <package name="develpackage" project="project_1">
+          <title>All Passion Spent</title>
+          <description>Facere modi iste ut.</description>
+        </package>
+  recorded_at: Wed, 22 Feb 2023 18:04:31 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project_1/develpackage/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="develpackage" project="project_1">
+          <title>All Passion Spent</title>
+          <description>Facere modi iste ut.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '146'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="develpackage" project="project_1">
+          <title>All Passion Spent</title>
+          <description>Facere modi iste ut.</description>
+        </package>
+  recorded_at: Wed, 22 Feb 2023 18:04:31 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/project_1/develpackage
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - ed350828-b086-4650-9aa4-d0335696caf4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '87'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="develpackage" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:04:32 GMT
 - request:
     method: post
     uri: http://backend:5352/source/project_1/develpackage?cmd=diff&expand=1&filelimit=10000&opackage=develpackage&oproject=home:package_test_user&tarlimit=10000&view=xml&withissues=1
@@ -294,7 +845,7 @@ http_interactions:
       Content-Type:
       - application/octet-stream
       X-Request-Id:
-      - 15746023-7354-4228-8eeb-50188bdc37cc
+      - ed350828-b086-4650-9aa4-d0335696caf4
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -303,8 +854,8 @@ http_interactions:
       - Ruby
   response:
     status:
-      code: 404
-      message: project 'project_1' does not exist
+      code: 200
+      message: OK
     headers:
       Content-Type:
       - text/xml
@@ -313,13 +864,14 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '146'
+      - '294'
     body:
       encoding: UTF-8
       string: |
-        <status code="404">
-          <summary>project 'project_1' does not exist</summary>
-          <details>404 project 'project_1' does not exist</details>
-        </status>
-  recorded_at: Thu, 14 Oct 2021 09:19:56 GMT
-recorded_with: VCR 6.0.0
+        <sourcediff key="6d2cdcce5fb3ea2f733599c942bbb707">
+          <old project="home:package_test_user" package="develpackage" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="project_1" package="develpackage" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <files/>
+        </sourcediff>
+  recorded_at: Wed, 22 Feb 2023 18:04:32 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Packages/creating_a_package/in_a_project_not_owned_by_the_user/allowed_as_admin.yml
+++ b/src/api/spec/cassettes/Packages/creating_a_package/in_a_project_not_owned_by_the_user/allowed_as_admin.yml
@@ -39,16 +39,16 @@ http_interactions:
           <description></description>
           <person userid="package_test_user" role="maintainer"/>
         </project>
-  recorded_at: Fri, 25 Jun 2021 11:33:44 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:52 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=user_54
+    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=user_21
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>His Dark Materials</title>
-          <description>Aliquam eos inventore non.</description>
+          <title>The Soldier's Art</title>
+          <description>Blanditiis voluptate nihil ut.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -69,21 +69,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '166'
+      - '169'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>His Dark Materials</title>
-          <description>Aliquam eos inventore non.</description>
+          <title>The Soldier's Art</title>
+          <description>Blanditiis voluptate nihil ut.</description>
         </package>
-  recorded_at: Fri, 25 Jun 2021 11:33:44 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:52 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_config
     body:
       encoding: UTF-8
-      string: Dolorem maiores veritatis. Quam libero quo. Qui rerum sed.
+      string: Temporibus ab omnis. Ducimus recusandae ullam. Placeat deleniti beatae.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -107,21 +107,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="30" vrev="30">
-          <srcmd5>af20eea290696ccf29f7ff182b05cd04</srcmd5>
+        <revision rev="55" vrev="55">
+          <srcmd5>077d2d9fe18b28a32e4324776b9bf269</srcmd5>
           <version>unknown</version>
-          <time>1624620824</time>
+          <time>1677088732</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Fri, 25 Jun 2021 11:33:44 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:52 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Aut rerum animi. Est non qui. Molestiae perferendis est.
+      string: Et nulla similique. Distinctio assumenda qui. Illum aut autem.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -145,15 +145,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="31" vrev="31">
-          <srcmd5>087b47e511b412641a67dfb0dde29cc8</srcmd5>
+        <revision rev="56" vrev="56">
+          <srcmd5>46049ddb63fcca34654d14a80a1922f4</srcmd5>
           <version>unknown</version>
-          <time>1624620824</time>
+          <time>1677088732</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Fri, 25 Jun 2021 11:33:44 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:52 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/_meta?user=other_package_test_user
@@ -193,16 +193,16 @@ http_interactions:
           <description></description>
           <person userid="other_package_test_user" role="maintainer"/>
         </project>
-  recorded_at: Fri, 25 Jun 2021 11:33:44 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:52 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=user_55
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=user_22
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>A Farewell to Arms</title>
-          <description>Suscipit autem enim dolor.</description>
+          <title>Oh! To be in England</title>
+          <description>Dolorem accusantium consectetur reiciendis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -223,21 +223,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '179'
+      - '198'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>A Farewell to Arms</title>
-          <description>Suscipit autem enim dolor.</description>
+          <title>Oh! To be in England</title>
+          <description>Dolorem accusantium consectetur reiciendis.</description>
         </package>
-  recorded_at: Fri, 25 Jun 2021 11:33:44 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:52 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_config
     body:
       encoding: UTF-8
-      string: Et quo unde. Esse eos numquam. Nobis et deserunt.
+      string: Quia voluptate facilis. Perspiciatis inventore earum. Qui qui non.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -261,21 +261,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="29" vrev="29">
-          <srcmd5>4bae5057aea244a14caee247eba9e878</srcmd5>
+        <revision rev="49" vrev="49">
+          <srcmd5>a70f51395fb1101b758cea96ed9e5c61</srcmd5>
           <version>unknown</version>
-          <time>1624620824</time>
+          <time>1677088732</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Fri, 25 Jun 2021 11:33:44 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:52 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Eum perferendis dolore. Recusandae in quae. Modi eius in.
+      string: Nobis est aut. Sequi est cupiditate. Quidem animi iste.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -299,25 +299,25 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="30" vrev="30">
-          <srcmd5>b11146208399ce3bbb9b7e6fcf2663f7</srcmd5>
+        <revision rev="50" vrev="50">
+          <srcmd5>76075b3d1d752ef82262d139d14fedcb</srcmd5>
           <version>unknown</version>
-          <time>1624620824</time>
+          <time>1677088732</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Fri, 25 Jun 2021 11:33:44 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:52 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:user_56/_meta?user=user_56
+    uri: http://backend:5352/source/home:user_23/_meta?user=user_23
     body:
       encoding: UTF-8
       string: |
-        <project name="home:user_56">
+        <project name="home:user_23">
           <title/>
           <description/>
-          <person userid="user_56" role="maintainer"/>
+          <person userid="user_23" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -342,20 +342,20 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <project name="home:user_56">
+        <project name="home:user_23">
           <title></title>
           <description></description>
-          <person userid="user_56" role="maintainer"/>
+          <person userid="user_23" role="maintainer"/>
         </project>
-  recorded_at: Fri, 25 Jun 2021 11:33:44 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:52 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/global_project/_meta?user=user_56
+    uri: http://backend:5352/source/global_project/_meta?user=user_23
     body:
       encoding: UTF-8
       string: |
         <project name="global_project">
-          <title>Of Mice and Men</title>
+          <title>The Yellow Meads of Asphodel</title>
           <description/>
         </project>
     headers:
@@ -377,18 +377,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '106'
+      - '119'
     body:
       encoding: UTF-8
       string: |
         <project name="global_project">
-          <title>Of Mice and Men</title>
+          <title>The Yellow Meads of Asphodel</title>
           <description></description>
         </project>
-  recorded_at: Fri, 25 Jun 2021 11:33:45 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:53 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/global_project/coolstuff/_meta?user=user_56
+    uri: http://backend:5352/source/global_project/coolstuff/_meta?user=user_23
     body:
       encoding: UTF-8
       string: |
@@ -423,7 +423,7 @@ http_interactions:
           <title></title>
           <description></description>
         </package>
-  recorded_at: Fri, 25 Jun 2021 11:33:45 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:54 GMT
 - request:
     method: get
     uri: http://backend:5352/source/global_project/coolstuff
@@ -432,7 +432,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - af316583-0713-4e70-b83d-77901e0e510c
+      - 03f0fc97-91fe-4947-83ba-132198d97c40
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -457,7 +457,7 @@ http_interactions:
       string: |
         <directory name="coolstuff" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Fri, 25 Jun 2021 11:33:45 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:54 GMT
 - request:
     method: get
     uri: http://backend:5352/source/global_project/coolstuff?expand=1
@@ -489,7 +489,41 @@ http_interactions:
       string: |
         <directory name="coolstuff" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Fri, 25 Jun 2021 11:33:45 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:54 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/global_project/coolstuff/_history?deleted=1&meta=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 03f0fc97-91fe-4947-83ba-132198d97c40
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Wed, 22 Feb 2023 17:58:54 GMT
 - request:
     method: get
     uri: http://backend:5352/source/global_project/coolstuff
@@ -498,7 +532,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - af316583-0713-4e70-b83d-77901e0e510c
+      - 03f0fc97-91fe-4947-83ba-132198d97c40
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -523,7 +557,7 @@ http_interactions:
       string: |
         <directory name="coolstuff" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Fri, 25 Jun 2021 11:33:46 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:54 GMT
 - request:
     method: get
     uri: http://backend:5352/source/global_project/coolstuff
@@ -532,7 +566,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - af316583-0713-4e70-b83d-77901e0e510c
+      - 03f0fc97-91fe-4947-83ba-132198d97c40
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -557,5 +591,175 @@ http_interactions:
       string: |
         <directory name="coolstuff" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Fri, 25 Jun 2021 11:33:46 GMT
-recorded_with: VCR 6.0.0
+  recorded_at: Wed, 22 Feb 2023 17:58:54 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/global_project/coolstuff
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 3395574b-750c-4b23-87e4-63911f22ba99
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '84'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="coolstuff" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 17:58:54 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/global_project/_result?lastbuild=1&locallink=1&multibuild=1&package=coolstuff&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 3395574b-750c-4b23-87e4-63911f22ba99
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 17:58:54 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/global_project/coolstuff
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 4aa11f80-77ff-429b-aa74-bf83dd222bcb
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '84'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="coolstuff" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 17:58:54 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/global_project/_result?lastbuild=1&locallink=1&multibuild=1&package=coolstuff&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 4aa11f80-77ff-429b-aa74-bf83dd222bcb
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 17:58:54 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/global_project/_result?package=coolstuff&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 34fe8e67-9b97-4e2a-96fe-b56aa415379b
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 17:58:54 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Packages/creating_a_package/in_a_project_owned_by_the_user/creates_a_package.yml
+++ b/src/api/spec/cassettes/Packages/creating_a_package/in_a_project_owned_by_the_user/creates_a_package.yml
@@ -39,16 +39,16 @@ http_interactions:
           <description></description>
           <person userid="package_test_user" role="maintainer"/>
         </project>
-  recorded_at: Fri, 25 Jun 2021 11:33:52 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:49 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=user_61
+    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=user_19
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>Endless Night</title>
-          <description>Earum blanditiis sint officia.</description>
+          <title>The Cricket on the Hearth</title>
+          <description>Iure excepturi saepe et.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -69,21 +69,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '165'
+      - '171'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>Endless Night</title>
-          <description>Earum blanditiis sint officia.</description>
+          <title>The Cricket on the Hearth</title>
+          <description>Iure excepturi saepe et.</description>
         </package>
-  recorded_at: Fri, 25 Jun 2021 11:33:52 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_config
     body:
       encoding: UTF-8
-      string: Sapiente quaerat rerum. Aliquam labore voluptas. Ut voluptas animi.
+      string: Dolorem dicta aut. Molestias eum vero. Velit numquam qui.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -107,21 +107,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="36" vrev="36">
-          <srcmd5>63318f189aa0a1dcaa7e3a9189681d0b</srcmd5>
+        <revision rev="53" vrev="53">
+          <srcmd5>8ab2d7cd158469593015b6de4be9f398</srcmd5>
           <version>unknown</version>
-          <time>1624620832</time>
+          <time>1677088729</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Fri, 25 Jun 2021 11:33:52 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Harum velit voluptatem. Aut alias ut. Optio dolores minima.
+      string: Assumenda exercitationem eos. Quis maxime quas. Sapiente eius et.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -145,15 +145,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="37" vrev="37">
-          <srcmd5>789168dbb8ebceca526a14d283656fef</srcmd5>
+        <revision rev="54" vrev="54">
+          <srcmd5>baa9ae3140d09c53f9a611060e3214d7</srcmd5>
           <version>unknown</version>
-          <time>1624620832</time>
+          <time>1677088729</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Fri, 25 Jun 2021 11:33:52 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/_meta?user=other_package_test_user
@@ -193,16 +193,16 @@ http_interactions:
           <description></description>
           <person userid="other_package_test_user" role="maintainer"/>
         </project>
-  recorded_at: Fri, 25 Jun 2021 11:33:52 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:49 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=user_62
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=user_20
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>The Sun Also Rises</title>
-          <description>Ea officia ut laborum.</description>
+          <title>Waiting for the Barbarians</title>
+          <description>Non enim et esse.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -223,21 +223,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '175'
+      - '178'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>The Sun Also Rises</title>
-          <description>Ea officia ut laborum.</description>
+          <title>Waiting for the Barbarians</title>
+          <description>Non enim et esse.</description>
         </package>
-  recorded_at: Fri, 25 Jun 2021 11:33:52 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_config
     body:
       encoding: UTF-8
-      string: Nihil cupiditate non. Vitae error reiciendis. Impedit consequuntur accusantium.
+      string: Et quo ipsa. Dolore ratione nostrum. Illum repellat optio.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -261,21 +261,22 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="35" vrev="35">
-          <srcmd5>76769dc2e6e7046267ba665834833940</srcmd5>
+        <revision rev="47" vrev="47">
+          <srcmd5>616ef6ef019b982e927e3a78495ae794</srcmd5>
           <version>unknown</version>
-          <time>1624620832</time>
+          <time>1677088729</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Fri, 25 Jun 2021 11:33:52 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Aut nihil earum. Tempora quas error. Pariatur occaecati non.
+      string: Recusandae ut doloribus. Error dignissimos maiores. Aliquam pariatur
+        et.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -299,15 +300,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="36" vrev="36">
-          <srcmd5>1f9f36b6a778c279bc23d2c8c46a8365</srcmd5>
+        <revision rev="48" vrev="48">
+          <srcmd5>7a114c477aab8fb348e79e86f9a136a1</srcmd5>
           <version>unknown</version>
-          <time>1624620832</time>
+          <time>1677088729</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Fri, 25 Jun 2021 11:33:52 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:49 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/coolstuff/_meta?user=package_test_user
@@ -316,7 +317,7 @@ http_interactions:
       string: |
         <package name="coolstuff" project="home:package_test_user">
           <title>cool stuff everyone needs</title>
-          <description>Dolor voluptas minima. Adipisci est explicabo. Cum ipsa possimus. Ab excepturi ex. Ipsam atque saepe. Temporibus sint eum. Dolores consequatur eaque. Est quis laborum. Hic perferendis maxime. Sunt impedit sint. Aliquam nihil numquam. Maxime ut amet. Itaque est rem. Illo quis non. Quibusdam et consequuntur. Aut est eos. Sit consequuntur id. Nihil omnis odio. Qui et temporibus. Et adipisci voluptatibus.</description>
+          <description>Earum sint eos. Consequatur molestiae consectetur. Qui autem vel. Eaque odio fugit. Beatae nulla neque. Minima qui eaque. Sed eveniet non. Aut iste voluptatum. Animi consequatur corporis. Distinctio nobis vel. Possimus tempora ratione. Incidunt sit pariatur. Sed tempore blanditiis. Enim qui error. Commodi repudiandae ullam. Reprehenderit aliquid commodi. Asperiores a quos. Dolorum veritatis corrupti. Enim mollitia repellendus. Voluptatem veniam pariatur.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -337,15 +338,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '548'
+      - '602'
     body:
       encoding: UTF-8
       string: |
         <package name="coolstuff" project="home:package_test_user">
           <title>cool stuff everyone needs</title>
-          <description>Dolor voluptas minima. Adipisci est explicabo. Cum ipsa possimus. Ab excepturi ex. Ipsam atque saepe. Temporibus sint eum. Dolores consequatur eaque. Est quis laborum. Hic perferendis maxime. Sunt impedit sint. Aliquam nihil numquam. Maxime ut amet. Itaque est rem. Illo quis non. Quibusdam et consequuntur. Aut est eos. Sit consequuntur id. Nihil omnis odio. Qui et temporibus. Et adipisci voluptatibus.</description>
+          <description>Earum sint eos. Consequatur molestiae consectetur. Qui autem vel. Eaque odio fugit. Beatae nulla neque. Minima qui eaque. Sed eveniet non. Aut iste voluptatum. Animi consequatur corporis. Distinctio nobis vel. Possimus tempora ratione. Incidunt sit pariatur. Sed tempore blanditiis. Enim qui error. Commodi repudiandae ullam. Reprehenderit aliquid commodi. Asperiores a quos. Dolorum veritatis corrupti. Enim mollitia repellendus. Voluptatem veniam pariatur.</description>
         </package>
-  recorded_at: Fri, 25 Jun 2021 11:33:53 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:51 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/coolstuff
@@ -354,7 +355,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 2aa9db8f-6d81-4c42-8511-4a2cd28c8764
+      - 225b40eb-8ef4-49e3-98dd-4e3bfbd6ec14
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -379,7 +380,7 @@ http_interactions:
       string: |
         <directory name="coolstuff" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Fri, 25 Jun 2021 11:33:53 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:51 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/coolstuff?expand=1
@@ -411,7 +412,41 @@ http_interactions:
       string: |
         <directory name="coolstuff" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Fri, 25 Jun 2021 11:33:53 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:51 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/coolstuff/_history?deleted=1&meta=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 225b40eb-8ef4-49e3-98dd-4e3bfbd6ec14
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Wed, 22 Feb 2023 17:58:51 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/coolstuff
@@ -420,7 +455,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 2aa9db8f-6d81-4c42-8511-4a2cd28c8764
+      - 225b40eb-8ef4-49e3-98dd-4e3bfbd6ec14
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -445,7 +480,7 @@ http_interactions:
       string: |
         <directory name="coolstuff" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Fri, 25 Jun 2021 11:33:53 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:51 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/coolstuff
@@ -454,7 +489,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 2aa9db8f-6d81-4c42-8511-4a2cd28c8764
+      - 225b40eb-8ef4-49e3-98dd-4e3bfbd6ec14
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -479,16 +514,50 @@ http_interactions:
       string: |
         <directory name="coolstuff" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Fri, 25 Jun 2021 11:33:53 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:51 GMT
 - request:
     method: get
-    uri: http://backend:5352/build/home:package_test_user/_result?package=coolstuff&view=status
+    uri: http://backend:5352/source/home:package_test_user/coolstuff
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - ba5a05d0-698b-4cde-99e1-8aacba99af61
+      - 35182ba6-3aa1-452c-b584-a93c652b8663
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '84'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="coolstuff" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 17:58:51 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:package_test_user/_result?lastbuild=1&locallink=1&multibuild=1&package=coolstuff&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 35182ba6-3aa1-452c-b584-a93c652b8663
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -513,5 +582,107 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Fri, 25 Jun 2021 11:33:55 GMT
-recorded_with: VCR 6.0.0
+  recorded_at: Wed, 22 Feb 2023 17:58:51 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/coolstuff
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 197bd4f0-0306-40ee-8bd3-f8ade3bad157
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '84'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="coolstuff" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 17:58:51 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:package_test_user/_result?lastbuild=1&locallink=1&multibuild=1&package=coolstuff&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 197bd4f0-0306-40ee-8bd3-f8ade3bad157
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 17:58:51 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:package_test_user/_result?package=coolstuff&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 90cdc590-da31-4426-81e2-81c8b20b9276
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 17:58:51 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Packages/editing_a_package_s_details/updates_the_package_title_and_description.yml
+++ b/src/api/spec/cassettes/Packages/editing_a_package_s_details/updates_the_package_title_and_description.yml
@@ -39,16 +39,16 @@ http_interactions:
           <description></description>
           <person userid="package_test_user" role="maintainer"/>
         </project>
-  recorded_at: Fri, 25 Jun 2021 11:34:06 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:53 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=user_70
+    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=user_42
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>Death Be Not Proud</title>
-          <description>Qui unde et at.</description>
+          <title>Gone with the Wind</title>
+          <description>Sed praesentium tempora sit.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -69,21 +69,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '155'
+      - '168'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>Death Be Not Proud</title>
-          <description>Qui unde et at.</description>
+          <title>Gone with the Wind</title>
+          <description>Sed praesentium tempora sit.</description>
         </package>
-  recorded_at: Fri, 25 Jun 2021 11:34:06 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:53 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_config
     body:
       encoding: UTF-8
-      string: Et quaerat ipsa. Aut molestiae atque. Vitae amet excepturi.
+      string: Veniam mollitia sed. Non quae quis. Nemo minus cupiditate.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -107,21 +107,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="44" vrev="44">
-          <srcmd5>92b0d79e6be8d31357a5e41b3c032014</srcmd5>
+        <revision rev="80" vrev="80">
+          <srcmd5>5daae07e677026e3774b1bc4349e2dac</srcmd5>
           <version>unknown</version>
-          <time>1624620846</time>
+          <time>1677089153</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Fri, 25 Jun 2021 11:34:06 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:53 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Ut voluptatum sint. Explicabo aliquam aut. Voluptatum eos facilis.
+      string: Odio ex facilis. Id et libero. Dolorum consequatur sunt.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -145,15 +145,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="45" vrev="45">
-          <srcmd5>216908658b473edf733f2fd7899628c7</srcmd5>
+        <revision rev="81" vrev="81">
+          <srcmd5>51df50e3267b37936548ad0ef1065a15</srcmd5>
           <version>unknown</version>
-          <time>1624620846</time>
+          <time>1677089153</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Fri, 25 Jun 2021 11:34:06 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:53 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/_meta?user=other_package_test_user
@@ -193,16 +193,16 @@ http_interactions:
           <description></description>
           <person userid="other_package_test_user" role="maintainer"/>
         </project>
-  recorded_at: Fri, 25 Jun 2021 11:34:06 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:53 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=user_71
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=user_43
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>A Monstrous Regiment of Women</title>
-          <description>Molestiae harum asperiores consequatur.</description>
+          <title>A Time to Kill</title>
+          <description>Eligendi unde sed dolor.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -223,21 +223,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '203'
+      - '173'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>A Monstrous Regiment of Women</title>
-          <description>Molestiae harum asperiores consequatur.</description>
+          <title>A Time to Kill</title>
+          <description>Eligendi unde sed dolor.</description>
         </package>
-  recorded_at: Fri, 25 Jun 2021 11:34:06 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:53 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_config
     body:
       encoding: UTF-8
-      string: Voluptas sit consequatur. Voluptas est similique. Quae qui porro.
+      string: Facere voluptatem tempora. Excepturi fuga quo. Rem doloremque est.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -261,21 +261,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="41" vrev="41">
-          <srcmd5>044de004b1709fe56e7154af6389a52e</srcmd5>
+        <revision rev="73" vrev="73">
+          <srcmd5>0234410dbbcdad8a37f25a124405247c</srcmd5>
           <version>unknown</version>
-          <time>1624620846</time>
+          <time>1677089153</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Fri, 25 Jun 2021 11:34:06 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:54 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Sunt iste libero. Neque eligendi laudantium. Dolores sint doloribus.
+      string: Assumenda aut quia. Voluptate voluptas omnis. Aut necessitatibus nam.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -299,15 +299,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="42" vrev="42">
-          <srcmd5>56c1cadcbf65f89d4dd79f87f7efc525</srcmd5>
+        <revision rev="74" vrev="74">
+          <srcmd5>b8df4de81a39fb8e75338415f4cc8b45</srcmd5>
           <version>unknown</version>
-          <time>1624620846</time>
+          <time>1677089154</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Fri, 25 Jun 2021 11:34:06 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:54 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package
@@ -316,7 +316,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 2e49ffdc-6b08-4ab4-b520-d10ddc492ca7
+      - ab920621-a3cf-4705-80f1-06fa91db7cc2
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -339,15 +339,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="45" vrev="45" srcmd5="216908658b473edf733f2fd7899628c7">
-          <entry name="_config" md5="3c72d802845eead193620ea22dea3a56" size="59" mtime="1624620846"/>
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1624620688"/>
-          <entry name="somefile.txt" md5="c8e7cf888c379a42a29c3f0ae5b49ac1" size="66" mtime="1624620846"/>
+        <directory name="test_package" rev="81" vrev="81" srcmd5="51df50e3267b37936548ad0ef1065a15">
+          <entry name="_config" md5="eaf10f19533a8b007cb2c993a24b86c5" size="58" mtime="1677089153"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="a94f4066aa137baf3e7cb6272b6e9bf9" size="56" mtime="1677089153"/>
         </directory>
-  recorded_at: Fri, 25 Jun 2021 11:34:07 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:55 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package?expand=1&rev=45
+    uri: http://backend:5352/source/home:package_test_user/test_package?expand=1&rev=81
     body:
       encoding: US-ASCII
       string: ''
@@ -374,58 +374,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="45" vrev="45" srcmd5="216908658b473edf733f2fd7899628c7">
-          <entry name="_config" md5="3c72d802845eead193620ea22dea3a56" size="59" mtime="1624620846"/>
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1624620688"/>
-          <entry name="somefile.txt" md5="c8e7cf888c379a42a29c3f0ae5b49ac1" size="66" mtime="1624620846"/>
+        <directory name="test_package" rev="81" vrev="81" srcmd5="51df50e3267b37936548ad0ef1065a15">
+          <entry name="_config" md5="eaf10f19533a8b007cb2c993a24b86c5" size="58" mtime="1677089153"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="a94f4066aa137baf3e7cb6272b6e9bf9" size="56" mtime="1677089153"/>
         </directory>
-  recorded_at: Fri, 25 Jun 2021 11:34:07 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:55 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Request-Id:
-      - 2e49ffdc-6b08-4ab4-b520-d10ddc492ca7
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '393'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="test_package" rev="45" vrev="45" srcmd5="216908658b473edf733f2fd7899628c7">
-          <entry name="_config" md5="3c72d802845eead193620ea22dea3a56" size="59" mtime="1624620846"/>
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1624620688"/>
-          <entry name="somefile.txt" md5="c8e7cf888c379a42a29c3f0ae5b49ac1" size="66" mtime="1624620846"/>
-        </directory>
-  recorded_at: Fri, 25 Jun 2021 11:34:07 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package
+    uri: http://backend:5352/source/home:package_test_user/test_package/_history?deleted=1&meta=1&rev=81
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - 2e49ffdc-6b08-4ab4-b520-d10ddc492ca7
+      - ab920621-a3cf-4705-80f1-06fa91db7cc2
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -444,327 +407,167 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '393'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="test_package" rev="45" vrev="45" srcmd5="216908658b473edf733f2fd7899628c7">
-          <entry name="_config" md5="3c72d802845eead193620ea22dea3a56" size="59" mtime="1624620846"/>
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1624620688"/>
-          <entry name="somefile.txt" md5="c8e7cf888c379a42a29c3f0ae5b49ac1" size="66" mtime="1624620846"/>
-        </directory>
-  recorded_at: Fri, 25 Jun 2021 11:34:07 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package/_history
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '8303'
+      - '31'
     body:
       encoding: UTF-8
       string: |
         <revisionlist>
-          <revision rev="1" vrev="1">
-            <srcmd5>a7feca4b99d529ab106b6666f98a5d5a</srcmd5>
-            <version>unknown</version>
-            <time>1624620657</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="2" vrev="2">
-            <srcmd5>11bc7bc10a1ea1609de8a814bef6ef24</srcmd5>
-            <version>unknown</version>
-            <time>1624620657</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="3" vrev="3">
-            <srcmd5>ec9a3f3c992577783f0f4ed7876c79f3</srcmd5>
-            <version>unknown</version>
-            <time>1624620670</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="4" vrev="4">
-            <srcmd5>ff563efe05eba8ca10caba706f5a7a05</srcmd5>
-            <version>unknown</version>
-            <time>1624620670</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="5" vrev="5">
-            <srcmd5>1919e65dd94439ce8046297a51deba51</srcmd5>
-            <version>unknown</version>
-            <time>1624620678</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="6" vrev="6">
-            <srcmd5>38020a66a90d7871c8a30222b18d9672</srcmd5>
-            <version>unknown</version>
-            <time>1624620678</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="7" vrev="7">
-            <srcmd5>7a6fe3aa87ff6c50313564b157278a11</srcmd5>
-            <version>unknown</version>
-            <time>1624620684</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="8" vrev="8">
-            <srcmd5>dff72a268ab90b0a16143afc79b8eb23</srcmd5>
-            <version>unknown</version>
-            <time>1624620684</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="9" vrev="9">
-            <srcmd5>63e12210830bf9ce362f78797ba011e1</srcmd5>
-            <version>unknown</version>
-            <time>1624620688</time>
-            <user>package_test_user</user>
-          </revision>
-          <revision rev="10" vrev="10">
-            <srcmd5>367335854550b857232c9a2721cb7dd2</srcmd5>
-            <version>unknown</version>
-            <time>1624620690</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="11" vrev="11">
-            <srcmd5>538b80692b39d509774c240cada1049a</srcmd5>
-            <version>unknown</version>
-            <time>1624620690</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="12" vrev="12">
-            <srcmd5>753964ef08fa4a8c7bd7cadc888e14e6</srcmd5>
-            <version>unknown</version>
-            <time>1624620692</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="13" vrev="13">
-            <srcmd5>c5b1f840a697d26d516ee9862ee820ea</srcmd5>
-            <version>unknown</version>
-            <time>1624620692</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="14" vrev="14">
-            <srcmd5>c22f11a4da0f6c1b22a3f602ba221337</srcmd5>
-            <version>unknown</version>
-            <time>1624620694</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="15" vrev="15">
-            <srcmd5>63487802ea076af50fea42c469aedf79</srcmd5>
-            <version>unknown</version>
-            <time>1624620694</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="16" vrev="16">
-            <srcmd5>2349da763188d72be50090e4257898df</srcmd5>
-            <version>unknown</version>
-            <time>1624620703</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="17" vrev="17">
-            <srcmd5>f4733c5074a7c63ddf192d0d03ce427e</srcmd5>
-            <version>unknown</version>
-            <time>1624620703</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="18" vrev="18">
-            <srcmd5>54dc2e2080f3efdce7f5f09915fb32e2</srcmd5>
-            <version>unknown</version>
-            <time>1624620801</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="19" vrev="19">
-            <srcmd5>154771f7d36cafbcffc792b89a91f158</srcmd5>
-            <version>unknown</version>
-            <time>1624620801</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="20" vrev="20">
-            <srcmd5>f73851ae8824a8390c5e9124dbcb90d4</srcmd5>
-            <version>unknown</version>
-            <time>1624620803</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="21" vrev="21">
-            <srcmd5>93bde33fce2f50ad0aca9c2b68953b54</srcmd5>
-            <version>unknown</version>
-            <time>1624620803</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="22" vrev="22">
-            <srcmd5>77cbb32379cbe98f56c3b05198de9f9a</srcmd5>
-            <version>unknown</version>
-            <time>1624620806</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="23" vrev="23">
-            <srcmd5>9335db31dbe84bff72c641bf0ec92011</srcmd5>
-            <version>unknown</version>
-            <time>1624620806</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="24" vrev="24">
-            <srcmd5>0638f5ddf7f630f5bb403b4bbfab2ec4</srcmd5>
-            <version>unknown</version>
-            <time>1624620812</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="25" vrev="25">
-            <srcmd5>8f47cfc6ea9cbb180c25d5530b6312fb</srcmd5>
-            <version>unknown</version>
-            <time>1624620812</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="26" vrev="26">
-            <srcmd5>fba2aaf6e0386927c29656cb5064a118</srcmd5>
-            <version>unknown</version>
-            <time>1624620820</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="27" vrev="27">
-            <srcmd5>c310d1c92f05600400237130cd9aef9f</srcmd5>
-            <version>unknown</version>
-            <time>1624620820</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="28" vrev="28">
-            <srcmd5>d4bf9318b3ad604497286d288f6e58ee</srcmd5>
-            <version>unknown</version>
-            <time>1624620822</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="29" vrev="29">
-            <srcmd5>a68d24cf68cab96ccb40fd6ebd64d188</srcmd5>
-            <version>unknown</version>
-            <time>1624620822</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="30" vrev="30">
-            <srcmd5>af20eea290696ccf29f7ff182b05cd04</srcmd5>
-            <version>unknown</version>
-            <time>1624620824</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="31" vrev="31">
-            <srcmd5>087b47e511b412641a67dfb0dde29cc8</srcmd5>
-            <version>unknown</version>
-            <time>1624620824</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="32" vrev="32">
-            <srcmd5>ceeb8058f72950af7ee4edbd5e59578f</srcmd5>
-            <version>unknown</version>
-            <time>1624620827</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="33" vrev="33">
-            <srcmd5>d338a6e463a2d06188396490bd2ac123</srcmd5>
-            <version>unknown</version>
-            <time>1624620828</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="34" vrev="34">
-            <srcmd5>787e11acd03d27552023abc5505d990e</srcmd5>
-            <version>unknown</version>
-            <time>1624620830</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="35" vrev="35">
-            <srcmd5>71f2a98ddf0bda0ae195d667661d8cd3</srcmd5>
-            <version>unknown</version>
-            <time>1624620830</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="36" vrev="36">
-            <srcmd5>63318f189aa0a1dcaa7e3a9189681d0b</srcmd5>
-            <version>unknown</version>
-            <time>1624620832</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="37" vrev="37">
-            <srcmd5>789168dbb8ebceca526a14d283656fef</srcmd5>
-            <version>unknown</version>
-            <time>1624620832</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="38" vrev="38">
-            <srcmd5>b120956913fb5c4ff040bd44690e84d1</srcmd5>
-            <version>unknown</version>
-            <time>1624620837</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="39" vrev="39">
-            <srcmd5>5ac0cdf68d506936b4dc37b24cb9c725</srcmd5>
-            <version>unknown</version>
-            <time>1624620837</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="40" vrev="40">
-            <srcmd5>28c74f5fffb596b569bfc3d7848b3e9f</srcmd5>
-            <version>unknown</version>
-            <time>1624620842</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="41" vrev="41">
-            <srcmd5>7dafafd66e7b8dfc244c5106a95b658e</srcmd5>
-            <version>unknown</version>
-            <time>1624620842</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="42" vrev="42">
-            <srcmd5>835881bc381e37b83721175e6a5efd96</srcmd5>
-            <version>unknown</version>
-            <time>1624620844</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="43" vrev="43">
-            <srcmd5>125f5231a3ff4b1ff04ecbf679862d2b</srcmd5>
-            <version>unknown</version>
-            <time>1624620844</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="44" vrev="44">
-            <srcmd5>92b0d79e6be8d31357a5e41b3c032014</srcmd5>
-            <version>unknown</version>
-            <time>1624620846</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="45" vrev="45">
-            <srcmd5>216908658b473edf733f2fd7899628c7</srcmd5>
-            <version>unknown</version>
-            <time>1624620846</time>
-            <user>unknown</user>
-          </revision>
         </revisionlist>
-  recorded_at: Fri, 25 Jun 2021 11:34:08 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:55 GMT
 - request:
     method: get
-    uri: http://backend:5352/build/home:package_test_user/_result?package=test_package&view=status
+    uri: http://backend:5352/source/home:package_test_user/test_package
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - 311f6726-e707-4111-b76e-d1c4d7c70949
+      - ab920621-a3cf-4705-80f1-06fa91db7cc2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '393'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test_package" rev="81" vrev="81" srcmd5="51df50e3267b37936548ad0ef1065a15">
+          <entry name="_config" md5="eaf10f19533a8b007cb2c993a24b86c5" size="58" mtime="1677089153"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="a94f4066aa137baf3e7cb6272b6e9bf9" size="56" mtime="1677089153"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:05:55 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - ab920621-a3cf-4705-80f1-06fa91db7cc2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '393'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test_package" rev="81" vrev="81" srcmd5="51df50e3267b37936548ad0ef1065a15">
+          <entry name="_config" md5="eaf10f19533a8b007cb2c993a24b86c5" size="58" mtime="1677089153"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="a94f4066aa137baf3e7cb6272b6e9bf9" size="56" mtime="1677089153"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:05:55 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package/_history?deleted=1&meta=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - ab920621-a3cf-4705-80f1-06fa91db7cc2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Wed, 22 Feb 2023 18:05:55 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - b0e52fe7-c9b9-467e-8d79-7b48f9a8d77c
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '393'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test_package" rev="81" vrev="81" srcmd5="51df50e3267b37936548ad0ef1065a15">
+          <entry name="_config" md5="eaf10f19533a8b007cb2c993a24b86c5" size="58" mtime="1677089153"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="a94f4066aa137baf3e7cb6272b6e9bf9" size="56" mtime="1677089153"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:05:55 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:package_test_user/_result?lastbuild=1&locallink=1&multibuild=1&package=test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - b0e52fe7-c9b9-467e-8d79-7b48f9a8d77c
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -789,7 +592,112 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Fri, 25 Jun 2021 11:34:09 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:55 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - face0389-ced5-4b63-8b0b-84b8929e8ec7
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '393'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test_package" rev="81" vrev="81" srcmd5="51df50e3267b37936548ad0ef1065a15">
+          <entry name="_config" md5="eaf10f19533a8b007cb2c993a24b86c5" size="58" mtime="1677089153"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="a94f4066aa137baf3e7cb6272b6e9bf9" size="56" mtime="1677089153"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:05:55 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:package_test_user/_result?lastbuild=1&locallink=1&multibuild=1&package=test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - face0389-ced5-4b63-8b0b-84b8929e8ec7
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 18:05:55 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:package_test_user/_result?package=test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - ed481c56-8c8f-4464-bf0f-af07c469549f
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 18:05:55 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=package_test_user
@@ -829,5 +737,5 @@ http_interactions:
           <description>test description</description>
           <url>https://test.url</url>
         </package>
-  recorded_at: Fri, 25 Jun 2021 11:34:11 GMT
-recorded_with: VCR 6.0.0
+  recorded_at: Wed, 22 Feb 2023 18:05:55 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Packages/editing_package_files/editing_an_existing_file.yml
+++ b/src/api/spec/cassettes/Packages/editing_package_files/editing_an_existing_file.yml
@@ -39,16 +39,16 @@ http_interactions:
           <description></description>
           <person userid="package_test_user" role="maintainer"/>
         </project>
-  recorded_at: Thu, 03 Nov 2022 09:44:59 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:56 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=user_41
+    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=user_44
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>No Country for Old Men</title>
-          <description>Recusandae mollitia nemo ut.</description>
+          <title>Blithe Spirit</title>
+          <description>Delectus rerum quia nam.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -69,21 +69,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '172'
+      - '159'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>No Country for Old Men</title>
-          <description>Recusandae mollitia nemo ut.</description>
+          <title>Blithe Spirit</title>
+          <description>Delectus rerum quia nam.</description>
         </package>
-  recorded_at: Thu, 03 Nov 2022 09:44:59 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:56 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_config
     body:
       encoding: UTF-8
-      string: Occaecati molestias rerum. Reprehenderit in nobis. Quis esse nemo.
+      string: Ratione velit delectus. Voluptatem odit maxime. Impedit ipsum veritatis.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -107,21 +107,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="67" vrev="67">
-          <srcmd5>73e8e671b0d5bb586596c219337a0af6</srcmd5>
+        <revision rev="82" vrev="82">
+          <srcmd5>50309306a9a914e730290fac1d5468a1</srcmd5>
           <version>unknown</version>
-          <time>1667468699</time>
+          <time>1677089156</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 03 Nov 2022 09:44:59 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:56 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Est dicta recusandae. Sed aperiam animi. Assumenda et doloribus.
+      string: Veritatis sit quia. Dolor assumenda et. Quidem distinctio numquam.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -145,15 +145,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="68" vrev="68">
-          <srcmd5>18f28a8ccfde66de595a39500509d921</srcmd5>
+        <revision rev="83" vrev="83">
+          <srcmd5>037798e3e16b9e923112ffc4421d187e</srcmd5>
           <version>unknown</version>
-          <time>1667468699</time>
+          <time>1677089156</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 03 Nov 2022 09:44:59 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:56 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/_meta?user=other_package_test_user
@@ -193,16 +193,16 @@ http_interactions:
           <description></description>
           <person userid="other_package_test_user" role="maintainer"/>
         </project>
-  recorded_at: Thu, 03 Nov 2022 09:44:59 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:56 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=user_42
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=user_45
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>Let Us Now Praise Famous Men</title>
-          <description>Eum culpa animi perferendis.</description>
+          <title>I Know Why the Caged Bird Sings</title>
+          <description>Vel nihil repellendus id.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -228,16 +228,16 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>Let Us Now Praise Famous Men</title>
-          <description>Eum culpa animi perferendis.</description>
+          <title>I Know Why the Caged Bird Sings</title>
+          <description>Vel nihil repellendus id.</description>
         </package>
-  recorded_at: Thu, 03 Nov 2022 09:44:59 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:56 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_config
     body:
       encoding: UTF-8
-      string: Et placeat iure. Et sunt temporibus. Quo quia facilis.
+      string: Laboriosam expedita aut. Ut ut inventore. Est illum vel.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -261,21 +261,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="61" vrev="61">
-          <srcmd5>10fe7bba883fa52efb592cd3d921012a</srcmd5>
+        <revision rev="75" vrev="75">
+          <srcmd5>a1c613620a572e16e6b3284c5aa5f9b8</srcmd5>
           <version>unknown</version>
-          <time>1667468699</time>
+          <time>1677089156</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 03 Nov 2022 09:44:59 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:56 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Occaecati cupiditate minima. Vitae autem aut. Quas non soluta.
+      string: Aut fugiat ex. Quibusdam animi tempore. Error voluptates porro.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -299,15 +299,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="62" vrev="62">
-          <srcmd5>fc0319b25d63a49ffba128ada653abfd</srcmd5>
+        <revision rev="76" vrev="76">
+          <srcmd5>40af937ace76a1de425a8d759388c64f</srcmd5>
           <version>unknown</version>
-          <time>1667468699</time>
+          <time>1677089157</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 03 Nov 2022 09:44:59 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:57 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/file_edit_test_package/_meta?user=package_test_user
@@ -315,8 +315,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="file_edit_test_package" project="home:package_test_user">
-          <title>Clouds of Witness</title>
-          <description>Est nobis occaecati vel.</description>
+          <title>Things Fall Apart</title>
+          <description>Repellat dolorum deserunt vel.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -337,21 +337,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '173'
+      - '179'
     body:
       encoding: UTF-8
       string: |
         <package name="file_edit_test_package" project="home:package_test_user">
-          <title>Clouds of Witness</title>
-          <description>Est nobis occaecati vel.</description>
+          <title>Things Fall Apart</title>
+          <description>Repellat dolorum deserunt vel.</description>
         </package>
-  recorded_at: Thu, 03 Nov 2022 09:45:00 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:57 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/file_edit_test_package/_config
     body:
       encoding: UTF-8
-      string: Impedit unde quod. Ea animi eum. Cupiditate debitis ab.
+      string: Placeat id pariatur. Nostrum odio asperiores. Et voluptatem corrupti.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -375,21 +375,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="8" vrev="8">
-          <srcmd5>ad3240c3b097d05df9ea6ca3947731cb</srcmd5>
+        <revision rev="6" vrev="6">
+          <srcmd5>d1cf708b73726dc47a3701216b873568</srcmd5>
           <version>unknown</version>
-          <time>1667468700</time>
+          <time>1677089158</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 03 Nov 2022 09:45:00 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:58 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/file_edit_test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Ut aut consequatur. Corrupti et nesciunt. Id est rem.
+      string: Molestiae nam perferendis. Molestiae id itaque. Eius eos aperiam.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -413,15 +413,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="9" vrev="9">
-          <srcmd5>72c67df63213d0c1bbf2de2e9e7c4400</srcmd5>
+        <revision rev="7" vrev="7">
+          <srcmd5>9c04d01ead039dd2a01b605dc8005f1c</srcmd5>
           <version>unknown</version>
-          <time>1667468700</time>
+          <time>1677089158</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 03 Nov 2022 09:45:00 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:58 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/file_edit_test_package
@@ -430,7 +430,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 4a796476-b208-400d-96e8-c6cd312f2bec
+      - 98865f2a-1e8e-4a53-854d-e0d5e3e5790e
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -453,14 +453,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="file_edit_test_package" rev="9" vrev="9" srcmd5="72c67df63213d0c1bbf2de2e9e7c4400">
-          <entry name="_config" md5="27dac7eae51d6b91850c5730647d529a" size="55" mtime="1667468700"/>
-          <entry name="somefile.txt" md5="4ea31f0f3ebc275fb495ae7414962207" size="53" mtime="1667468700"/>
+        <directory name="file_edit_test_package" rev="7" vrev="7" srcmd5="9c04d01ead039dd2a01b605dc8005f1c">
+          <entry name="_config" md5="e06bca0f5e82763b49387df3c3092d95" size="69" mtime="1677089157"/>
+          <entry name="somefile.txt" md5="52ee666775eeea71a40fe8306596e074" size="65" mtime="1677089158"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:45:00 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:58 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:package_test_user/file_edit_test_package?expand=1&rev=9
+    uri: http://backend:5352/source/home:package_test_user/file_edit_test_package?expand=1&rev=7
     body:
       encoding: US-ASCII
       string: ''
@@ -487,56 +487,20 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="file_edit_test_package" rev="9" vrev="9" srcmd5="72c67df63213d0c1bbf2de2e9e7c4400">
-          <entry name="_config" md5="27dac7eae51d6b91850c5730647d529a" size="55" mtime="1667468700"/>
-          <entry name="somefile.txt" md5="4ea31f0f3ebc275fb495ae7414962207" size="53" mtime="1667468700"/>
+        <directory name="file_edit_test_package" rev="7" vrev="7" srcmd5="9c04d01ead039dd2a01b605dc8005f1c">
+          <entry name="_config" md5="e06bca0f5e82763b49387df3c3092d95" size="69" mtime="1677089157"/>
+          <entry name="somefile.txt" md5="52ee666775eeea71a40fe8306596e074" size="65" mtime="1677089158"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:45:00 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:58 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:package_test_user/file_edit_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Request-Id:
-      - 4a796476-b208-400d-96e8-c6cd312f2bec
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '307'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="file_edit_test_package" rev="9" vrev="9" srcmd5="72c67df63213d0c1bbf2de2e9e7c4400">
-          <entry name="_config" md5="27dac7eae51d6b91850c5730647d529a" size="55" mtime="1667468700"/>
-          <entry name="somefile.txt" md5="4ea31f0f3ebc275fb495ae7414962207" size="53" mtime="1667468700"/>
-        </directory>
-  recorded_at: Thu, 03 Nov 2022 09:45:00 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/file_edit_test_package
+    uri: http://backend:5352/source/home:package_test_user/file_edit_test_package/_history?deleted=1&meta=1&rev=7
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - 4a796476-b208-400d-96e8-c6cd312f2bec
+      - 98865f2a-1e8e-4a53-854d-e0d5e3e5790e
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -555,101 +519,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '307'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="file_edit_test_package" rev="9" vrev="9" srcmd5="72c67df63213d0c1bbf2de2e9e7c4400">
-          <entry name="_config" md5="27dac7eae51d6b91850c5730647d529a" size="55" mtime="1667468700"/>
-          <entry name="somefile.txt" md5="4ea31f0f3ebc275fb495ae7414962207" size="53" mtime="1667468700"/>
-        </directory>
-  recorded_at: Thu, 03 Nov 2022 09:45:00 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/file_edit_test_package/_history
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '1699'
+      - '31'
     body:
       encoding: UTF-8
       string: |
         <revisionlist>
-          <revision rev="1" vrev="1">
-            <srcmd5>cdc2043a66d6bb78a16be4246bfe9929</srcmd5>
-            <version>unknown</version>
-            <time>1667463245</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="2" vrev="2">
-            <srcmd5>d845337daad29a9e54c9f6a164a83d74</srcmd5>
-            <version>unknown</version>
-            <time>1667463245</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="3" vrev="3">
-            <srcmd5>6cb12d48f010aa3c9fc13ca43b0da470</srcmd5>
-            <version>unknown</version>
-            <time>1667463246</time>
-            <user>package_test_user</user>
-          </revision>
-          <revision rev="4" vrev="4">
-            <srcmd5>664a053e0901ba49ac7f757eb780676a</srcmd5>
-            <version>unknown</version>
-            <time>1667464754</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="5" vrev="5">
-            <srcmd5>51c62124e376d9c2fecd03a871b528cc</srcmd5>
-            <version>unknown</version>
-            <time>1667464754</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="6" vrev="6">
-            <srcmd5>664a053e0901ba49ac7f757eb780676a</srcmd5>
-            <version>unknown</version>
-            <time>1667464755</time>
-            <user>package_test_user</user>
-          </revision>
-          <revision rev="7" vrev="7">
-            <srcmd5>664a053e0901ba49ac7f757eb780676a</srcmd5>
-            <version>unknown</version>
-            <time>1667467828</time>
-            <user>package_test_user</user>
-          </revision>
-          <revision rev="8" vrev="8">
-            <srcmd5>ad3240c3b097d05df9ea6ca3947731cb</srcmd5>
-            <version>unknown</version>
-            <time>1667468700</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="9" vrev="9">
-            <srcmd5>72c67df63213d0c1bbf2de2e9e7c4400</srcmd5>
-            <version>unknown</version>
-            <time>1667468700</time>
-            <user>unknown</user>
-          </revision>
         </revisionlist>
-  recorded_at: Thu, 03 Nov 2022 09:45:00 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:58 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/file_edit_test_package
@@ -658,7 +534,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 47da6785-3680-440f-9309-a7db8cf289c7
+      - 98865f2a-1e8e-4a53-854d-e0d5e3e5790e
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -681,11 +557,117 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="file_edit_test_package" rev="9" vrev="9" srcmd5="72c67df63213d0c1bbf2de2e9e7c4400">
-          <entry name="_config" md5="27dac7eae51d6b91850c5730647d529a" size="55" mtime="1667468700"/>
-          <entry name="somefile.txt" md5="4ea31f0f3ebc275fb495ae7414962207" size="53" mtime="1667468700"/>
+        <directory name="file_edit_test_package" rev="7" vrev="7" srcmd5="9c04d01ead039dd2a01b605dc8005f1c">
+          <entry name="_config" md5="e06bca0f5e82763b49387df3c3092d95" size="69" mtime="1677089157"/>
+          <entry name="somefile.txt" md5="52ee666775eeea71a40fe8306596e074" size="65" mtime="1677089158"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:45:00 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:58 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/file_edit_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 98865f2a-1e8e-4a53-854d-e0d5e3e5790e
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '307'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="file_edit_test_package" rev="7" vrev="7" srcmd5="9c04d01ead039dd2a01b605dc8005f1c">
+          <entry name="_config" md5="e06bca0f5e82763b49387df3c3092d95" size="69" mtime="1677089157"/>
+          <entry name="somefile.txt" md5="52ee666775eeea71a40fe8306596e074" size="65" mtime="1677089158"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:05:58 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/file_edit_test_package/_history?deleted=1&meta=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 98865f2a-1e8e-4a53-854d-e0d5e3e5790e
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Wed, 22 Feb 2023 18:05:58 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/file_edit_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - c4aee372-e0f8-4824-ab7c-af10a757adde
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '307'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="file_edit_test_package" rev="7" vrev="7" srcmd5="9c04d01ead039dd2a01b605dc8005f1c">
+          <entry name="_config" md5="e06bca0f5e82763b49387df3c3092d95" size="69" mtime="1677089157"/>
+          <entry name="somefile.txt" md5="52ee666775eeea71a40fe8306596e074" size="65" mtime="1677089158"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:05:58 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:package_test_user/_result?lastbuild=1&locallink=1&multibuild=1&package=file_edit_test_package&view=status
@@ -694,7 +676,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 47da6785-3680-440f-9309-a7db8cf289c7
+      - c4aee372-e0f8-4824-ab7c-af10a757adde
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -719,7 +701,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:45:00 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:58 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/file_edit_test_package
@@ -728,7 +710,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - ecb8fe2c-0a18-4ecd-9e65-6f7b28057cc9
+      - 69ba4e50-c3e7-4517-bc32-824569937bf9
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -751,11 +733,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="file_edit_test_package" rev="9" vrev="9" srcmd5="72c67df63213d0c1bbf2de2e9e7c4400">
-          <entry name="_config" md5="27dac7eae51d6b91850c5730647d529a" size="55" mtime="1667468700"/>
-          <entry name="somefile.txt" md5="4ea31f0f3ebc275fb495ae7414962207" size="53" mtime="1667468700"/>
+        <directory name="file_edit_test_package" rev="7" vrev="7" srcmd5="9c04d01ead039dd2a01b605dc8005f1c">
+          <entry name="_config" md5="e06bca0f5e82763b49387df3c3092d95" size="69" mtime="1677089157"/>
+          <entry name="somefile.txt" md5="52ee666775eeea71a40fe8306596e074" size="65" mtime="1677089158"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:45:00 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:58 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:package_test_user/_result?lastbuild=1&locallink=1&multibuild=1&package=file_edit_test_package&view=status
@@ -764,7 +746,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - ecb8fe2c-0a18-4ecd-9e65-6f7b28057cc9
+      - 69ba4e50-c3e7-4517-bc32-824569937bf9
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -789,7 +771,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:45:00 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:58 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:package_test_user/_result?package=file_edit_test_package&view=status
@@ -798,7 +780,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 514674da-3c72-4c87-b2f5-e0960198a7e8
+      - 421e0a7d-cf82-4a0a-bf98-4c06847cd9b1
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -823,7 +805,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Thu, 03 Nov 2022 09:45:00 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:58 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/file_edit_test_package?expand=1
@@ -853,11 +835,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="file_edit_test_package" rev="9" vrev="9" srcmd5="72c67df63213d0c1bbf2de2e9e7c4400">
-          <entry name="_config" md5="27dac7eae51d6b91850c5730647d529a" size="55" mtime="1667468700"/>
-          <entry name="somefile.txt" md5="4ea31f0f3ebc275fb495ae7414962207" size="53" mtime="1667468700"/>
+        <directory name="file_edit_test_package" rev="7" vrev="7" srcmd5="9c04d01ead039dd2a01b605dc8005f1c">
+          <entry name="_config" md5="e06bca0f5e82763b49387df3c3092d95" size="69" mtime="1677089157"/>
+          <entry name="somefile.txt" md5="52ee666775eeea71a40fe8306596e074" size="65" mtime="1677089158"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:45:00 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:58 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/file_edit_test_package/somefile.txt?expand=1
@@ -879,15 +861,15 @@ http_interactions:
       Content-Type:
       - application/octet-stream
       Content-Length:
-      - '53'
+      - '65'
       Cache-Control:
       - no-cache
       Connection:
       - close
     body:
       encoding: UTF-8
-      string: Ut aut consequatur. Corrupti et nesciunt. Id est rem.
-  recorded_at: Thu, 03 Nov 2022 09:45:00 GMT
+      string: Molestiae nam perferendis. Molestiae id itaque. Eius eos aperiam.
+  recorded_at: Wed, 22 Feb 2023 18:05:58 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/file_edit_test_package
@@ -896,7 +878,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 99f37864-ee4a-4285-8939-0e3a79de32b6
+      - 6d350dc6-9b7f-48f9-9592-5d29f0533e8c
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -919,11 +901,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="file_edit_test_package" rev="9" vrev="9" srcmd5="72c67df63213d0c1bbf2de2e9e7c4400">
-          <entry name="_config" md5="27dac7eae51d6b91850c5730647d529a" size="55" mtime="1667468700"/>
-          <entry name="somefile.txt" md5="4ea31f0f3ebc275fb495ae7414962207" size="53" mtime="1667468700"/>
+        <directory name="file_edit_test_package" rev="7" vrev="7" srcmd5="9c04d01ead039dd2a01b605dc8005f1c">
+          <entry name="_config" md5="e06bca0f5e82763b49387df3c3092d95" size="69" mtime="1677089157"/>
+          <entry name="somefile.txt" md5="52ee666775eeea71a40fe8306596e074" size="65" mtime="1677089158"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:45:01 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:58 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/file_edit_test_package/somefile.txt?comment=&user=package_test_user
@@ -932,7 +914,7 @@ http_interactions:
       string: added some new text
     headers:
       X-Request-Id:
-      - 99f37864-ee4a-4285-8939-0e3a79de32b6
+      - 6d350dc6-9b7f-48f9-9592-5d29f0533e8c
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -951,19 +933,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '219'
+      - '217'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="10" vrev="10">
-          <srcmd5>ad3240c3b097d05df9ea6ca3947731cb</srcmd5>
+        <revision rev="8" vrev="8">
+          <srcmd5>8a25d5eb8966401d87a60f8802785a23</srcmd5>
           <version>unknown</version>
-          <time>1667468701</time>
+          <time>1677089158</time>
           <user>package_test_user</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 03 Nov 2022 09:45:01 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:58 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/file_edit_test_package/_meta?user=package_test_user
@@ -971,8 +953,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="file_edit_test_package" project="home:package_test_user">
-          <title>Clouds of Witness</title>
-          <description>Est nobis occaecati vel.</description>
+          <title>Things Fall Apart</title>
+          <description>Repellat dolorum deserunt vel.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -993,15 +975,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '173'
+      - '179'
     body:
       encoding: UTF-8
       string: |
         <package name="file_edit_test_package" project="home:package_test_user">
-          <title>Clouds of Witness</title>
-          <description>Est nobis occaecati vel.</description>
+          <title>Things Fall Apart</title>
+          <description>Repellat dolorum deserunt vel.</description>
         </package>
-  recorded_at: Thu, 03 Nov 2022 09:45:01 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:59 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/file_edit_test_package
@@ -1027,15 +1009,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '309'
+      - '307'
     body:
       encoding: UTF-8
       string: |
-        <directory name="file_edit_test_package" rev="10" vrev="10" srcmd5="ad3240c3b097d05df9ea6ca3947731cb">
-          <entry name="_config" md5="27dac7eae51d6b91850c5730647d529a" size="55" mtime="1667468700"/>
-          <entry name="somefile.txt" md5="c2dcd3738b5c9e18215917e07a27d974" size="19" mtime="1667463246"/>
+        <directory name="file_edit_test_package" rev="8" vrev="8" srcmd5="8a25d5eb8966401d87a60f8802785a23">
+          <entry name="_config" md5="e06bca0f5e82763b49387df3c3092d95" size="69" mtime="1677089157"/>
+          <entry name="somefile.txt" md5="c2dcd3738b5c9e18215917e07a27d974" size="19" mtime="1677064888"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:45:01 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:59 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/file_edit_test_package?view=info
@@ -1044,7 +1026,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 99f37864-ee4a-4285-8939-0e3a79de32b6
+      - 6d350dc6-9b7f-48f9-9592-5d29f0533e8c
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1063,14 +1045,14 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '242'
+      - '240'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="file_edit_test_package" rev="10" vrev="10" srcmd5="ad3240c3b097d05df9ea6ca3947731cb" verifymd5="ad3240c3b097d05df9ea6ca3947731cb">
+        <sourceinfo package="file_edit_test_package" rev="8" vrev="8" srcmd5="8a25d5eb8966401d87a60f8802785a23" verifymd5="8a25d5eb8966401d87a60f8802785a23">
           <error>bad build configuration, no build type defined or detected</error>
         </sourceinfo>
-  recorded_at: Thu, 03 Nov 2022 09:45:01 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:59 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/file_edit_test_package
@@ -1079,7 +1061,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 99f37864-ee4a-4285-8939-0e3a79de32b6
+      - 6d350dc6-9b7f-48f9-9592-5d29f0533e8c
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1098,15 +1080,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '309'
+      - '307'
     body:
       encoding: UTF-8
       string: |
-        <directory name="file_edit_test_package" rev="10" vrev="10" srcmd5="ad3240c3b097d05df9ea6ca3947731cb">
-          <entry name="_config" md5="27dac7eae51d6b91850c5730647d529a" size="55" mtime="1667468700"/>
-          <entry name="somefile.txt" md5="c2dcd3738b5c9e18215917e07a27d974" size="19" mtime="1667463246"/>
+        <directory name="file_edit_test_package" rev="8" vrev="8" srcmd5="8a25d5eb8966401d87a60f8802785a23">
+          <entry name="_config" md5="e06bca0f5e82763b49387df3c3092d95" size="69" mtime="1677089157"/>
+          <entry name="somefile.txt" md5="c2dcd3738b5c9e18215917e07a27d974" size="19" mtime="1677064888"/>
         </directory>
-  recorded_at: Thu, 03 Nov 2022 09:45:01 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:59 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:package_test_user/file_edit_test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -1134,18 +1116,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '351'
+      - '350'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="680b9e3c90bfb100d2eeb65d93886079">
+        <sourcediff key="1ad8f5001c57aff7991d68ff20b340eb">
           <old project="home:package_test_user" package="file_edit_test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:package_test_user" package="file_edit_test_package" rev="10" srcmd5="ad3240c3b097d05df9ea6ca3947731cb"/>
+          <new project="home:package_test_user" package="file_edit_test_package" rev="8" srcmd5="8a25d5eb8966401d87a60f8802785a23"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 03 Nov 2022 09:45:01 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:59 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/file_edit_test_package/somefile.txt
@@ -1175,5 +1157,5 @@ http_interactions:
     body:
       encoding: UTF-8
       string: added some new text
-  recorded_at: Thu, 03 Nov 2022 09:45:01 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:59 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Packages/existing_requests/see_a_request.yml
+++ b/src/api/spec/cassettes/Packages/existing_requests/see_a_request.yml
@@ -39,16 +39,16 @@ http_interactions:
           <description></description>
           <person userid="package_test_user" role="maintainer"/>
         </project>
-  recorded_at: Fri, 25 Jun 2021 11:33:32 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:36 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=user_45
+    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=user_9
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>That Hideous Strength</title>
-          <description>Assumenda sed eos neque.</description>
+          <title>The Lathe of Heaven</title>
+          <description>Nostrum voluptate voluptas corporis.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -69,21 +69,22 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '177'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>That Hideous Strength</title>
-          <description>Assumenda sed eos neque.</description>
+          <title>The Lathe of Heaven</title>
+          <description>Nostrum voluptate voluptas corporis.</description>
         </package>
-  recorded_at: Fri, 25 Jun 2021 11:33:32 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:36 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_config
     body:
       encoding: UTF-8
-      string: Eius atque amet. Debitis amet et. Molestias mollitia ut.
+      string: Quia fugiat perferendis. Veritatis necessitatibus vero. Quisquam aut
+        quidem.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -107,21 +108,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="24" vrev="24">
-          <srcmd5>0638f5ddf7f630f5bb403b4bbfab2ec4</srcmd5>
+        <revision rev="72" vrev="72">
+          <srcmd5>220b74d18d3ebe3ad528a49c49cda346</srcmd5>
           <version>unknown</version>
-          <time>1624620812</time>
+          <time>1677089076</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Fri, 25 Jun 2021 11:33:32 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:36 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Accusamus nesciunt aliquid. Officiis nulla in. Dolorem quasi deserunt.
+      string: Et accusamus adipisci. Et impedit recusandae. Sint aspernatur corrupti.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -145,15 +146,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="25" vrev="25">
-          <srcmd5>8f47cfc6ea9cbb180c25d5530b6312fb</srcmd5>
+        <revision rev="73" vrev="73">
+          <srcmd5>c3b4d7b28507f991ff3c3c28309ffd60</srcmd5>
           <version>unknown</version>
-          <time>1624620812</time>
+          <time>1677089076</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Fri, 25 Jun 2021 11:33:32 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:36 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/_meta?user=other_package_test_user
@@ -193,16 +194,168 @@ http_interactions:
           <description></description>
           <person userid="other_package_test_user" role="maintainer"/>
         </project>
-  recorded_at: Fri, 25 Jun 2021 11:33:32 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:36 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=user_46
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=user_10
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>The Moving Toyshop</title>
-          <description>Sint fugiat dolores nemo.</description>
+          <title>To Sail Beyond the Sunset</title>
+          <description>Repellat dolor autem quaerat.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '189'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_package_test_user">
+          <title>To Sail Beyond the Sunset</title>
+          <description>Repellat dolor autem quaerat.</description>
+        </package>
+  recorded_at: Wed, 22 Feb 2023 18:04:36 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_config
+    body:
+      encoding: UTF-8
+      string: Et eum error. Assumenda recusandae dolorum. Et quia aut.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="65" vrev="65">
+          <srcmd5>81981a9e155030ae356aa29d045e725a</srcmd5>
+          <version>unknown</version>
+          <time>1677089076</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 22 Feb 2023 18:04:36 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Non autem aliquam. Minima nihil sit. Aut quos rerum.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="66" vrev="66">
+          <srcmd5>c2ff914e704833f07171236535deff6a</srcmd5>
+          <version>unknown</version>
+          <time>1677089076</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 22 Feb 2023 18:04:36 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/source_project/_meta?user=user_11
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="source_project">
+          <title>Dulce et Decorum Est</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '111'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="source_project">
+          <title>Dulce et Decorum Est</title>
+          <description></description>
+        </project>
+  recorded_at: Wed, 22 Feb 2023 18:04:37 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/source_project/package_1/_meta?user=user_12
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_1" project="source_project">
+          <title>Let Us Now Praise Famous Men</title>
+          <description>Tempore reprehenderit praesentium enim.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -227,135 +380,20 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <package name="branch_test_package" project="home:other_package_test_user">
-          <title>The Moving Toyshop</title>
-          <description>Sint fugiat dolores nemo.</description>
+        <package name="package_1" project="source_project">
+          <title>Let Us Now Praise Famous Men</title>
+          <description>Tempore reprehenderit praesentium enim.</description>
         </package>
-  recorded_at: Fri, 25 Jun 2021 11:33:32 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:37 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_config
-    body:
-      encoding: UTF-8
-      string: Qui accusamus exercitationem. Earum quis consequatur. Ipsam veritatis
-        voluptatum.
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '209'
-    body:
-      encoding: UTF-8
-      string: |
-        <revision rev="23" vrev="23">
-          <srcmd5>7c76cb90c1f501585dc638d88f2f091f</srcmd5>
-          <version>unknown</version>
-          <time>1624620812</time>
-          <user>unknown</user>
-          <comment></comment>
-          <requestid/>
-        </revision>
-  recorded_at: Fri, 25 Jun 2021 11:33:32 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/somefile.txt
-    body:
-      encoding: UTF-8
-      string: Quod doloribus error. Et vero voluptatibus. Fugit placeat ut.
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '209'
-    body:
-      encoding: UTF-8
-      string: |
-        <revision rev="24" vrev="24">
-          <srcmd5>4571a9b3f8b863b2dd52de2611a1ca04</srcmd5>
-          <version>unknown</version>
-          <time>1624620812</time>
-          <user>unknown</user>
-          <comment></comment>
-          <requestid/>
-        </revision>
-  recorded_at: Fri, 25 Jun 2021 11:33:32 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/source_project/_meta?user=user_47
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="source_project">
-          <title>The Painted Veil</title>
-          <description/>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '107'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="source_project">
-          <title>The Painted Veil</title>
-          <description></description>
-        </project>
-  recorded_at: Fri, 25 Jun 2021 11:33:32 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/source_project/package_1/_meta?user=user_48
+    uri: http://backend:5352/source/source_project/package_1/_meta?user=user_12
     body:
       encoding: UTF-8
       string: |
         <package name="package_1" project="source_project">
-          <title>Cabbages and Kings</title>
-          <description>Nostrum id asperiores necessitatibus.</description>
+          <title>Let Us Now Praise Famous Men</title>
+          <description>Tempore reprehenderit praesentium enim.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -376,452 +414,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '166'
+      - '178'
     body:
       encoding: UTF-8
       string: |
         <package name="package_1" project="source_project">
-          <title>Cabbages and Kings</title>
-          <description>Nostrum id asperiores necessitatibus.</description>
+          <title>Let Us Now Praise Famous Men</title>
+          <description>Tempore reprehenderit praesentium enim.</description>
         </package>
-  recorded_at: Fri, 25 Jun 2021 11:33:32 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/source_project/package_1/_meta?user=user_48
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="package_1" project="source_project">
-          <title>Cabbages and Kings</title>
-          <description>Nostrum id asperiores necessitatibus.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '166'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="package_1" project="source_project">
-          <title>Cabbages and Kings</title>
-          <description>Nostrum id asperiores necessitatibus.</description>
-        </package>
-  recorded_at: Fri, 25 Jun 2021 11:33:32 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Request-Id:
-      - f277e172-022f-4191-8385-7892f4459b4f
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '393'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="test_package" rev="25" vrev="25" srcmd5="8f47cfc6ea9cbb180c25d5530b6312fb">
-          <entry name="_config" md5="66469fae2a338c0b90fec0b03428b6fc" size="56" mtime="1624620812"/>
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1624620688"/>
-          <entry name="somefile.txt" md5="561837058d2864a72730dc0b67cff8e6" size="70" mtime="1624620812"/>
-        </directory>
-  recorded_at: Fri, 25 Jun 2021 11:33:33 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package?expand=1&rev=25
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '393'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="test_package" rev="25" vrev="25" srcmd5="8f47cfc6ea9cbb180c25d5530b6312fb">
-          <entry name="_config" md5="66469fae2a338c0b90fec0b03428b6fc" size="56" mtime="1624620812"/>
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1624620688"/>
-          <entry name="somefile.txt" md5="561837058d2864a72730dc0b67cff8e6" size="70" mtime="1624620812"/>
-        </directory>
-  recorded_at: Fri, 25 Jun 2021 11:33:33 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Request-Id:
-      - f277e172-022f-4191-8385-7892f4459b4f
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '393'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="test_package" rev="25" vrev="25" srcmd5="8f47cfc6ea9cbb180c25d5530b6312fb">
-          <entry name="_config" md5="66469fae2a338c0b90fec0b03428b6fc" size="56" mtime="1624620812"/>
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1624620688"/>
-          <entry name="somefile.txt" md5="561837058d2864a72730dc0b67cff8e6" size="70" mtime="1624620812"/>
-        </directory>
-  recorded_at: Fri, 25 Jun 2021 11:33:33 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Request-Id:
-      - f277e172-022f-4191-8385-7892f4459b4f
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '393'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="test_package" rev="25" vrev="25" srcmd5="8f47cfc6ea9cbb180c25d5530b6312fb">
-          <entry name="_config" md5="66469fae2a338c0b90fec0b03428b6fc" size="56" mtime="1624620812"/>
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1624620688"/>
-          <entry name="somefile.txt" md5="561837058d2864a72730dc0b67cff8e6" size="70" mtime="1624620812"/>
-        </directory>
-  recorded_at: Fri, 25 Jun 2021 11:33:33 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package/_history
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '4623'
-    body:
-      encoding: UTF-8
-      string: |
-        <revisionlist>
-          <revision rev="1" vrev="1">
-            <srcmd5>a7feca4b99d529ab106b6666f98a5d5a</srcmd5>
-            <version>unknown</version>
-            <time>1624620657</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="2" vrev="2">
-            <srcmd5>11bc7bc10a1ea1609de8a814bef6ef24</srcmd5>
-            <version>unknown</version>
-            <time>1624620657</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="3" vrev="3">
-            <srcmd5>ec9a3f3c992577783f0f4ed7876c79f3</srcmd5>
-            <version>unknown</version>
-            <time>1624620670</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="4" vrev="4">
-            <srcmd5>ff563efe05eba8ca10caba706f5a7a05</srcmd5>
-            <version>unknown</version>
-            <time>1624620670</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="5" vrev="5">
-            <srcmd5>1919e65dd94439ce8046297a51deba51</srcmd5>
-            <version>unknown</version>
-            <time>1624620678</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="6" vrev="6">
-            <srcmd5>38020a66a90d7871c8a30222b18d9672</srcmd5>
-            <version>unknown</version>
-            <time>1624620678</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="7" vrev="7">
-            <srcmd5>7a6fe3aa87ff6c50313564b157278a11</srcmd5>
-            <version>unknown</version>
-            <time>1624620684</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="8" vrev="8">
-            <srcmd5>dff72a268ab90b0a16143afc79b8eb23</srcmd5>
-            <version>unknown</version>
-            <time>1624620684</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="9" vrev="9">
-            <srcmd5>63e12210830bf9ce362f78797ba011e1</srcmd5>
-            <version>unknown</version>
-            <time>1624620688</time>
-            <user>package_test_user</user>
-          </revision>
-          <revision rev="10" vrev="10">
-            <srcmd5>367335854550b857232c9a2721cb7dd2</srcmd5>
-            <version>unknown</version>
-            <time>1624620690</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="11" vrev="11">
-            <srcmd5>538b80692b39d509774c240cada1049a</srcmd5>
-            <version>unknown</version>
-            <time>1624620690</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="12" vrev="12">
-            <srcmd5>753964ef08fa4a8c7bd7cadc888e14e6</srcmd5>
-            <version>unknown</version>
-            <time>1624620692</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="13" vrev="13">
-            <srcmd5>c5b1f840a697d26d516ee9862ee820ea</srcmd5>
-            <version>unknown</version>
-            <time>1624620692</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="14" vrev="14">
-            <srcmd5>c22f11a4da0f6c1b22a3f602ba221337</srcmd5>
-            <version>unknown</version>
-            <time>1624620694</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="15" vrev="15">
-            <srcmd5>63487802ea076af50fea42c469aedf79</srcmd5>
-            <version>unknown</version>
-            <time>1624620694</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="16" vrev="16">
-            <srcmd5>2349da763188d72be50090e4257898df</srcmd5>
-            <version>unknown</version>
-            <time>1624620703</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="17" vrev="17">
-            <srcmd5>f4733c5074a7c63ddf192d0d03ce427e</srcmd5>
-            <version>unknown</version>
-            <time>1624620703</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="18" vrev="18">
-            <srcmd5>54dc2e2080f3efdce7f5f09915fb32e2</srcmd5>
-            <version>unknown</version>
-            <time>1624620801</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="19" vrev="19">
-            <srcmd5>154771f7d36cafbcffc792b89a91f158</srcmd5>
-            <version>unknown</version>
-            <time>1624620801</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="20" vrev="20">
-            <srcmd5>f73851ae8824a8390c5e9124dbcb90d4</srcmd5>
-            <version>unknown</version>
-            <time>1624620803</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="21" vrev="21">
-            <srcmd5>93bde33fce2f50ad0aca9c2b68953b54</srcmd5>
-            <version>unknown</version>
-            <time>1624620803</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="22" vrev="22">
-            <srcmd5>77cbb32379cbe98f56c3b05198de9f9a</srcmd5>
-            <version>unknown</version>
-            <time>1624620806</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="23" vrev="23">
-            <srcmd5>9335db31dbe84bff72c641bf0ec92011</srcmd5>
-            <version>unknown</version>
-            <time>1624620806</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="24" vrev="24">
-            <srcmd5>0638f5ddf7f630f5bb403b4bbfab2ec4</srcmd5>
-            <version>unknown</version>
-            <time>1624620812</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="25" vrev="25">
-            <srcmd5>8f47cfc6ea9cbb180c25d5530b6312fb</srcmd5>
-            <version>unknown</version>
-            <time>1624620812</time>
-            <user>unknown</user>
-          </revision>
-        </revisionlist>
-  recorded_at: Fri, 25 Jun 2021 11:33:33 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:package_test_user/_result?package=test_package&view=status
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Request-Id:
-      - 5f3b20aa-9531-442b-a90d-03c72d4a1a1a
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '55'
-    body:
-      encoding: UTF-8
-      string: '<resultlist state="00000000000000000000000000000000"/>
-
-'
-  recorded_at: Fri, 25 Jun 2021 11:33:36 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Request-Id:
-      - d2ed1761-8689-4fd4-a792-2662f0c2ad78
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '393'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="test_package" rev="25" vrev="25" srcmd5="8f47cfc6ea9cbb180c25d5530b6312fb">
-          <entry name="_config" md5="66469fae2a338c0b90fec0b03428b6fc" size="56" mtime="1624620812"/>
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1624620688"/>
-          <entry name="somefile.txt" md5="561837058d2864a72730dc0b67cff8e6" size="70" mtime="1624620812"/>
-        </directory>
-  recorded_at: Fri, 25 Jun 2021 11:33:38 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:37 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/package_1
@@ -829,8 +430,6 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      X-Request-Id:
-      - 5c3c9078-6c22-498b-b5d0-ff174a6e438f
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -855,7 +454,7 @@ http_interactions:
       string: |
         <directory name="package_1" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Fri, 25 Jun 2021 11:33:38 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:37 GMT
 - request:
     method: post
     uri: http://backend:5352/source/source_project/package_1?cmd=diff&expand=1&filelimit=10000&opackage=test_package&oproject=home:package_test_user&tarlimit=10000&view=xml&withissues=1
@@ -865,8 +464,6 @@ http_interactions:
     headers:
       Content-Type:
       - application/octet-stream
-      X-Request-Id:
-      - 5c3c9078-6c22-498b-b5d0-ff174a6e438f
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -885,18 +482,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '991'
+      - '1012'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="d3b75160b4aff6f1ba75b507f0ef54c9">
-          <old project="home:package_test_user" package="test_package" rev="25" srcmd5="8f47cfc6ea9cbb180c25d5530b6312fb"/>
+        <sourcediff key="4709e34ee973a72c900f40b56a3ad4ed">
+          <old project="home:package_test_user" package="test_package" rev="73" srcmd5="c3b4d7b28507f991ff3c3c28309ffd60"/>
           <new project="source_project" package="package_1" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files>
             <file state="deleted">
-              <old name="_config" md5="66469fae2a338c0b90fec0b03428b6fc" size="56"/>
+              <old name="_config" md5="e40d404906ca32ad3dcd9a760d780fb5" size="76"/>
               <diff lines="3">@@ -1,1 +0,0 @@
-        -Eius atque amet. Debitis amet et. Molestias mollitia ut.
+        -Quia fugiat perferendis. Veritatis necessitatibus vero. Quisquam aut quidem.
         \ No newline at end of file
         </diff>
             </file>
@@ -905,9 +502,9 @@ http_interactions:
               <diff lines="0"></diff>
             </file>
             <file state="deleted">
-              <old name="somefile.txt" md5="561837058d2864a72730dc0b67cff8e6" size="70"/>
+              <old name="somefile.txt" md5="2da982dd2dc454fc27c5a0b02eae1a03" size="71"/>
               <diff lines="3">@@ -1,1 +0,0 @@
-        -Accusamus nesciunt aliquid. Officiis nulla in. Dolorem quasi deserunt.
+        -Et accusamus adipisci. Et impedit recusandae. Sint aspernatur corrupti.
         \ No newline at end of file
         </diff>
             </file>
@@ -915,7 +512,7 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Fri, 25 Jun 2021 11:33:38 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:37 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package
@@ -924,7 +521,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 5c3c9078-6c22-498b-b5d0-ff174a6e438f
+      - 1cf5aa8b-713b-40a9-bcea-365c378a664d
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -947,10 +544,494 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="25" vrev="25" srcmd5="8f47cfc6ea9cbb180c25d5530b6312fb">
-          <entry name="_config" md5="66469fae2a338c0b90fec0b03428b6fc" size="56" mtime="1624620812"/>
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1624620688"/>
-          <entry name="somefile.txt" md5="561837058d2864a72730dc0b67cff8e6" size="70" mtime="1624620812"/>
+        <directory name="test_package" rev="73" vrev="73" srcmd5="c3b4d7b28507f991ff3c3c28309ffd60">
+          <entry name="_config" md5="e40d404906ca32ad3dcd9a760d780fb5" size="76" mtime="1677089076"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="2da982dd2dc454fc27c5a0b02eae1a03" size="71" mtime="1677089076"/>
         </directory>
-  recorded_at: Fri, 25 Jun 2021 11:33:38 GMT
-recorded_with: VCR 6.0.0
+  recorded_at: Wed, 22 Feb 2023 18:04:38 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package?expand=1&rev=73
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '393'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test_package" rev="73" vrev="73" srcmd5="c3b4d7b28507f991ff3c3c28309ffd60">
+          <entry name="_config" md5="e40d404906ca32ad3dcd9a760d780fb5" size="76" mtime="1677089076"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="2da982dd2dc454fc27c5a0b02eae1a03" size="71" mtime="1677089076"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:04:38 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package/_history?deleted=1&meta=1&rev=73
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 1cf5aa8b-713b-40a9-bcea-365c378a664d
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Wed, 22 Feb 2023 18:04:38 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 1cf5aa8b-713b-40a9-bcea-365c378a664d
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '393'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test_package" rev="73" vrev="73" srcmd5="c3b4d7b28507f991ff3c3c28309ffd60">
+          <entry name="_config" md5="e40d404906ca32ad3dcd9a760d780fb5" size="76" mtime="1677089076"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="2da982dd2dc454fc27c5a0b02eae1a03" size="71" mtime="1677089076"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:04:38 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 1cf5aa8b-713b-40a9-bcea-365c378a664d
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '393'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test_package" rev="73" vrev="73" srcmd5="c3b4d7b28507f991ff3c3c28309ffd60">
+          <entry name="_config" md5="e40d404906ca32ad3dcd9a760d780fb5" size="76" mtime="1677089076"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="2da982dd2dc454fc27c5a0b02eae1a03" size="71" mtime="1677089076"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:04:38 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package/_history?deleted=1&meta=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 1cf5aa8b-713b-40a9-bcea-365c378a664d
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Wed, 22 Feb 2023 18:04:38 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - f7e0099e-5e78-41a8-98cb-3674fc7b5030
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '393'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test_package" rev="73" vrev="73" srcmd5="c3b4d7b28507f991ff3c3c28309ffd60">
+          <entry name="_config" md5="e40d404906ca32ad3dcd9a760d780fb5" size="76" mtime="1677089076"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="2da982dd2dc454fc27c5a0b02eae1a03" size="71" mtime="1677089076"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:04:38 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:package_test_user/_result?lastbuild=1&locallink=1&multibuild=1&package=test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - f7e0099e-5e78-41a8-98cb-3674fc7b5030
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 18:04:47 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:package_test_user/_result?package=test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 2914b87d-94f6-469e-8425-ec2e3c2c6f96
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 18:04:47 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - f167f67d-cd3d-4378-91fe-5a40d48a6816
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '393'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test_package" rev="73" vrev="73" srcmd5="c3b4d7b28507f991ff3c3c28309ffd60">
+          <entry name="_config" md5="e40d404906ca32ad3dcd9a760d780fb5" size="76" mtime="1677089076"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="2da982dd2dc454fc27c5a0b02eae1a03" size="71" mtime="1677089076"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:04:47 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:package_test_user/_result?lastbuild=1&locallink=1&multibuild=1&package=test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - f167f67d-cd3d-4378-91fe-5a40d48a6816
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 18:04:47 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - d6531381-28ec-4a10-9a25-0b7b7172ee73
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '393'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test_package" rev="73" vrev="73" srcmd5="c3b4d7b28507f991ff3c3c28309ffd60">
+          <entry name="_config" md5="e40d404906ca32ad3dcd9a760d780fb5" size="76" mtime="1677089076"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="2da982dd2dc454fc27c5a0b02eae1a03" size="71" mtime="1677089076"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:04:48 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/source_project/package_1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 79c788e4-f6c3-407f-b765-9e1ad35e65bd
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '84'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_1" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:04:48 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/source_project/package_1?cacheonly=1&cmd=diff&expand=1&filelimit=10000&opackage=test_package&oproject=home:package_test_user&tarlimit=10000&view=xml&withissues=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      X-Request-Id:
+      - 79c788e4-f6c3-407f-b765-9e1ad35e65bd
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '1012'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="4709e34ee973a72c900f40b56a3ad4ed">
+          <old project="home:package_test_user" package="test_package" rev="73" srcmd5="c3b4d7b28507f991ff3c3c28309ffd60"/>
+          <new project="source_project" package="package_1" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <files>
+            <file state="deleted">
+              <old name="_config" md5="e40d404906ca32ad3dcd9a760d780fb5" size="76"/>
+              <diff lines="3">@@ -1,1 +0,0 @@
+        -Quia fugiat perferendis. Veritatis necessitatibus vero. Quisquam aut quidem.
+        \ No newline at end of file
+        </diff>
+            </file>
+            <file state="deleted">
+              <old name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0"/>
+              <diff lines="0"></diff>
+            </file>
+            <file state="deleted">
+              <old name="somefile.txt" md5="2da982dd2dc454fc27c5a0b02eae1a03" size="71"/>
+              <diff lines="3">@@ -1,1 +0,0 @@
+        -Et accusamus adipisci. Et impedit recusandae. Sint aspernatur corrupti.
+        \ No newline at end of file
+        </diff>
+            </file>
+          </files>
+          <issues>
+          </issues>
+        </sourcediff>
+  recorded_at: Wed, 22 Feb 2023 18:04:48 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Packages/log/download_logfile_succesfully.yml
+++ b/src/api/spec/cassettes/Packages/log/download_logfile_succesfully.yml
@@ -39,16 +39,16 @@ http_interactions:
           <description></description>
           <person userid="package_test_user" role="maintainer"/>
         </project>
-  recorded_at: Fri, 25 Jun 2021 11:31:32 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:50 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=user_11
+    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=user_40
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>That Hideous Strength</title>
-          <description>Veritatis et nobis vitae.</description>
+          <title>Stranger in a Strange Land</title>
+          <description>In voluptatibus ipsam et.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -69,21 +69,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '168'
+      - '173'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>That Hideous Strength</title>
-          <description>Veritatis et nobis vitae.</description>
+          <title>Stranger in a Strange Land</title>
+          <description>In voluptatibus ipsam et.</description>
         </package>
-  recorded_at: Fri, 25 Jun 2021 11:31:32 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:50 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_config
     body:
       encoding: UTF-8
-      string: Ut aperiam alias. Voluptates neque culpa. Ut velit vel.
+      string: Natus in commodi. Quisquam voluptatem molestiae. Sint perferendis ut.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -107,21 +107,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="12" vrev="12">
-          <srcmd5>753964ef08fa4a8c7bd7cadc888e14e6</srcmd5>
+        <revision rev="78" vrev="78">
+          <srcmd5>790e4a84e531ecea9c77a5ebbe583ad3</srcmd5>
           <version>unknown</version>
-          <time>1624620692</time>
+          <time>1677089150</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Fri, 25 Jun 2021 11:31:32 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:50 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Veniam molestiae voluptas. Dicta ea ut. Ut et velit.
+      string: Natus et vero. Iure et explicabo. Et quisquam laborum.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -145,15 +145,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="13" vrev="13">
-          <srcmd5>c5b1f840a697d26d516ee9862ee820ea</srcmd5>
+        <revision rev="79" vrev="79">
+          <srcmd5>dc986284b7a3e602a213c2873b0fad51</srcmd5>
           <version>unknown</version>
-          <time>1624620692</time>
+          <time>1677089150</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Fri, 25 Jun 2021 11:31:32 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:50 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/_meta?user=other_package_test_user
@@ -193,16 +193,16 @@ http_interactions:
           <description></description>
           <person userid="other_package_test_user" role="maintainer"/>
         </project>
-  recorded_at: Fri, 25 Jun 2021 11:31:32 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:50 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=user_12
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=user_41
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>The Sun Also Rises</title>
-          <description>Voluptatum veritatis optio natus.</description>
+          <title>The Monkey's Raincoat</title>
+          <description>Ut reprehenderit aut aspernatur.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -223,21 +223,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '186'
+      - '188'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>The Sun Also Rises</title>
-          <description>Voluptatum veritatis optio natus.</description>
+          <title>The Monkey's Raincoat</title>
+          <description>Ut reprehenderit aut aspernatur.</description>
         </package>
-  recorded_at: Fri, 25 Jun 2021 11:31:32 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:50 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_config
     body:
       encoding: UTF-8
-      string: Asperiores quia quos. Hic repellendus architecto. Repellendus ex voluptatibus.
+      string: Itaque possimus voluptatem. Beatae impedit consectetur. Ad aperiam odit.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -261,21 +261,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="11" vrev="11">
-          <srcmd5>77de82f928edc48b7702fe6d92d72bd7</srcmd5>
+        <revision rev="71" vrev="71">
+          <srcmd5>69a45b7d8c8e85974e27870746c3e409</srcmd5>
           <version>unknown</version>
-          <time>1624620692</time>
+          <time>1677089150</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Fri, 25 Jun 2021 11:31:32 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:50 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Et ad impedit. Sed sequi dignissimos. Soluta ab corrupti.
+      string: Incidunt rerum fuga. Modi dolor consequatur. Qui recusandae autem.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -299,15 +299,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="12" vrev="12">
-          <srcmd5>51171e8d7b412cb50d43df1641f3277f</srcmd5>
+        <revision rev="72" vrev="72">
+          <srcmd5>aa604c9670562c990b6c16efedd86655</srcmd5>
           <version>unknown</version>
-          <time>1624620692</time>
+          <time>1677089150</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Fri, 25 Jun 2021 11:31:32 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:50 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:package_test_user/test_package
@@ -316,7 +316,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - a26de570-0d90-49ea-b522-ceb2871d5981
+      - 1833cd1f-264e-4bb3-8ac2-58c44966518f
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -339,15 +339,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="13" vrev="13" srcmd5="c5b1f840a697d26d516ee9862ee820ea">
-          <entry name="_config" md5="de05decc97d6138ff86ad2f2fe9115a1" size="55" mtime="1624620692"/>
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1624620688"/>
-          <entry name="somefile.txt" md5="35b262d8ebe59673cd17464e34a3d69d" size="52" mtime="1624620692"/>
+        <directory name="test_package" rev="79" vrev="79" srcmd5="dc986284b7a3e602a213c2873b0fad51">
+          <entry name="_config" md5="7bef0f31180661d0520cc8eb982b956e" size="69" mtime="1677089150"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="8cc84a6612aaddb839278859f48a354e" size="54" mtime="1677089150"/>
         </directory>
-  recorded_at: Fri, 25 Jun 2021 11:31:33 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:51 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package?expand=1&rev=13
+    uri: http://backend:5352/source/home:package_test_user/test_package?expand=1&rev=79
     body:
       encoding: US-ASCII
       string: ''
@@ -374,58 +374,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="13" vrev="13" srcmd5="c5b1f840a697d26d516ee9862ee820ea">
-          <entry name="_config" md5="de05decc97d6138ff86ad2f2fe9115a1" size="55" mtime="1624620692"/>
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1624620688"/>
-          <entry name="somefile.txt" md5="35b262d8ebe59673cd17464e34a3d69d" size="52" mtime="1624620692"/>
+        <directory name="test_package" rev="79" vrev="79" srcmd5="dc986284b7a3e602a213c2873b0fad51">
+          <entry name="_config" md5="7bef0f31180661d0520cc8eb982b956e" size="69" mtime="1677089150"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="8cc84a6612aaddb839278859f48a354e" size="54" mtime="1677089150"/>
         </directory>
-  recorded_at: Fri, 25 Jun 2021 11:31:33 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:52 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Request-Id:
-      - a26de570-0d90-49ea-b522-ceb2871d5981
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '393'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="test_package" rev="13" vrev="13" srcmd5="c5b1f840a697d26d516ee9862ee820ea">
-          <entry name="_config" md5="de05decc97d6138ff86ad2f2fe9115a1" size="55" mtime="1624620692"/>
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1624620688"/>
-          <entry name="somefile.txt" md5="35b262d8ebe59673cd17464e34a3d69d" size="52" mtime="1624620692"/>
-        </directory>
-  recorded_at: Fri, 25 Jun 2021 11:31:33 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package
+    uri: http://backend:5352/source/home:package_test_user/test_package/_history?deleted=1&meta=1&rev=79
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - a26de570-0d90-49ea-b522-ceb2871d5981
+      - 1833cd1f-264e-4bb3-8ac2-58c44966518f
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -444,135 +407,167 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '393'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="test_package" rev="13" vrev="13" srcmd5="c5b1f840a697d26d516ee9862ee820ea">
-          <entry name="_config" md5="de05decc97d6138ff86ad2f2fe9115a1" size="55" mtime="1624620692"/>
-          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1624620688"/>
-          <entry name="somefile.txt" md5="35b262d8ebe59673cd17464e34a3d69d" size="52" mtime="1624620692"/>
-        </directory>
-  recorded_at: Fri, 25 Jun 2021 11:31:33 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:package_test_user/test_package/_history
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '2415'
+      - '31'
     body:
       encoding: UTF-8
       string: |
         <revisionlist>
-          <revision rev="1" vrev="1">
-            <srcmd5>a7feca4b99d529ab106b6666f98a5d5a</srcmd5>
-            <version>unknown</version>
-            <time>1624620657</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="2" vrev="2">
-            <srcmd5>11bc7bc10a1ea1609de8a814bef6ef24</srcmd5>
-            <version>unknown</version>
-            <time>1624620657</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="3" vrev="3">
-            <srcmd5>ec9a3f3c992577783f0f4ed7876c79f3</srcmd5>
-            <version>unknown</version>
-            <time>1624620670</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="4" vrev="4">
-            <srcmd5>ff563efe05eba8ca10caba706f5a7a05</srcmd5>
-            <version>unknown</version>
-            <time>1624620670</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="5" vrev="5">
-            <srcmd5>1919e65dd94439ce8046297a51deba51</srcmd5>
-            <version>unknown</version>
-            <time>1624620678</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="6" vrev="6">
-            <srcmd5>38020a66a90d7871c8a30222b18d9672</srcmd5>
-            <version>unknown</version>
-            <time>1624620678</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="7" vrev="7">
-            <srcmd5>7a6fe3aa87ff6c50313564b157278a11</srcmd5>
-            <version>unknown</version>
-            <time>1624620684</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="8" vrev="8">
-            <srcmd5>dff72a268ab90b0a16143afc79b8eb23</srcmd5>
-            <version>unknown</version>
-            <time>1624620684</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="9" vrev="9">
-            <srcmd5>63e12210830bf9ce362f78797ba011e1</srcmd5>
-            <version>unknown</version>
-            <time>1624620688</time>
-            <user>package_test_user</user>
-          </revision>
-          <revision rev="10" vrev="10">
-            <srcmd5>367335854550b857232c9a2721cb7dd2</srcmd5>
-            <version>unknown</version>
-            <time>1624620690</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="11" vrev="11">
-            <srcmd5>538b80692b39d509774c240cada1049a</srcmd5>
-            <version>unknown</version>
-            <time>1624620690</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="12" vrev="12">
-            <srcmd5>753964ef08fa4a8c7bd7cadc888e14e6</srcmd5>
-            <version>unknown</version>
-            <time>1624620692</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="13" vrev="13">
-            <srcmd5>c5b1f840a697d26d516ee9862ee820ea</srcmd5>
-            <version>unknown</version>
-            <time>1624620692</time>
-            <user>unknown</user>
-          </revision>
         </revisionlist>
-  recorded_at: Fri, 25 Jun 2021 11:31:34 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:52 GMT
 - request:
     method: get
-    uri: http://backend:5352/build/home:package_test_user/_result?lastbuild=0&package=test_package&view=status
+    uri: http://backend:5352/source/home:package_test_user/test_package
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - 7bbe52f3-aa61-4469-9740-eba308a1b0a5
+      - 1833cd1f-264e-4bb3-8ac2-58c44966518f
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '393'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test_package" rev="79" vrev="79" srcmd5="dc986284b7a3e602a213c2873b0fad51">
+          <entry name="_config" md5="7bef0f31180661d0520cc8eb982b956e" size="69" mtime="1677089150"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="8cc84a6612aaddb839278859f48a354e" size="54" mtime="1677089150"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:05:52 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 1833cd1f-264e-4bb3-8ac2-58c44966518f
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '393'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test_package" rev="79" vrev="79" srcmd5="dc986284b7a3e602a213c2873b0fad51">
+          <entry name="_config" md5="7bef0f31180661d0520cc8eb982b956e" size="69" mtime="1677089150"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="8cc84a6612aaddb839278859f48a354e" size="54" mtime="1677089150"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:05:52 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package/_history?deleted=1&meta=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 1833cd1f-264e-4bb3-8ac2-58c44966518f
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Wed, 22 Feb 2023 18:05:52 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - aea4faef-2018-4117-9cec-8b9e4b3e5962
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '393'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test_package" rev="79" vrev="79" srcmd5="dc986284b7a3e602a213c2873b0fad51">
+          <entry name="_config" md5="7bef0f31180661d0520cc8eb982b956e" size="69" mtime="1677089150"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="8cc84a6612aaddb839278859f48a354e" size="54" mtime="1677089150"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:05:52 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:package_test_user/_result?lastbuild=1&locallink=1&multibuild=1&package=test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - aea4faef-2018-4117-9cec-8b9e4b3e5962
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -597,7 +592,112 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Fri, 25 Jun 2021 11:31:34 GMT
+  recorded_at: Wed, 22 Feb 2023 18:05:52 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 96e71768-5805-4851-9281-839cf8a93a3e
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '393'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test_package" rev="79" vrev="79" srcmd5="dc986284b7a3e602a213c2873b0fad51">
+          <entry name="_config" md5="7bef0f31180661d0520cc8eb982b956e" size="69" mtime="1677089150"/>
+          <entry name="new_file" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1676381155"/>
+          <entry name="somefile.txt" md5="8cc84a6612aaddb839278859f48a354e" size="54" mtime="1677089150"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:05:52 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:package_test_user/_result?lastbuild=1&locallink=1&multibuild=1&package=test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 96e71768-5805-4851-9281-839cf8a93a3e
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 18:05:52 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:package_test_user/_result?package=test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 1486cb9f-bb53-4f1d-94ab-54a16b4a971d
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 18:05:52 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:package_test_user/package_test_repository/i586/test_package/_jobstatus
@@ -606,7 +706,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 5590c680-d686-4bd9-8978-2e4227205b73
+      - d329a41f-7ceb-46d7-84ed-f0965d3ec216
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -633,5 +733,5 @@ http_interactions:
           <summary>project 'home:package_test_user' has no repository 'package_test_repository'</summary>
           <details>404 project 'home:package_test_user' has no repository 'package_test_repository'</details>
         </status>
-  recorded_at: Fri, 25 Jun 2021 11:31:34 GMT
-recorded_with: VCR 6.0.0
+  recorded_at: Wed, 22 Feb 2023 18:05:52 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Packages/requesting_package_deletion.yml
+++ b/src/api/spec/cassettes/Packages/requesting_package_deletion.yml
@@ -39,16 +39,16 @@ http_interactions:
           <description></description>
           <person userid="package_test_user" role="maintainer"/>
         </project>
-  recorded_at: Fri, 25 Jun 2021 11:31:10 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:33 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=user_3
+    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=user_7
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>The Stars' Tennis Balls</title>
-          <description>At assumenda rerum quia.</description>
+          <title>No Country for Old Men</title>
+          <description>Quo sit cumque mollitia.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -69,21 +69,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '169'
+      - '168'
     body:
       encoding: UTF-8
       string: |
         <package name="test_package" project="home:package_test_user">
-          <title>The Stars' Tennis Balls</title>
-          <description>At assumenda rerum quia.</description>
+          <title>No Country for Old Men</title>
+          <description>Quo sit cumque mollitia.</description>
         </package>
-  recorded_at: Fri, 25 Jun 2021 11:31:10 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:33 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/_config
     body:
       encoding: UTF-8
-      string: Tempore odit enim. Vitae quibusdam commodi. Vel alias nihil.
+      string: Ipsam ut ex. Sint et ipsum. Inventore earum expedita.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -103,26 +103,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="3" vrev="3">
-          <srcmd5>ec9a3f3c992577783f0f4ed7876c79f3</srcmd5>
+        <revision rev="70" vrev="70">
+          <srcmd5>ed4b3143b4dcfb9ef00b986fef435bcf</srcmd5>
           <version>unknown</version>
-          <time>1624620670</time>
+          <time>1677089073</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Fri, 25 Jun 2021 11:31:10 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:33 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:package_test_user/test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Fugiat doloremque eos. Dolores maxime consequuntur. Nostrum corporis
-        ut.
+      string: Aut maxime ex. Rerum voluptates non. Consequatur adipisci ut.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -142,19 +141,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="4" vrev="4">
-          <srcmd5>ff563efe05eba8ca10caba706f5a7a05</srcmd5>
+        <revision rev="71" vrev="71">
+          <srcmd5>223a2f10f837b1b13d19cbd3539b2652</srcmd5>
           <version>unknown</version>
-          <time>1624620670</time>
+          <time>1677089073</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Fri, 25 Jun 2021 11:31:10 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:33 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/_meta?user=other_package_test_user
@@ -194,16 +193,16 @@ http_interactions:
           <description></description>
           <person userid="other_package_test_user" role="maintainer"/>
         </project>
-  recorded_at: Fri, 25 Jun 2021 11:31:10 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:33 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=user_4
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=user_8
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>An Acceptable Time</title>
-          <description>Ad quia recusandae in.</description>
+          <title>Noli Me Tangere</title>
+          <description>Et non dolores est.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -224,21 +223,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '175'
+      - '169'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_package_test_user">
-          <title>An Acceptable Time</title>
-          <description>Ad quia recusandae in.</description>
+          <title>Noli Me Tangere</title>
+          <description>Et non dolores est.</description>
         </package>
-  recorded_at: Fri, 25 Jun 2021 11:31:10 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:33 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_config
     body:
       encoding: UTF-8
-      string: Ut recusandae laudantium. Nobis qui quia. Qui incidunt vel.
+      string: Rerum qui omnis. Ipsam dolorum eveniet. Esse dicta vel.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -258,25 +257,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="3" vrev="3">
-          <srcmd5>33c4df58014abaecde70d47b219f62a4</srcmd5>
+        <revision rev="63" vrev="63">
+          <srcmd5>6da8ba12ee03152236148828a3d9bd06</srcmd5>
           <version>unknown</version>
-          <time>1624620670</time>
+          <time>1677089073</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Fri, 25 Jun 2021 11:31:10 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:33 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Harum laudantium temporibus. Numquam libero odit. In delectus debitis.
+      string: Dolorem unde quos. Fugiat omnis recusandae. Qui reprehenderit et.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -296,19 +295,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="4" vrev="4">
-          <srcmd5>53bfa32fe400382f419c00a01ba4a111</srcmd5>
+        <revision rev="64" vrev="64">
+          <srcmd5>f56f18d88594a3d62b5c75d06699357e</srcmd5>
           <version>unknown</version>
-          <time>1624620670</time>
+          <time>1677089073</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Fri, 25 Jun 2021 11:31:10 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:33 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:other_package_test_user/branch_test_package
@@ -317,7 +316,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - eac10d88-d970-4ac8-9510-4beef20bc74a
+      - 6defcd1f-8728-4434-a5a5-8625dd937fd8
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -336,18 +335,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '304'
+      - '306'
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="4" vrev="4" srcmd5="53bfa32fe400382f419c00a01ba4a111">
-          <entry name="_config" md5="1224b66ab2f5b8d40e60a1b58299bbf6" size="59" mtime="1624620670"/>
-          <entry name="somefile.txt" md5="0f0fc41e34ee06d0b6e25e4da7250818" size="70" mtime="1624620670"/>
+        <directory name="branch_test_package" rev="64" vrev="64" srcmd5="f56f18d88594a3d62b5c75d06699357e">
+          <entry name="_config" md5="d627d41b7f5b0383e8b24a1df8d3f177" size="55" mtime="1677089073"/>
+          <entry name="somefile.txt" md5="0ed1d839b181afa260046d7f6b20343a" size="65" mtime="1677089073"/>
         </directory>
-  recorded_at: Fri, 25 Jun 2021 11:31:12 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:34 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package?expand=1&rev=4
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package?expand=1&rev=64
     body:
       encoding: US-ASCII
       string: ''
@@ -370,80 +369,128 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '304'
+      - '306'
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="4" vrev="4" srcmd5="53bfa32fe400382f419c00a01ba4a111">
-          <entry name="_config" md5="1224b66ab2f5b8d40e60a1b58299bbf6" size="59" mtime="1624620670"/>
-          <entry name="somefile.txt" md5="0f0fc41e34ee06d0b6e25e4da7250818" size="70" mtime="1624620670"/>
+        <directory name="branch_test_package" rev="64" vrev="64" srcmd5="f56f18d88594a3d62b5c75d06699357e">
+          <entry name="_config" md5="d627d41b7f5b0383e8b24a1df8d3f177" size="55" mtime="1677089073"/>
+          <entry name="somefile.txt" md5="0ed1d839b181afa260046d7f6b20343a" size="65" mtime="1677089073"/>
         </directory>
-  recorded_at: Fri, 25 Jun 2021 11:31:12 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:34 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_history
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '759'
-    body:
-      encoding: UTF-8
-      string: |
-        <revisionlist>
-          <revision rev="1" vrev="1">
-            <srcmd5>5195c4c564cc151779614eebafb9d444</srcmd5>
-            <version>unknown</version>
-            <time>1624620657</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="2" vrev="2">
-            <srcmd5>33afbeb32473f90fd2963ecda85f70dd</srcmd5>
-            <version>unknown</version>
-            <time>1624620658</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="3" vrev="3">
-            <srcmd5>33c4df58014abaecde70d47b219f62a4</srcmd5>
-            <version>unknown</version>
-            <time>1624620670</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="4" vrev="4">
-            <srcmd5>53bfa32fe400382f419c00a01ba4a111</srcmd5>
-            <version>unknown</version>
-            <time>1624620670</time>
-            <user>unknown</user>
-          </revision>
-        </revisionlist>
-  recorded_at: Fri, 25 Jun 2021 11:31:12 GMT
-- request:
-    method: get
-    uri: http://backend:5352/build/home:other_package_test_user/_result?package=branch_test_package&view=status
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_history?deleted=1&meta=1&rev=64
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - 298fe3ca-dcd9-4330-b48c-6f84672ed897
+      - 6defcd1f-8728-4434-a5a5-8625dd937fd8
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Wed, 22 Feb 2023 18:04:34 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_history?deleted=1&meta=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 6defcd1f-8728-4434-a5a5-8625dd937fd8
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Wed, 22 Feb 2023 18:04:34 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 151c20cd-c6a0-4dfa-be41-1e3b77557a4c
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '306'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="branch_test_package" rev="64" vrev="64" srcmd5="f56f18d88594a3d62b5c75d06699357e">
+          <entry name="_config" md5="d627d41b7f5b0383e8b24a1df8d3f177" size="55" mtime="1677089073"/>
+          <entry name="somefile.txt" md5="0ed1d839b181afa260046d7f6b20343a" size="65" mtime="1677089073"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:04:34 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:other_package_test_user/_result?lastbuild=1&locallink=1&multibuild=1&package=branch_test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 151c20cd-c6a0-4dfa-be41-1e3b77557a4c
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -468,18 +515,16 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Fri, 25 Jun 2021 11:31:14 GMT
+  recorded_at: Wed, 22 Feb 2023 18:04:34 GMT
 - request:
-    method: post
-    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package?cmd=diff&expand=1&filelimit=0&rev=0&view=xml
+    method: get
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package
     body:
-      encoding: UTF-8
+      encoding: US-ASCII
       string: ''
     headers:
-      Content-Type:
-      - application/octet-stream
       X-Request-Id:
-      - 820ba0d5-21a0-4e77-b7f6-0c7d92f75279
+      - b8e90f70-8a2a-4b41-823e-1fe83274afda
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -498,29 +543,135 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '861'
+      - '306'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="aa03af0ca6e45b328c9802029b4de336">
-          <old project="home:other_package_test_user" package="branch_test_package" rev="4" srcmd5="53bfa32fe400382f419c00a01ba4a111"/>
+        <directory name="branch_test_package" rev="64" vrev="64" srcmd5="f56f18d88594a3d62b5c75d06699357e">
+          <entry name="_config" md5="d627d41b7f5b0383e8b24a1df8d3f177" size="55" mtime="1677089073"/>
+          <entry name="somefile.txt" md5="0ed1d839b181afa260046d7f6b20343a" size="65" mtime="1677089073"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:04:34 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:other_package_test_user/_result?lastbuild=1&locallink=1&multibuild=1&package=branch_test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - b8e90f70-8a2a-4b41-823e-1fe83274afda
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 18:04:34 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:other_package_test_user/_result?package=branch_test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 95211ffa-b65a-4682-9dc8-7d746aa72b8a
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 18:04:35 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package?cmd=diff&expand=1&filelimit=0&rev=0&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      X-Request-Id:
+      - e931926a-6439-493c-98c7-9395698d6035
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '853'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="b031374787e4c05a2fe061691d9614ae">
+          <old project="home:other_package_test_user" package="branch_test_package" rev="64" srcmd5="f56f18d88594a3d62b5c75d06699357e"/>
           <new project="home:other_package_test_user" package="branch_test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files>
             <file state="deleted">
-              <old name="_config" md5="1224b66ab2f5b8d40e60a1b58299bbf6" size="59"/>
+              <old name="_config" md5="d627d41b7f5b0383e8b24a1df8d3f177" size="55"/>
               <diff lines="3">@@ -1,1 +0,0 @@
-        -Ut recusandae laudantium. Nobis qui quia. Qui incidunt vel.
+        -Rerum qui omnis. Ipsam dolorum eveniet. Esse dicta vel.
         \ No newline at end of file
         </diff>
             </file>
             <file state="deleted">
-              <old name="somefile.txt" md5="0f0fc41e34ee06d0b6e25e4da7250818" size="70"/>
+              <old name="somefile.txt" md5="0ed1d839b181afa260046d7f6b20343a" size="65"/>
               <diff lines="3">@@ -1,1 +0,0 @@
-        -Harum laudantium temporibus. Numquam libero odit. In delectus debitis.
+        -Dolorem unde quos. Fugiat omnis recusandae. Qui reprehenderit et.
         \ No newline at end of file
         </diff>
             </file>
           </files>
         </sourcediff>
-  recorded_at: Fri, 25 Jun 2021 11:31:16 GMT
-recorded_with: VCR 6.0.0
+  recorded_at: Wed, 22 Feb 2023 18:04:35 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Projects/branching/an_existing_package.yml
+++ b/src/api/spec/cassettes/Projects/branching/an_existing_package.yml
@@ -2,14 +2,14 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/home:user_7/_meta?user=user_7
+    uri: http://backend:5352/source/home:user_8/_meta?user=user_8
     body:
       encoding: UTF-8
       string: |
-        <project name="home:user_7">
+        <project name="home:user_8">
           <title/>
           <description/>
-          <person userid="user_7" role="maintainer"/>
+          <person userid="user_8" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -34,13 +34,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <project name="home:user_7">
+        <project name="home:user_8">
           <title></title>
           <description></description>
-          <person userid="user_7" role="maintainer"/>
+          <person userid="user_8" role="maintainer"/>
         </project>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:06:28 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:13 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Jane/_meta?user=Jane
@@ -80,8 +79,7 @@ http_interactions:
           <description></description>
           <person userid="Jane" role="maintainer"/>
         </project>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:06:28 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:13 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/_meta?user=other_user
@@ -121,17 +119,16 @@ http_interactions:
           <description></description>
           <person userid="other_user" role="maintainer"/>
         </project>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:06:28 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:13 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta?user=user_8
+    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta?user=user_9
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_user">
-          <title>Françoise Sagan</title>
-          <description>Totam dolores eum est.</description>
+          <title>The Torment of Others</title>
+          <description>Officia minima perferendis mollitia.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -152,19 +149,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '160'
+      - '179'
     body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        PHBhY2thZ2UgbmFtZT0iYnJhbmNoX3Rlc3RfcGFja2FnZSIgcHJvamVjdD0iaG9tZTpvdGhlcl91c2VyIj4KICA8dGl0bGU+RnJhbsOnb2lzZSBTYWdhbjwvdGl0bGU+CiAgPGRlc2NyaXB0aW9uPlRvdGFtIGRvbG9yZXMgZXVtIGVzdC48L2Rlc2NyaXB0aW9uPgo8L3BhY2thZ2U+Cg==
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:06:28 GMT
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_user">
+          <title>The Torment of Others</title>
+          <description>Officia minima perferendis mollitia.</description>
+        </package>
+  recorded_at: Wed, 22 Feb 2023 17:58:13 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/branch_test_package/_config
     body:
       encoding: UTF-8
-      string: Ut dolorem iste. Minima qui non. Et commodi quisquam.
+      string: Nostrum placeat harum. Hic voluptates totam. Sequi consequatur voluptas.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -184,26 +183,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="7" vrev="7">
-          <srcmd5>fc1a0b5d10e03df14df6084e48f6c884</srcmd5>
+        <revision rev="13" vrev="13">
+          <srcmd5>53463f3a403a0df7b315fc2a69b0be34</srcmd5>
           <version>unknown</version>
-          <time>1568127988</time>
+          <time>1677088693</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:06:28 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:13 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/branch_test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Vel assumenda pariatur. Facilis harum ut. Unde accusantium animi.
+      string: Qui aut quo. Fuga architecto similique. Aut placeat et.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -223,20 +221,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="8" vrev="8">
-          <srcmd5>04bc017c126b379ea6b9f27f9aa0146b</srcmd5>
+        <revision rev="14" vrev="14">
+          <srcmd5>7d8277ba3a4bc8c2bba6d897da3a39fa</srcmd5>
           <version>unknown</version>
-          <time>1568127988</time>
+          <time>1677088693</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:06:28 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:13 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:Jane/_result?code=unresolvable&view=status
@@ -244,6 +241,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - b8c7dbcd-701f-4b7c-8388-3eb4f1fbced7
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -268,8 +267,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:06:30 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:14 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Jane/_keyinfo?donotcreatecert=1&withsslcert=1
@@ -277,6 +275,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - b8c7dbcd-701f-4b7c-8388-3eb4f1fbced7
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -299,8 +299,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "<keyinfo/>\n"
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:06:30 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:14 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:Jane/_result?view=summary
@@ -308,6 +307,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - '08131634-4439-4e46-900f-cefb1d86abad'
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -332,8 +333,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:06:30 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:14 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22branch_test_package%22%20and%20linkinfo/@project=%22home:other_user%22%20and%20@project=%22home:other_user%22)
@@ -367,8 +367,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:06:30 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:15 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Jane/branch_test_package/_meta?user=Jane
@@ -376,8 +375,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:Jane">
-          <title>Françoise Sagan</title>
-          <description>Totam dolores eum est.</description>
+          <title>The Torment of Others</title>
+          <description>Officia minima perferendis mollitia.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -398,13 +397,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '154'
+      - '173'
     body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        PHBhY2thZ2UgbmFtZT0iYnJhbmNoX3Rlc3RfcGFja2FnZSIgcHJvamVjdD0iaG9tZTpKYW5lIj4KICA8dGl0bGU+RnJhbsOnb2lzZSBTYWdhbjwvdGl0bGU+CiAgPGRlc2NyaXB0aW9uPlRvdGFtIGRvbG9yZXMgZXVtIGVzdC48L2Rlc2NyaXB0aW9uPgo8L3BhY2thZ2U+Cg==
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:06:30 GMT
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:Jane">
+          <title>The Torment of Others</title>
+          <description>Officia minima perferendis mollitia.</description>
+        </package>
+  recorded_at: Wed, 22 Feb 2023 17:58:15 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Jane/branch_test_package?cmd=branch&noservice=1&opackage=branch_test_package&oproject=home:other_user&user=Jane
@@ -436,16 +437,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="3" vrev="3">
-          <srcmd5>9131d0c61a2a1accc89616ce5096be29</srcmd5>
+        <revision rev="6" vrev="6">
+          <srcmd5>ef747ae29b0c2ba62260d3940f79fc71</srcmd5>
           <version>unknown</version>
-          <time>1568127990</time>
+          <time>1677088695</time>
           <user>Jane</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:06:30 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:15 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Jane/branch_test_package/_meta?user=Jane
@@ -453,8 +453,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:Jane">
-          <title>Françoise Sagan</title>
-          <description>Totam dolores eum est.</description>
+          <title>The Torment of Others</title>
+          <description>Officia minima perferendis mollitia.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -475,13 +475,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '154'
+      - '173'
     body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        PHBhY2thZ2UgbmFtZT0iYnJhbmNoX3Rlc3RfcGFja2FnZSIgcHJvamVjdD0iaG9tZTpKYW5lIj4KICA8dGl0bGU+RnJhbsOnb2lzZSBTYWdhbjwvdGl0bGU+CiAgPGRlc2NyaXB0aW9uPlRvdGFtIGRvbG9yZXMgZXVtIGVzdC48L2Rlc2NyaXB0aW9uPgo8L3BhY2thZ2U+Cg==
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:06:30 GMT
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:Jane">
+          <title>The Torment of Others</title>
+          <description>Officia minima perferendis mollitia.</description>
+        </package>
+  recorded_at: Wed, 22 Feb 2023 17:58:15 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Jane/branch_test_package
@@ -511,14 +513,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="3" vrev="3" srcmd5="9131d0c61a2a1accc89616ce5096be29">
-          <linkinfo project="home:other_user" package="branch_test_package" srcmd5="04bc017c126b379ea6b9f27f9aa0146b" baserev="04bc017c126b379ea6b9f27f9aa0146b" xsrcmd5="5d8509ca10f320596cf41f2431f9b561" lsrcmd5="9131d0c61a2a1accc89616ce5096be29"/>
-          <entry name="_config" md5="7a247c51a52a0f1f3090db3106cff62e" size="53" mtime="1568127988"/>
-          <entry name="_link" md5="cf4b039e6e38fbad2c41f7c09266914d" size="123" mtime="1568127990"/>
-          <entry name="somefile.txt" md5="d912744ebbc07612405fc0987f7dcba3" size="65" mtime="1568127988"/>
+        <directory name="branch_test_package" rev="6" vrev="6" srcmd5="ef747ae29b0c2ba62260d3940f79fc71">
+          <linkinfo project="home:other_user" package="branch_test_package" srcmd5="7d8277ba3a4bc8c2bba6d897da3a39fa" baserev="7d8277ba3a4bc8c2bba6d897da3a39fa" xsrcmd5="bab0a0559ae4d7fd8c5f8627c50a62b4" lsrcmd5="ef747ae29b0c2ba62260d3940f79fc71"/>
+          <entry name="_config" md5="90f85c0db7009e7c8c13080684f09188" size="72" mtime="1677088693"/>
+          <entry name="_link" md5="d5cfac488fe38faeda9f58aaa0540dc7" size="123" mtime="1677088695"/>
+          <entry name="somefile.txt" md5="ae99286d197ce7dafe5f8bd94e966209" size="55" mtime="1677088693"/>
         </directory>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:06:31 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:15 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Jane/branch_test_package?view=info
@@ -526,6 +527,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - 2414ddd4-cb53-4852-a3f8-5e609c188f19
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -548,12 +551,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="branch_test_package" rev="3" vrev="11" srcmd5="5d8509ca10f320596cf41f2431f9b561" lsrcmd5="9131d0c61a2a1accc89616ce5096be29" verifymd5="04bc017c126b379ea6b9f27f9aa0146b">
+        <sourceinfo package="branch_test_package" rev="6" vrev="20" srcmd5="bab0a0559ae4d7fd8c5f8627c50a62b4" lsrcmd5="ef747ae29b0c2ba62260d3940f79fc71" verifymd5="7d8277ba3a4bc8c2bba6d897da3a39fa">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="home:other_user" package="branch_test_package"/>
         </sourceinfo>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:06:31 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:15 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Jane/branch_test_package
@@ -561,6 +563,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - 2414ddd4-cb53-4852-a3f8-5e609c188f19
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -583,14 +587,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="3" vrev="3" srcmd5="9131d0c61a2a1accc89616ce5096be29">
-          <linkinfo project="home:other_user" package="branch_test_package" srcmd5="04bc017c126b379ea6b9f27f9aa0146b" baserev="04bc017c126b379ea6b9f27f9aa0146b" xsrcmd5="5d8509ca10f320596cf41f2431f9b561" lsrcmd5="9131d0c61a2a1accc89616ce5096be29"/>
-          <entry name="_config" md5="7a247c51a52a0f1f3090db3106cff62e" size="53" mtime="1568127988"/>
-          <entry name="_link" md5="cf4b039e6e38fbad2c41f7c09266914d" size="123" mtime="1568127990"/>
-          <entry name="somefile.txt" md5="d912744ebbc07612405fc0987f7dcba3" size="65" mtime="1568127988"/>
+        <directory name="branch_test_package" rev="6" vrev="6" srcmd5="ef747ae29b0c2ba62260d3940f79fc71">
+          <linkinfo project="home:other_user" package="branch_test_package" srcmd5="7d8277ba3a4bc8c2bba6d897da3a39fa" baserev="7d8277ba3a4bc8c2bba6d897da3a39fa" xsrcmd5="bab0a0559ae4d7fd8c5f8627c50a62b4" lsrcmd5="ef747ae29b0c2ba62260d3940f79fc71"/>
+          <entry name="_config" md5="90f85c0db7009e7c8c13080684f09188" size="72" mtime="1677088693"/>
+          <entry name="_link" md5="d5cfac488fe38faeda9f58aaa0540dc7" size="123" mtime="1677088695"/>
+          <entry name="somefile.txt" md5="ae99286d197ce7dafe5f8bd94e966209" size="55" mtime="1677088693"/>
         </directory>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:06:31 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:15 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Jane/branch_test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -622,15 +625,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="bd743fc4988e2d10a9270c5aedfc0616">
+        <sourcediff key="32e990e9dc328b412df5982412822747">
           <old project="home:Jane" package="branch_test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Jane" package="branch_test_package" rev="3" srcmd5="9131d0c61a2a1accc89616ce5096be29"/>
+          <new project="home:Jane" package="branch_test_package" rev="6" srcmd5="ef747ae29b0c2ba62260d3940f79fc71"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:06:31 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:15 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Jane/branch_test_package?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -662,13 +664,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="95ab19f4ec3e2cfca3e9a17a05ae07fa">
-          <old project="home:other_user" package="branch_test_package" rev="04bc017c126b379ea6b9f27f9aa0146b" srcmd5="04bc017c126b379ea6b9f27f9aa0146b"/>
-          <new project="home:Jane" package="branch_test_package" rev="5d8509ca10f320596cf41f2431f9b561" srcmd5="5d8509ca10f320596cf41f2431f9b561"/>
+        <sourcediff key="aa6919b19fa1599279d18d16adc3fb77">
+          <old project="home:other_user" package="branch_test_package" rev="7d8277ba3a4bc8c2bba6d897da3a39fa" srcmd5="7d8277ba3a4bc8c2bba6d897da3a39fa"/>
+          <new project="home:Jane" package="branch_test_package" rev="bab0a0559ae4d7fd8c5f8627c50a62b4" srcmd5="bab0a0559ae4d7fd8c5f8627c50a62b4"/>
           <files/>
         </sourcediff>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:06:31 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:15 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Jane/_meta?user=Jane
@@ -681,6 +682,8 @@ http_interactions:
           <person userid="Jane" role="maintainer"/>
         </project>
     headers:
+      X-Request-Id:
+      - 2414ddd4-cb53-4852-a3f8-5e609c188f19
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -708,8 +711,7 @@ http_interactions:
           <description></description>
           <person userid="Jane" role="maintainer"/>
         </project>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:06:31 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:15 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:other_user/branch_test_package?view=info
@@ -717,6 +719,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - c21a7bb3-8591-403d-a471-db861fe9b212
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -735,15 +739,14 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '237'
+      - '239'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="branch_test_package" rev="8" vrev="8" srcmd5="04bc017c126b379ea6b9f27f9aa0146b" verifymd5="04bc017c126b379ea6b9f27f9aa0146b">
+        <sourceinfo package="branch_test_package" rev="14" vrev="14" srcmd5="7d8277ba3a4bc8c2bba6d897da3a39fa" verifymd5="7d8277ba3a4bc8c2bba6d897da3a39fa">
           <error>bad build configuration, no build type defined or detected</error>
         </sourceinfo>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:06:31 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:15 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:other_user/branch_test_package
@@ -751,6 +754,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - c21a7bb3-8591-403d-a471-db861fe9b212
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -769,16 +774,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '304'
+      - '306'
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="8" vrev="8" srcmd5="04bc017c126b379ea6b9f27f9aa0146b">
-          <entry name="_config" md5="7a247c51a52a0f1f3090db3106cff62e" size="53" mtime="1568127988"/>
-          <entry name="somefile.txt" md5="d912744ebbc07612405fc0987f7dcba3" size="65" mtime="1568127988"/>
+        <directory name="branch_test_package" rev="14" vrev="14" srcmd5="7d8277ba3a4bc8c2bba6d897da3a39fa">
+          <entry name="_config" md5="90f85c0db7009e7c8c13080684f09188" size="72" mtime="1677088693"/>
+          <entry name="somefile.txt" md5="ae99286d197ce7dafe5f8bd94e966209" size="55" mtime="1677088693"/>
         </directory>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:06:31 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:15 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:other_user/branch_test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -806,19 +810,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '330'
+      - '331'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="8b3c7037a16fecf76e0d802cd130fe27">
+        <sourcediff key="875662a4a7af3cec937ae87ae71a24ce">
           <old project="home:other_user" package="branch_test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:other_user" package="branch_test_package" rev="8" srcmd5="04bc017c126b379ea6b9f27f9aa0146b"/>
+          <new project="home:other_user" package="branch_test_package" rev="14" srcmd5="7d8277ba3a4bc8c2bba6d897da3a39fa"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:06:31 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:15 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Jane/branch_test_package
@@ -826,6 +829,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - c21a7bb3-8591-403d-a471-db861fe9b212
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -848,17 +853,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="3" vrev="3" srcmd5="9131d0c61a2a1accc89616ce5096be29">
-          <linkinfo project="home:other_user" package="branch_test_package" srcmd5="04bc017c126b379ea6b9f27f9aa0146b" baserev="04bc017c126b379ea6b9f27f9aa0146b" xsrcmd5="5d8509ca10f320596cf41f2431f9b561" lsrcmd5="9131d0c61a2a1accc89616ce5096be29"/>
-          <entry name="_config" md5="7a247c51a52a0f1f3090db3106cff62e" size="53" mtime="1568127988"/>
-          <entry name="_link" md5="cf4b039e6e38fbad2c41f7c09266914d" size="123" mtime="1568127990"/>
-          <entry name="somefile.txt" md5="d912744ebbc07612405fc0987f7dcba3" size="65" mtime="1568127988"/>
+        <directory name="branch_test_package" rev="6" vrev="6" srcmd5="ef747ae29b0c2ba62260d3940f79fc71">
+          <linkinfo project="home:other_user" package="branch_test_package" srcmd5="7d8277ba3a4bc8c2bba6d897da3a39fa" baserev="7d8277ba3a4bc8c2bba6d897da3a39fa" xsrcmd5="bab0a0559ae4d7fd8c5f8627c50a62b4" lsrcmd5="ef747ae29b0c2ba62260d3940f79fc71"/>
+          <entry name="_config" md5="90f85c0db7009e7c8c13080684f09188" size="72" mtime="1677088693"/>
+          <entry name="_link" md5="d5cfac488fe38faeda9f58aaa0540dc7" size="123" mtime="1677088695"/>
+          <entry name="somefile.txt" md5="ae99286d197ce7dafe5f8bd94e966209" size="55" mtime="1677088693"/>
         </directory>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:06:31 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:15 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Jane/branch_test_package?expand=1&rev=3
+    uri: http://backend:5352/source/home:Jane/branch_test_package?expand=1&rev=6
     body:
       encoding: US-ASCII
       string: ''
@@ -885,20 +889,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="5d8509ca10f320596cf41f2431f9b561" vrev="11" srcmd5="5d8509ca10f320596cf41f2431f9b561">
-          <linkinfo project="home:other_user" package="branch_test_package" srcmd5="04bc017c126b379ea6b9f27f9aa0146b" baserev="04bc017c126b379ea6b9f27f9aa0146b" lsrcmd5="9131d0c61a2a1accc89616ce5096be29"/>
-          <entry name="_config" md5="7a247c51a52a0f1f3090db3106cff62e" size="53" mtime="1568127988"/>
-          <entry name="somefile.txt" md5="d912744ebbc07612405fc0987f7dcba3" size="65" mtime="1568127988"/>
+        <directory name="branch_test_package" rev="bab0a0559ae4d7fd8c5f8627c50a62b4" vrev="20" srcmd5="bab0a0559ae4d7fd8c5f8627c50a62b4">
+          <linkinfo project="home:other_user" package="branch_test_package" srcmd5="7d8277ba3a4bc8c2bba6d897da3a39fa" baserev="7d8277ba3a4bc8c2bba6d897da3a39fa" lsrcmd5="ef747ae29b0c2ba62260d3940f79fc71"/>
+          <entry name="_config" md5="90f85c0db7009e7c8c13080684f09188" size="72" mtime="1677088693"/>
+          <entry name="somefile.txt" md5="ae99286d197ce7dafe5f8bd94e966209" size="55" mtime="1677088693"/>
         </directory>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:06:31 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:16 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Jane/branch_test_package
+    uri: http://backend:5352/source/home:Jane/branch_test_package/_history?deleted=1&meta=1&rev=6
     body:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - c21a7bb3-8591-403d-a471-db861fe9b212
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -917,113 +922,132 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '638'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="branch_test_package" rev="3" vrev="3" srcmd5="9131d0c61a2a1accc89616ce5096be29">
-          <linkinfo project="home:other_user" package="branch_test_package" srcmd5="04bc017c126b379ea6b9f27f9aa0146b" baserev="04bc017c126b379ea6b9f27f9aa0146b" xsrcmd5="5d8509ca10f320596cf41f2431f9b561" lsrcmd5="9131d0c61a2a1accc89616ce5096be29"/>
-          <entry name="_config" md5="7a247c51a52a0f1f3090db3106cff62e" size="53" mtime="1568127988"/>
-          <entry name="_link" md5="cf4b039e6e38fbad2c41f7c09266914d" size="123" mtime="1568127990"/>
-          <entry name="somefile.txt" md5="d912744ebbc07612405fc0987f7dcba3" size="65" mtime="1568127988"/>
-        </directory>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:06:31 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Jane/branch_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '638'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="branch_test_package" rev="3" vrev="3" srcmd5="9131d0c61a2a1accc89616ce5096be29">
-          <linkinfo project="home:other_user" package="branch_test_package" srcmd5="04bc017c126b379ea6b9f27f9aa0146b" baserev="04bc017c126b379ea6b9f27f9aa0146b" xsrcmd5="5d8509ca10f320596cf41f2431f9b561" lsrcmd5="9131d0c61a2a1accc89616ce5096be29"/>
-          <entry name="_config" md5="7a247c51a52a0f1f3090db3106cff62e" size="53" mtime="1568127988"/>
-          <entry name="_link" md5="cf4b039e6e38fbad2c41f7c09266914d" size="123" mtime="1568127990"/>
-          <entry name="somefile.txt" md5="d912744ebbc07612405fc0987f7dcba3" size="65" mtime="1568127988"/>
-        </directory>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:06:31 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Jane/branch_test_package/_history
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '574'
+      - '31'
     body:
       encoding: UTF-8
       string: |
         <revisionlist>
-          <revision rev="1" vrev="1">
-            <srcmd5>fb44fff1a5071c5138acc0d893d955fb</srcmd5>
-            <version>unknown</version>
-            <time>1568127964</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="2" vrev="2">
-            <srcmd5>0eeb88778c6037273dd8719cdf26254c</srcmd5>
-            <version>unknown</version>
-            <time>1568127964</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="3" vrev="3">
-            <srcmd5>9131d0c61a2a1accc89616ce5096be29</srcmd5>
-            <version>unknown</version>
-            <time>1568127990</time>
-            <user>Jane</user>
-          </revision>
         </revisionlist>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:06:31 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:16 GMT
 - request:
     method: get
-    uri: http://backend:5352/build/home:Jane/_result?package=branch_test_package&view=status
+    uri: http://backend:5352/source/home:Jane/branch_test_package
     body:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - c21a7bb3-8591-403d-a471-db861fe9b212
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '638'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="branch_test_package" rev="6" vrev="6" srcmd5="ef747ae29b0c2ba62260d3940f79fc71">
+          <linkinfo project="home:other_user" package="branch_test_package" srcmd5="7d8277ba3a4bc8c2bba6d897da3a39fa" baserev="7d8277ba3a4bc8c2bba6d897da3a39fa" xsrcmd5="bab0a0559ae4d7fd8c5f8627c50a62b4" lsrcmd5="ef747ae29b0c2ba62260d3940f79fc71"/>
+          <entry name="_config" md5="90f85c0db7009e7c8c13080684f09188" size="72" mtime="1677088693"/>
+          <entry name="_link" md5="d5cfac488fe38faeda9f58aaa0540dc7" size="123" mtime="1677088695"/>
+          <entry name="somefile.txt" md5="ae99286d197ce7dafe5f8bd94e966209" size="55" mtime="1677088693"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 17:58:16 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Jane/branch_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - c21a7bb3-8591-403d-a471-db861fe9b212
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '638'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="branch_test_package" rev="6" vrev="6" srcmd5="ef747ae29b0c2ba62260d3940f79fc71">
+          <linkinfo project="home:other_user" package="branch_test_package" srcmd5="7d8277ba3a4bc8c2bba6d897da3a39fa" baserev="7d8277ba3a4bc8c2bba6d897da3a39fa" xsrcmd5="bab0a0559ae4d7fd8c5f8627c50a62b4" lsrcmd5="ef747ae29b0c2ba62260d3940f79fc71"/>
+          <entry name="_config" md5="90f85c0db7009e7c8c13080684f09188" size="72" mtime="1677088693"/>
+          <entry name="_link" md5="d5cfac488fe38faeda9f58aaa0540dc7" size="123" mtime="1677088695"/>
+          <entry name="somefile.txt" md5="ae99286d197ce7dafe5f8bd94e966209" size="55" mtime="1677088693"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 17:58:16 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Jane/branch_test_package/_history?deleted=1&meta=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - c21a7bb3-8591-403d-a471-db861fe9b212
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Wed, 22 Feb 2023 17:58:16 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:Jane/_result?lastbuild=1&locallink=1&multibuild=1&package=branch_test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 43ce2e21-543a-47bd-811a-2553871634bb
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1048,6 +1072,73 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:06:31 GMT
-recorded_with: VCR 5.0.0
+  recorded_at: Wed, 22 Feb 2023 17:58:16 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:Jane/_result?lastbuild=1&locallink=1&multibuild=1&package=branch_test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 27f26996-0b97-4e8b-ac2f-97d3be859d7f
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 17:58:16 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:Jane/_result?package=branch_test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - b188ae6f-9b92-493a-b41b-94cca3cfbd97
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 17:58:16 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Projects/branching/an_existing_package_but_chose_a_different_target_package_name.yml
+++ b/src/api/spec/cassettes/Projects/branching/an_existing_package_but_chose_a_different_target_package_name.yml
@@ -2,14 +2,14 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/home:user_1/_meta?user=user_1
+    uri: http://backend:5352/source/home:user_6/_meta?user=user_6
     body:
       encoding: UTF-8
       string: |
-        <project name="home:user_1">
+        <project name="home:user_6">
           <title/>
           <description/>
-          <person userid="user_1" role="maintainer"/>
+          <person userid="user_6" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -34,13 +34,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <project name="home:user_1">
+        <project name="home:user_6">
           <title></title>
           <description></description>
-          <person userid="user_1" role="maintainer"/>
+          <person userid="user_6" role="maintainer"/>
         </project>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:05:46 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:09 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Jane/_meta?user=Jane
@@ -80,8 +79,7 @@ http_interactions:
           <description></description>
           <person userid="Jane" role="maintainer"/>
         </project>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:05:46 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:09 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/_meta?user=other_user
@@ -121,17 +119,16 @@ http_interactions:
           <description></description>
           <person userid="other_user" role="maintainer"/>
         </project>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:05:46 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:09 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta?user=user_2
+    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta?user=user_7
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_user">
-          <title>Dulce et Decorum Est</title>
-          <description>Sit et odit eligendi.</description>
+          <title>Butter In a Lordly Dish</title>
+          <description>Repudiandae doloribus architecto rerum.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -152,22 +149,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '163'
+      - '184'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_user">
-          <title>Dulce et Decorum Est</title>
-          <description>Sit et odit eligendi.</description>
+          <title>Butter In a Lordly Dish</title>
+          <description>Repudiandae doloribus architecto rerum.</description>
         </package>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:05:46 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:09 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/branch_test_package/_config
     body:
       encoding: UTF-8
-      string: Pariatur sed dolores. Numquam quo deleniti. Fugit amet ad.
+      string: Mollitia officiis voluptatibus. Quidem et commodi. Odit aliquam omnis.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -187,26 +183,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1" vrev="1">
-          <srcmd5>bbb0786e04a21e2096c745b4bebbdc51</srcmd5>
+        <revision rev="11" vrev="11">
+          <srcmd5>1026abbe8ecc0c0cc28ea2ba768fca1d</srcmd5>
           <version>unknown</version>
-          <time>1568127947</time>
+          <time>1677088689</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:05:47 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:09 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/branch_test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Id voluptas mollitia. Modi facere ut. Voluptatem placeat commodi.
+      string: Ullam cum aut. Explicabo rerum officia. Aut provident est.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -226,20 +221,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="2" vrev="2">
-          <srcmd5>af72d1f0e3cded30c9ef4595024c1675</srcmd5>
+        <revision rev="12" vrev="12">
+          <srcmd5>fa0e62a3d7328291097f7c9c0c773f67</srcmd5>
           <version>unknown</version>
-          <time>1568127947</time>
+          <time>1677088689</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:05:47 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:09 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:Jane/_result?code=unresolvable&view=status
@@ -247,6 +241,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - 3755889f-550e-48bf-8cbc-7af3b9d6772c
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -271,8 +267,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:05:49 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:10 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Jane/_keyinfo?donotcreatecert=1&withsslcert=1
@@ -280,6 +275,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - 3755889f-550e-48bf-8cbc-7af3b9d6772c
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -302,8 +299,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "<keyinfo/>\n"
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:05:49 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:10 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:Jane/_result?view=summary
@@ -311,6 +307,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - 9d7699c3-8080-4f21-8b4a-683418e64dbb
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -335,8 +333,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:05:50 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:11 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22branch_test_package%22%20and%20linkinfo/@project=%22home:other_user%22%20and%20@project=%22home:other_user%22)
@@ -370,8 +367,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:05:50 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:12 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Jane/some_different_name/_meta?user=Jane
@@ -379,8 +375,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="some_different_name" project="home:Jane">
-          <title>Dulce et Decorum Est</title>
-          <description>Sit et odit eligendi.</description>
+          <title>Butter In a Lordly Dish</title>
+          <description>Repudiandae doloribus architecto rerum.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -401,16 +397,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '157'
+      - '178'
     body:
       encoding: UTF-8
       string: |
         <package name="some_different_name" project="home:Jane">
-          <title>Dulce et Decorum Est</title>
-          <description>Sit et odit eligendi.</description>
+          <title>Butter In a Lordly Dish</title>
+          <description>Repudiandae doloribus architecto rerum.</description>
         </package>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:05:50 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:12 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Jane/some_different_name?cmd=branch&noservice=1&opackage=branch_test_package&oproject=home:other_user&user=Jane
@@ -442,16 +437,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1" vrev="1">
-          <srcmd5>704d1c24a4efb812cf899eae5a5ec787</srcmd5>
+        <revision rev="4" vrev="4">
+          <srcmd5>70e985d2c7e3e051c2f3f559ce76b209</srcmd5>
           <version>unknown</version>
-          <time>1568127950</time>
+          <time>1677088692</time>
           <user>Jane</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:05:50 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:12 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Jane/some_different_name/_meta?user=Jane
@@ -459,8 +453,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="some_different_name" project="home:Jane">
-          <title>Dulce et Decorum Est</title>
-          <description>Sit et odit eligendi.</description>
+          <title>Butter In a Lordly Dish</title>
+          <description>Repudiandae doloribus architecto rerum.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -481,16 +475,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '157'
+      - '178'
     body:
       encoding: UTF-8
       string: |
         <package name="some_different_name" project="home:Jane">
-          <title>Dulce et Decorum Est</title>
-          <description>Sit et odit eligendi.</description>
+          <title>Butter In a Lordly Dish</title>
+          <description>Repudiandae doloribus architecto rerum.</description>
         </package>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:05:50 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:12 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Jane/some_different_name
@@ -520,14 +513,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="some_different_name" rev="1" vrev="1" srcmd5="704d1c24a4efb812cf899eae5a5ec787">
-          <linkinfo project="home:other_user" package="branch_test_package" srcmd5="af72d1f0e3cded30c9ef4595024c1675" baserev="af72d1f0e3cded30c9ef4595024c1675" xsrcmd5="ce50d07b587e381b3139b3f27c038c49" lsrcmd5="704d1c24a4efb812cf899eae5a5ec787"/>
-          <entry name="_config" md5="00f41849254835ea65f21545b04452e3" size="58" mtime="1568127947"/>
-          <entry name="_link" md5="2c8c59f5b669924c9efb65f08d0fb6e2" size="153" mtime="1568127950"/>
-          <entry name="somefile.txt" md5="48b061a98468258f71f62a9e13fad934" size="65" mtime="1568127947"/>
+        <directory name="some_different_name" rev="4" vrev="4" srcmd5="70e985d2c7e3e051c2f3f559ce76b209">
+          <linkinfo project="home:other_user" package="branch_test_package" srcmd5="fa0e62a3d7328291097f7c9c0c773f67" baserev="fa0e62a3d7328291097f7c9c0c773f67" xsrcmd5="35256742dfbc97a4b892f74c4cda3d9b" lsrcmd5="70e985d2c7e3e051c2f3f559ce76b209"/>
+          <entry name="_config" md5="22edd93135955fa0c44fa3d6396da3cc" size="70" mtime="1677088689"/>
+          <entry name="_link" md5="48a2a853472235c143beb814c05cac9e" size="153" mtime="1677088692"/>
+          <entry name="somefile.txt" md5="3e228c07fe57c281a06f82beedb6a8f0" size="58" mtime="1677088689"/>
         </directory>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:05:50 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:12 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Jane/some_different_name?view=info
@@ -535,6 +527,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - 50f09237-eaa2-47fb-938c-703405bcb3b0
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -553,16 +547,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '348'
+      - '349'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="some_different_name" rev="1" vrev="3" srcmd5="ce50d07b587e381b3139b3f27c038c49" lsrcmd5="704d1c24a4efb812cf899eae5a5ec787" verifymd5="af72d1f0e3cded30c9ef4595024c1675">
+        <sourceinfo package="some_different_name" rev="4" vrev="16" srcmd5="35256742dfbc97a4b892f74c4cda3d9b" lsrcmd5="70e985d2c7e3e051c2f3f559ce76b209" verifymd5="fa0e62a3d7328291097f7c9c0c773f67">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="home:other_user" package="branch_test_package"/>
         </sourceinfo>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:05:50 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:12 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Jane/some_different_name
@@ -570,6 +563,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - 50f09237-eaa2-47fb-938c-703405bcb3b0
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -592,14 +587,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="some_different_name" rev="1" vrev="1" srcmd5="704d1c24a4efb812cf899eae5a5ec787">
-          <linkinfo project="home:other_user" package="branch_test_package" srcmd5="af72d1f0e3cded30c9ef4595024c1675" baserev="af72d1f0e3cded30c9ef4595024c1675" xsrcmd5="ce50d07b587e381b3139b3f27c038c49" lsrcmd5="704d1c24a4efb812cf899eae5a5ec787"/>
-          <entry name="_config" md5="00f41849254835ea65f21545b04452e3" size="58" mtime="1568127947"/>
-          <entry name="_link" md5="2c8c59f5b669924c9efb65f08d0fb6e2" size="153" mtime="1568127950"/>
-          <entry name="somefile.txt" md5="48b061a98468258f71f62a9e13fad934" size="65" mtime="1568127947"/>
+        <directory name="some_different_name" rev="4" vrev="4" srcmd5="70e985d2c7e3e051c2f3f559ce76b209">
+          <linkinfo project="home:other_user" package="branch_test_package" srcmd5="fa0e62a3d7328291097f7c9c0c773f67" baserev="fa0e62a3d7328291097f7c9c0c773f67" xsrcmd5="35256742dfbc97a4b892f74c4cda3d9b" lsrcmd5="70e985d2c7e3e051c2f3f559ce76b209"/>
+          <entry name="_config" md5="22edd93135955fa0c44fa3d6396da3cc" size="70" mtime="1677088689"/>
+          <entry name="_link" md5="48a2a853472235c143beb814c05cac9e" size="153" mtime="1677088692"/>
+          <entry name="somefile.txt" md5="3e228c07fe57c281a06f82beedb6a8f0" size="58" mtime="1677088689"/>
         </directory>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:05:50 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:12 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Jane/some_different_name?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -631,15 +625,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="1b87cee8f5cee4b66ebd7cfe65d7c1e5">
+        <sourcediff key="f3ff838b956951fba22fe48d42531636">
           <old project="home:Jane" package="some_different_name" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:Jane" package="some_different_name" rev="1" srcmd5="704d1c24a4efb812cf899eae5a5ec787"/>
+          <new project="home:Jane" package="some_different_name" rev="4" srcmd5="70e985d2c7e3e051c2f3f559ce76b209"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:05:50 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:12 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:Jane/some_different_name?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -671,15 +664,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="5127f1fbcf5a4ca95a7363e9b5e47056">
-          <old project="home:other_user" package="branch_test_package" rev="af72d1f0e3cded30c9ef4595024c1675" srcmd5="af72d1f0e3cded30c9ef4595024c1675"/>
-          <new project="home:Jane" package="some_different_name" rev="ce50d07b587e381b3139b3f27c038c49" srcmd5="ce50d07b587e381b3139b3f27c038c49"/>
+        <sourcediff key="fa726caa50836df6060b6bea5c007461">
+          <old project="home:other_user" package="branch_test_package" rev="fa0e62a3d7328291097f7c9c0c773f67" srcmd5="fa0e62a3d7328291097f7c9c0c773f67"/>
+          <new project="home:Jane" package="some_different_name" rev="35256742dfbc97a4b892f74c4cda3d9b" srcmd5="35256742dfbc97a4b892f74c4cda3d9b"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:05:50 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:12 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Jane/_meta?user=Jane
@@ -692,6 +684,8 @@ http_interactions:
           <person userid="Jane" role="maintainer"/>
         </project>
     headers:
+      X-Request-Id:
+      - 50f09237-eaa2-47fb-938c-703405bcb3b0
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -719,8 +713,7 @@ http_interactions:
           <description></description>
           <person userid="Jane" role="maintainer"/>
         </project>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:05:51 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:12 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:other_user/branch_test_package?view=info
@@ -728,6 +721,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - 072b87a5-04b1-4805-9578-3de0eabba702
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -746,15 +741,14 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '237'
+      - '239'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="branch_test_package" rev="2" vrev="2" srcmd5="af72d1f0e3cded30c9ef4595024c1675" verifymd5="af72d1f0e3cded30c9ef4595024c1675">
+        <sourceinfo package="branch_test_package" rev="12" vrev="12" srcmd5="fa0e62a3d7328291097f7c9c0c773f67" verifymd5="fa0e62a3d7328291097f7c9c0c773f67">
           <error>bad build configuration, no build type defined or detected</error>
         </sourceinfo>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:05:51 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:12 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:other_user/branch_test_package
@@ -762,6 +756,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - 072b87a5-04b1-4805-9578-3de0eabba702
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -780,16 +776,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '304'
+      - '306'
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="2" vrev="2" srcmd5="af72d1f0e3cded30c9ef4595024c1675">
-          <entry name="_config" md5="00f41849254835ea65f21545b04452e3" size="58" mtime="1568127947"/>
-          <entry name="somefile.txt" md5="48b061a98468258f71f62a9e13fad934" size="65" mtime="1568127947"/>
+        <directory name="branch_test_package" rev="12" vrev="12" srcmd5="fa0e62a3d7328291097f7c9c0c773f67">
+          <entry name="_config" md5="22edd93135955fa0c44fa3d6396da3cc" size="70" mtime="1677088689"/>
+          <entry name="somefile.txt" md5="3e228c07fe57c281a06f82beedb6a8f0" size="58" mtime="1677088689"/>
         </directory>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:05:51 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:12 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:other_user/branch_test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -817,19 +812,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '330'
+      - '331'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="caa53f16bc760dadb62b9f0d9e2e69fc">
+        <sourcediff key="899e6dc1f247ef883adcb520d4737ad6">
           <old project="home:other_user" package="branch_test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:other_user" package="branch_test_package" rev="2" srcmd5="af72d1f0e3cded30c9ef4595024c1675"/>
+          <new project="home:other_user" package="branch_test_package" rev="12" srcmd5="fa0e62a3d7328291097f7c9c0c773f67"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:05:51 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:12 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Jane/some_different_name
@@ -837,6 +831,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - 072b87a5-04b1-4805-9578-3de0eabba702
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -859,17 +855,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="some_different_name" rev="1" vrev="1" srcmd5="704d1c24a4efb812cf899eae5a5ec787">
-          <linkinfo project="home:other_user" package="branch_test_package" srcmd5="af72d1f0e3cded30c9ef4595024c1675" baserev="af72d1f0e3cded30c9ef4595024c1675" xsrcmd5="ce50d07b587e381b3139b3f27c038c49" lsrcmd5="704d1c24a4efb812cf899eae5a5ec787"/>
-          <entry name="_config" md5="00f41849254835ea65f21545b04452e3" size="58" mtime="1568127947"/>
-          <entry name="_link" md5="2c8c59f5b669924c9efb65f08d0fb6e2" size="153" mtime="1568127950"/>
-          <entry name="somefile.txt" md5="48b061a98468258f71f62a9e13fad934" size="65" mtime="1568127947"/>
+        <directory name="some_different_name" rev="4" vrev="4" srcmd5="70e985d2c7e3e051c2f3f559ce76b209">
+          <linkinfo project="home:other_user" package="branch_test_package" srcmd5="fa0e62a3d7328291097f7c9c0c773f67" baserev="fa0e62a3d7328291097f7c9c0c773f67" xsrcmd5="35256742dfbc97a4b892f74c4cda3d9b" lsrcmd5="70e985d2c7e3e051c2f3f559ce76b209"/>
+          <entry name="_config" md5="22edd93135955fa0c44fa3d6396da3cc" size="70" mtime="1677088689"/>
+          <entry name="_link" md5="48a2a853472235c143beb814c05cac9e" size="153" mtime="1677088692"/>
+          <entry name="somefile.txt" md5="3e228c07fe57c281a06f82beedb6a8f0" size="58" mtime="1677088689"/>
         </directory>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:05:51 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:12 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Jane/some_different_name?expand=1&rev=1
+    uri: http://backend:5352/source/home:Jane/some_different_name?expand=1&rev=4
     body:
       encoding: US-ASCII
       string: ''
@@ -892,24 +887,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '533'
+      - '534'
     body:
       encoding: UTF-8
       string: |
-        <directory name="some_different_name" rev="ce50d07b587e381b3139b3f27c038c49" vrev="3" srcmd5="ce50d07b587e381b3139b3f27c038c49">
-          <linkinfo project="home:other_user" package="branch_test_package" srcmd5="af72d1f0e3cded30c9ef4595024c1675" baserev="af72d1f0e3cded30c9ef4595024c1675" lsrcmd5="704d1c24a4efb812cf899eae5a5ec787"/>
-          <entry name="_config" md5="00f41849254835ea65f21545b04452e3" size="58" mtime="1568127947"/>
-          <entry name="somefile.txt" md5="48b061a98468258f71f62a9e13fad934" size="65" mtime="1568127947"/>
+        <directory name="some_different_name" rev="35256742dfbc97a4b892f74c4cda3d9b" vrev="16" srcmd5="35256742dfbc97a4b892f74c4cda3d9b">
+          <linkinfo project="home:other_user" package="branch_test_package" srcmd5="fa0e62a3d7328291097f7c9c0c773f67" baserev="fa0e62a3d7328291097f7c9c0c773f67" lsrcmd5="70e985d2c7e3e051c2f3f559ce76b209"/>
+          <entry name="_config" md5="22edd93135955fa0c44fa3d6396da3cc" size="70" mtime="1677088689"/>
+          <entry name="somefile.txt" md5="3e228c07fe57c281a06f82beedb6a8f0" size="58" mtime="1677088689"/>
         </directory>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:05:51 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:12 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Jane/some_different_name
+    uri: http://backend:5352/source/home:Jane/some_different_name/_history?deleted=1&meta=1&rev=4
     body:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - 072b87a5-04b1-4805-9578-3de0eabba702
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -928,101 +924,132 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '638'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="some_different_name" rev="1" vrev="1" srcmd5="704d1c24a4efb812cf899eae5a5ec787">
-          <linkinfo project="home:other_user" package="branch_test_package" srcmd5="af72d1f0e3cded30c9ef4595024c1675" baserev="af72d1f0e3cded30c9ef4595024c1675" xsrcmd5="ce50d07b587e381b3139b3f27c038c49" lsrcmd5="704d1c24a4efb812cf899eae5a5ec787"/>
-          <entry name="_config" md5="00f41849254835ea65f21545b04452e3" size="58" mtime="1568127947"/>
-          <entry name="_link" md5="2c8c59f5b669924c9efb65f08d0fb6e2" size="153" mtime="1568127950"/>
-          <entry name="somefile.txt" md5="48b061a98468258f71f62a9e13fad934" size="65" mtime="1568127947"/>
-        </directory>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:05:51 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Jane/some_different_name
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '638'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="some_different_name" rev="1" vrev="1" srcmd5="704d1c24a4efb812cf899eae5a5ec787">
-          <linkinfo project="home:other_user" package="branch_test_package" srcmd5="af72d1f0e3cded30c9ef4595024c1675" baserev="af72d1f0e3cded30c9ef4595024c1675" xsrcmd5="ce50d07b587e381b3139b3f27c038c49" lsrcmd5="704d1c24a4efb812cf899eae5a5ec787"/>
-          <entry name="_config" md5="00f41849254835ea65f21545b04452e3" size="58" mtime="1568127947"/>
-          <entry name="_link" md5="2c8c59f5b669924c9efb65f08d0fb6e2" size="153" mtime="1568127950"/>
-          <entry name="somefile.txt" md5="48b061a98468258f71f62a9e13fad934" size="65" mtime="1568127947"/>
-        </directory>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:05:51 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Jane/some_different_name/_history
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '210'
+      - '31'
     body:
       encoding: UTF-8
       string: |
         <revisionlist>
-          <revision rev="1" vrev="1">
-            <srcmd5>704d1c24a4efb812cf899eae5a5ec787</srcmd5>
-            <version>unknown</version>
-            <time>1568127950</time>
-            <user>Jane</user>
-          </revision>
         </revisionlist>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:05:51 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:12 GMT
 - request:
     method: get
-    uri: http://backend:5352/build/home:Jane/_result?package=some_different_name&view=status
+    uri: http://backend:5352/source/home:Jane/some_different_name
     body:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - 072b87a5-04b1-4805-9578-3de0eabba702
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '638'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="some_different_name" rev="4" vrev="4" srcmd5="70e985d2c7e3e051c2f3f559ce76b209">
+          <linkinfo project="home:other_user" package="branch_test_package" srcmd5="fa0e62a3d7328291097f7c9c0c773f67" baserev="fa0e62a3d7328291097f7c9c0c773f67" xsrcmd5="35256742dfbc97a4b892f74c4cda3d9b" lsrcmd5="70e985d2c7e3e051c2f3f559ce76b209"/>
+          <entry name="_config" md5="22edd93135955fa0c44fa3d6396da3cc" size="70" mtime="1677088689"/>
+          <entry name="_link" md5="48a2a853472235c143beb814c05cac9e" size="153" mtime="1677088692"/>
+          <entry name="somefile.txt" md5="3e228c07fe57c281a06f82beedb6a8f0" size="58" mtime="1677088689"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 17:58:12 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Jane/some_different_name
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 072b87a5-04b1-4805-9578-3de0eabba702
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '638'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="some_different_name" rev="4" vrev="4" srcmd5="70e985d2c7e3e051c2f3f559ce76b209">
+          <linkinfo project="home:other_user" package="branch_test_package" srcmd5="fa0e62a3d7328291097f7c9c0c773f67" baserev="fa0e62a3d7328291097f7c9c0c773f67" xsrcmd5="35256742dfbc97a4b892f74c4cda3d9b" lsrcmd5="70e985d2c7e3e051c2f3f559ce76b209"/>
+          <entry name="_config" md5="22edd93135955fa0c44fa3d6396da3cc" size="70" mtime="1677088689"/>
+          <entry name="_link" md5="48a2a853472235c143beb814c05cac9e" size="153" mtime="1677088692"/>
+          <entry name="somefile.txt" md5="3e228c07fe57c281a06f82beedb6a8f0" size="58" mtime="1677088689"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 17:58:12 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Jane/some_different_name/_history?deleted=1&meta=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 072b87a5-04b1-4805-9578-3de0eabba702
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Wed, 22 Feb 2023 17:58:12 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:Jane/_result?lastbuild=1&locallink=1&multibuild=1&package=some_different_name&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - e6feaed8-4729-423a-8091-4dde19826c92
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1047,6 +1074,73 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:05:51 GMT
-recorded_with: VCR 5.0.0
+  recorded_at: Wed, 22 Feb 2023 17:58:12 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:Jane/_result?lastbuild=1&locallink=1&multibuild=1&package=some_different_name&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - eb09f7f8-e02d-4169-8389-c5c8e020eb5c
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 17:58:12 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:Jane/_result?package=some_different_name&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 1d0a1c7e-43d2-428b-b06f-ce34a9120118
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 17:58:12 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Projects/branching/an_existing_package_were_the_target_package_already_exists.yml
+++ b/src/api/spec/cassettes/Projects/branching/an_existing_package_were_the_target_package_already_exists.yml
@@ -2,14 +2,14 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/home:user_3/_meta?user=user_3
+    uri: http://backend:5352/source/home:user_10/_meta?user=user_10
     body:
       encoding: UTF-8
       string: |
-        <project name="home:user_3">
+        <project name="home:user_10">
           <title/>
           <description/>
-          <person userid="user_3" role="maintainer"/>
+          <person userid="user_10" role="maintainer"/>
         </project>
     headers:
       Accept-Encoding:
@@ -30,17 +30,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '134'
+      - '136'
     body:
       encoding: UTF-8
       string: |
-        <project name="home:user_3">
+        <project name="home:user_10">
           <title></title>
           <description></description>
-          <person userid="user_3" role="maintainer"/>
+          <person userid="user_10" role="maintainer"/>
         </project>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:06:01 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:16 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Jane/_meta?user=Jane
@@ -80,8 +79,7 @@ http_interactions:
           <description></description>
           <person userid="Jane" role="maintainer"/>
         </project>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:06:02 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:17 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/_meta?user=other_user
@@ -121,17 +119,16 @@ http_interactions:
           <description></description>
           <person userid="other_user" role="maintainer"/>
         </project>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:06:02 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:17 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta?user=user_4
+    uri: http://backend:5352/source/home:other_user/branch_test_package/_meta?user=user_11
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_user">
-          <title>The Proper Study</title>
-          <description>Eum est voluptatum omnis.</description>
+          <title>Dulce et Decorum Est</title>
+          <description>Facilis vel doloribus sed.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -152,22 +149,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '163'
+      - '168'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:other_user">
-          <title>The Proper Study</title>
-          <description>Eum est voluptatum omnis.</description>
+          <title>Dulce et Decorum Est</title>
+          <description>Facilis vel doloribus sed.</description>
         </package>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:06:02 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:17 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/branch_test_package/_config
     body:
       encoding: UTF-8
-      string: Fugit voluptates voluptatem. In at odio. Et vel odio.
+      string: Quas et ipsam. Excepturi eaque nostrum. Est tenetur magnam.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -187,26 +183,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="3" vrev="3">
-          <srcmd5>4f6f45139b580a4ca83b92a63b88139d</srcmd5>
+        <revision rev="15" vrev="15">
+          <srcmd5>2798510a851154a4cdda70070e70cd22</srcmd5>
           <version>unknown</version>
-          <time>1568127962</time>
+          <time>1677088697</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:06:02 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:17 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:other_user/branch_test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Beatae ut consectetur. Reprehenderit excepturi enim. Qui aut dolorum.
+      string: Repudiandae quaerat optio. Totam est dolorem. Autem commodi nostrum.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -226,20 +221,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="4" vrev="4">
-          <srcmd5>cca4108cfa3a006c1e83baf2710f32d4</srcmd5>
+        <revision rev="16" vrev="16">
+          <srcmd5>86a5600c6ca1c881a77d5e3bcf0a73a0</srcmd5>
           <version>unknown</version>
-          <time>1568127962</time>
+          <time>1677088697</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:06:02 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:17 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:Jane/_result?code=unresolvable&view=status
@@ -247,6 +241,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - c4c186cd-7103-4ef8-bdff-876460ecaef9
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -271,8 +267,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:06:03 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:18 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Jane/_keyinfo?donotcreatecert=1&withsslcert=1
@@ -280,6 +275,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - c4c186cd-7103-4ef8-bdff-876460ecaef9
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -302,8 +299,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: "<keyinfo/>\n"
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:06:03 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:18 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:Jane/_result?view=summary
@@ -311,6 +307,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - 1c3d20a8-03d2-4122-962c-0ac07f56cb68
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -335,8 +333,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:06:03 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:18 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Jane/branch_test_package/_meta?user=Jane
@@ -344,8 +341,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:Jane">
-          <title>The Way Through the Woods</title>
-          <description>Vitae accusantium tempore rerum.</description>
+          <title>All Passion Spent</title>
+          <description>Culpa vero hic et.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -366,22 +363,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '173'
+      - '151'
     body:
       encoding: UTF-8
       string: |
         <package name="branch_test_package" project="home:Jane">
-          <title>The Way Through the Woods</title>
-          <description>Vitae accusantium tempore rerum.</description>
+          <title>All Passion Spent</title>
+          <description>Culpa vero hic et.</description>
         </package>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:06:03 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:18 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Jane/branch_test_package/_config
     body:
       encoding: UTF-8
-      string: Ut omnis optio. Maxime accusantium id. Neque quibusdam atque.
+      string: Aliquam eos illo. Eveniet est sapiente. Praesentium pariatur voluptate.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -405,22 +401,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1" vrev="1">
-          <srcmd5>fb44fff1a5071c5138acc0d893d955fb</srcmd5>
+        <revision rev="7" vrev="7">
+          <srcmd5>0d89b1ce03853e1ae7cb41a7bb383143</srcmd5>
           <version>unknown</version>
-          <time>1568127964</time>
+          <time>1677088698</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:06:04 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:18 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:Jane/branch_test_package/somefile.txt
     body:
       encoding: UTF-8
-      string: Assumenda reiciendis voluptatem. Vero soluta ut. Vitae officiis qui.
+      string: Itaque quibusdam commodi. Fugiat eius et. Aut nulla ut.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -444,16 +439,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="2" vrev="2">
-          <srcmd5>0eeb88778c6037273dd8719cdf26254c</srcmd5>
+        <revision rev="8" vrev="8">
+          <srcmd5>786f5cefe905e953390c86c126dd2ae9</srcmd5>
           <version>unknown</version>
-          <time>1568127964</time>
+          <time>1677088699</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:06:04 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:19 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22branch_test_package%22%20and%20linkinfo/@project=%22home:other_user%22%20and%20@project=%22home:other_user%22)
@@ -487,8 +481,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:06:04 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:19 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Jane/branch_test_package
@@ -496,6 +489,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - 7530a85e-e699-4156-8a15-9030d8fff5f7
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -514,19 +509,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '304'
+      - '586'
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="2" vrev="2" srcmd5="0eeb88778c6037273dd8719cdf26254c">
-          <entry name="_config" md5="8af397537d53010aefcfab1d723d4a83" size="61" mtime="1568127963"/>
-          <entry name="somefile.txt" md5="cab7b99edd61410fc34344e01c28ef2d" size="68" mtime="1568127964"/>
+        <directory name="branch_test_package" rev="8" vrev="8" srcmd5="786f5cefe905e953390c86c126dd2ae9">
+          <linkinfo project="home:other_user" package="branch_test_package" baserev="7d8277ba3a4bc8c2bba6d897da3a39fa" xsrcmd5="f9ff898318470f496046293cc9d41f46" error="conflict in file _config"/>
+          <entry name="_config" md5="d5fe78f9a8f896f0d3275ac9e96da5df" size="71" mtime="1677088698"/>
+          <entry name="_link" md5="d5cfac488fe38faeda9f58aaa0540dc7" size="123" mtime="1677088695"/>
+          <entry name="somefile.txt" md5="fa49b91981aa7c7daad4e6c3ea41fbe3" size="55" mtime="1677088698"/>
         </directory>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:06:04 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:19 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Jane/branch_test_package?expand=1&rev=2
+    uri: http://backend:5352/source/home:Jane/branch_test_package?expand=1&rev=8
     body:
       encoding: US-ASCII
       string: ''
@@ -539,8 +535,8 @@ http_interactions:
       - Ruby
   response:
     status:
-      code: 200
-      message: OK
+      code: 400
+      message: conflict in file _config
     headers:
       Content-Type:
       - text/xml
@@ -549,51 +545,14 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '304'
+      - '76'
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="2" vrev="2" srcmd5="0eeb88778c6037273dd8719cdf26254c">
-          <entry name="_config" md5="8af397537d53010aefcfab1d723d4a83" size="61" mtime="1568127963"/>
-          <entry name="somefile.txt" md5="cab7b99edd61410fc34344e01c28ef2d" size="68" mtime="1568127964"/>
-        </directory>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:06:04 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:Jane/branch_test_package
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '304'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="branch_test_package" rev="2" vrev="2" srcmd5="0eeb88778c6037273dd8719cdf26254c">
-          <entry name="_config" md5="8af397537d53010aefcfab1d723d4a83" size="61" mtime="1568127963"/>
-          <entry name="somefile.txt" md5="cab7b99edd61410fc34344e01c28ef2d" size="68" mtime="1568127964"/>
-        </directory>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:06:04 GMT
+        <status code="400">
+          <summary>conflict in file _config</summary>
+        </status>
+  recorded_at: Wed, 22 Feb 2023 17:58:19 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:Jane/branch_test_package
@@ -601,6 +560,8 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - 7530a85e-e699-4156-8a15-9030d8fff5f7
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -619,19 +580,20 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '304'
+      - '586'
     body:
       encoding: UTF-8
       string: |
-        <directory name="branch_test_package" rev="2" vrev="2" srcmd5="0eeb88778c6037273dd8719cdf26254c">
-          <entry name="_config" md5="8af397537d53010aefcfab1d723d4a83" size="61" mtime="1568127963"/>
-          <entry name="somefile.txt" md5="cab7b99edd61410fc34344e01c28ef2d" size="68" mtime="1568127964"/>
+        <directory name="branch_test_package" rev="8" vrev="8" srcmd5="786f5cefe905e953390c86c126dd2ae9">
+          <linkinfo project="home:other_user" package="branch_test_package" baserev="7d8277ba3a4bc8c2bba6d897da3a39fa" xsrcmd5="f9ff898318470f496046293cc9d41f46" error="conflict in file _config"/>
+          <entry name="_config" md5="d5fe78f9a8f896f0d3275ac9e96da5df" size="71" mtime="1677088698"/>
+          <entry name="_link" md5="d5cfac488fe38faeda9f58aaa0540dc7" size="123" mtime="1677088695"/>
+          <entry name="somefile.txt" md5="fa49b91981aa7c7daad4e6c3ea41fbe3" size="55" mtime="1677088698"/>
         </directory>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:06:04 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:19 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:Jane/branch_test_package/_history
+    uri: http://backend:5352/source/home:Jane/branch_test_package?expand=0&rev=8
     body:
       encoding: US-ASCII
       string: ''
@@ -654,33 +616,212 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '395'
+      - '586'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="branch_test_package" rev="8" vrev="8" srcmd5="786f5cefe905e953390c86c126dd2ae9">
+          <linkinfo project="home:other_user" package="branch_test_package" baserev="7d8277ba3a4bc8c2bba6d897da3a39fa" xsrcmd5="f9ff898318470f496046293cc9d41f46" error="conflict in file _config"/>
+          <entry name="_config" md5="d5fe78f9a8f896f0d3275ac9e96da5df" size="71" mtime="1677088698"/>
+          <entry name="_link" md5="d5cfac488fe38faeda9f58aaa0540dc7" size="123" mtime="1677088695"/>
+          <entry name="somefile.txt" md5="fa49b91981aa7c7daad4e6c3ea41fbe3" size="55" mtime="1677088698"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 17:58:19 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Jane/branch_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 7530a85e-e699-4156-8a15-9030d8fff5f7
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '586'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="branch_test_package" rev="8" vrev="8" srcmd5="786f5cefe905e953390c86c126dd2ae9">
+          <linkinfo project="home:other_user" package="branch_test_package" baserev="7d8277ba3a4bc8c2bba6d897da3a39fa" xsrcmd5="f9ff898318470f496046293cc9d41f46" error="conflict in file _config"/>
+          <entry name="_config" md5="d5fe78f9a8f896f0d3275ac9e96da5df" size="71" mtime="1677088698"/>
+          <entry name="_link" md5="d5cfac488fe38faeda9f58aaa0540dc7" size="123" mtime="1677088695"/>
+          <entry name="somefile.txt" md5="fa49b91981aa7c7daad4e6c3ea41fbe3" size="55" mtime="1677088698"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 17:58:19 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Jane/branch_test_package/_history?deleted=1&meta=1&rev=8
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 7530a85e-e699-4156-8a15-9030d8fff5f7
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
     body:
       encoding: UTF-8
       string: |
         <revisionlist>
-          <revision rev="1" vrev="1">
-            <srcmd5>fb44fff1a5071c5138acc0d893d955fb</srcmd5>
-            <version>unknown</version>
-            <time>1568127964</time>
-            <user>unknown</user>
-          </revision>
-          <revision rev="2" vrev="2">
-            <srcmd5>0eeb88778c6037273dd8719cdf26254c</srcmd5>
-            <version>unknown</version>
-            <time>1568127964</time>
-            <user>unknown</user>
-          </revision>
         </revisionlist>
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:06:04 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:19 GMT
 - request:
     method: get
-    uri: http://backend:5352/build/home:Jane/_result?package=branch_test_package&view=status
+    uri: http://backend:5352/source/home:Jane/branch_test_package
     body:
       encoding: US-ASCII
       string: ''
     headers:
+      X-Request-Id:
+      - 7530a85e-e699-4156-8a15-9030d8fff5f7
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '586'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="branch_test_package" rev="8" vrev="8" srcmd5="786f5cefe905e953390c86c126dd2ae9">
+          <linkinfo project="home:other_user" package="branch_test_package" baserev="7d8277ba3a4bc8c2bba6d897da3a39fa" xsrcmd5="f9ff898318470f496046293cc9d41f46" error="conflict in file _config"/>
+          <entry name="_config" md5="d5fe78f9a8f896f0d3275ac9e96da5df" size="71" mtime="1677088698"/>
+          <entry name="_link" md5="d5cfac488fe38faeda9f58aaa0540dc7" size="123" mtime="1677088695"/>
+          <entry name="somefile.txt" md5="fa49b91981aa7c7daad4e6c3ea41fbe3" size="55" mtime="1677088698"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 17:58:19 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Jane/branch_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 7530a85e-e699-4156-8a15-9030d8fff5f7
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '586'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="branch_test_package" rev="8" vrev="8" srcmd5="786f5cefe905e953390c86c126dd2ae9">
+          <linkinfo project="home:other_user" package="branch_test_package" baserev="7d8277ba3a4bc8c2bba6d897da3a39fa" xsrcmd5="f9ff898318470f496046293cc9d41f46" error="conflict in file _config"/>
+          <entry name="_config" md5="d5fe78f9a8f896f0d3275ac9e96da5df" size="71" mtime="1677088698"/>
+          <entry name="_link" md5="d5cfac488fe38faeda9f58aaa0540dc7" size="123" mtime="1677088695"/>
+          <entry name="somefile.txt" md5="fa49b91981aa7c7daad4e6c3ea41fbe3" size="55" mtime="1677088698"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 17:58:19 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Jane/branch_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - a82265ac-b882-435d-b31c-1050db424868
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '586'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="branch_test_package" rev="8" vrev="8" srcmd5="786f5cefe905e953390c86c126dd2ae9">
+          <linkinfo project="home:other_user" package="branch_test_package" baserev="7d8277ba3a4bc8c2bba6d897da3a39fa" xsrcmd5="f9ff898318470f496046293cc9d41f46" error="conflict in file _config"/>
+          <entry name="_config" md5="d5fe78f9a8f896f0d3275ac9e96da5df" size="71" mtime="1677088698"/>
+          <entry name="_link" md5="d5cfac488fe38faeda9f58aaa0540dc7" size="123" mtime="1677088695"/>
+          <entry name="somefile.txt" md5="fa49b91981aa7c7daad4e6c3ea41fbe3" size="55" mtime="1677088698"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 17:58:19 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:Jane/_result?lastbuild=1&locallink=1&multibuild=1&package=branch_test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - a82265ac-b882-435d-b31c-1050db424868
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -705,6 +846,111 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-    http_version: 
-  recorded_at: Tue, 10 Sep 2019 15:06:05 GMT
-recorded_with: VCR 5.0.0
+  recorded_at: Wed, 22 Feb 2023 17:58:19 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:Jane/branch_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 679649ae-51f2-4f78-bbbd-ed7276c84623
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '586'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="branch_test_package" rev="8" vrev="8" srcmd5="786f5cefe905e953390c86c126dd2ae9">
+          <linkinfo project="home:other_user" package="branch_test_package" baserev="7d8277ba3a4bc8c2bba6d897da3a39fa" xsrcmd5="f9ff898318470f496046293cc9d41f46" error="conflict in file _config"/>
+          <entry name="_config" md5="d5fe78f9a8f896f0d3275ac9e96da5df" size="71" mtime="1677088698"/>
+          <entry name="_link" md5="d5cfac488fe38faeda9f58aaa0540dc7" size="123" mtime="1677088695"/>
+          <entry name="somefile.txt" md5="fa49b91981aa7c7daad4e6c3ea41fbe3" size="55" mtime="1677088698"/>
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 17:58:19 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:Jane/_result?lastbuild=1&locallink=1&multibuild=1&package=branch_test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 679649ae-51f2-4f78-bbbd-ed7276c84623
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 17:58:19 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:Jane/_result?package=branch_test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 133f18b3-b1eb-42de-9ddf-458042a94099
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 17:58:20 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Watchlists/add_and_remove_items_from_watchlist.yml
+++ b/src/api/spec/cassettes/Watchlists/add_and_remove_items_from_watchlist.yml
@@ -39,7 +39,7 @@ http_interactions:
           <description></description>
           <person userid="kody" role="maintainer"/>
         </project>
-  recorded_at: Sat, 26 Nov 2022 00:25:43 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:14 GMT
 - request:
     method: put
     uri: http://backend:5352/source/watchlist_test_project_a/_meta?user=kody
@@ -47,7 +47,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="watchlist_test_project_a">
-          <title>Precious Bane</title>
+          <title>An Instant In The Wind</title>
           <description/>
         </project>
     headers:
@@ -69,15 +69,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '114'
+      - '123'
     body:
       encoding: UTF-8
       string: |
         <project name="watchlist_test_project_a">
-          <title>Precious Bane</title>
+          <title>An Instant In The Wind</title>
           <description></description>
         </project>
-  recorded_at: Sat, 26 Nov 2022 00:25:48 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:21 GMT
 - request:
     method: get
     uri: http://backend:5352/build/watchlist_test_project_a/_result?code=unresolvable&view=status
@@ -86,7 +86,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 8712463a-990e-4075-8003-d91c98c7b7a6
+      - 3a46f28b-6f20-42b0-a0b4-198486d1019a
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -111,7 +111,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Sat, 26 Nov 2022 00:25:48 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:21 GMT
 - request:
     method: get
     uri: http://backend:5352/build/watchlist_test_project_a/_result?view=summary
@@ -120,7 +120,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 6ee2c8a8-5827-4463-9558-a59736b9eb9f
+      - 8340be00-22fa-447c-9bad-7cb88c20622a
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -145,7 +145,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Sat, 26 Nov 2022 00:25:49 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:22 GMT
 - request:
     method: put
     uri: http://backend:5352/source/watchlist_test_project_b/_meta?user=kody
@@ -153,7 +153,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="watchlist_test_project_b">
-          <title>If Not Now, When?</title>
+          <title>The Moving Finger</title>
           <description/>
         </project>
     headers:
@@ -180,10 +180,10 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="watchlist_test_project_b">
-          <title>If Not Now, When?</title>
+          <title>The Moving Finger</title>
           <description></description>
         </project>
-  recorded_at: Sat, 26 Nov 2022 00:25:49 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:22 GMT
 - request:
     method: get
     uri: http://backend:5352/build/watchlist_test_project_b/_result?code=unresolvable&view=status
@@ -192,7 +192,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 55f998a3-832d-4be7-bddb-ef6b585bf941
+      - 07f748c9-b1d6-49a7-8f3a-4cc4c19bc534
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -217,7 +217,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Sat, 26 Nov 2022 00:25:49 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:22 GMT
 - request:
     method: get
     uri: http://backend:5352/build/watchlist_test_project_b/_result?view=summary
@@ -226,7 +226,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - a109d30e-5862-4c5a-a4cf-fe371f66dd78
+      - 295eabea-eca3-4fae-ba6a-5bf7be411756
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -251,7 +251,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Sat, 26 Nov 2022 00:25:49 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:23 GMT
 - request:
     method: put
     uri: http://backend:5352/source/watchlist_test_project_a/watchlist_test_package/_meta?user=kody
@@ -259,8 +259,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="watchlist_test_package" project="watchlist_test_project_a">
-          <title>Postern of Fate</title>
-          <description>At eos illum recusandae.</description>
+          <title>No Country for Old Men</title>
+          <description>Doloribus maxime explicabo labore.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -281,15 +281,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '173'
+      - '190'
     body:
       encoding: UTF-8
       string: |
         <package name="watchlist_test_package" project="watchlist_test_project_a">
-          <title>Postern of Fate</title>
-          <description>At eos illum recusandae.</description>
+          <title>No Country for Old Men</title>
+          <description>Doloribus maxime explicabo labore.</description>
         </package>
-  recorded_at: Sat, 26 Nov 2022 00:25:50 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:23 GMT
 - request:
     method: get
     uri: http://backend:5352/source/watchlist_test_project_a/watchlist_test_package
@@ -298,7 +298,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - f5621bd8-a46d-49d3-b098-d66dec08d22a
+      - 52ace113-062b-4af2-8348-e7be403d7c17
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -323,7 +323,7 @@ http_interactions:
       string: |
         <directory name="watchlist_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Sat, 26 Nov 2022 00:25:50 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:23 GMT
 - request:
     method: get
     uri: http://backend:5352/source/watchlist_test_project_a/watchlist_test_package?expand=1
@@ -355,16 +355,84 @@ http_interactions:
       string: |
         <directory name="watchlist_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Sat, 26 Nov 2022 00:25:50 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:23 GMT
 - request:
     method: get
-    uri: http://backend:5352/build/watchlist_test_project_a/_result?package=watchlist_test_package&view=status
+    uri: http://backend:5352/source/watchlist_test_project_a/watchlist_test_package/_history?deleted=1&meta=1
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - ce55c9dd-3a8c-406b-9d08-444f5fbdd3ab
+      - 52ace113-062b-4af2-8348-e7be403d7c17
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Wed, 22 Feb 2023 18:11:23 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/watchlist_test_project_a/watchlist_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 2269ee52-89ca-4b17-b504-6adc70be9404
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '97'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="watchlist_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:11:23 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/watchlist_test_project_a/_result?lastbuild=1&locallink=1&multibuild=1&package=watchlist_test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 2269ee52-89ca-4b17-b504-6adc70be9404
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -389,5 +457,107 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Sat, 26 Nov 2022 00:25:50 GMT
+  recorded_at: Wed, 22 Feb 2023 18:11:23 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/watchlist_test_project_a/watchlist_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - f038950e-b898-4f48-a74c-f8ade4347e39
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '97'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="watchlist_test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Wed, 22 Feb 2023 18:11:23 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/watchlist_test_project_a/_result?lastbuild=1&locallink=1&multibuild=1&package=watchlist_test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - f038950e-b898-4f48-a74c-f8ade4347e39
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 18:11:23 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/watchlist_test_project_a/_result?package=watchlist_test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - c7cc673d-61a2-4d91-8b02-c6113f2269a2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 22 Feb 2023 18:11:23 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Webui_PackageController/GET_show/revision_handling/with_a_rev_parameter_with_existent_revision/1_4_5_1_1.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/GET_show/revision_handling/with_a_rev_parameter_with_existent_revision/1_4_5_1_1.yml
@@ -39,16 +39,16 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-  recorded_at: Fri, 05 Jun 2020 11:29:02 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:20 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/rev_package/_meta?user=user_3
+    uri: http://backend:5352/source/home:tom/rev_package/_meta?user=user_13
     body:
       encoding: UTF-8
       string: |
         <package name="rev_package" project="home:tom">
-          <title>Mother Night</title>
-          <description>Minus itaque ut aut.</description>
+          <title>A Monstrous Regiment of Women</title>
+          <description>Quod quaerat doloremque repudiandae.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -69,15 +69,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '139'
+      - '172'
     body:
       encoding: UTF-8
       string: |
         <package name="rev_package" project="home:tom">
-          <title>Mother Night</title>
-          <description>Minus itaque ut aut.</description>
+          <title>A Monstrous Regiment of Women</title>
+          <description>Quod quaerat doloremque repudiandae.</description>
         </package>
-  recorded_at: Fri, 05 Jun 2020 11:29:02 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:20 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/rev_package/somefile.txt
@@ -110,12 +110,12 @@ http_interactions:
         <revision rev="1" vrev="1">
           <srcmd5>cabf9a1f9a0b7c19d4f7ff46166f4ee0</srcmd5>
           <version>unknown</version>
-          <time>1591356542</time>
+          <time>1677088700</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Fri, 05 Jun 2020 11:29:02 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:20 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/rev_package/somefile.txt
@@ -148,12 +148,12 @@ http_interactions:
         <revision rev="2" vrev="2">
           <srcmd5>efbe5f0a5dd48df5129b4319df43aa45</srcmd5>
           <version>unknown</version>
-          <time>1591356542</time>
+          <time>1677088700</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Fri, 05 Jun 2020 11:29:02 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:20 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/rev_package/somefile.txt
@@ -186,12 +186,12 @@ http_interactions:
         <revision rev="3" vrev="3">
           <srcmd5>6ba292a7c75f8b46e4d39ac7cb20ebcd</srcmd5>
           <version>unknown</version>
-          <time>1591356542</time>
+          <time>1677088700</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Fri, 05 Jun 2020 11:29:02 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:20 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom/rev_package
@@ -222,9 +222,9 @@ http_interactions:
       encoding: UTF-8
       string: |
         <directory name="rev_package" rev="3" vrev="3" srcmd5="6ba292a7c75f8b46e4d39ac7cb20ebcd">
-          <entry name="somefile.txt" md5="c81e728d9d4c2f636f067f89cc14862c" size="1" mtime="1591356541"/>
+          <entry name="somefile.txt" md5="c81e728d9d4c2f636f067f89cc14862c" size="1" mtime="1677088700"/>
         </directory>
-  recorded_at: Fri, 05 Jun 2020 11:29:02 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:20 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom/rev_package?expand=1&rev=2
@@ -255,12 +255,44 @@ http_interactions:
       encoding: UTF-8
       string: |
         <directory name="rev_package" rev="2" vrev="2" srcmd5="efbe5f0a5dd48df5129b4319df43aa45">
-          <entry name="somefile.txt" md5="c4ca4238a0b923820dcc509a6f75849b" size="1" mtime="1591356541"/>
+          <entry name="somefile.txt" md5="c4ca4238a0b923820dcc509a6f75849b" size="1" mtime="1677088700"/>
         </directory>
-  recorded_at: Fri, 05 Jun 2020 11:29:02 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:20 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:tom/rev_package/_history?deleted=1&meta=1&rev=2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Wed, 22 Feb 2023 17:58:20 GMT
 - request:
     method: delete
-    uri: http://backend:5352/source/home:tom/rev_package?comment&user=user_3
+    uri: http://backend:5352/source/home:tom/rev_package?comment&user=user_13
     body:
       encoding: US-ASCII
       string: ''
@@ -289,5 +321,5 @@ http_interactions:
       string: '<status code="ok" />
 
 '
-  recorded_at: Fri, 05 Jun 2020 11:29:02 GMT
-recorded_with: VCR 6.0.0
+  recorded_at: Wed, 22 Feb 2023 17:58:20 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Webui_PackageController/GET_show/revision_handling/with_a_rev_parameter_with_existent_revision/1_4_5_1_2.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/GET_show/revision_handling/with_a_rev_parameter_with_existent_revision/1_4_5_1_2.yml
@@ -39,16 +39,16 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-  recorded_at: Fri, 05 Jun 2020 11:29:02 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:21 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/rev_package/_meta?user=user_4
+    uri: http://backend:5352/source/home:tom/rev_package/_meta?user=user_14
     body:
       encoding: UTF-8
       string: |
         <package name="rev_package" project="home:tom">
-          <title>The Little Foxes</title>
-          <description>Et voluptas at quo.</description>
+          <title>For a Breath I Tarry</title>
+          <description>Atque aut qui dicta.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -69,15 +69,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '142'
+      - '147'
     body:
       encoding: UTF-8
       string: |
         <package name="rev_package" project="home:tom">
-          <title>The Little Foxes</title>
-          <description>Et voluptas at quo.</description>
+          <title>For a Breath I Tarry</title>
+          <description>Atque aut qui dicta.</description>
         </package>
-  recorded_at: Fri, 05 Jun 2020 11:29:02 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:21 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/rev_package/somefile.txt
@@ -110,12 +110,12 @@ http_interactions:
         <revision rev="1" vrev="1">
           <srcmd5>cabf9a1f9a0b7c19d4f7ff46166f4ee0</srcmd5>
           <version>unknown</version>
-          <time>1591356542</time>
+          <time>1677088701</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Fri, 05 Jun 2020 11:29:02 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:21 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/rev_package/somefile.txt
@@ -148,12 +148,12 @@ http_interactions:
         <revision rev="2" vrev="2">
           <srcmd5>efbe5f0a5dd48df5129b4319df43aa45</srcmd5>
           <version>unknown</version>
-          <time>1591356542</time>
+          <time>1677088701</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Fri, 05 Jun 2020 11:29:02 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:21 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom/rev_package/somefile.txt
@@ -186,12 +186,12 @@ http_interactions:
         <revision rev="3" vrev="3">
           <srcmd5>6ba292a7c75f8b46e4d39ac7cb20ebcd</srcmd5>
           <version>unknown</version>
-          <time>1591356542</time>
+          <time>1677088701</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Fri, 05 Jun 2020 11:29:02 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:21 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom/rev_package
@@ -222,9 +222,9 @@ http_interactions:
       encoding: UTF-8
       string: |
         <directory name="rev_package" rev="3" vrev="3" srcmd5="6ba292a7c75f8b46e4d39ac7cb20ebcd">
-          <entry name="somefile.txt" md5="c81e728d9d4c2f636f067f89cc14862c" size="1" mtime="1591356541"/>
+          <entry name="somefile.txt" md5="c81e728d9d4c2f636f067f89cc14862c" size="1" mtime="1677088700"/>
         </directory>
-  recorded_at: Fri, 05 Jun 2020 11:29:02 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:21 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom/rev_package?expand=1&rev=2
@@ -255,12 +255,51 @@ http_interactions:
       encoding: UTF-8
       string: |
         <directory name="rev_package" rev="2" vrev="2" srcmd5="efbe5f0a5dd48df5129b4319df43aa45">
-          <entry name="somefile.txt" md5="c4ca4238a0b923820dcc509a6f75849b" size="1" mtime="1591356541"/>
+          <entry name="somefile.txt" md5="c4ca4238a0b923820dcc509a6f75849b" size="1" mtime="1677088700"/>
         </directory>
-  recorded_at: Fri, 05 Jun 2020 11:29:02 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:21 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:tom/rev_package/_history?deleted=1&meta=1&rev=2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '230'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+          <revision rev="2" vrev="">
+            <srcmd5>28ac64e62fc06376cc63d2490080695c</srcmd5>
+            <version></version>
+            <time>1677088700</time>
+            <user>user_13</user>
+            <comment>1</comment>
+          </revision>
+        </revisionlist>
+  recorded_at: Wed, 22 Feb 2023 17:58:21 GMT
 - request:
     method: delete
-    uri: http://backend:5352/source/home:tom/rev_package?comment&user=user_4
+    uri: http://backend:5352/source/home:tom/rev_package?comment&user=user_14
     body:
       encoding: US-ASCII
       string: ''
@@ -289,5 +328,5 @@ http_interactions:
       string: '<status code="ok" />
 
 '
-  recorded_at: Fri, 05 Jun 2020 11:29:02 GMT
-recorded_with: VCR 6.0.0
+  recorded_at: Wed, 22 Feb 2023 17:58:21 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Webui_PackageController/GET_show/with_a_package_that_has_a_broken_service/1_4_3_1.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/GET_show/with_a_package_that_has_a_broken_service/1_4_3_1.yml
@@ -326,4 +326,36 @@ http_interactions:
         service daemon error:
          400 remote error: unknown element 'service' (http://backend:5152/sourceupdate/home:tom/package_with_broken_service)
   recorded_at: Fri, 05 Jun 2020 11:30:00 GMT
-recorded_with: VCR 6.0.0
+- request:
+    method: get
+    uri: http://backend:5352/source/home:tom/package_with_broken_service/_history?deleted=1&meta=1&rev=2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Thu, 23 Feb 2023 08:49:22 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Webui_PackageController/GET_show/with_a_package_that_has_a_broken_service/1_4_3_2.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/GET_show/with_a_package_that_has_a_broken_service/1_4_3_2.yml
@@ -326,4 +326,36 @@ http_interactions:
         service daemon error:
          400 remote error: unknown element 'service' (http://backend:5152/sourceupdate/home:tom/package_with_broken_service)
   recorded_at: Fri, 05 Jun 2020 11:29:59 GMT
-recorded_with: VCR 6.0.0
+- request:
+    method: get
+    uri: http://backend:5352/source/home:tom/package_with_broken_service/_history?deleted=1&meta=1&rev=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Thu, 23 Feb 2023 08:49:23 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Webui_PackageController/GET_show/with_a_valid_package/assigns_package.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/GET_show/with_a_valid_package/assigns_package.yml
@@ -39,17 +39,16 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:37:17 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:20 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/home:tom/my_package/_meta?user=user_46
+    uri: http://backend:5352/source/home:tom/my_package/_meta?user=user_12
     body:
       encoding: UTF-8
       string: |
         <package name="my_package" project="home:tom">
-          <title>A Swiftly Tilting Planet</title>
-          <description>Corrupti quam amet iure.</description>
+          <title>The Monkey's Raincoat</title>
+          <description>Quae eaque repellendus facere.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -70,16 +69,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '154'
+      - '157'
     body:
       encoding: UTF-8
       string: |
         <package name="my_package" project="home:tom">
-          <title>A Swiftly Tilting Planet</title>
-          <description>Corrupti quam amet iure.</description>
+          <title>The Monkey's Raincoat</title>
+          <description>Quae eaque repellendus facere.</description>
         </package>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:37:17 GMT
+  recorded_at: Wed, 22 Feb 2023 17:58:20 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom/my_package
@@ -105,17 +103,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '85'
+      - '308'
     body:
-      encoding: UTF-8
-      string: |
-        <directory name="my_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
-        </directory>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:37:17 GMT
+      encoding: ASCII-8BIT
+      string: !binary |-
+        PGRpcmVjdG9yeSBuYW1lPSJteV9wYWNrYWdlIiByZXY9IjEyIiB2cmV2PSIxMiIgc3JjbWQ1PSIyNTA2ZGJhY2EyMGNkOWZlYzgwZDMwZDdhMGM1MDlhYyI+CiAgPGVudHJ5IG5hbWU9Im5ld2x5X2NyZWF0ZWRfZmlsZSIgbWQ1PSJkNDFkOGNkOThmMDBiMjA0ZTk4MDA5OThlY2Y4NDI3ZSIgc2l6ZT0iMCIgbXRpbWU9IjE2NzQ4MjY2MzIiLz4KICA8ZW50cnkgbmFtZT0i5a2m5Lmg5oC757uTIiBtZDU9IjZiYTE2N2Q3MmU5Y2M2MDEwOGE3NTY3Y2RhZWM3MjBmIiBzaXplPSI5NzciIG10aW1lPSIxNjc0ODI5MTU3Ii8+CjwvZGlyZWN0b3J5Pgo=
+  recorded_at: Wed, 22 Feb 2023 17:58:20 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:tom/my_package?expand=1
+    uri: http://backend:5352/source/home:tom/my_package?expand=1&rev=12
     body:
       encoding: US-ASCII
       string: ''
@@ -138,12 +134,48 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '85'
+      - '308'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        PGRpcmVjdG9yeSBuYW1lPSJteV9wYWNrYWdlIiByZXY9IjEyIiB2cmV2PSIxMiIgc3JjbWQ1PSIyNTA2ZGJhY2EyMGNkOWZlYzgwZDMwZDdhMGM1MDlhYyI+CiAgPGVudHJ5IG5hbWU9Im5ld2x5X2NyZWF0ZWRfZmlsZSIgbWQ1PSJkNDFkOGNkOThmMDBiMjA0ZTk4MDA5OThlY2Y4NDI3ZSIgc2l6ZT0iMCIgbXRpbWU9IjE2NzQ4MjY2MzIiLz4KICA8ZW50cnkgbmFtZT0i5a2m5Lmg5oC757uTIiBtZDU9IjZiYTE2N2Q3MmU5Y2M2MDEwOGE3NTY3Y2RhZWM3MjBmIiBzaXplPSI5NzciIG10aW1lPSIxNjc0ODI5MTU3Ii8+CjwvZGlyZWN0b3J5Pgo=
+  recorded_at: Wed, 22 Feb 2023 17:58:20 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:tom/my_package/_history?deleted=1&meta=1&rev=12
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '202'
     body:
       encoding: UTF-8
       string: |
-        <directory name="my_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
-        </directory>
-    http_version: null
-  recorded_at: Fri, 29 May 2020 15:37:17 GMT
-recorded_with: VCR 5.1.0
+        <revisionlist>
+          <revision rev="12" vrev="">
+            <srcmd5>80e0775da94377ec751b04b75935160f</srcmd5>
+            <version></version>
+            <time>1676383607</time>
+            <user>tom</user>
+          </revision>
+        </revisionlist>
+  recorded_at: Wed, 22 Feb 2023 17:58:20 GMT
+recorded_with: VCR 6.1.0


### PR DESCRIPTION
This is intended to fix #13871, by performing a caching operation of just the latest commit if it wasn't cached already, and returning it quickly