### PR TITLE
Perform a single query to check which lines have comments

### DIFF
--- a/src/api/app/components/diff_component.html.haml
+++ b/src/api/app/components/diff_component.html.haml
@@ -22,7 +22,7 @@
                 = line.content[1..]
         - if commentable
           .line-comment{ id: "comment#{id}" }
-            - if commentable.comments.where(diff_ref: id).present?
+            - if commented_lines.include?(id)
               .p-3.border-top.border-bottom
                 .comments-list
                   = render(partial: 'webui/comment/comment_list',

--- a/src/api/app/components/diff_component.rb
+++ b/src/api/app/components/diff_component.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 
 class DiffComponent < ApplicationComponent
-  attr_reader :diff, :file_index, :commentable
+  attr_reader :diff, :file_index, :commentable, :commented_lines
 
-  def initialize(diff:, file_index:, commentable: nil)
+  def initialize(diff:, file_index:, commentable: nil, commented_lines: [])
     super
     @diff = parse_diff(diff)
     @file_index = file_index
     @commentable = commentable
+    @commented_lines = commented_lines
   end
 
   def render?

--- a/src/api/app/components/diff_list_component.html.haml
+++ b/src/api/app/components/diff_list_component.html.haml
@@ -14,4 +14,4 @@
             = name
           %span.badge.ms-1{ class: badge_for_state(state) }= state.capitalize
       .accordion-collapse.collapse{ class: expanded ? 'show' : '', id: "diff-item-#{name.parameterize}", 'data-object': view_id }
-        = render(DiffComponent.new(diff: file_info.dig('diff', '_content'), file_index:, commentable:))
+        = render(DiffComponent.new(diff: file_info.dig('diff', '_content'), file_index:, commentable:, commented_lines:))

--- a/src/api/app/components/diff_list_component.rb
+++ b/src/api/app/components/diff_list_component.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 
 class DiffListComponent < ApplicationComponent
-  attr_reader :diff_list, :view_id, :commentable
+  attr_reader :diff_list, :view_id, :commentable, :commented_lines
 
   def initialize(diff_list:, view_id: nil, commentable: nil)
     super
     @diff_list = diff_list
     @view_id = view_id
     @commentable = commentable
+    @commented_lines = commentable ? commentable.comments.map(&:diff_ref).uniq.compact : []
   end
 
   def badge_for_state(state)


### PR DESCRIPTION
This is a quick fix for performance issues in the inline comments on diffs mentioned in #14020. This is likely not the full solution to the problem, but should speed up the page load significantly for longer diffs