### PR TITLE
Make `force` parameter boolean, in `DELETE /source/<project>/<package>` API endpoint

### DIFF
--- a/src/api/app/controllers/source_controller.rb
+++ b/src/api/app/controllers/source_controller.rb
@@ -98,7 +98,7 @@ class SourceController < ApplicationController
     raise DeletePackageNoPermission, "no permission to delete package #{@target_package_name} in project #{@target_project_name}" unless User.session!.can_modify?(tpkg)
 
     # deny deleting if other packages use this as develpackage
-    tpkg.check_weak_dependencies! unless params[:force]
+    tpkg.check_weak_dependencies! unless params[:force] == '1'
 
     logger.info "destroying package object #{tpkg.name}"
     tpkg.commit_opts = { comment: params[:comment] }


### PR DESCRIPTION
Prevent cases like `force=0` from being understood as a truth value.

Related to #13302.