### PR TITLE
OpenAPI specifications for GET/POST source files - without attribute parameter

### DIFF
--- a/src/api/public/apidocs-new/OBS-v2.10.50.yaml
+++ b/src/api/public/apidocs-new/OBS-v2.10.50.yaml
@@ -380,6 +380,8 @@ paths:
     $ref: 'paths/source_project_name_package_name_file_name.yaml'
   /source/{project_name}/{package_name}/{binary_filename}/_attribute/{attribute_name}:
     $ref: 'paths/source_project_name_package_name_binary_filename_attribute_name.yaml'
+  /source/{project_name}/{package_name}/{binary_filename}/_attribute:
+    $ref: 'paths/source_project_name_package_name_binary_filename_attribute.yaml'
 
   /trigger/{operation}:
     $ref: 'paths/trigger_operation.yaml'

--- a/src/api/public/apidocs-new/paths/source_project_name_package_name_binary_filename_attribute.yaml
+++ b/src/api/public/apidocs-new/paths/source_project_name_package_name_binary_filename_attribute.yaml
@@ -1,0 +1,60 @@
+get:
+  summary: Get list of attributes and attribute values with binary parameter
+  description: |
+    Get a list of all attributes and their values for a given binary
+  security:
+    - basic_authentication: []
+  parameters:
+    - $ref: '../components/parameters/project_name.yaml'
+    - $ref: '../components/parameters/package_name.yaml'
+    - $ref: '../components/parameters/binary_filename.yaml'
+  responses:
+    '200':
+      description: OK. The request has succeeded.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/source/attributes.yaml'
+          example:
+            - name: AllowSubmitToMaintenanceRelease
+              namespace: OBS
+              binary: SLES-cd-DVD-x86_64
+            - name: OwnerRootProjectTest
+              namespace: OBS
+              binary: Ceph
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '404':
+      $ref: '../components/responses/unknown_project_or_package.yaml'
+  tags:
+    - Sources - Files
+
+post:
+  summary: Add an attribute
+  description: |
+    Add an attribute with binary to a package
+  security:
+    - basic_authentication: []
+  parameters:
+    - $ref: '../components/parameters/project_name.yaml'
+    - $ref: '../components/parameters/package_name.yaml'
+    - $ref: '../components/parameters/binary_filename.yaml'
+  requestBody:
+    description: Attributes you want to update
+    content:
+      application/xml; charset=utf-8:
+        schema:
+          $ref: '../components/schemas/source/attributes.yaml'
+        example:
+          name: MaintenanceProject
+          namespace: OBS
+          binary: Ceph
+  responses:
+    '200':
+      $ref: '../components/responses/succeeded.yaml'
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '404':
+      $ref: '../components/responses/unknown_project_or_package.yaml'
+  tags:
+    - Sources - Files


### PR DESCRIPTION
Specifications for `GET/POST source/:project/:package/:binary/_attribute/` 