### PR TITLE
Fix bogus message '1' when deleting a package

### DIFF
--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -758,7 +758,8 @@ class Package < ApplicationRecord
     if CONFIG['global_write_through'] && !@commit_opts[:no_backend_write]
       path = source_path
 
-      h = { user: commit_user.login, comment: commit_opts[:comment] }
+      h = { user: commit_user.login }
+      h[:comment] = commit_opts[:comment] if commit_opts[:comment]
       h[:requestid] = commit_opts[:request].number if commit_opts[:request]
       path << Backend::Connection.build_query_from_hash(h, [:user, :comment, :requestid])
       begin


### PR DESCRIPTION
This happens when removing a package from:
- from the `DELETE /source/<project>/<package>` API endpoint, if no comment parameter is passed, and
- from the web-ui

The output of `osc log -D project_1 package_1` was:
**Before:**
```
----------------------------------------------------------------------------
r9 | Admin | 2023-03-09 16:43:41 | d41d8cd98f00b204e9800998ecf8427e | None |

1
----------------------------------------------------------------------------
```
**After:**
```
----------------------------------------------------------------------------
r13 | Admin | 2023-03-09 16:49:22 | d41d8cd98f00b204e9800998ecf8427e | None |

package was deleted
----------------------------------------------------------------------------
```

Fixes #1610.