### PR TITLE
Add preview for HistoryElement::RequestReviewAdded

### DIFF
--- a/src/api/spec/components/previews/bs_request_history_element_component_preview.rb
+++ b/src/api/spec/components/previews/bs_request_history_element_component_preview.rb
@@ -1,9 +1,16 @@
 class BsRequestHistoryElementComponentPreview < ViewComponent::Preview
+  # /rails/view_components/bs_request_history_element_component/with_history_element_request_superseded
   def with_history_element_request_superseded
     render(BsRequestHistoryElementComponent.new(element: HistoryElement::RequestSuperseded.last))
   end
 
+  # /rails/view_components/bs_request_history_element_component/with_history_element_request_accepted
   def with_history_element_request_accepted
     render(BsRequestHistoryElementComponent.new(element: HistoryElement::RequestAccepted.last))
+  end
+
+  # /rails/view_components/bs_request_history_element_component/with_history_element_request_review_added
+  def with_history_element_request_review_added
+    render(BsRequestHistoryElementComponent.new(element: HistoryElement::RequestReviewAdded.last))
   end
 end


### PR DESCRIPTION
Both `RequestReviewAdded` and `RequestSuperseded` history elements look different from the rest of the history elements' types.  So it's worth having a preview of the first one too.
