### PR TITLE
Deprecate broken endpoints source rebuild and wipe

### DIFF
--- a/src/api/public/apidocs-new/OBS-v2.10.50.yaml
+++ b/src/api/public/apidocs-new/OBS-v2.10.50.yaml
@@ -329,6 +329,8 @@ paths:
     $ref: 'paths/source_project_name_package_name_cmd_linkdiff.yaml'
   /source/{project_name}/{package_name}?cmd=mergeservice:
     $ref: 'paths/source_project_name_package_name_cmd_mergeservice.yaml'
+  /source/{project_name}/{package_name}?cmd=rebuild:
+    $ref: 'paths/source_project_name_package_name_cmd_rebuild.yaml'
   /source/{project_name}/{package_name}?cmd=remove_flag:
     $ref: 'paths/source_project_name_package_name_cmd_remove_flag.yaml'
   /source/{project_name}/{package_name}?cmd=runservice:
@@ -343,6 +345,8 @@ paths:
     $ref: 'paths/source_project_name_package_name_cmd_undelete.yaml'
   /source/{project_name}/{package_name}?cmd=waitservice:
     $ref: 'paths/source_project_name_package_name_cmd_waitservice.yaml'
+  /source/{project_name}/{package_name}?cmd=wipe:
+    $ref: 'paths/source_project_name_package_name_cmd_wipe.yaml'
   /source/{project_name}/{package_name}/_attribute:
     $ref: 'paths/source_project_name_package_name_attribute.yaml'
 

--- a/src/api/public/apidocs-new/paths/source_project_name_package_name_cmd_rebuild.yaml
+++ b/src/api/public/apidocs-new/paths/source_project_name_package_name_cmd_rebuild.yaml
@@ -1,0 +1,9 @@
+post:
+  deprecated: true
+  summary: Trigger a package rebuild.
+  description: |
+    Triggers a rebuild of the package. This endpoint
+    is broken and will be removed.
+    See [`POST /build/{project_name}?cmd=rebuild`](#/Build/post_build__project_name__cmd_rebuild).
+  tags:
+    - Sources - Packages

--- a/src/api/public/apidocs-new/paths/source_project_name_package_name_cmd_wipe.yaml
+++ b/src/api/public/apidocs-new/paths/source_project_name_package_name_cmd_wipe.yaml
@@ -1,0 +1,9 @@
+post:
+  deprecated: true
+  summary: Wipe package build results.
+  description: |
+    Wipe all build results of this package. This endpoint
+    is broken and will be removed.
+    See [`POST /build/{project_name}?cmd=wipe`](#/Build/post_build__project_name__cmd_wipe).
+  tags:
+    - Sources - Packages


### PR DESCRIPTION
The following two endpoints are broken and have working alternatives on the build side of the api, so we are deprecating them.