### PR TITLE
Load rubocop-capybara in config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,7 @@ inherit_from: .rubocop_todo.yml
 require:
   - rubocop-performance
   - rubocop-rspec
+  - rubocop-capybara
 
 AllCops:
   NewCops: enable

--- a/src/api/.rubocop.yml
+++ b/src/api/.rubocop.yml
@@ -2,6 +2,7 @@ require:
   - rubocop-rails
   - rubocop-rspec
   - rubocop-performance
+  - rubocop-capybara
   - ./lib/rubocop/cop/view_component/avoid_global_state.rb
   - ./lib/rubocop/cop/view_component/file_name.rb
   - ./lib/rubocop/cop/view_component/class_name.rb


### PR DESCRIPTION
This is what we get when running Rubocop in development environment:

> The following RuboCop extension libraries are installed but not loaded in config:
>   * rubocop-capybara
> 
> You can opt out of this message by adding the following to your config (see https://docs.rubocop.org/rubocop/extensions.html#extension-suggestions for more options):
>   AllCops:
>     SuggestExtensions: false

Indeed, we use Capybara for specs in [dist/t/spec/*](https://github.com/openSUSE/open-build-service/blob/master/dist/t/spec/spec_helper.rb#L4) and in [src/api/specs/*](https://github.com/openSUSE/open-build-service/blob/c883341cade03e28d65d18faa244cf36e2c66360/src/api/spec/browser_helper.rb#L5) so it makes sense to load `rubocop-capybara` in both `.rubocop.yml` config files.