### PR TITLE
[backend] container: Allow to publish multi-os

### DIFF
--- a/src/backend/BSPublisher/Container.pm
+++ b/src/backend/BSPublisher/Container.pm
@@ -200,6 +200,7 @@ sub upload_all_containers {
       my $arch = $containerinfo->{'arch'};
       my $goarch = $containerinfo->{'goarch'};
       $goarch .= ":$containerinfo->{'govariant'}" if $containerinfo->{'govariant'};
+      $goarch .= "_$containerinfo->{'goos'}" if $containerinfo->{'goos'} && $containerinfo->{'goos'} ne 'linux';
       my @tags = $mapper->($registry, $containerinfo, $projid, $repoid, $arch);
       for my $tag (@tags) {
 	my ($reponame, $repotag) = ($tag, 'latest');

--- a/src/backend/BSRepServer/Containerinfo.pm
+++ b/src/backend/BSRepServer/Containerinfo.pm
@@ -68,6 +68,8 @@ sub containerinfo2obsbinlnk {
   my ($dir, $containerinfo, $packid) = @_;
   my $d = readcontainerinfo($dir, $containerinfo);
   return unless $d;
+  # currently no other OS containers. Alternative would be to rename them to avoid conflicts.
+  return if $d->{'goos'} ne 'linux';
   my $lnk = containerinfo2nevra($d);
   # need to have a source so that it goes into the :full tree
   $lnk->{'source'} = $lnk->{'name'};


### PR DESCRIPTION
Allow to publish multiple containers with same tag, but for different operating systems via the registry

Avoid conflicts in repository build pool by limiting it to linux OS containers for now.