### PR TITLE
Adjust colors after Bootstrap 5 migration

### DIFF
--- a/src/api/app/assets/stylesheets/webui/application.scss
+++ b/src/api/app/assets/stylesheets/webui/application.scss
@@ -74,6 +74,7 @@
 @import 'request_show_redesign/build_results';
 @import 'accordion-reviews-component';
 @import 'tokens';
+@import 'colors';
 
 html {
     overflow-y: scroll !important;

--- a/src/api/app/assets/stylesheets/webui/colors.scss
+++ b/src/api/app/assets/stylesheets/webui/colors.scss
@@ -1,0 +1,3 @@
+.bg-gray-800 {
+  background-color: $gray-800;
+}

--- a/src/api/app/assets/stylesheets/webui/navbar.scss
+++ b/src/api/app/assets/stylesheets/webui/navbar.scss
@@ -1,9 +1,10 @@
 .navbar-dark {
+  // Dropdown: Your profile & Logout
   .dropdown-menu {
-    @extend .bg-dark;
+    background-color: $gray-800;
 
     .dropdown-item:hover {
-      @extend .bg-dark;
+      background-color: $gray-800;
       color: $gray-300;
     }
   }
@@ -19,7 +20,6 @@
       padding-left: 1rem;
       overflow-y: auto;
       visibility: hidden;
-      background-color: #343a40;
       color: $gray-400;
       transition: visibility .3s ease-in-out, -webkit-transform .3s ease-in-out;
       transition: transform .3s ease-in-out, visibility .3s ease-in-out;

--- a/src/api/app/views/layouts/webui/_bottom_navigation.html.haml
+++ b/src/api/app/views/layouts/webui/_bottom_navigation.html.haml
@@ -1,4 +1,4 @@
-%nav.navbar.fixed-bottom.navbar-dark.bg-dark.border-top.border-gray-500.p-0
+%nav.navbar.fixed-bottom.navbar-dark.bg-gray-800.border-top.border-gray-500.p-0
   %ul.nav.justify-content-center.w-100.nav-justified
     - if User.session
       %li.nav-item

--- a/src/api/app/views/layouts/webui/_bottom_navigation_collapse.html.haml
+++ b/src/api/app/views/layouts/webui/_bottom_navigation_collapse.html.haml
@@ -1,4 +1,4 @@
-.navbar-collapse.navbar-dark{ class: "#{collapse_type}-collapse" }
+.navbar-collapse.navbar-dark.bg-gray-800{ class: "#{collapse_type}-collapse" }
   .navbar-nav
     .nav.justify-content-end.py-2
       %button.navbar-toggler{ type: 'button', 'data-toggle': collapse_type, aria: { expanded: 'false', label: "Toggle #{collapse_type}" } }

--- a/src/api/app/views/layouts/webui/_left_navigation_collapse_button.html.haml
+++ b/src/api/app/views/layouts/webui/_left_navigation_collapse_button.html.haml
@@ -1,4 +1,4 @@
-.bg-dark.border-top.border-gray-500#toggle-sidebar-button
+.navbar-dark.bg-gray-800.border-top.border-gray-500#toggle-sidebar-button
   %ul.nav.flex-column.ms-auto.pt-0.text-nowrap.menu-options
     %li.nav-item
       %a.nav-link{ type: 'button' }

--- a/src/api/app/views/layouts/webui/_top_navigation.html.haml
+++ b/src/api/app/views/layouts/webui/_top_navigation.html.haml
@@ -1,4 +1,4 @@
-%nav.navbar.navbar-dark.bg-dark.fixed-top
+%nav.navbar.navbar-dark.bg-gray-800.fixed-top
   .container-fluid.d-flex.flex-nowrap.justify-content-between.w-100
     = link_to(root_path, class: 'navbar-brand', alt: 'Logo') do
       = image_tag('obs-logo_small.svg')

--- a/src/api/app/views/layouts/webui/webui.html.haml
+++ b/src/api/app/views/layouts/webui/webui.html.haml
@@ -42,7 +42,7 @@
     #grid
       #top-navigation-area
         = render partial: 'layouts/webui/top_navigation'
-      .bg-dark#left-navigation-area{ class: "#{'collapsed' if sidebar_collapsed?}" }
+      .navbar-dark.bg-gray-800#left-navigation-area{ class: "#{'collapsed' if sidebar_collapsed?}" }
         = render partial: 'layouts/webui/left_navigation', locals: { spider_bot: @spider_bot }
         = render partial: 'layouts/webui/left_navigation_collapse_button'
       .d-flex.flex-column#content-area
@@ -76,7 +76,7 @@
 
       -# Collapsible menu shared between top and bottom navigation
       - if User.session
-        .navbar-collapse.watchlist-collapse.navbar-dark
+        .navbar-dark.bg-gray-800.navbar-collapse.watchlist-collapse
           = render WatchlistComponent.new(user: User.session!,
                                           bs_request: @bs_request,
                                           package: @package,


### PR DESCRIPTION
Before these changes, the background colors of the navigation areas were inconsistent. Something that started to happen after the migration to Bootstrap 5.
Compare the Watchlist bar and the top bar, for example.

![Screenshot 2023-03-03 at 13-37-04 Open Build Service](https://user-images.githubusercontent.com/2581944/222727788-66e68175-73e0-4f36-aa77-05974c04627a.png)

After these changes, I bring back the dark gray color for all of the navigation areas:

![Screenshot 2023-03-03 at 13-41-53 Open Build Service](https://user-images.githubusercontent.com/2581944/222727806-a0b2af36-e3d1-48d1-bb2f-daf956b38198.png)

**What happened with the migration?**

We were using `.bg-dark` for the background color of the navigation areas. However, `bg-dark` was `#343a40` in the past ([see v4.6 docu](https://getbootstrap.com/docs/4.6/utilities/colors/#background-color)), but now it is `#212529`, a darker color ([see v5.0 docu](https://getbootstrap.com/docs/5.0/customize/color/#theme-colors)).

Checking the new Sass variables I see Bootstrap still has both colors set in variables.
The new `bg-dark` (`bg-dark = $gray-900 = #212529`) and the color we used before  (`$gray-800 = #343a40`).

~That's why I now set `$gray-800` as the background color in `.navbar-dark` which is a class used by all the navigation areas and stop relying on `bg-dark`.~

That's why I now set a new Sass variable `.bg-gray-800` and use it, together with `.navbar-dark`, in all the navigation areas.