### PR TITLE
Document GET `/source/{project_name}/_attribute` endpoint

### DIFF
--- a/src/api/app/controllers/source_attribute_controller.rb
+++ b/src/api/app/controllers/source_attribute_controller.rb
@@ -15,6 +15,7 @@ class SourceAttributeController < SourceController
   end
 
   # GET
+  # /source/:project/_attribute
   # /source/:project/_attribute/:attribute
   # /source/:project/:package/_attribute/:attribute
   # /source/:project/:package/:binary/_attribute/:attribute

--- a/src/api/public/apidocs-new/OBS-v2.10.50.yaml
+++ b/src/api/public/apidocs-new/OBS-v2.10.50.yaml
@@ -270,6 +270,8 @@ paths:
     $ref: 'paths/source_project_name_project.yaml'
   /source/{project_name}/_pubkey:
     $ref: 'paths/source_project_name_pubkey.yaml'
+  /source/{project_name}/_attribute:
+    $ref: 'paths/source_project_name_attribute.yaml'
   /source/{project_name}/_attribute/{attribute_name}:
     $ref: 'paths/source_project_name_attribute_attribute_name.yaml'
   /source/{project_name}/_project/{file_name}:

--- a/src/api/public/apidocs-new/paths/source_project_name_attribute.yaml
+++ b/src/api/public/apidocs-new/paths/source_project_name_attribute.yaml
@@ -1,0 +1,62 @@
+get:
+  summary: Get all the project's attributes
+  parameters:
+    - $ref: '../components/parameters/project_name.yaml'
+    # Query Strings:
+    # `rev`: doesn't make sense in project level and makes the endpoint crash.
+    # `meta`: either you pass `meta` or not, it's always replaced by meta: 1.
+    # `with_project`: does not make sense in project level and makes the endpoint crash.
+    - name: view
+      in: query
+      schema:
+        type: string
+        enum:
+          - blame
+      description: With view=blame, information about who changed each XML tag and when is displayed.
+      example: blame
+    - name: with_default
+      in: query
+      schema:
+        type: string
+      description: |
+        If the attribute doesn't contain any value and `with_default` is present,
+        the default values will be displayed, if any.
+      example: 1
+  responses:
+    '200':
+      description: OK. The request has succeeded.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/source/attributes.yaml'
+          examples:
+            listOfAttributes:
+              value:
+                - name: MaintenanceProject
+                  namespace: OBS
+                - name: ScreenShots
+                  namespace: OBS
+            viewBlame:
+              description: Passing view=blame.
+              value: |
+                10 (Admin        2023-03-09 11:46:01     1) <attributes>
+                12 (Iggy         2023-03-13 14:46:01     5)   <attribute namespace="OBS" name="MakeOriginOlder"/>
+                14 (Admin        2023-03-13 15:14:21     6)   <attribute namespace="OBS" name="QualityCategory">
+                14 (Admin        2023-03-13 15:14:21     7)     <value>Development</value>
+                14 (Admin        2023-03-13 15:14:21     8)   </attribute>
+                10 (Admin        2023-03-09 11:46:01     9) </attributes>
+    '400':
+      description: Bad Request.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          example:
+              code: remote_project
+              summary: Attribute access to remote project is not yet supported
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '404':
+      $ref: '../components/responses/unknown_project.yaml'
+  tags:
+    - Sources - Projects


### PR DESCRIPTION
We already documented the `GET /source/{project_name}/_attribute/{attribute_name}` endpoint. But `GET /source/{project_name}/_attribute` is also accepted but wasn't documented until now.

The endpoint documented in this PR is in charge of listing all the attributes of a project.

**Testing Tips**

- Go to the Attributes tab on the project show page.
- Add some attributes
- Run `curl -u foo:bar -H 'Content-Type: application/xml; charset=utf-8' -X GET 'http://localhost:3000/source/home:Admin/_attribute`