### PR TITLE
Record unsupported webhook event errors in the workflow

### DIFF
--- a/src/api/app/services/trigger_controller_service/scm_extractor.rb
+++ b/src/api/app/services/trigger_controller_service/scm_extractor.rb
@@ -1,5 +1,7 @@
 module TriggerControllerService
   class SCMExtractor
+    attr_reader :extractor
+
     SCM_EXTRACTORS = {
       'github' => {
         'pull_request' => GithubPayload::PullRequest,
@@ -17,18 +19,27 @@ module TriggerControllerService
     }.freeze
 
     def initialize(scm, event, webhook_payload)
-      # TODO: What should we do when the user sends a wwwurlencoded payload? Raise an exception?
-      @webhook_payload = webhook_payload.deep_symbolize_keys
       @scm = scm
       @event = event
+      @webhook_payload = webhook_payload.deep_symbolize_keys
+      @extractor = SCM_EXTRACTORS.dig(@scm, @event)
     end
 
     # TODO: What happens when some of the keys are missing?
     def call
-      extractor = SCM_EXTRACTORS.dig(@scm, @event)
       return unless extractor
 
       SCMWebhook.new(payload: extractor.new(@webhook_payload).payload)
+    end
+
+    def valid?
+      @scm.present? && @extractor.present?
+    end
+
+    def error_message
+      return 'Only GitHub, GitLab and Gitea are supported. Could not find the required HTTP request headers X-GitHub-Event, X-Gitlab-Event or X-Gitea-Event.' if @scm.nil?
+
+      'This SCM event is not supported' if @extractor.nil?
     end
   end
 end


### PR DESCRIPTION
When we receive events we don't have mapped in the [Scm Payload Extractor map](https://github.com/openSUSE/open-build-service/blob/0134d09bb1a2ef85a37763ab760888aa396a9a44/src/api/app/services/trigger_controller_service/scm_extractor.rb#L3) (for example, a [new branch gets created](https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#create)), we end up having no payload extractor (receiving Nil [here](https://github.com/openSUSE/open-build-service/blob/0134d09bb1a2ef85a37763ab760888aa396a9a44/src/api/app/services/trigger_controller_service/scm_extractor.rb#L28)). This nil bubbles up [to the controller](https://github.com/openSUSE/open-build-service/blob/0134d09bb1a2ef85a37763ab760888aa396a9a44/src/api/app/controllers/trigger_workflow_controller.rb#L13) and crashes inside the [Token Workflow](https://github.com/openSUSE/open-build-service/blob/0134d09bb1a2ef85a37763ab760888aa396a9a44/src/api/app/models/token/workflow.rb#L29).

This PR adds a new validation to notify the user is using an unsupported event. 

Fixes #13849