### PR TITLE
Fix use of element name in RelaxNG schemas

### DIFF
--- a/docs/api/api/link.rng
+++ b/docs/api/api/link.rng
@@ -31,8 +31,7 @@
   </define>
 
   <define name="patches-element">
-    <element>
-      <name ns="">patches</name>
+    <element ns="" name="patches">
       <interleave>
         <zeroOrMore>
           <element ns="" name="add">
@@ -82,8 +81,7 @@
         </zeroOrMore>
 
         <optional>
-          <element>
-            <name ns="">branch</name>
+          <element ns="" name="branch">
             <a:documentation>
               If present, then perform a full copy of all sources from the link
               source into the current package.
@@ -93,8 +91,7 @@
         </optional>
 
         <zeroOrMore>
-          <element>
-            <name ns="">topadd</name>
+          <element ns="" name="topadd">
             <a:documentation>
               Add the given string to the top of the spec file in the package sources.
             </a:documentation>
@@ -107,8 +104,7 @@
   </define>
 
   <define name="link-element">
-    <element>
-      <name ns="">link</name>
+    <element ns="" name="link">
       <a:documentation>
         A source link element instructs OBS to link a certain package into a
         different project and optionally to apply modifications, like patches,

--- a/docs/api/api/multibuild.rng
+++ b/docs/api/api/multibuild.rng
@@ -6,19 +6,15 @@
   </start>
 
   <define name="multibuild-element">
-    <element>
-      <name ns="">multibuild</name>
-
+    <element ns="" name="multibuild">
       <choice>
         <oneOrMore>
-          <element>
-            <name ns="">flavor</name>
+          <element ns="" name="flavor">
             <text/>
           </element>
         </oneOrMore>
         <oneOrMore> <!-- obsolete, but needs to stay for compability -->
-          <element>
-            <name ns="">package</name>
+          <element ns="" name="package">
             <text/>
           </element>
         </oneOrMore>

--- a/docs/api/api/package.rng
+++ b/docs/api/api/package.rng
@@ -37,9 +37,7 @@
   </start>
 
   <define name="package-element">
-    <element>
-      <name ns="">package</name>
-
+    <element ns="" name="package">
       <optional>
         <attribute name="name"/>
       </optional>

--- a/docs/api/api/project.rng
+++ b/docs/api/api/project.rng
@@ -48,9 +48,7 @@
   </define>
 
   <define name="project-element">
-    <element>
-      <name ns="">project</name>
-
+    <element ns="" name="project">
       <optional>
         <attribute name="name" />
       </optional>


### PR DESCRIPTION
I was parsing the schemas and realized that some elements names are specified differently than others.
This patch fixes the inconsistency so I can parse the schemas consistently.