### PR TITLE
Fix preview comment tab click under bootstrap 5

### DIFF
--- a/src/api/app/assets/javascripts/webui/comment.js
+++ b/src/api/app/assets/javascripts/webui/comment.js
@@ -109,28 +109,4 @@ $(document).ready(function(){
   $('body').on('click', '.cancel-comment', function (e) {
     $(e.target).closest('.collapse').collapse('hide');
   });
-
-  // This is used to preview comments from the beta request show view: inside timeline thread (.timeline) and outside timeline (body)
-  // and also from the legacy request view (.comments-list): inside and outside the thread.
-  $('.comments-list, .timeline, body').on('show.bs.tab', '.preview-comment-tab:not(.active)', function (e) {
-      var commentContainer = $(e.target).closest('[class*="-comment-form"]');
-      var commentBody = commentContainer.find('.comment-field').val();
-      var commentPreview = commentContainer.find('.comment-preview');
-      if (commentBody) {
-        $.ajax({
-          method: 'POST',
-          url: commentContainer.data('previewCommentUrl'),
-          dataType: 'json',
-          data: { 'comment[body]': commentBody },
-          success: function(data) {
-            commentPreview.html(data.markdown);
-          },
-          error: function() {
-            commentPreview.html('Error loading markdown preview');
-          }
-        });
-      } else {
-        commentPreview.html('Nothing to preview');
-      }
-  });
 });

--- a/src/api/app/assets/javascripts/webui/comment.js
+++ b/src/api/app/assets/javascripts/webui/comment.js
@@ -112,7 +112,7 @@ $(document).ready(function(){
 
   // This is used to preview comments from the beta request show view: inside timeline thread (.timeline) and outside timeline (body)
   // and also from the legacy request view (.comments-list): inside and outside the thread.
-  $('.comments-list, .timeline, body').on('click', '.preview-comment-tab:not(.active)', function (e) {
+  $('.comments-list, .timeline, body').on('show.bs.tab', '.preview-comment-tab:not(.active)', function (e) {
       var commentContainer = $(e.target).closest('[class*="-comment-form"]');
       var commentBody = commentContainer.find('.comment-field').val();
       var commentPreview = commentContainer.find('.comment-preview');

--- a/src/api/app/assets/javascripts/webui/write_and_preview.js
+++ b/src/api/app/assets/javascripts/webui/write_and_preview.js
@@ -1,4 +1,5 @@
-$(document).ready(function(){
+function attachPreviewMessageOnCommentBoxes() {
+  $('.write-and-preview').off('show.bs.tab', '.preview-message-tab:not(.active)');
   $('.write-and-preview').on('show.bs.tab', '.preview-message-tab:not(.active)', function (e) {
       var messageContainer = $(e.target).closest('.write-and-preview');
       var messageText = messageContainer.find('.message-field').val();
@@ -24,4 +25,8 @@ $(document).ready(function(){
         messagePreview.html('Nothing to preview');
       }
   });
+}
+
+$(document).ready(function(){
+  attachPreviewMessageOnCommentBoxes();
 });

--- a/src/api/app/assets/javascripts/webui/write_and_preview.js
+++ b/src/api/app/assets/javascripts/webui/write_and_preview.js
@@ -4,11 +4,15 @@ $(document).ready(function(){
       var messageText = messageContainer.find('.message-field').val();
       var messagePreview = messageContainer.find('.message-preview');
       if (messageText) {
+        // This is done like this because we cannot set keys from variables in the object definition
+        var data = {};
+        data[messageContainer.data('messageBodyParam')] = messageText;
+
         $.ajax({
           method: 'POST',
-          url: $(this).data('previewMessageUrl'),
+          url: messageContainer.data('previewMessageUrl'),
           dataType: 'json',
-          data: { 'status_message[message]': messageText },
+          data: data,
           success: function(data) {
             messagePreview.html(data.markdown);
           },

--- a/src/api/app/components/write_and_preview_component.html.haml
+++ b/src/api/app/components/write_and_preview_component.html.haml
@@ -1,4 +1,4 @@
-.card.write-and-preview
+.card.write-and-preview{ data: { preview_message_url: preview_message_url, message_body_param: 'status_message[message]' } }
   %ul.nav.nav-tabs.px-3.pt-2.disable-link-generation{ role: 'tablist' }
     %li.nav-item
       = link_to('Write', '#write_message', class: 'nav-link active', data: { 'bs-toggle': 'tab' }, role: 'tab',

--- a/src/api/app/components/write_and_preview_component.html.haml
+++ b/src/api/app/components/write_and_preview_component.html.haml
@@ -14,3 +14,6 @@
         class: 'w-100 form-control message-field')
     .tab-pane.fade{ id: 'preview_message', role: 'tabpanel', 'aria-labelledby': 'preview-message-tab' }
       .message-preview.my-3
+
+:javascript
+  attachPreviewMessageOnCommentBoxes();

--- a/src/api/app/views/webui/comment/_comment_field.html.haml
+++ b/src/api/app/views/webui/comment/_comment_field.html.haml
@@ -30,3 +30,6 @@ data: { preview_message_url: preview_comments_path, message_body_param: 'comment
         - if has_cancel
           %a.cancel-comment.btn.btn-outline-secondary
             Cancel
+
+:javascript
+  attachPreviewMessageOnCommentBoxes();

--- a/src/api/app/views/webui/comment/_comment_field.html.haml
+++ b/src/api/app/views/webui/comment/_comment_field.html.haml
@@ -1,5 +1,6 @@
 = form_for(comment, method: form_method, remote: true, html: { id: "#{element_suffix}_form",
-class: "#{form_method}-comment-form" }, data: { preview_comment_url: preview_comments_path }) do |f|
+class: "#{form_method}-comment-form write-and-preview" },
+data: { preview_message_url: preview_comments_path, message_body_param: 'comment[body]' }) do |f|
   = hidden_field_tag :commentable_type, commentable.class.name, { id: "#{element_suffix}_commentable_type" }
   = hidden_field_tag :commentable_id, commentable.id, { id: "#{element_suffix}_commentable_id" }
   - if defined?(line)
@@ -11,15 +12,15 @@ class: "#{form_method}-comment-form" }, data: { preview_comment_url: preview_com
         = link_to('Write', "#write_#{element_suffix}", class: 'nav-link active', data: { 'bs-toggle': 'tab' }, role: 'tab',
         aria: { controls: 'write-comment-tab', selected: 'true' })
       %li.nav-item
-        = link_to('Preview', "#preview_#{element_suffix}", class: 'nav-link preview-comment-tab', data: { 'bs-toggle': 'tab' },
-        role: 'tab', aria: { controls: 'preview-comment-tab', selected: 'false' })
+        = link_to('Preview', "#preview_#{element_suffix}", class: 'nav-link preview-message-tab', data: { 'bs-toggle': 'tab' },
+        role: 'tab', aria: { controls: 'preview-message-tab', selected: 'false' })
     .tab-content.px-3
       .tab-pane.fade.show.active.my-3{ id: "write_#{element_suffix}", role: 'tabpanel', 'aria-labelledby': 'write-comment-tab' }
         ~ f.text_area :body, id: "#{element_suffix}_body", rows: '4',
         placeholder: 'Write your comment here... (Markdown markup is supported)', required: true,
-        class: 'w-100 form-control comment-field'
-      .tab-pane.fade{ id: "preview_#{element_suffix}", role: 'tabpanel', 'aria-labelledby': 'preview-comment-tab' }
-        .comment-preview.border-bottom.border-gray-300.my-3
+        class: 'w-100 form-control comment-field message-field'
+      .tab-pane.fade{ id: "preview_#{element_suffix}", role: 'tabpanel', 'aria-labelledby': 'preview-message-tab' }
+        .comment-preview.message-preview.border-bottom.border-gray-300.my-3
       .comment-controls.mb-3
         - case form_method
         - when :post


### PR DESCRIPTION
Like in #13878, since the upgrade to Bootstrap 5 the preview comment tab in the Project's and Package's page stopped working because Bootstrap 5 doesn't use jQuery anymore.

Additionally we get rid of the previewer com [comments.js](https://github.com/openSUSE/open-build-service/blob/1d66ab1913201d464ae17b9793b8537868633d14/src/api/app/assets/javascripts/webui/comment.js#L115) and use the generic from [write-and-preview.js](https://github.com/openSUSE/open-build-service/blob/master/src/api/app/assets/javascripts/webui/write_and_preview.js)

Fixes #13901

## How To Test This PR

- Go into the [home:Admin's project page](https://obs-reviewlab.opensuse.org/danidoni-fix-comments-preview-tab/project/show/home:Admin) logged in as Admin.
- Write some message into the comments box.
- Click on the Preview tab
- You should get your comment rendered back in the Preview tab (that does not work right now on [our production instance](https://build.opensuse.org/project/show/home:danidoni))