### PR TITLE
Document  GET `/source/{project_name}/{package_name}/_attribute` endpoint

### DIFF
--- a/src/api/app/controllers/source_attribute_controller.rb
+++ b/src/api/app/controllers/source_attribute_controller.rb
@@ -17,6 +17,7 @@ class SourceAttributeController < SourceController
   # GET
   # /source/:project/_attribute
   # /source/:project/_attribute/:attribute
+  # /source/:project/:package/_attribute
   # /source/:project/:package/_attribute/:attribute
   # /source/:project/:package/:binary/_attribute/:attribute
   #--------------------------------------------------------

--- a/src/api/public/apidocs-new/OBS-v2.10.50.yaml
+++ b/src/api/public/apidocs-new/OBS-v2.10.50.yaml
@@ -343,6 +343,8 @@ paths:
     $ref: 'paths/source_project_name_package_name_cmd_undelete.yaml'
   /source/{project_name}/{package_name}?cmd=waitservice:
     $ref: 'paths/source_project_name_package_name_cmd_waitservice.yaml'
+  /source/{project_name}/{package_name}/_attribute:
+    $ref: 'paths/source_project_name_package_name_attribute.yaml'
 
   /trigger/{operation}:
     $ref: 'paths/trigger_operation.yaml'

--- a/src/api/public/apidocs-new/paths/source_project_name_package_name_attribute.yaml
+++ b/src/api/public/apidocs-new/paths/source_project_name_package_name_attribute.yaml
@@ -1,0 +1,77 @@
+get:
+  summary: List the attibutes of a package
+  parameters:
+    - $ref: '../components/parameters/project_name.yaml'
+    - $ref: '../components/parameters/package_name.yaml'
+    # Query Strings:
+    # `meta`: either you pass `meta` or not, it's always replaced by meta: 1.
+    - name: rev
+      in: query
+      schema:
+        type: string
+      description: |
+        Passing the number of the revision, this endpoint displays the attributes' XML as it was at that point.
+      example: 3
+    - name: view
+      in: query
+      schema:
+        type: string
+        enum:
+          - blame
+      description: With `view=blame`, information about who changed each XML tag and when is displayed.
+      example: blame
+    - name: with_default
+      in: query
+      schema:
+        type: string
+      description: |
+        If the attribute doesn't contain any value and `with_default` is present,
+        the default values will be displayed, if any.
+      example: 1
+    - name: with_project
+      in: query
+      schema:
+        type: string
+      description: |
+        Passing `with_project`, the response displays the attributes of the package's project in addition to the package ones.
+      example: 1
+  responses:
+    '200':
+      description: OK. The request has succeeded.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/source/attributes.yaml'
+          examples:
+            manyAttributes:
+              value:
+                - name: MaintenanceProject
+                  namespace: OBS
+                - name: ScreenShots
+                  namespace: OBS
+            viewBlame:
+              description: Passing `view=blame`.
+              value: |
+                10 (Admin        2023-03-09 11:46:01     1) <attributes>
+                12 (Iggy         2023-03-13 14:46:01     5)   <attribute namespace="OBS" name="MakeOriginOlder"/>
+                14 (Admin        2023-03-13 15:14:21     6)   <attribute namespace="OBS" name="QualityCategory">
+                14 (Admin        2023-03-13 15:14:21     7)     <value>Development</value>
+                14 (Admin        2023-03-13 15:14:21     8)   </attribute>
+                10 (Admin        2023-03-09 11:46:01     9) </attributes>
+    '400':
+      description: Bad Request.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          examples:
+            remoteProject:
+              value:
+                code: remote_project
+                summary: Attribute access to remote project is not yet supported
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '404':
+      $ref: '../components/responses/unknown_project_or_package.yaml'
+  tags:
+    - Sources - Packages


### PR DESCRIPTION
The endpoint documented in this PR is in charge of listing all the attributes of a package.


**Testing Tips**

- Go to the Attributes tab on the package show page.
- Add some attributes
- Run `curl -u foo:bar -H 'Content-Type: application/xml; charset=utf-8' -X GET 'http://localhost:3000/source/home:Admin/hello_world/_attribute`