### PR TITLE
Fix: computing timeline icon and avatar alignment

### DIFF
--- a/src/api/app/assets/stylesheets/webui/timeline.scss
+++ b/src/api/app/assets/stylesheets/webui/timeline.scss
@@ -1,7 +1,9 @@
 // This stylesheet defines styles for use in the comments and request history merged timeline
 .timeline {
     $timeline-border-width: 0.125rem;
-    $timeline-offset: -(($avatars-counter-size / 2) + $timeline-border-width);
+    $timeline-item-avatar-width: 1.5rem;
+    $timeline-item-avatar-height: 1.5rem;
+    $timeline-offset: -(($timeline-item-avatar-width / 2) + ($timeline-border-width / 2));
     border-left: $timeline-border-width solid $gray-400;
 
     .timeline-item {
@@ -9,20 +11,11 @@
         left: $timeline-offset; // The avatars of users involved in timeline items will be displayed on the timeline border
 
         .d-inline-flex i:first-child {
-            padding-top: $avatars-counter-size / 2;
-            height: $avatars-counter-size;
+            padding-top: $timeline-item-avatar-height / 2;
+            height: $timeline-item-avatar-height;
+            width: $timeline-item-avatar-width;
+            text-align: center;
             @extend .bg-white;
-
-            // Align specific icons with the timeline border, this differs depending on the icon shape
-            &.fa-code-commit {
-                padding-left: $timeline-border-width / 2;
-            }
-            &.fa-check, &.fa-comment {
-                padding-left: $timeline-border-width;
-            }
-            &.fa-circle, &.fa-times {
-                padding-left: $timeline-border-width * 2;
-            }
         }
 
         $timeline-item-avatar-margin: 0.5rem;
@@ -32,7 +25,7 @@
         }
 
         .timeline-item-comment {
-            margin-left: $avatars-counter-size + $timeline-border-width + $timeline-item-avatar-margin;
+            margin-left: $timeline-item-avatar-width + ($avatars-counter-size / 2);
         }
 
         i.timeline-break, i.timeline-offset {


### PR DESCRIPTION
Since https://github.com/openSUSE/open-build-service/pull/13876 the timeline icon alignment was partially broken. It is fixed now giving the `timeline-item-avatar` a fixed size and aligning the rest accordingly.

## Before
![timeline-alignment-before](https://user-images.githubusercontent.com/7080830/222769845-4aeda16a-8727-4005-9114-7ced1e6b0668.png)

## After
![timeline-alignment-after](https://user-images.githubusercontent.com/7080830/222769881-f3dfc8e0-3271-4923-8ea4-048f918e4bff.png)
