### PR TITLE
Ensure that the status summary is a string

### DIFF
--- a/src/api/app/controllers/application_controller.rb
+++ b/src/api/app/controllers/application_controller.rb
@@ -123,7 +123,7 @@ class ApplicationController < ActionController::Base
 
   def gather_exception_defaults(opt)
     if opt[:message]
-      @summary = opt[:message]
+      @summary = opt[:message].to_s
     elsif @exception
       @summary = @exception.message
     end


### PR DESCRIPTION
Make sure that the content of `summary` can be searched for null bytes and replaced with a valid XML string. Valid for the case of an XML status response.

Related to #13788.

Fixes #13883.