### PR TITLE
Document POST `/source/{project_name}/{package_name}/_attribute` endpoint

### DIFF
--- a/src/api/public/apidocs-new/paths/source_project_name_package_name_attribute.yaml
+++ b/src/api/public/apidocs-new/paths/source_project_name_package_name_attribute.yaml
@@ -75,3 +75,49 @@ get:
       $ref: '../components/responses/unknown_project_or_package.yaml'
   tags:
     - Sources - Packages
+
+post:
+  summary: Create or update the package's attribute given in the request body
+  parameters:
+    - $ref: '../components/parameters/project_name.yaml'
+    - $ref: '../components/parameters/package_name.yaml'
+  security:
+    - basic_authentication: []
+  requestBody:
+    description: Attribute you want to create or update
+    content:
+      application/xml; charset=utf-8:
+        schema:
+          $ref: '../components/schemas/source/attributes.yaml'
+        example:
+          - name: MaintenanceProject
+            namespace: OBS
+  responses:
+    '200':
+      $ref: '../components/responses/succeeded.yaml'
+    '400':
+      description: |
+        Bad Request.
+
+        XML Schema used for body validation: [status.xsd](../schema/status.xsd).
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          examples:
+            invalid_attribute:
+              description: Wrong attribute name.
+              value:
+                code: invalid_attribute
+                summary: "Attribute 'OwnerRootProjectTest' must be in the $NAMESPACE:$NAME style"
+            invalid_xml:
+              description: When not passing an XML body to the requset.
+              value:
+                code: invalid_xml
+                summary: Invalid XML
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '404':
+      $ref: '../components/responses/unknown_project_or_package.yaml'
+  tags:
+    - Sources - Packages


### PR DESCRIPTION
We can create or update an attribute without passing its attribute name as a parameter. It is enough to pass the information in the request body, with an XML like the following one:

```
<?xml version="1.0" encoding="UTF-8"?>
<attributes>
  <attribute name="ScreenShots" namespace="OBS"></attribute>
</attributes>
```

**Testing Tips**

[Link in review-app](https://obs-reviewlab.opensuse.org/saraycp-post_package_attribute_endpoint/apidocs-new/index.html#/Sources%20-%20Packages/post_source__project_name___package_name___attribute).

```
curl -u Admin:opensuse -H 'Content-Type: application/xml; charset=utf-8' -X POST 'http://localhost:3000/source/home:Admin/ad/_attribute' --data @xml.xml
```
