### PR TITLE
Allow commenting on submit request diff lines

### DIFF
--- a/src/api/app/assets/stylesheets/webui/diff.scss
+++ b/src/api/app/assets/stylesheets/webui/diff.scss
@@ -24,8 +24,23 @@
   .diff {
     min-width: 100%;
     width: max-content;
-    font-family: $font-family-monospace;
+    .line-container {
+      .line-new-comment {
+        display: none;
+      }
+      &:hover .line-new-comment {
+        display: block;
+        position: absolute;
+        z-index: 1000;
+        margin-left: calc(2 * (var(--line-index-digits) + 2rem + #{$card-border-width}) + 0.5rem + #{$card-border-width});
+        margin-top: -1.75rem;
+      }
+      .line-comment hr:first-of-type {
+        display: none;
+      }
+    }
     .line {
+      font-family: $font-family-monospace;
       display: flex;
       .character {
         width: 1ch;

--- a/src/api/app/components/diff_component.html.haml
+++ b/src/api/app/components/diff_component.html.haml
@@ -2,20 +2,35 @@
   .diff{ class: "digits-#{diff.max_digits}" }>
     - diff.lines&.each do |line|
       - id = "diff_#{file_index}_n#{line.index}"
-      %div{ class: "line #{line.state}", id: }>
-        - case line.state
-        - when 'comment', 'range'
-          .offset
-            .text-muted.text
-              = line.content
-        - else
-          = link_to("##{id}", class: 'd-flex') do
-            .number<
-              = line.original_index
-            .number<
-              = line.changed_index
-          .value<
-            %span.character><
-              = line.content[0]
-            %span.content><
-              = line.content[1..]
+      .line-container{ id: }
+        %div{ class: "line #{line.state}" }>
+          - case line.state
+          - when 'comment', 'range'
+            .offset
+              .text-muted.text
+                = line.content
+          - else
+            = link_to("##{id}", class: 'd-flex') do
+              .number<
+                = line.original_index
+              .number<
+                = line.changed_index
+            .value<
+              %span.character><
+                = line.content[0]
+              %span.content><
+                = line.content[1..]
+        - if commentable
+          .line-comment{ id: "comment#{id}" }
+            - if commentable.comments.where(diff_ref: id).present?
+              .p-3.border-top.border-bottom
+                .comments-list
+                  = render(partial: 'webui/comment/comment_list',
+                           locals: { comment: Comment.new, commentable: commentable, diff_ref: id })
+            - else
+              .comments-list
+                = link_to(request_inline_comment_path(commentable.bs_request, commentable, id),
+                          class: 'btn btn-sm btn-primary line-new-comment', remote: true, title: 'Add comment') do
+                  %i.fas.fa-comment-medical
+                  .visually-hidden
+                    Add comment

--- a/src/api/app/components/diff_component.rb
+++ b/src/api/app/components/diff_component.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
 class DiffComponent < ApplicationComponent
-  attr_reader :diff, :file_index
+  attr_reader :diff, :file_index, :commentable
 
-  def initialize(diff:, file_index:)
+  def initialize(diff:, file_index:, commentable: nil)
     super
     @diff = parse_diff(diff)
     @file_index = file_index
+    @commentable = commentable
   end
 
   def render?

--- a/src/api/app/components/diff_list_component.html.haml
+++ b/src/api/app/components/diff_list_component.html.haml
@@ -12,4 +12,4 @@
             = name
           %span.badge.ms-1{ class: badge_for_state(state) }= state.capitalize
       .accordion-collapse.collapse{ class: expand?(name, state) ? 'show' : '', id: "diff-item-#{name.parameterize}", 'data-object': view_id }
-        = render(DiffComponent.new(diff: file_info.dig('diff', '_content'), file_index:))
+        = render(DiffComponent.new(diff: file_info.dig('diff', '_content'), file_index:, commentable:))

--- a/src/api/app/components/diff_list_component.rb
+++ b/src/api/app/components/diff_list_component.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
 class DiffListComponent < ApplicationComponent
-  attr_reader :diff_list, :view_id
+  attr_reader :diff_list, :view_id, :commentable
 
-  def initialize(diff_list:, view_id: nil)
+  def initialize(diff_list:, view_id: nil, commentable: nil)
     super
     @diff_list = diff_list
     @view_id = view_id
+    @commentable = commentable
   end
 
   def badge_for_state(state)

--- a/src/api/app/components/sourcediff_component.html.haml
+++ b/src/api/app/components/sourcediff_component.html.haml
@@ -23,7 +23,7 @@
             %h4
               #{diff_label(sourcediff['new'])} – #{diff_label(sourcediff['old'])}
           - if sourcediff['filenames'].present?
-            = render(DiffListComponent.new(diff_list: sourcediff['files'], view_id: @action[:spkg]))
+            = render(DiffListComponent.new(diff_list: sourcediff['files'], view_id: @action[:spkg], commentable:))
           - else
             .mb-2
               %p.lead

--- a/src/api/app/components/sourcediff_component.rb
+++ b/src/api/app/components/sourcediff_component.rb
@@ -13,6 +13,10 @@ class SourcediffComponent < ApplicationComponent
     @refresh = refresh
   end
 
+  def commentable
+    BsRequestAction.find(@action[:id])
+  end
+
   def file_view_path(filename, sourcediff)
     return if sourcediff['files'][filename]['state'] == 'deleted'
 

--- a/src/api/app/controllers/webui/comments_controller.rb
+++ b/src/api/app/controllers/webui/comments_controller.rb
@@ -26,7 +26,7 @@ class Webui::CommentsController < Webui::WebuiController
              status: status)
     else
       render(partial: 'webui/comment/comment_list',
-             locals: { commentable: @commentable },
+             locals: { commentable: @commentable, diff_ref: comment.root.diff_ref },
              status: status,
              root_comment: comment.root)
     end
@@ -53,7 +53,7 @@ class Webui::CommentsController < Webui::WebuiController
                  status: status)
         else
           render(partial: 'webui/comment/comment_list',
-                 locals: { commentable: comment.commentable },
+                 locals: { commentable: comment.commentable, diff_ref: comment.root.diff_ref },
                  status: status)
         end
       end
@@ -92,7 +92,7 @@ class Webui::CommentsController < Webui::WebuiController
              locals: { comment: comment.root, commentable: @commentable, level: 1 },
              status: status)
     else
-      render(partial: 'webui/comment/comment_list', locals: { commentable: @commentable }, status: status)
+      render(partial: 'webui/comment/comment_list', locals: { commentable: @commentable, diff_ref: comment.root.diff_ref }, status: status)
     end
   end
   # rubocop:enable Metrics/PerceivedComplexity
@@ -108,11 +108,11 @@ class Webui::CommentsController < Webui::WebuiController
   private
 
   def permitted_params
-    params.require(:comment).permit(:body, :parent_id)
+    params.require(:comment).permit(:body, :parent_id, :diff_ref)
   end
 
   def set_commented
-    @commentable_type = [Project, Package, BsRequest].find { |klass| klass.name == params[:commentable_type] }
+    @commentable_type = [Project, Package, BsRequest, BsRequestActionSubmit].find { |klass| klass.name == params[:commentable_type] }
     @commented = @commentable_type&.find_by(id: params[:commentable_id])
     return if @commentable_type.present?
 

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -1,10 +1,10 @@
 class Webui::RequestController < Webui::WebuiController
   helper 'webui/package'
 
-  before_action :require_login, except: [:show, :sourcediff, :diff, :request_action, :request_action_changes]
+  before_action :require_login, except: [:show, :sourcediff, :diff, :request_action, :request_action_changes, :inline_comment]
   # requests do not really add much value for our page rank :)
   before_action :lockout_spiders
-  before_action :require_request, only: [:changerequest, :show, :request_action, :request_action_changes]
+  before_action :require_request, only: [:changerequest, :show, :request_action, :request_action_changes, :inline_comment]
   before_action :set_superseded_request, only: [:show, :request_action, :request_action_changes]
   before_action :check_ajax, only: :sourcediff
 
@@ -327,6 +327,17 @@ class Webui::RequestController < Webui::WebuiController
   # used by mixins
   def main_object
     BsRequest.find_by_number(params[:number])
+  end
+
+  def inline_comment
+    # Handling request actions
+    action_id = params[:request_action_id] || @bs_request.bs_request_actions.first.id
+    @active_action = @bs_request.bs_request_actions.find(action_id)
+
+    @line = params[:line]
+    respond_to do |format|
+      format.js
+    end
   end
 
   private

--- a/src/api/app/models/bs_request_action.rb
+++ b/src/api/app/models/bs_request_action.rb
@@ -12,6 +12,7 @@ class BsRequestAction < ApplicationRecord
   #### Associations macros (Belongs to, Has one, Has many)
   belongs_to :bs_request, touch: true, optional: true
   has_one :bs_request_action_accept_info, dependent: :delete
+  has_many :comments, as: :commentable, dependent: :destroy
 
   belongs_to :target_package_object, class_name: 'Package', foreign_key: 'target_package_id', optional: true
   belongs_to :target_project_object, class_name: 'Project', foreign_key: 'target_project_id', optional: true
@@ -846,6 +847,23 @@ class BsRequestAction < ApplicationRecord
     else
       seen_by_users << user
     end
+  end
+
+  def event_parameters
+    params = { id: bs_request.id,
+               number: bs_request.number,
+               description: bs_request.description,
+               state: bs_request.state,
+               when: bs_request.updated_when.strftime('%Y-%m-%dT%H:%M:%S'),
+               comment: bs_request.comment,
+               author: bs_request.creator,
+               namespace: bs_request.namespace }
+
+    params[:oldstate] = bs_request.state_was if bs_request.state_changed?
+    params[:who] = bs_request.commenter if bs_request.commenter.present?
+
+    params[:actions] = [notify_params]
+    params
   end
 
   private

--- a/src/api/app/views/webui/comment/_comment_field.html.haml
+++ b/src/api/app/views/webui/comment/_comment_field.html.haml
@@ -2,6 +2,8 @@
 class: "#{form_method}-comment-form" }, data: { preview_comment_url: preview_comments_path }) do |f|
   = hidden_field_tag :commentable_type, commentable.class.name, { id: "#{element_suffix}_commentable_type" }
   = hidden_field_tag :commentable_id, commentable.id, { id: "#{element_suffix}_commentable_id" }
+  - if defined?(line)
+    = f.hidden_field :diff_ref, value: line, id: "#{element_suffix}_diff_ref"
   = f.hidden_field :parent_id, value: comment.parent_id, id: "#{element_suffix}_parent_id"
   .card
     %ul.card-header.nav.nav-tabs.px-3.pt-2.pb-0.disable-link-generation{ role: 'tablist' }

--- a/src/api/app/views/webui/comment/_comment_list.html.haml
+++ b/src/api/app/views/webui/comment/_comment_list.html.haml
@@ -1,8 +1,9 @@
-- commentable.comments.without_parent.includes(:user).each do |comment|
+- opts = defined?(diff_ref) ? { diff_ref: } : {}
+- commentable.comments.where(opts).without_parent.includes(:user).each do |comment|
   = render partial: 'webui/comment/content', locals: { comment: comment, commentable: commentable, level: 1 }
 
 .comment_new.mt-3
-  = render partial: 'webui/comment/new', locals: { commentable: commentable }
+  = render partial: 'webui/comment/new', locals: opts.merge({ commentable: commentable })
 
 :javascript
   $(document).ready(function() {

--- a/src/api/app/views/webui/comment/_new.html.haml
+++ b/src/api/app/views/webui/comment/_new.html.haml
@@ -1,6 +1,7 @@
 - if User.session
+  - opts = defined?(diff_ref) ? { line: diff_ref, element_suffix: "new_comment_#{diff_ref}" } : {}
   = render(partial: 'webui/comment/comment_field',
-    locals: { form_method: :post, comment: Comment.new, commentable: commentable, element_suffix: 'new_comment', has_cancel: false })
+    locals: { form_method: :post, comment: Comment.new, commentable: commentable, element_suffix: 'new_comment', has_cancel: false }.merge(opts))
 - else
   .alert.alert-warning{ role: 'alert' }
     Login required, please

--- a/src/api/app/views/webui/request/_inline_comment.html.haml
+++ b/src/api/app/views/webui/request/_inline_comment.html.haml
@@ -1,0 +1,4 @@
+.p-3.border-top.border-bottom
+  .comments-list
+    = render(partial: 'webui/comment/comment_list',
+      locals: { comment: Comment.new, commentable:, diff_ref: })

--- a/src/api/app/views/webui/request/inline_comment.js.erb
+++ b/src/api/app/views/webui/request/inline_comment.js.erb
@@ -1,0 +1,3 @@
+$('#flash').empty();
+$('#comment<%= @line %> .comments-list').html("<%= escape_javascript(render(partial: 'webui/request/inline_comment', locals: { comment: @comment, commentable: @active_action, diff_ref: @line })) %>");
+$("#comment<%= @line %> .comments-list textarea").focus();

--- a/src/api/config/routes/webui_routes.rb
+++ b/src/api/config/routes/webui_routes.rb
@@ -297,6 +297,7 @@ OBSApi::Application.routes.draw do
       post 'request/set_bugowner_request' => :set_bugowner_request
       get 'request/:number/request_action/:id' => :request_action, as: 'request_action'
       get 'request/:number/request_action/:id/changes' => :request_action_changes, as: 'request_action_changes'
+      get 'request/:number/request_action/:id/inline_comment/:line' => :inline_comment, constraints: cons, as: 'request_inline_comment'
     end
 
     resources :requests, only: [], param: :number, controller: 'webui/bs_requests' do

--- a/src/api/db/migrate/202302224114624_add_diff_ref_to_comments.rb
+++ b/src/api/db/migrate/202302224114624_add_diff_ref_to_comments.rb
@@ -1,0 +1,5 @@
+class AddDiffRefToComments < ActiveRecord::Migration[7.0]
+  def change
+    add_column :comments, :diff_ref, :string
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_16_143207) do
+ActiveRecord::Schema[7.0].define(version: 202302224114624) do
   create_table "architectures", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "name", null: false, collation: "utf8mb3_general_ci"
     t.boolean "available", default: false
@@ -302,6 +302,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_16_143207) do
     t.integer "user_id", null: false
     t.string "commentable_type", collation: "utf8mb3_unicode_ci"
     t.integer "commentable_id"
+    t.string "diff_ref"
     t.index ["commentable_type", "commentable_id"], name: "index_comments_on_commentable_type_and_commentable_id"
     t.index ["parent_id"], name: "parent_id"
     t.index ["user_id"], name: "user_id"


### PR DESCRIPTION
Depends on #13910 

Allows users to comment on submit request action diffs.

![Screenshot from 2023-02-28 13-06-33](https://user-images.githubusercontent.com/114928900/221850174-869bffcb-02c1-496a-a74c-efe5198e11e6.png)

# How to test

1. Create a submit request with a diff
2. Open changes tab
3. Hover over a line
4. Click a button that shows up
5. Write a comment and save it

