### PR TITLE
Document POST `/source/{project_name}/{package_name}?cmd=collectbuildenv` endpoints

### DIFF
--- a/src/api/public/apidocs-new/OBS-v2.10.50.yaml
+++ b/src/api/public/apidocs-new/OBS-v2.10.50.yaml
@@ -315,6 +315,8 @@ paths:
     $ref: 'paths/source_project_name_package_name.yaml'
   /source/{project_name}/{package_name}/_history:
     $ref: 'paths/source_project_name_package_name_history.yaml'
+  /source/{project_name}/{package_name}?cmd=collectbuildenv:
+    $ref: 'paths/source_project_name_package_name_cmd_collectbuildenv.yaml'
   /source/{project_name}/{package_name}?cmd=commit:
     $ref: 'paths/source_project_name_package_name_cmd_commit.yaml'
   /source/{project_name}/{package_name}?cmd=commitfilelist:

--- a/src/api/public/apidocs-new/paths/source_project_name_package_name_cmd_collectbuildenv.yaml
+++ b/src/api/public/apidocs-new/paths/source_project_name_package_name_cmd_collectbuildenv.yaml
@@ -1,0 +1,83 @@
+post:
+  summary: Collect build environment information.
+  description: |
+    Creates _buildenv files based on origin package builds. This can be used
+    to re-use exact older build enviroment even when further new binary packages
+    got added. For example to re-build an old maintenance update in the same way.
+  security:
+    - basic_authentication: []
+  parameters:
+    - $ref: '../components/parameters/project_name.yaml'
+    - $ref: '../components/parameters/package_name.yaml'
+    - in: query
+      name: oproject
+      required: true
+      schema:
+        type: string
+      description: Origin project. The project that the Origin Package will have the build information copied from.
+    - in: query
+      name: opackage
+      schema:
+        type: string
+      description: Origin package. Build environment information of the package that will be copied.
+    - in: query
+      name: orev
+      schema:
+        type: string
+      description: Origin package revision. Revision of the Origin Package on which to base the build environment collection.
+    - in: query
+      name: comment
+      description: Comment for the new revision.
+  responses:
+    '200':
+      description: OK
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/revision.yaml'
+          examples:
+            Copy:
+              value:
+                rev: 3
+                vrev: 3
+                srcmd5: d41d8cd98f00b204e9800998ecf8427e
+                version: 20220902.37b45c2
+                time: 1678785078
+                user: Admin
+                comment: Copying the build environment from origin
+                requestid:
+    '400':
+      description: |
+        Bad Request.
+
+        XML Schema used for body validation: [status.xsd](../schema/status.xsd)
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          examples:
+            Missing Parameter:
+              value:
+                code: missing_parameter
+                summary: Required Parameter opackage missing
+            Bad Revision:
+              value:
+                code: 400
+                origin: backend
+                summary: "bad revision '-3'"
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '403':
+      description: Forbidden.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          example:
+            code: cmd_execution_no_permission
+            summary: no permission to modify package test in project home:Admin
+    '404':
+      $ref: '../components/responses/unknown_project_or_package.yaml'
+  tags:
+    - Sources - Packages
+


### PR DESCRIPTION
Adds documentation for 2 out of 3 endpoints from my card. I found out that the third endpoint, `?cmd=wipe` isn't even properly defined, so there's no way to use it, not to mention documenting it.

`?cmd=rebuild` has broken repository fetching, so setting a repo value causes an error 500, it works just fine if you don't set repo value. It should be considered for deprecation as mentioned in https://github.com/openSUSE/open-build-service/blob/ba63db9bb6e0bdcbe44205725a6daa5544007912/src/api/app/controllers/source_controller.rb#L849

For reviewers:
https://obs-reviewlab.opensuse.org/hellcp-work-apidocs-sources-package-builds/apidocs-new/index#/Sources%20-%20Packages/post_source__project_name___package_name__cmd_collectbuildenv