### PR TITLE
Clarify request staging information

### DIFF
--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -511,19 +511,13 @@ class Webui::RequestController < Webui::WebuiController
     if staging_review.for_project?
       staging_project = {
         name: staging_review.project.name[target_project.name.length + 1..],
-        staging_url: staging_workflow_staging_project_path(target_project.name, staging_review.project.name)
+        url: staging_workflow_staging_project_path(target_project.name, staging_review.project.name)
       }
     end
 
     {
       staging_project: staging_project,
-      target_project:
-      {
-        name: request.target_project_name,
-        url: project_show_path(target_project),
-        staging_url: staging_workflow_path(request.target_project_name)
-      },
-      status: staging_review.accepted?
+      target_project_staging_url: staging_workflow_path(request.target_project_name)
     }
   end
 end

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -509,13 +509,21 @@ class Webui::RequestController < Webui::WebuiController
     return nil unless (staging_review = request.reviews.staging(target_project).last)
 
     if staging_review.for_project?
-      { name: staging_review.project.name[target_project.name.length + 1..],
-        title: "staged in #{staging_review.project}",
-        url: staging_workflow_staging_project_path(target_project.name, staging_review.project.name) }
-    elsif staging_review.for_group?
-      { name: staging_review.accepted? ? 'Staged' : 'Unstaged',
-        title: 'submitted against a staging project',
-        url: staging_workflow_path(@bs_request.target_project_name) }
+      staging_project = {
+        name: staging_review.project.name[target_project.name.length + 1..],
+        staging_url: staging_workflow_staging_project_path(target_project.name, staging_review.project.name)
+      }
     end
+
+    {
+      staging_project: staging_project,
+      target_project:
+      {
+        name: request.target_project_name,
+        url: project_show_path(target_project),
+        staging_url: staging_workflow_path(request.target_project_name)
+      },
+      status: staging_review.accepted?
+    }
   end
 end

--- a/src/api/app/views/webui/request/beta_show.html.haml
+++ b/src/api/app/views/webui/request/beta_show.html.haml
@@ -60,21 +60,16 @@
         -# staging statement
         - if @staging_status
           - staging_project = @staging_status[:staging_project]
-          - target_project = @staging_status[:target_project]
           %li
-            = link_to target_project[:name], target_project[:url]
-            has a
-            %mark.text-light.bg-staging.text-nowrap.text-decoration-underline= link_to 'Staging Workflow', target_project[:staging_url]
-            \: this request is
             - if staging_project
-              %strong staged
+              %mark.text-light.bg-staging.text-nowrap.text Staged
               in
-              = link_to staging_project[:name], staging_project[:staging_url]
-            - elsif @staging_status[:status]
-              %strong staged
-              but not assigned to any staging project yet
+              = link_to staging_project[:name], staging_project[:url]
             - else
-              %strong not yet staged
+              %strong Waiting
+              for a
+              %mark.text-light.bg-staging.text-nowrap.text-decoration-underline
+                = link_to 'staging project', @staging_status[:target_project_staging_url]
         -# auto-accept statement
         - if @bs_request.accept_at.present?
           %li

--- a/src/api/app/views/webui/request/beta_show.html.haml
+++ b/src/api/app/views/webui/request/beta_show.html.haml
@@ -59,11 +59,22 @@
               = link_to "##{supersed['number']}", number: supersed['number']
         -# staging statement
         - if @staging_status
+          - staging_project = @staging_status[:staging_project]
+          - target_project = @staging_status[:target_project]
           %li
-            %strong Staged
-            in
-            %mark.text-light.bg-staging.text-nowrap.text-decoration-underline
-              = link_to @staging_status[:title], @staging_status[:url]
+            = link_to target_project[:name], target_project[:url]
+            has a
+            %mark.text-light.bg-staging.text-nowrap.text-decoration-underline= link_to 'Staging Workflow', target_project[:staging_url]
+            \: this request is
+            - if staging_project
+              %strong staged
+              in
+              = link_to staging_project[:name], staging_project[:staging_url]
+            - elsif @staging_status[:status]
+              %strong staged
+              but not assigned to any staging project yet
+            - else
+              %strong not yet staged
         -# auto-accept statement
         - if @bs_request.accept_at.present?
           %li

--- a/src/api/spec/features/webui/requests/submissions_spec.rb
+++ b/src/api/spec/features/webui/requests/submissions_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe 'Bootstrap_Requests_Submissions', js: true, vcr: true do
           expect(page).to have_text('Select Action')
           expect(page).to have_text('Next')
           expect(page).to have_text("(of #{bs_request.bs_request_actions.count})")
-          expect(page).to have_text('has a Staging Workflow')
+          expect(page).to have_css('.bg-staging')
         end
       end
     end

--- a/src/api/spec/features/webui/requests/submissions_spec.rb
+++ b/src/api/spec/features/webui/requests/submissions_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe 'Bootstrap_Requests_Submissions', js: true, vcr: true do
           expect(page).to have_text('Select Action')
           expect(page).to have_text('Next')
           expect(page).to have_text("(of #{bs_request.bs_request_actions.count})")
-          expect(page).to have_text('Staged in')
+          expect(page).to have_text('has a Staging Workflow')
         end
       end
     end

--- a/src/api/spec/features/webui/requests_spec.rb
+++ b/src/api/spec/features/webui/requests_spec.rb
@@ -386,7 +386,7 @@ RSpec.describe 'Bootstrap_Requests', js: true, vcr: true do
       Flipper.enable(:request_show_redesign)
     end
 
-    it 'does not set badge for submit request' do
+    it 'does not set stage information for submit request' do
       login submitter
       visit request_show_path(bs_request)
       click_on('Add Reviewer')
@@ -395,7 +395,8 @@ RSpec.describe 'Bootstrap_Requests', js: true, vcr: true do
         fill_in 'Project', with: staging_project.name
         click_button('Accept')
       end
-      expect(page).not_to have_css('.badge-staging')
+      expect(page).not_to have_text('has a Staging Workflow')
+      expect(page).not_to have_css('.bg-staging')
     end
   end
 
@@ -421,7 +422,7 @@ RSpec.describe 'Bootstrap_Requests', js: true, vcr: true do
         fill_in 'Project', with: staging_project.name
         click_button('Accept')
       end
-      expect(page).to have_text('Staged in')
+      expect(page).to have_text('has a Staging Workflow')
       expect(page).to have_css('.bg-staging')
     end
   end

--- a/src/api/spec/features/webui/requests_spec.rb
+++ b/src/api/spec/features/webui/requests_spec.rb
@@ -395,7 +395,7 @@ RSpec.describe 'Bootstrap_Requests', js: true, vcr: true do
         fill_in 'Project', with: staging_project.name
         click_button('Accept')
       end
-      expect(page).not_to have_text('has a Staging Workflow')
+      expect(page).not_to have_text('Staged in')
       expect(page).not_to have_css('.bg-staging')
     end
   end
@@ -422,7 +422,7 @@ RSpec.describe 'Bootstrap_Requests', js: true, vcr: true do
         fill_in 'Project', with: staging_project.name
         click_button('Accept')
       end
-      expect(page).to have_text('has a Staging Workflow')
+      expect(page).to have_text('Staged in')
       expect(page).to have_css('.bg-staging')
     end
   end


### PR DESCRIPTION
$subject

Standardize the staging information for the scenarios when a request is open against a project that has a staging  worflow:
- Case A: the request is not assigned to any staging project (this is what it is called a staged request `for_group`). [review-app link of Case A](https://obs-reviewlab.opensuse.org/ncounter-fix-spec-tests/request/show/2)
- Case B: the request is assigned to a staging project in a staging workflow process  (this is what it is called a request `for_project`). [review-app link of Case B](https://obs-reviewlab.opensuse.org/ncounter-fix-spec-tests/request/show/4)

## Before
**for group**
![staged-group-before-1](https://user-images.githubusercontent.com/7080830/223471866-138d94cb-4da7-431b-a0b1-02a8192bc8fe.png)

**for project**
![staging-project-before](https://user-images.githubusercontent.com/7080830/223469959-8b6e8051-5df9-418e-8e19-d4a98ebfbdc2.png)


## After
**for group** - case A
![staging-3](https://user-images.githubusercontent.com/7080830/228228000-834a8470-bc03-46b0-acaf-613c5144a3f1.png)


**for project** - case B
![staging-1](https://user-images.githubusercontent.com/7080830/228190938-aaa9273f-e4a5-42ad-b316-6f5cee7219b8.png)
