### PR TITLE
Implement next and previous buttons for paginating actions

### DIFF
--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -26,7 +26,15 @@ class Webui::RequestController < Webui::WebuiController
       action_id = params[:request_action_id] || @bs_request.bs_request_actions.first.id
       @action = @bs_request.webui_actions(filelimit: @diff_limit, tarlimit: @diff_limit, diff_to_superseded: @diff_to_superseded,
                                           diffs: true, action_id: action_id.to_i, cacheonly: 1).first
-      @active_action = @bs_request.bs_request_actions.find(action_id)
+      actions = @bs_request.bs_request_actions
+      @active_action = actions.find(action_id)
+      # Change supported_actions below into actions here when all actions are supported
+      supported_actions = actions.where(type: [:add_role, :submit])
+      active_action_index = supported_actions.index(@active_action)
+      if active_action_index
+        @prev_action = supported_actions[active_action_index - 1] unless active_action_index.zero?
+        @next_action = supported_actions[active_action_index + 1] if active_action_index + 1 < supported_actions.length
+      end
 
       target_project = Project.find_by_name(@bs_request.target_project_name)
       @request_reviews = @bs_request.reviews.for_non_staging_projects(target_project)

--- a/src/api/app/views/webui/request/_actions_details.html.haml
+++ b/src/api/app/views/webui/request/_actions_details.html.haml
@@ -5,26 +5,33 @@
 - if submit_actions_count > 1
   .d-flex.align-items-center
     %p.mb-0 This request contains #{submit_actions_count} actions
-    .dropdown.ms-2#request-actions
-      %button.btn.btn-outline-primary.btn-sm.dropdown-toggle{ 'aria-expanded' => 'false', 'data-bs-toggle' => 'dropdown',
-                                                              :type => 'button', 'data-boundary' => 'viewport' }
-        Select Action
-      %ul.dropdown-menu.dropdown-menu-start.scrollable-dropdown.pt-0
-        %li.card-header.px-1.sticky-top
-          %h6.dropdown-header
-            - if User.session
-              %span Seen
-            %span Action
-            %span.float-end Revision
-        - submit_actions.each_with_index do |action_item, action_index|
-          %li.border-top
-            = link_to((render partial: 'action_text', locals: { action: action_item, action_index: action_index }),
-                                                      request_show_path(number: bs_request.number,
-                                                                        request_action_id: action_item.id,
-                                                                        full_diff: diff_limit,
-                                                                        diff_to_superseded: diff_to_superseded_id),
-                                                      class: "dropdown-item #{action_item.id == active_action.id ? 'active' : ''}",
-                                                      'aria-current': 'true')
+    .input-group.ms-2.w-auto
+      = link_to('Previous', request_show_path(number: bs_request.number, request_action_id: prev_action&.id,
+                                              full_diff: diff_limit, diff_to_superseded: diff_to_superseded_id),
+                class: "btn btn-primary btn-sm #{prev_action ? '' : 'disabled'}")
+      .dropdown#request-actions
+        %button.btn.btn-outline-primary.btn-sm.dropdown-toggle.rounded-0{ 'aria-expanded' => 'false', 'data-bs-toggle' => 'dropdown',
+                                                                          :type => 'button', 'data-boundary' => 'viewport' }
+          Select Action
+        %ul.dropdown-menu.dropdown-menu-start.scrollable-dropdown.pt-0
+          %li.card-header.px-1.sticky-top
+            %h6.dropdown-header
+              - if User.session
+                %span Seen
+              %span Action
+              %span.float-end Revision
+          - submit_actions.each_with_index do |action_item, action_index|
+            %li.border-top
+              = link_to((render partial: 'action_text', locals: { action: action_item, action_index: action_index }),
+                                                        request_show_path(number: bs_request.number,
+                                                                          request_action_id: action_item.id,
+                                                                          full_diff: diff_limit,
+                                                                          diff_to_superseded: diff_to_superseded_id),
+                                                        class: "dropdown-item #{action_item.id == active_action.id ? 'active' : ''}",
+                                                        'aria-current': 'true')
+      = link_to('Next', request_show_path(number: bs_request.number, request_action_id: next_action&.id,
+                                          full_diff: diff_limit, diff_to_superseded: diff_to_superseded_id),
+                class: "btn btn-primary btn-sm #{next_action ? '' : 'disabled'}")
 %p
   - if submit_actions_count > 1
     - if User.session

--- a/src/api/app/views/webui/request/beta_show.html.haml
+++ b/src/api/app/views/webui/request/beta_show.html.haml
@@ -53,6 +53,7 @@
             = link_to "##{supersed['number']}", number: supersed['number']
 
         = render partial: 'actions_details', locals: { bs_request: @bs_request, action: @action, active_action: @active_action,
+                                                       prev_action: @prev_action, next_action: @next_action,
                                                        diff_to_superseded_id: @diff_to_superseded_id, diff_limit: @diff_limit }
         - if @staging_status
           This request is currently


### PR DESCRIPTION
Allows you to quickly switch between subsequent actions in a request
![image](https://user-images.githubusercontent.com/114928900/220650279-8d25c465-0d2a-4f1b-98b7-1df478dbba98.png)
