### PR TITLE
Rescue from Backend::Error in Project::KeyInfo

### DIFF
--- a/src/api/app/models/project/key_info.rb
+++ b/src/api/app/models/project/key_info.rb
@@ -15,6 +15,7 @@ class Project
 
     def self.find_by_project(project)
       response = key_info_for_project(project)
+      return if response.blank?
 
       parsed_response = Xmlhash.parse(response)
 
@@ -40,6 +41,8 @@ class Project
     def self.key_info_for_project(project)
       Rails.cache.fetch("key_info_project_#{project.cache_key_with_version}", expires_in: CACHE_EXPIRY_TIME) do
         Backend::Api::Sources::Project.key_info(project.name)
+      rescue Backend::Error
+        {}
       end
     end
   end

--- a/src/api/spec/models/project/key_info_spec.rb
+++ b/src/api/spec/models/project/key_info_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe Project::KeyInfo do
+  describe '#find_by_project' do
+    context 'when the backend throws an error' do
+      let(:project) { create(:project, name: 'foo') }
+
+      before do
+        allow(Backend::Api::Sources::Project).to receive(:key_info).and_raise(Backend::Error)
+      end
+
+      it 'rescues from the error and returns nil' do
+        expect(described_class.find_by_project(project)).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
We don't handle exceptions coming from the Backend class when attempting to fetch the keyinfo's for a project. This is causing issues since the keyinfos are displayed in the project views, which fail with a http code 500 when any error occurs.

Fixes #14007