### PR TITLE
Document package command getprojectservices with OpenAPI

### DIFF
--- a/src/api/public/apidocs-new/OBS-v2.10.50.yaml
+++ b/src/api/public/apidocs-new/OBS-v2.10.50.yaml
@@ -340,6 +340,8 @@ paths:
     $ref: 'paths/source_project_name_package_name_cmd_deleteuploadrev.yaml'
   /source/{project_name}/{package_name}?cmd=diff:
     $ref: 'paths/source_project_name_package_name_cmd_diff.yaml'
+  /source/{project_name}/{package_name}?cmd=getprojectservices:
+    $ref: 'paths/source_project_name_package_name_cmd_getprojectservices.yaml'
   /source/{project_name}/{package_name}?cmd=instantiate:
     $ref: 'paths/source_project_name_package_name_cmd_instantiate.yaml'
   /source/{project_name}/{package_name}?cmd=linkdiff:

--- a/src/api/public/apidocs-new/components/schemas/services.yaml
+++ b/src/api/public/apidocs-new/components/schemas/services.yaml
@@ -1,0 +1,17 @@
+type: array
+items:
+  type: object
+  properties:
+    name:
+      type: string
+      xml:
+        attribute: true
+    mode:
+      type: string
+      xml:
+        attribute: true
+  xml:
+    name: service
+xml:
+  wrapped: true
+  name: services

--- a/src/api/public/apidocs-new/paths/source_project_name_package_name_cmd_getprojectservices.yaml
+++ b/src/api/public/apidocs-new/paths/source_project_name_package_name_cmd_getprojectservices.yaml
@@ -1,0 +1,36 @@
+post:
+  summary:  List all services related to a package.
+  description: |
+    List all services defined in the project spaces for this package.
+
+    Despite using the method `POST`, this endpoint doesn't alter any data.
+  security:
+    - basic_authentication: []
+  parameters:
+    - $ref: '../components/parameters/project_name.yaml'
+    - $ref: '../components/parameters/package_name.yaml'
+    - in: query
+      name: cmd
+      required: true
+      schema:
+        type: string
+        enum:
+          - getprojectservices
+  responses:
+    '200':
+      description:
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/services.yaml'
+          example:
+            - name: format_spec_file
+              mode: localonly
+            - name: download_files
+              mode: disabled
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '404':
+      $ref: '../components/responses/unknown_project_or_package.yaml'
+  tags:
+    - Sources - Packages


### PR DESCRIPTION
### For reviewers

Access to the documented enpoint in the review-app through [this link](https://obs-reviewlab.opensuse.org/eduardoj-apidocs_newsource_package_cmd_getprojectservices/apidocs-new/index.html#/Sources%20-%20Packages/post_source__project_name___package_name__cmd_getprojectservices).