### PR TITLE
Reduce redundancy on add_role action text

### DIFF
--- a/src/api/app/views/webui/request/_action_text.html.haml
+++ b/src/api/app/views/webui/request/_action_text.html.haml
@@ -22,15 +22,14 @@
       %p.mt-0.mb-0.fw-normal
         %span.me-2 ##{action_index + 1}
         - if action.type == 'add_role'
-          #{action.type.titleize} for
-          = project_or_package_text(action.target_project, action.target_package)
+          #{action.type.titleize}
         - else
           = action.name
     -# add_role, delete and set_bugowner are actions on the target repo, so they don't need to mention where they are coming from
     - unless %w[delete set_bugowner].include?(action.type)
       %p.mb-0.mt-0.small
         - if action.type == 'add_role'
-          #{action.person_name} as #{action.role} for
+          Add #{action.person_name} as #{action.role} of
           = project_or_package_text(action.target_project, action.target_package)
         - else
           from


### PR DESCRIPTION
The text for the add_role actions seems a bit redundant to me. Sorry I didn't realize before.

What about this?

**Before:**

![add_role_action_text_not_simplified](https://user-images.githubusercontent.com/2581944/222454888-6fe8387f-634a-4939-b082-1d62c80d3b3d.png)

**After:**

![add_role_action_text_simplified](https://user-images.githubusercontent.com/2581944/222454899-7e4dde12-83e0-43c3-8db7-ca6c2dfbf33e.png)
