### PR TITLE
Gather metrics about comment creation on request action diffs

### DIFF
--- a/src/api/app/models/comment.rb
+++ b/src/api/app/models/comment.rb
@@ -61,7 +61,7 @@ class Comment < ApplicationRecord
     when 'BsRequest'
       Event::CommentForRequest.create(event_parameters)
     when 'BsRequestAction'
-      Event::CommentForRequest.create(event_parameters.merge({ id: commentable.bs_request.id }))
+      Event::CommentForRequest.create(event_parameters.merge({ id: commentable.bs_request.id, diff_ref: diff_ref }))
     end
   end
 

--- a/src/api/app/models/event/comment_for_request.rb
+++ b/src/api/app/models/event/comment_for_request.rb
@@ -3,7 +3,7 @@ module Event
     include CommentEvent
     self.message_bus_routing_key = 'request.comment'
     self.description = 'New comment for request created'
-    payload_keys :request_number
+    payload_keys :request_number, :diff_ref
     receiver_roles :source_maintainer, :target_maintainer, :creator, :reviewer, :source_watcher, :target_watcher,
                    :source_package_watcher, :target_package_watcher, :request_watcher
 
@@ -16,6 +16,18 @@ module Event
       attribs['comment'] = attribs['comment'][0..800] if attribs['comment'].present?
       attribs['files'] = attribs['files'][0..800] if attribs['files'].present?
       super(attribs, keys)
+    end
+
+    def metric_measurement
+      'comment'
+    end
+
+    def metric_tags
+      { diff_ref: payload['diff_ref'].present? }
+    end
+
+    def metric_fields
+      { value: 1 }
     end
   end
 end


### PR DESCRIPTION
Instrumenting the feature introduced in https://github.com/openSUSE/open-build-service/pull/13912

~DO NOT MERGE : We first need to merge https://github.com/openSUSE/open-build-service/pull/13967 in order to create the event on comment creation.~