### PR TITLE
Fix preview message tab click under bootstrap 5

### DIFF
--- a/src/api/app/assets/javascripts/webui/write_and_preview.js
+++ b/src/api/app/assets/javascripts/webui/write_and_preview.js
@@ -1,5 +1,5 @@
 $(document).ready(function(){
-  $('.write-and-preview').on('click', '.preview-message-tab:not(.active)', function (e) {
+  $('.write-and-preview').on('show.bs.tab', '.preview-message-tab:not(.active)', function (e) {
       var messageContainer = $(e.target).closest('.write-and-preview');
       var messageText = messageContainer.find('.message-field').val();
       var messagePreview = messageContainer.find('.message-preview');


### PR DESCRIPTION
Since the upgrade to Bootstrap 5 the preview message tab in the [Create News Item](https://build.opensuse.org/news_items/new) page stopped working because Bootstrap 5 doesn't use jQuery anymore.

## How To Test This PR

- Go into the [Create News Item page](https://obs-reviewlab.opensuse.org/danidoni-fix-create-status-preview-tab/news_items/new) logged in as Admin.
- Write some message into the Message box.
- Click on the Preview tab
- You should get you message rendered back in the Preview tab (that does not work right now on [our production instance](https://build.opensuse.org/news_items/new))