### PR TITLE
Use colors set on Sass variables

### DIFF
--- a/src/api/app/assets/stylesheets/webui/layout.scss
+++ b/src/api/app/assets/stylesheets/webui/layout.scss
@@ -32,7 +32,8 @@
     span.d-block { line-height: 1rem; }
 
     &.active {
-      background-color: darken($dark, 10%);
+      background-color: $gray-900;
+
       @extend .rounded;
     }
   }

--- a/src/api/app/assets/stylesheets/webui/watchlist.scss
+++ b/src/api/app/assets/stylesheets/webui/watchlist.scss
@@ -7,7 +7,7 @@
   @extend .d-flex;
   @extend .flex-column;
   position: relative;
-  background-color: lighten($dark, 10%);
+  background-color: $gray-700;
   max-height: 100vh;
   transition: max-height .3s 0s ease-in-out, mrgin-bottom .1s .1s linear;
 
@@ -18,7 +18,7 @@
     top: -.5rem;
     border-left: .5rem solid transparent;
     border-right: .5rem solid transparent;
-    border-bottom: .5rem solid lighten($dark, 10%);
+    border-bottom: .5rem solid $gray-700;
     transition: top .3s .1s ease-in-out, opacity 0.1s .2s ease-in-out;
 
     &.left { left: .5rem; }


### PR DESCRIPTION
Instead of calculating new colors using lighten or darken functions, we better use specific colors already set in Sass variables. Getting the same result:

![lighter_and_darken](https://user-images.githubusercontent.com/2581944/222759711-ae7e8547-01d7-45b0-ae9d-0b75793e233d.png)
