### PR TITLE
Drop broken parameter `limit` in `source` `get_file`

### DIFF
--- a/src/api/app/controllers/source_controller.rb
+++ b/src/api/app/controllers/source_controller.rb
@@ -312,7 +312,7 @@ class SourceController < ApplicationController
     end
 
     path = Package.source_path(project_name, package_name, file)
-    path += build_query_from_hash(params, [:rev, :meta, :deleted, :limit, :expand, :view])
+    path += build_query_from_hash(params, [:rev, :meta, :deleted, :expand, :view])
     pass_to_backend(path)
   end
 


### PR DESCRIPTION
Code line https://github.com/openSUSE/open-build-service/blob/master/src/api/app/controllers/source_controller.rb#L315 seems to recognize `limit` as a parameter, but hitting the endpoint with something like
```
http://localhost:3000/source/home:Admin/hello_world/new_file?limit=10
```
returns
```
<status code="400">
  <summary>unknown parameter 'limit'</summary>
</status>
```

This PR drops the parameter as it looks like a stale useless one.