### PR TITLE
[backend] rename "--filelists-ext" parameter for createrepo

### DIFF
--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -617,7 +617,7 @@ sub createrepo_rpmmd {
   push @createrepoargs, '--content', 'debug' if $data->{'dbgsplit'};
   push @createrepoargs, '--content', 'update' if ($repoinfo->{'projectkind'} || '') eq 'maintenance_incident';
   push @createrepoargs, '--content', 'update' if ($repoinfo->{'projectkind'} || '') eq 'maintenance_release';
-  push @createrepoargs, '--filelists_ext' if $options{'filelists_ext'};
+  push @createrepoargs, '--filelists-ext' if ($options{'filelists-ext'} || $options{'filelists_ext'});
   my @legacyargs;
   if ($options{'sha512'}) {
     push @legacyargs, '--unique-md-filenames', '--checksum=sha512';


### PR DESCRIPTION
createrepo_c renamed the --filelists_ext to --filelists-ext before the release, and this patch follow the rename.

See #12358 for more information.