### PR TITLE
Fix arrangement of request show view HTML elements

### DIFF
--- a/src/api/app/views/webui/request/_actions_details.html.haml
+++ b/src/api/app/views/webui/request/_actions_details.html.haml
@@ -3,8 +3,8 @@
   submit_actions_count = submit_actions.count
 
 - if submit_actions_count > 1
-  .d-flex.align-items-center
-    %p.mb-0 This request contains #{submit_actions_count} actions
+  .d-flex.flex-wrap.mb-3.align-items-center
+    This request contains #{submit_actions_count} actions
     .input-group.ms-2.w-auto
       = link_to('Previous', request_show_path(number: bs_request.number, request_action_id: prev_action&.id,
                                               full_diff: diff_limit, diff_to_superseded: diff_to_superseded_id),
@@ -32,18 +32,18 @@
       = link_to('Next', request_show_path(number: bs_request.number, request_action_id: next_action&.id,
                                           full_diff: diff_limit, diff_to_superseded: diff_to_superseded_id),
                 class: "btn btn-primary btn-sm #{next_action ? '' : 'disabled'}")
-%p
+.d-flex.flex-wrap.mb-3.align-items-center
   - if submit_actions_count > 1
     - if User.session
-      .d-inline#action-seen-by-user-wrapper
+      #action-seen-by-user-wrapper
         = render ActionSeenByUserComponent.new(action: active_action, user: User.session!)
 
     - active_action_index = submit_actions.find_index(active_action) + 1
-    %span.ms-2.align-middle
+    .ms-2
       Showing
       %em action ##{active_action_index}
       \-
-  %span.font-italic.align-middle= request_action_header(action, bs_request.creator)
+  .fst-italic= request_action_header(action, bs_request.creator)
 
 - content_for :ready_function do
   :plain

--- a/src/api/app/views/webui/request/beta_show.html.haml
+++ b/src/api/app/views/webui/request/beta_show.html.haml
@@ -25,25 +25,25 @@
 
 .card
   .card-body.p-0
-    .card-title.p-4.mb-0
-      %h3<>
-        Request #{@bs_request.number}
-        %span.badge.ms-2{ class: "bg-#{request_badge_color(@bs_request.state)}" }>
-          = @bs_request.state
-          - if @bs_request.superseded_by.present?
-            by
-            = link_to(@bs_request.superseded_by, { number: @bs_request.superseded_by }, class: 'link-light')
-        - if @staging_status
-          - staging_title = @staging_status[:title]
-          - staging_title[0].capitalize
-          = link_to @staging_status[:name], @staging_status[:url], title: staging_title, class: 'badge badge-staging ms-2'
-        - if @bs_request.accept_at.present?
-          %span.badge.alert.alert-warning.border-0.ms-2.mb-0.p-2 auto-accept
-        - if User.session
-          .d-inline.align-bottom.ms-1#watchlist-icon-wrapper
-            = render WatchlistIconComponent.new(user: User.session!, bs_request: @bs_request, current_object: @bs_request)
+    %h3.card-title.pt-4.px-4
+      Request #{@bs_request.number}
+      %span.badge.ms-2{ class: "bg-#{request_badge_color(@bs_request.state)}" }>
+        = @bs_request.state
+        - if @bs_request.superseded_by.present?
+          by
+          = link_to(@bs_request.superseded_by, { number: @bs_request.superseded_by }, class: 'link-light')
+      - if @staging_status
+        - staging_title = @staging_status[:title]
+        - staging_title[0].capitalize
+        = link_to @staging_status[:name], @staging_status[:url], title: staging_title, class: 'badge badge-staging ms-2'
+      - if @bs_request.accept_at.present?
+        %span.badge.alert.alert-warning.border-0.ms-2.mb-0.p-2 auto-accept
+      - if User.session
+        .d-inline.align-bottom.ms-1#watchlist-icon-wrapper
+          = render WatchlistIconComponent.new(user: User.session!, bs_request: @bs_request, current_object: @bs_request)
 
-      %p.font-italic
+    .card-text.px-4.pb-4
+      %p.fst-italic
         Created by
         = user_with_realname_and_icon(@bs_request.creator)
         = render FuzzyTimeComponent.new(time: @bs_request.created_at)
@@ -52,10 +52,11 @@
           - @bs_request.superseding.each do |supersed|
             = link_to "##{supersed['number']}", number: supersed['number']
 
-        = render partial: 'actions_details', locals: { bs_request: @bs_request, action: @action, active_action: @active_action,
-                                                       prev_action: @prev_action, next_action: @next_action,
-                                                       diff_to_superseded_id: @diff_to_superseded_id, diff_limit: @diff_limit }
-        - if @staging_status
+      = render partial: 'actions_details', locals: { bs_request: @bs_request, action: @action, active_action: @active_action,
+                                                     prev_action: @prev_action, next_action: @next_action,
+                                                     diff_to_superseded_id: @diff_to_superseded_id, diff_limit: @diff_limit }
+      - if @staging_status
+        %p
           This request is currently
           = link_to @staging_status[:title], @staging_status[:url]
 


### PR DESCRIPTION
Fix including `<p>` elements inside other `<p>` elements in the requests and actions views. That results in an invalid HTML, and the HAML parser was preventing this from happening creating `<p></p>` groups of HTML elements.

A series of changes have been made in this pull request:
- Rearrange the title of the card and the text of the card, adjusting margins. Before, all the text belonged to the  `card-title` CSS class.
- Substitute `font-italic` with `fst-italic`. This should have been changed in the migration to Bootstrap 5.
- Wrap simple text not including `<p>` elements into `<p>` elements.
- Wrap the rest of the text groups into `<div>` elements with the following classes: `.d-flex.flex-wrap.mb-3.align-items-center`. That allowed to remove the use of `.align-middle`.