### PR TITLE
Instrument the "Request Action Seen" feature

### DIFF
--- a/src/api/app/models/bs_request_action.rb
+++ b/src/api/app/models/bs_request_action.rb
@@ -16,7 +16,8 @@ class BsRequestAction < ApplicationRecord
   belongs_to :target_package_object, class_name: 'Package', foreign_key: 'target_package_id', optional: true
   belongs_to :target_project_object, class_name: 'Project', foreign_key: 'target_project_id', optional: true
 
-  has_and_belongs_to_many :seen_by_users, class_name: 'User', join_table: :bs_request_actions_seen_by_users
+  has_many :bs_request_actions_seen_by_users, dependent: :nullify
+  has_many :seen_by_users, through: :bs_request_actions_seen_by_users, source: :user
 
   scope :bs_request_ids_of_involved_projects, ->(project_ids) { where(target_project_id: project_ids).select(:bs_request_id) }
   scope :bs_request_ids_of_involved_packages, ->(package_ids) { where(target_package_id: package_ids).select(:bs_request_id) }

--- a/src/api/app/models/bs_request_actions_seen_by_user.rb
+++ b/src/api/app/models/bs_request_actions_seen_by_user.rb
@@ -1,0 +1,24 @@
+class BsRequestActionsSeenByUser < ApplicationRecord
+  belongs_to :bs_request_action
+  belongs_to :user
+
+  after_create do |_record|
+    RabbitmqBus.send_to_bus('metrics', 'bs_request_action,seen=true count=1')
+  end
+
+  after_destroy do |_record|
+    RabbitmqBus.send_to_bus('metrics', 'bs_request_action,seen=false count=1')
+  end
+end
+
+# == Schema Information
+#
+# Table name: bs_request_actions_seen_by_users
+#
+#  bs_request_action_id :bigint           not null, indexed => [user_id]
+#  user_id              :bigint           not null, indexed => [bs_request_action_id]
+#
+# Indexes
+#
+#  bs_request_actions_seen_by_users_index  (bs_request_action_id,user_id)
+#

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -46,7 +46,8 @@ class User < ApplicationRecord
   # users have a n:m relation to roles
   has_and_belongs_to_many :roles, -> { distinct }
 
-  has_and_belongs_to_many :bs_request_actions_seen, class_name: 'BsRequestAction', join_table: :bs_request_actions_seen_by_users
+  has_many :bs_request_actions_seen_by_users, dependent: :nullify
+  has_many :bs_request_actions_seen, through: :bs_request_actions_seen_by_users, source: :bs_request_action
 
   # users have 0..1 user_registration records assigned to them
   has_one :user_registration


### PR DESCRIPTION
This feature was implemented in #13702.

Updating specs isn't needed since the method [BsRequestAction#toggle_seen_by](https://github.com/openSUSE/open-build-service/blob/b637d1118d0c9b3a6937959a281fb01cd13e19df/src/api/app/models/bs_request_action.rb#L840-L848) is already covered by [specs](https://github.com/openSUSE/open-build-service/blob/b637d1118d0c9b3a6937959a281fb01cd13e19df/src/api/spec/models/bs_request_action_spec.rb#L400-L433), so associations are correctly defined.