### PR TITLE
Extend specs for BsRequestHistoryElementComponent

### DIFF
--- a/src/api/spec/components/bs_request_history_element_component_spec.rb
+++ b/src/api/spec/components/bs_request_history_element_component_spec.rb
@@ -3,39 +3,51 @@ require 'rails_helper'
 RSpec.describe BsRequestHistoryElementComponent, type: :component do
   let(:user) { create(:confirmed_user) }
 
-  it 'fails when the history element is not passed' do
-    expect { render_inline(described_class.new) }.to raise_error(ArgumentError, 'missing keyword: :element')
+  before do
+    render_inline(described_class.new(element: element))
+  end
+
+  context 'for any kind of history elements' do
+    let(:element) { create(:history_element_request_accepted, user: user, created_at: Time.zone.yesterday) }
+
+    it 'displays an avatar' do
+      expect(rendered_content).to have_selector("img[title='#{user.realname}']", count: 1)
+    end
+
+    it 'displays the name of the user involved' do
+      expect(rendered_content).to have_text("#{user.realname} (#{user.login})")
+    end
+
+    it 'displays the time in words' do
+      expect(rendered_content).to have_text('1 day ago')
+    end
+
+    it 'displays the element comment' do
+      expect(rendered_content).to have_selector('.timeline-item-comment', text: element.comment)
+    end
   end
 
   context 'with a HistoryElement::RequestAccepted' do
     let(:element) { create(:history_element_request_accepted, user: user) }
 
-    it 'describes the element action' do
-      expect(render_inline(described_class.new(element: element))).to have_text('accepted request')
-    end
-
     it 'displays the right icon' do
-      expect(render_inline(described_class.new(element: element))).to have_css('i.fa-check')
+      expect(rendered_content).to have_css('i.fa-check')
     end
 
-    it 'displays the element comment' do
-      expect(render_inline(described_class.new(element: element))).to have_text(element.comment)
+    it 'describes the element action' do
+      expect(rendered_content).to have_text('accepted request')
     end
   end
 
   context 'with a HistoryElement::RequestSuperseded' do
     let(:element) { create(:history_element_request_superseded, user: user) }
 
-    it 'describes the element action' do
-      expect(render_inline(described_class.new(element: element))).to have_text('superseded this request with')
-    end
-
     it 'displays the right icon' do
-      expect(render_inline(described_class.new(element: element))).to have_css('i.fa-code-commit')
+      expect(rendered_content).to have_css('i.fa-code-commit')
     end
 
-    it 'displays the element comment' do
-      expect(render_inline(described_class.new(element: element))).to have_text(element.comment)
+    it 'describes the element action' do
+      expect(rendered_content).to have_text('superseded this request with')
     end
   end
 
@@ -43,32 +55,24 @@ RSpec.describe BsRequestHistoryElementComponent, type: :component do
     context 'with review' do
       let(:element) { create(:history_element_request_review_added_with_review, user: user) }
 
-      it 'describes the element action' do
-        expect(render_inline(described_class.new(element: element))).to have_text('as a reviewer')
-      end
-
       it 'displays the right icon' do
-        expect(render_inline(described_class.new(element: element))).to have_css('i.fa-circle')
+        expect(rendered_content).to have_css('i.fa-circle')
       end
 
-      it 'displays the element comment' do
-        expect(render_inline(described_class.new(element: element))).to have_text(element.comment)
+      it 'describes the element action' do
+        expect(rendered_content).to have_text('as a reviewer')
       end
     end
 
     context 'without review' do
       let(:element) { create(:history_element_request_review_added_without_review, user: user, description_extension: nil) }
 
-      it 'describes the element action' do
-        expect(render_inline(described_class.new(element: element))).to have_text('added a reviewer')
-      end
-
       it 'displays the right icon' do
-        expect(render_inline(described_class.new(element: element))).to have_css('i.fa-circle')
+        expect(rendered_content).to have_css('i.fa-circle')
       end
 
-      it 'displays the element comment' do
-        expect(render_inline(described_class.new(element: element))).to have_text(element.comment)
+      it 'describes the element action' do
+        expect(rendered_content).to have_text('added a reviewer')
       end
     end
   end

--- a/src/api/spec/factories/history_elements.rb
+++ b/src/api/spec/factories/history_elements.rb
@@ -1,65 +1,62 @@
 FactoryBot.define do
-  # Inheriting from HistoryElement::Review
-
-  factory :history_element_review_assigned, class: 'HistoryElement::ReviewAssigned' do
+  factory 'history_element' do
     user { create(:user) }
-    type { 'HistoryElement::ReviewAssigned' }
-  end
+    comment { Faker::Lorem.paragraph }
 
-  factory :history_element_review_accepted, class: 'HistoryElement::ReviewAccepted' do
-    user { create(:user) }
-    type { 'HistoryElement::ReviewAccepted' }
-  end
+    # Inheriting from HistoryElement::Review
 
-  factory :history_element_review_declined, class: 'HistoryElement::ReviewDeclined' do
-    user { create(:user) }
-    type { 'HistoryElement::ReviewDeclined' }
-  end
-
-  # Inheriting from HistoryElement::Request
-
-  factory :history_element_request_accepted, class: 'HistoryElement::RequestAccepted' do
-    user { create(:user) }
-    op_object_id { create(:bs_request_with_submit_action).id }
-    type { 'HistoryElement::RequestAccepted' }
-  end
-
-  factory :history_element_request_revoked, class: 'HistoryElement::RequestRevoked' do
-    user { create(:user) }
-    op_object_id { create(:bs_request_with_submit_action).id }
-    type { 'HistoryElement::RequestRevoked' }
-  end
-
-  factory :history_element_request_review_added_with_review, class: 'HistoryElement::RequestReviewAdded' do
-    user { create(:user) }
-    type { 'HistoryElement::RequestReviewAdded' }
-
-    before(:create) do |history_element|
-      bs_request = create(:bs_request_with_submit_action, review_by_user: create(:confirmed_user))
-      history_element.update(description_extension: bs_request.reviews.first.id.to_s, op_object_id: bs_request.id)
+    factory :history_element_review_assigned, class: 'HistoryElement::ReviewAssigned' do
+      type { 'HistoryElement::ReviewAssigned' }
     end
-  end
 
-  factory :history_element_request_review_added_without_review, class: 'HistoryElement::RequestReviewAdded' do
-    user { create(:user) }
-    type { 'HistoryElement::RequestReviewAdded' }
-    description_extension { nil }
-
-    before(:create) do |history_element|
-      bs_request = create(:bs_request_with_submit_action, review_by_user: create(:confirmed_user))
-      history_element.update(op_object_id: bs_request.id)
+    factory :history_element_review_accepted, class: 'HistoryElement::ReviewAccepted' do
+      type { 'HistoryElement::ReviewAccepted' }
     end
-  end
 
-  factory :history_element_request_superseded, class: 'HistoryElement::RequestSuperseded' do
-    user { create(:user) }
-    type { 'HistoryElement::RequestSuperseded' }
+    factory :history_element_review_declined, class: 'HistoryElement::ReviewDeclined' do
+      type { 'HistoryElement::ReviewDeclined' }
+    end
 
-    before(:create) do |history_element|
-      superseding_bs_request = create(:bs_request_with_submit_action)
-      superseded_bs_request = create(:superseded_bs_request, superseded_by_request: superseding_bs_request)
+    # Inheriting from HistoryElement::Request
 
-      history_element.update(description_extension: superseded_bs_request.superseded_by.to_s, op_object_id: superseded_bs_request.id)
+    factory :history_element_request_accepted, class: 'HistoryElement::RequestAccepted' do
+      op_object_id { create(:bs_request_with_submit_action).id }
+      type { 'HistoryElement::RequestAccepted' }
+    end
+
+    factory :history_element_request_revoked, class: 'HistoryElement::RequestRevoked' do
+      op_object_id { create(:bs_request_with_submit_action).id }
+      type { 'HistoryElement::RequestRevoked' }
+    end
+
+    factory :history_element_request_review_added_with_review, class: 'HistoryElement::RequestReviewAdded' do
+      type { 'HistoryElement::RequestReviewAdded' }
+
+      before(:create) do |history_element|
+        bs_request = create(:bs_request_with_submit_action, review_by_user: create(:confirmed_user))
+        history_element.update(description_extension: bs_request.reviews.first.id.to_s, op_object_id: bs_request.id)
+      end
+    end
+
+    factory :history_element_request_review_added_without_review, class: 'HistoryElement::RequestReviewAdded' do
+      type { 'HistoryElement::RequestReviewAdded' }
+      description_extension { nil }
+
+      before(:create) do |history_element|
+        bs_request = create(:bs_request_with_submit_action, review_by_user: create(:confirmed_user))
+        history_element.update(op_object_id: bs_request.id)
+      end
+    end
+
+    factory :history_element_request_superseded, class: 'HistoryElement::RequestSuperseded' do
+      type { 'HistoryElement::RequestSuperseded' }
+
+      before(:create) do |history_element|
+        superseding_bs_request = create(:bs_request_with_submit_action)
+        superseded_bs_request = create(:superseded_bs_request, superseded_by_request: superseding_bs_request)
+
+        history_element.update(description_extension: superseded_bs_request.superseded_by.to_s, op_object_id: superseded_bs_request.id)
+      end
     end
   end
 end


### PR DESCRIPTION
I decided to test, at least once, the elements that are always present after this [conversation](https://github.com/openSUSE/open-build-service/pull/13918#issuecomment-1451664915). Like the icon, time, avatar, etc.

So I extend the specs to do so and apply DRY rule too. I also added the missing `comment` parameter to the factories.

**Tip for reviewers:** don't compare with the previous version, review it as it was a new spec.