### PR TITLE
Correct commentable type in `create_event` callback on comment creation

### DIFF
--- a/src/api/app/models/comment.rb
+++ b/src/api/app/models/comment.rb
@@ -60,7 +60,7 @@ class Comment < ApplicationRecord
       Event::CommentForProject.create(event_parameters)
     when 'BsRequest'
       Event::CommentForRequest.create(event_parameters)
-    when 'BsRequestActionSubmit'
+    when 'BsRequestAction'
       Event::CommentForRequest.create(event_parameters.merge({ id: commentable.bs_request.id }))
     end
   end

--- a/src/api/spec/factories/comments.rb
+++ b/src/api/spec/factories/comments.rb
@@ -15,5 +15,9 @@ FactoryBot.define do
     factory :comment_request do
       commentable { create(:set_bugowner_request) }
     end
+
+    trait :bs_request_action do
+      association :commentable, factory: :bs_request_with_submit_action
+    end
   end
 end

--- a/src/api/spec/models/comment_spec.rb
+++ b/src/api/spec/models/comment_spec.rb
@@ -15,6 +15,14 @@ RSpec.describe Comment do
       comment_package.body = '😁'
       expect { comment_package.save! }.not_to raise_error
     end
+
+    context 'for a comment on a bs_request_action' do
+      let(:comment) { create(:comment, :bs_request_action) }
+
+      it 'creates the corresponding event' do
+        expect { comment.save! }.to change(Event::CommentForRequest, :count).by(1)
+      end
+    end
   end
 
   describe 'associations' do


### PR DESCRIPTION
The commentable type is `BsRequestAction` not `BsRequestActionSubmit`. Since it wasn't matching in the `create_event` method, no events got created for comments that have a relation to a request action.

This was introduced in https://github.com/openSUSE/open-build-service/pull/13912 for the comments on request diffs.