### PR TITLE
Replace rescuing `Exception` with `StandardError`

### DIFF
--- a/src/api/app/controllers/person_controller.rb
+++ b/src/api/app/controllers/person_controller.rb
@@ -214,7 +214,7 @@ class PersonController < ApplicationController
         email, password: password, note: note, status: status)
 
     render_ok
-  rescue Exception => e
+  rescue StandardError => e
     # Strip passwords from request environment and re-raise exception
     request.env['RAW_POST_DATA'] = request.env['RAW_POST_DATA'].sub(%r{<password>(.*)</password>}, '<password>STRIPPED<password>')
     raise e

--- a/src/api/app/controllers/public_controller.rb
+++ b/src/api/app/controllers/public_controller.rb
@@ -210,7 +210,7 @@ class PublicController < ApplicationController
     allowed = Rails.cache.fetch(key, expires_in: 30.minutes) do
       Package.get_by_project_and_name(project_name, package_name, use_source: false)
       true
-    rescue Exception
+    rescue StandardError
       false
     end
     raise Package::UnknownObjectError, "#{project_name} / #{package_name} " unless allowed


### PR DESCRIPTION
`Exception` is the root of Ruby's exception hierarchy. Rescuing from `Exception` will apply rescue to any error, including subclasses such as `SyntaxError`, `LoadError`, and `Interrupt`.

In the controllers of our Rails application, we need to rescue from exceptons thrown from the basecode, not other ones.