### PR TITLE
Conversation look and feel - light border and background

### DIFF
--- a/src/api/app/assets/stylesheets/webui/comments.scss
+++ b/src/api/app/assets/stylesheets/webui/comments.scss
@@ -21,13 +21,15 @@
 }
 
 .comment-bubble {
-  $comment-bubble-outline: $gray-400;
+  $comment-bubble-outline: $gray-300;
+  $comment-bubble-background: $gray-100;
   @extend .rounded;
   @extend .p-3;
   @extend .mb-2;
   border: 1px solid $comment-bubble-outline;
   position: relative;
   min-width: 20%;
+  background-color: $comment-bubble-background;
 
   // Arrow on the top left of the comment bubble
   $comment-bubble-arrow-top-position: 0;
@@ -48,7 +50,7 @@
     width: 0;
     height: 0;
     border: $comment-bubble-arrow-size solid transparent;
-    border-bottom-color: $gray-400;
+    border-bottom-color: $comment-bubble-outline;
     border-top: 0;
     border-left: 0;
     margin-left: -($comment-bubble-arrow-size / 2);
@@ -58,7 +60,7 @@
     top: $comment-bubble-arrow-top-position + 2px;
     left: $comment-bubble-arrow-left-position + 1px;
     z-index: 1;
-    border-bottom-color: $card-bg;
+    border-bottom-color: $comment-bubble-background;
   }
 
   .dropdown {

--- a/src/api/app/assets/stylesheets/webui/timeline.scss
+++ b/src/api/app/assets/stylesheets/webui/timeline.scss
@@ -4,7 +4,7 @@
     $timeline-item-avatar-width: 1.5rem;
     $timeline-item-avatar-height: 1.5rem;
     $timeline-offset: -(($timeline-item-avatar-width / 2) + ($timeline-border-width / 2));
-    border-left: $timeline-border-width solid $gray-400;
+    border-left: $timeline-border-width solid $gray-200;
 
     .timeline-item {
         position: relative;

--- a/src/api/app/components/bs_request_comment_component.html.haml
+++ b/src/api/app/components/bs_request_comment_component.html.haml
@@ -6,7 +6,7 @@
     wrote
     = link_to("#comment-#{comment.id}", title: l(comment.created_at.utc), name: "comment-#{comment.id}") do
       #{time_ago_in_words(comment.created_at)} ago
-.timeline-item-comment
+.timeline-item-comment.mb-4
   .comment-bubble
     - if policy(comment).update? || policy(comment).destroy?
       .dropdown.dropleft.float-end

--- a/src/api/app/components/bs_request_history_element_component.html.haml
+++ b/src/api/app/components/bs_request_history_element_component.html.haml
@@ -16,5 +16,5 @@
     = link_to("#status-history-#{element.id}", title: l(element.created_at.utc), name: "status-history-#{element.id}") do
       #{time_ago_in_words(element.created_at)} ago
 
-.timeline-item-comment
+.timeline-item-comment.mb-4
   = render partial: 'webui/shared/collapsible_text', locals: { text: element.comment, extra_css_classes: css_for_comment }


### PR DESCRIPTION
Tweaking border and background color in order to not grab the focus on the timeline line itself, and give more contrast to the relevant information, like the timeline item avatar and the comment bubble text.

## Before
![conversation-light-before](https://user-images.githubusercontent.com/7080830/222772849-57d6bbc2-a253-44cd-8d5a-85222f0cf730.png)


## After
![conversation-light-after](https://user-images.githubusercontent.com/7080830/222772866-a821f3ad-e84f-4dd9-a36d-94f641b2e53c.png)
