### PR TITLE
Document deprecated POST `/source/{project_name}/{package_name}?cmd=createSpecFileTemplate` endpoint

### DIFF
--- a/src/api/public/apidocs-new/OBS-v2.10.50.yaml
+++ b/src/api/public/apidocs-new/OBS-v2.10.50.yaml
@@ -315,6 +315,8 @@ paths:
     $ref: 'paths/source_project_name_package_name_cmd_commit.yaml'
   /source/{project_name}/{package_name}?cmd=copy:
     $ref: 'paths/source_project_name_package_name_cmd_copy.yaml'
+  /source/{project_name}/{package_name}?cmd=createSpecFileTemplate:
+    $ref: 'paths/source_project_name_package_name_cmd_createSpecFileTemplate.yaml'
   /source/{project_name}/{package_name}?cmd=diff:
     $ref: 'paths/source_project_name_package_name_cmd_diff.yaml'
   /source/{project_name}/{package_name}?cmd=linkdiff:

--- a/src/api/public/apidocs-new/paths/source_project_name_package_name_cmd_createSpecFileTemplate.yaml
+++ b/src/api/public/apidocs-new/paths/source_project_name_package_name_cmd_createSpecFileTemplate.yaml
@@ -1,0 +1,9 @@
+post:
+  deprecated: true
+  summary: Create a RPM Spec File Template for a specified package.
+  description: |
+    Create a RPM Spec File Template for a specified package. This endpoint
+    is broken and will be removed.
+    See [https://github.com/openSUSE/open-build-service/issues/9707](https://github.com/openSUSE/open-build-service/issues/9707)
+  tags:
+    - Sources - Packages


### PR DESCRIPTION
The endpoint is broken since a long time.
See https://github.com/openSUSE/open-build-service/issues/9707 Since there is no plan in fixing it and most likely completly removing it I marked it as deprecated in the new api documentation.