### PR TITLE
Remove association errors from database_consistency

### DIFF
--- a/src/api/.database_consistency.todo.yml
+++ b/src/api/.database_consistency.todo.yml
@@ -403,6 +403,16 @@ Role:
   title:
     MissingUniqueIndexChecker:
       enabled: false
+  attrib_type_modifiable_bies:
+    ForeignKeyChecker:
+      enabled: false
+    ForeignKeyTypeChecker:
+      enabled: false
+  relationships:
+    ForeignKeyChecker:
+      enabled: false
+    ForeignKeyTypeChecker:
+      enabled: false
 Review:
   id:
     PrimaryKeyTypeChecker:

--- a/src/api/app/models/role.rb
+++ b/src/api/app/models/role.rb
@@ -26,8 +26,8 @@ class Role < ApplicationRecord
                                   message: 'is the name of an already existing role' }
 
   belongs_to :groups_roles, optional: true
-  belongs_to :attrib_type_modifiable_bies, optional: true
-  belongs_to :relationships, optional: true
+  belongs_to :attrib_type_modifiable_bies, class_name: 'AttribTypeModifiableBy', optional: true
+  belongs_to :relationships, class_name: 'Relationship', optional: true
   belongs_to :roles_static_permissions, optional: true
   belongs_to :roles_users, optional: true
 


### PR DESCRIPTION
database_consistency couldn't find the following association class names, causing it to exit with error, this fixes the issue.