### PR TITLE
Increase `scroll-padding-top` value by height of notification toolbar

### DIFF
--- a/src/api/app/assets/stylesheets/webui/application.scss
+++ b/src/api/app/assets/stylesheets/webui/application.scss
@@ -77,5 +77,5 @@
 
 html {
     overflow-y: scroll !important;
-    scroll-padding-top: $top-navigation-height;
+    scroll-padding-top: $top-navigation-height + $notification-toolbar-height;
 }


### PR DESCRIPTION
Right now selected anchor tags are covered when the notification toolbar is present. Increasing the value by the height of the notification toolbar prevents it from happening.

Now:
![2023-02-23_16-26](https://user-images.githubusercontent.com/22001671/220953320-61b8063c-59fc-44f4-becc-8e40d5014836.png)
