### PR TITLE
Document `GET /source/{project_name}/{package_name}/_history` with OpenAPI

### DIFF
--- a/src/api/public/apidocs-new/OBS-v2.10.50.yaml
+++ b/src/api/public/apidocs-new/OBS-v2.10.50.yaml
@@ -311,6 +311,8 @@ paths:
 
   /source/{project_name}/{package_name}:
     $ref: 'paths/source_project_name_package_name.yaml'
+  /source/{project_name}/{package_name}/_history:
+    $ref: 'paths/source_project_name_package_name_history.yaml'
   /source/{project_name}/{package_name}?cmd=commit:
     $ref: 'paths/source_project_name_package_name_cmd_commit.yaml'
   /source/{project_name}/{package_name}?cmd=copy:

--- a/src/api/public/apidocs-new/components/schemas/revision_list.yaml
+++ b/src/api/public/apidocs-new/components/schemas/revision_list.yaml
@@ -1,0 +1,6 @@
+type: array
+items:
+  $ref: 'revision.yaml'
+xml:
+  name: revisionlist
+  wrapped: true

--- a/src/api/public/apidocs-new/paths/source_project_name_package_name_history.yaml
+++ b/src/api/public/apidocs-new/paths/source_project_name_package_name_history.yaml
@@ -1,0 +1,86 @@
+get:
+  summary: Get package commit history.
+  description: Get package commit history.
+  security:
+    - basic_authentication: []
+  parameters:
+    - $ref: '../components/parameters/project_name.yaml'
+    - $ref: '../components/parameters/package_name.yaml'
+    - in: query
+      name: deleted
+      schema:
+        type: string
+      description: Set to `1` to allow to retrieve the revision history of a deleted package.
+      example: 1
+    - in: query
+      name: limit
+      schema:
+        type: integer
+      description: Limit the number of retrieved revision history elements to the specified number.
+      example: 20
+    - in: query
+      name: meta
+      schema:
+        type: string
+      description: Set to `1` to retrieve the revision history of the meta file (`_meta`) of the package.
+      example: 1
+    - in: query
+      name: rev
+      schema:
+        type: string
+      description: Return the revision entry for a specific revision number.
+  responses:
+    '200':
+      description: |
+        OK. The request has succeeded.
+
+        XML Schema used for body validation: [revisionlist.rng](../schema/revisionlist.rng)
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/revision_list.yaml'
+          examples:
+            Two Revisions:
+              value:
+                - rev: 1
+                  vrev: ''
+                  srcmd5: d41d8cd98f00b204e9800998ecf8427e
+                  version: ''
+                  time: 1678364228
+                  user: Admin
+                  comment: package was deleted
+                - rev: 2
+                  vrev: ''
+                  srcmd5: d41d8cd98f00b204e9800998ecf8427e
+                  version: ''
+                  time: 1678364246
+                  user: Admin
+                  comment: package was undeleted
+            rev Parameter Specified (rev = 1):
+              value:
+                - rev: 1
+                  vrev: ''
+                  srcmd5: d41d8cd98f00b204e9800998ecf8427e
+                  version: ''
+                  time: 1678364228
+                  user: Admin
+                  comment: package was deleted
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '404':
+      description: Not Found.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          examples:
+            Unknown Project:
+              value:
+                code: unknown_project
+                summary: "Project not found: home:some_project"
+            Unknown Package:
+              value:
+                code: unknown_package
+                summary: "Package not found: home:some_project/some_package"
+  tags:
+    - Sources - Packages


### PR DESCRIPTION
Note: the parameters `delete` and `meta` will be recognized as a truthy value not only with the `?delete=1` case, but with the following cases:
- `?delete`
- `?delete=0`
- `?meta`
- `?meta=0`

### For reviewers

Access to the documented enpoint in the review-app through [this link](https://obs-reviewlab.opensuse.org/eduardoj-apidocs_newsource_package_history/apidocs-new/index.html#/Sources%20-%20Packages/get_source__project_name___package_name___history).