### PR TITLE
Use separate controller method for deprecated search endpoint routes

### DIFF
--- a/src/api/app/controllers/search_controller.rb
+++ b/src/api/app/controllers/search_controller.rb
@@ -13,12 +13,26 @@ class SearchController < ApplicationController
     search(:project, false)
   end
 
+  # DEPRECATED: '/search/project_id' is deprecated in favour of '/search/project/id'
+  # Lets use a different controller method for this route in order to track usage
+  # through influxdb-rails and to keep them separate for later removal
+  def project_id_deprecated
+    project_id
+  end
+
   def package
     search(:package, true)
   end
 
   def package_id
     search(:package, false)
+  end
+
+  # DEPRECATED: '/search/package_id' is deprecated in favour of '/search/package/id'
+  # Lets use a different controller method for this route in order to track usage
+  # through influxdb-rails and to keep them separate for later removal
+  def package_id_deprecated
+    package_id
   end
 
   def repository_id

--- a/src/api/config/routes/api_routes.rb
+++ b/src/api/config/routes/api_routes.rb
@@ -128,8 +128,8 @@ OBSApi::Application.routes.draw do
       match 'search/released/binary' => :released_binary, via: [:get, :post]
       match 'search/project/id' => :project_id, via: [:get, :post]
       match 'search/package/id' => :package_id, via: [:get, :post]
-      match 'search/project_id' => :project_id, via: [:get, :post] # FIXME3.0: to be removed
-      match 'search/package_id' => :package_id, via: [:get, :post] # FIXME3.0: to be removed
+      match 'search/project_id' => :project_id_deprecated, via: [:get, :post] # FIXME3.0: to be removed
+      match 'search/package_id' => :package_id_deprecated, via: [:get, :post] # FIXME3.0: to be removed
       match 'search/project' => :project, via: [:get, :post]
       match 'search/package' => :package, via: [:get, :post]
       match 'search/person' => :person, via: [:get, :post]


### PR DESCRIPTION
The routes '/search/package_id' and '/search/project_id' are deprecated but still using the same controller methods as the none deprecated ones. In order to track the usage through influxdb-rails and for later removal we can simply point those routes to separated controller methods.