### PR TITLE
Document package commitfilelist command with OpenAPI

### DIFF
--- a/src/api/public/apidocs-new/OBS-v2.10.50.yaml
+++ b/src/api/public/apidocs-new/OBS-v2.10.50.yaml
@@ -313,6 +313,8 @@ paths:
     $ref: 'paths/source_project_name_package_name.yaml'
   /source/{project_name}/{package_name}?cmd=commit:
     $ref: 'paths/source_project_name_package_name_cmd_commit.yaml'
+  /source/{project_name}/{package_name}?cmd=commitfilelist:
+    $ref: 'paths/source_project_name_package_name_cmd_commitfilelist.yaml'
   /source/{project_name}/{package_name}?cmd=copy:
     $ref: 'paths/source_project_name_package_name_cmd_copy.yaml'
   /source/{project_name}/{package_name}?cmd=diff:

--- a/src/api/public/apidocs-new/paths/source_project_name_package_name_cmd_commit.yaml
+++ b/src/api/public/apidocs-new/paths/source_project_name_package_name_cmd_commit.yaml
@@ -7,6 +7,12 @@ post:
     - $ref: '../components/parameters/project_name.yaml'
     - $ref: '../components/parameters/package_name.yaml'
     - in: query
+      name: comment
+      schema:
+        type: string
+      description: Provide a comment to the revision in history.
+      example: This was changed to improve foobar.
+    - in: query
       name: linkrev
       schema:
         type: string

--- a/src/api/public/apidocs-new/paths/source_project_name_package_name_cmd_commitfilelist.yaml
+++ b/src/api/public/apidocs-new/paths/source_project_name_package_name_cmd_commitfilelist.yaml
@@ -1,0 +1,112 @@
+post:
+  summary: Commit package changes from a filelist.
+  description: |
+    Create a new commit using defined files already uploaded to the repository.
+    
+    This requires a directory xml providing file name and md5 as body.
+    It is recommended to use the `withvalidate` parameter and add the
+    sha256 sum including "sha256:" prefix in "hash" attribute for security reasons.
+  security:
+    - basic_authentication: []
+  parameters:
+    - $ref: '../components/parameters/project_name.yaml'
+    - $ref: '../components/parameters/package_name.yaml'
+    - in: query
+      name: comment
+      schema:
+        type: string
+      description: Provide a comment to the revision
+      example: This was changed to improve foobar.
+    - in: query
+      name: linkrev
+      schema:
+        type: string
+      description: |
+        Link revision in base package. Set to `base` to use the commit revision.
+
+        Used together with the `keeplink` parameter.
+      example: base
+    - in: query
+      name: rev
+      schema:
+        type: string
+      description: Revision of the package.
+    - in: query
+      name: keeplink
+      schema:
+        type: string
+        enum:
+          - 1
+          - 0
+      default: 0
+      description: Set to `1` to preserve the link (`_link` file) on the source.
+      example: 1
+    - in: query
+      name: repairlink
+      schema:
+        type: string
+        enum:
+          - 1
+          - 0
+      default: 0
+      description: |
+        Set to `1` to solve conflicts.
+
+        Used together with `keeplink` parameter.
+      example: 1
+    - in: query
+      name: withvalidate
+      schema:
+        type: string
+        enum:
+          - 1
+          - 0
+      default: 0
+      description: Set to `1` to activate sha validation code (optional, but recommended)
+      example: 1
+  responses:
+    '200':
+      description: OK. Revision created with this commit.
+      content:
+        text/xml:
+          schema:
+            $ref: '../components/schemas/revision.yaml'
+          example:
+            rev: 86
+            vrev: 86
+            srcmd5: 55452f7326fe90cb67ca96bf9e9ffabc
+            version: 2.10~pre
+            time: 1665060711
+            user: Admin
+            comment:
+            requestid:
+    '400':
+      description: Bad Request.
+      content:
+        # The response is not "application/xml; charset=utf-8"
+        text/plain; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          examples:
+            Not Boolean:
+              description: Passing a value different than `0` or `1` to `keeplink`, for example.
+              value: |
+                <xml version="1.0" encoding="UTF-8"?>
+                <status code="400" origin="backend">
+                  <summary>not boolean</summary>
+                </status>
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '403':
+      description: Forbidden.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          example:
+            code: cmd_execution_no_permission
+            summary: no permission to modify package test in project home:Admin
+    '404':
+      $ref: '../components/responses/unknown_project_or_package.yaml'
+  tags:
+    - Sources - Packages


### PR DESCRIPTION
### For reviewers

Access to the documented enpoint in the review-app through [this link](https://obs-reviewlab.opensuse.org/bmwiedemann-dod1byy0/apidocs-new/index.html#/Sources%20-%20Packages/post_source__project_name___package_name__cmd_commitfilelist).