### PR TITLE
Follow information hierarchy in conversation timeline

### DIFF
--- a/src/api/app/assets/stylesheets/webui/timeline.scss
+++ b/src/api/app/assets/stylesheets/webui/timeline.scss
@@ -8,8 +8,26 @@
         position: relative;
         left: $timeline-offset; // The avatars of users involved in timeline items will be displayed on the timeline border
 
+        .d-inline-flex i:first-child {
+            padding-top: $avatars-counter-size / 2;
+            height: $avatars-counter-size;
+            @extend .bg-white;
+
+            // Align specific icons with the timeline border, this differs depending on the icon shape
+            &.fa-code-commit {
+                padding-left: $timeline-border-width / 2;
+            }
+            &.fa-check, &.fa-comment {
+                padding-left: $timeline-border-width;
+            }
+            &.fa-circle, &.fa-times {
+                padding-left: $timeline-border-width * 2;
+            }
+        }
+
         $timeline-item-avatar-margin: 0.5rem;
         img.avatars-counter {
+            margin-left: $timeline-item-avatar-margin;
             margin-right: $timeline-item-avatar-margin;
         }
 

--- a/src/api/app/components/bs_request_comment_component.html.haml
+++ b/src/api/app/components/bs_request_comment_component.html.haml
@@ -1,7 +1,7 @@
 .d-inline-flex
+  %i.fas.fa-lg.fa-comment.text-dark{ title: 'Comment' }
   = helpers.image_tag_for(comment.user, size: 35, custom_class: 'rounded-circle bg-light border border-gray-400 avatars-counter')
   %p
-    %i.fas.fa-comment.text-dark{ title: 'Comment' }
     = link_to(helpers.realname_with_login(comment.user), user_path(comment.user))
     wrote
     = link_to("#comment-#{comment.id}", title: l(comment.created_at.utc), name: "comment-#{comment.id}") do

--- a/src/api/app/components/bs_request_history_element_component.html.haml
+++ b/src/api/app/components/bs_request_history_element_component.html.haml
@@ -1,7 +1,7 @@
 .d-inline-flex
+  = icon
   = helpers.image_tag_for(element.user, size: 36, custom_class: 'rounded-circle bg-light border border-gray-400 avatars-counter')
   %p
-    = icon
     = link_to(helpers.realname_with_login(element.user), user_path(element.user))
     - if element.instance_of?(HistoryElement::RequestSuperseded)
       superseded this request with

--- a/src/api/app/components/bs_request_history_element_component.rb
+++ b/src/api/app/components/bs_request_history_element_component.rb
@@ -16,13 +16,13 @@ class BsRequestHistoryElementComponent < ApplicationComponent
   def icon
     case @element.type.demodulize
     when 'ReviewAccepted', 'RequestAccepted'
-      tag.i(nil, class: 'fas fa-check text-success')
+      tag.i(nil, class: 'fas fa-lg fa-check text-success')
     when 'ReviewDeclined', 'RequestDeclined'
-      tag.i(nil, class: 'fas fa-times text-danger')
+      tag.i(nil, class: 'fas fa-lg fa-times text-danger')
     when 'RequestReviewAdded'
-      tag.i(nil, class: 'fas fa-2xs fa-circle text-warning')
+      tag.i(nil, class: 'fas fa-sm fa-circle text-warning')
     else
-      tag.i(nil, class: 'fas fa-code-commit text-dark')
+      tag.i(nil, class: 'fas fa-lg fa-code-commit text-dark')
     end
   end
 

--- a/src/api/app/views/webui/request/beta_show_tabs/_conversation.html.haml
+++ b/src/api/app/views/webui/request/beta_show_tabs/_conversation.html.haml
@@ -21,10 +21,10 @@
     .timeline.pb-2.ms-3{ data: { comment_counter: local_assigns[:comment_counter_id] } }
       .timeline-item
         .d-inline-flex
+          %i.fas.fa-lg.fa-code-commit.text-dark
           - creator = User.find_by_login(bs_request.creator) || User.nobody
           = image_tag_for(creator, size: 35, custom_class: 'rounded-circle bg-light border border-gray-400 avatars-counter')
           %p
-            %i.fas.fa-code-commit.text-dark
             = link_to(realname_with_login(creator), user_path(creator))
             created this request
             = link_to('#request-creation', title: I18n.l(bs_request.created_at.utc), name: 'request-creation') do


### PR DESCRIPTION
The action, represented by an icon, is displayed first. The icon size was increased to show its importance. Right after, we display the user who did that action.

## Before:
![before](https://user-images.githubusercontent.com/1102934/220659485-2d0e979d-4f19-45e3-930f-19cec59c833b.png)

## Now:
![after](https://user-images.githubusercontent.com/1102934/220659480-3e773828-51e9-41db-a313-597400d28397.png)