### PR TITLE
added cargo_vendor/go_modules to call-service-in-container

### DIFF
--- a/src/backend/call-service-in-container
+++ b/src/backend/call-service-in-container
@@ -69,7 +69,7 @@ create_dir "$LOGDIR"
 
 shift
 case "$COMMAND" in
-  */download_url|*/download_src_package|*/update_source|*/download_files|*/generator_pom|*/snapcraft|*/kiwi_import|*/appimage|*/node_modules)
+  */download_url|*/download_src_package|*/update_source|*/download_files|*/generator_pom|*/snapcraft|*/kiwi_import|*/appimage|*/node_modules|*/cargo_vendor|*/go_modules)
     WITH_NET="1"
     ;;
   */bundle_gems)


### PR DESCRIPTION
This patch is required to enable network access in call-service-in-container for cargo_vendor/go_modules services