### PR TITLE
Add link to related roles for "Add Role" action

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -252,6 +252,11 @@ class Webui::PackageController < Webui::WebuiController
     @users = [@project.users, @package.users].flatten.uniq
     @groups = [@project.groups, @package.groups].flatten.uniq
     @roles = Role.local_roles
+    if User.session && params[:notification_id]
+      @current_notification = Notification.find(params[:notification_id])
+      authorize @current_notification, :update?, policy_class: NotificationPolicy
+    end
+    @current_request_action = BsRequestAction.find(params[:request_action_id]) if User.session && params[:request_action_id]
   end
 
   def requests

--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -167,6 +167,11 @@ class Webui::ProjectController < Webui::WebuiController
     @users = @project.users
     @groups = @project.groups
     @roles = Role.local_roles
+    if User.session && params[:notification_id]
+      @current_notification = Notification.find(params[:notification_id])
+      authorize @current_notification, :update?, policy_class: NotificationPolicy
+    end
+    @current_request_action = BsRequestAction.find(params[:request_action_id]) if User.session && params[:request_action_id]
   end
 
   def subprojects

--- a/src/api/app/views/layouts/webui/_notification_toolbar.html.haml
+++ b/src/api/app/views/layouts/webui/_notification_toolbar.html.haml
@@ -1,5 +1,12 @@
 .notification-toolbar.sticky-top.navbar.navbar-light.bg-light.border-bottom.border-gray-400
-  = link_to(my_notifications_path, class: 'btn btn-sm btn-outline-secondary', title: 'Back to notifications') do
-    %i.fas.fa-arrow-left
-    Back to notifications
-  = mark_as_read_or_unread_button(notification)
+  .container-fluid
+    - if request_action
+      = link_to(request_show_path(number: request_action.bs_request.number, request_action_id: request_action.id, notification_id: notification),
+                class: 'btn btn-sm btn-outline-secondary', title: 'Back to request action') do
+        %i.fas.fa-arrow-left
+        Back to request action "Add #{request_action.person_name} as #{request_action.role}"
+    - else
+      = link_to(my_notifications_path, class: 'btn btn-sm btn-outline-secondary', title: 'Back to notifications') do
+        %i.fas.fa-arrow-left
+        Back to notifications
+      = mark_as_read_or_unread_button(notification)

--- a/src/api/app/views/layouts/webui/webui.html.haml
+++ b/src/api/app/views/layouts/webui/webui.html.haml
@@ -46,8 +46,9 @@
         = render partial: 'layouts/webui/left_navigation', locals: { spider_bot: @spider_bot }
         = render partial: 'layouts/webui/left_navigation_collapse_button'
       .d-flex.flex-column#content-area
-        - if @current_notification
-          = render partial: 'layouts/webui/notification_toolbar', locals: { notification: @current_notification }
+        - if @current_notification || @current_request_action
+          = render partial: 'layouts/webui/notification_toolbar', locals: { notification: @current_notification,
+                                                                            request_action: @current_request_action }
         .container-xxl.flex-grow-1.pb-3.border-bottom.border-gray-400
           .sticky-top.flash-and-announcement.text-break
             = render partial: 'layouts/webui/status_message_announcement', locals: { current_announcement: @current_announcement }

--- a/src/api/app/views/webui/request/_actions_details.html.haml
+++ b/src/api/app/views/webui/request/_actions_details.html.haml
@@ -45,6 +45,23 @@
       \-
   .fst-italic= request_action_header(action, bs_request.creator)
 
+- if active_action.type == 'add_role'
+  :ruby
+    parameters = { project: active_action.target_project, request_action_id: active_action.id, notification_id: @current_notification }
+    roles_link = if active_action.target_package
+                   package_users_path(parameters.merge!(package: active_action.target_package))
+                 else
+                   project_users_path(parameters)
+                 end
+  %p
+    You might want to
+    = link_to(roles_link) do
+      check the current roles
+    of
+    %span<
+      = project_or_package_text(active_action.target_project, active_action.target_package)
+      \.
+
 - content_for :ready_function do
   :plain
     var hashRegexp = new RegExp(`\#${HASH_PREFIX}.+`);


### PR DESCRIPTION
The notification toolbar is used in the project and package roles pages to show a link to go back to the request action.

Also fixes #13890.

![Peek 2023-03-03 09-05_add_link_to_add_role_action](https://user-images.githubusercontent.com/24919/222665865-8c495ee1-6b1d-4d61-854d-7fca50985b16.gif)
