### PR TITLE
[backend] use use_certificate_chain_file instead of use_certificate_file

### DIFF
--- a/src/backend/BSSSL.pm
+++ b/src/backend/BSSSL.pm
@@ -92,7 +92,7 @@ sub TIEHANDLE {
     Net::SSLeay::use_PrivateKey_file($ssl, $opts{'keyfile'}, &Net::SSLeay::FILETYPE_PEM) || die("PrivateKey $opts{'keyfile'} failed to load\n");
   }
   if ($opts{'certfile'}) {
-    Net::SSLeay::use_certificate_file($ssl, $opts{'certfile'}, &Net::SSLeay::FILETYPE_PEM) || die("certificate $opts{'certfile'} failed\n");
+    Net::SSLeay::use_certificate_chain_file($ssl, $opts{'certfile'}) || die("certificate $opts{'certfile'} failed to load\n");
   }
   my $cert_ok;
   if ($opts{'verify'}) {


### PR DESCRIPTION
We already had that change in the context creation code. We always want to load a certificate chain instead of a single certificate.