### PR TITLE
Add missing security section for attribute endpoints

### DIFF
--- a/src/api/public/apidocs-new/paths/source_project_name_attribute.yaml
+++ b/src/api/public/apidocs-new/paths/source_project_name_attribute.yaml
@@ -1,5 +1,7 @@
 get:
   summary: Get all the project's attributes
+  security:
+  - basic_authentication: []
   parameters:
     - $ref: '../components/parameters/project_name.yaml'
     # Query Strings:

--- a/src/api/public/apidocs-new/paths/source_project_name_attribute_attribute_name.yaml
+++ b/src/api/public/apidocs-new/paths/source_project_name_attribute_attribute_name.yaml
@@ -2,6 +2,8 @@ get:
   summary: Get project's attribute
   description: |
     Get a specified attribute of the project
+  security:
+  - basic_authentication: []
   parameters:
     - $ref: '../components/parameters/project_name.yaml'
     - $ref: '../components/parameters/attribute_name.yaml'
@@ -68,6 +70,8 @@ post:
   summary: Modifies the specified attribute
   description: |
     Modifies the specified attribute
+  security:
+    - basic_authentication: []
   parameters:
     - $ref: '../components/parameters/project_name.yaml'
     - $ref: '../components/parameters/attribute_name.yaml'
@@ -109,6 +113,8 @@ delete:
   summary: Removes a specified attribute
   description: |
     Removes a specified attribute
+  security:
+    - basic_authentication: []
   parameters:
     - $ref: '../components/parameters/project_name.yaml'
     - $ref: '../components/parameters/attribute_name.yaml'

--- a/src/api/public/apidocs-new/paths/source_project_name_package_name_attribute.yaml
+++ b/src/api/public/apidocs-new/paths/source_project_name_package_name_attribute.yaml
@@ -1,5 +1,7 @@
 get:
   summary: List the attibutes of a package
+  security:
+  - basic_authentication: []
   parameters:
     - $ref: '../components/parameters/project_name.yaml'
     - $ref: '../components/parameters/package_name.yaml'

--- a/src/api/public/apidocs-new/paths/source_project_name_package_name_attribute_attribute_name.yaml
+++ b/src/api/public/apidocs-new/paths/source_project_name_package_name_attribute_attribute_name.yaml
@@ -2,6 +2,8 @@ get:
   summary: Get package's attribute
   description: |
     Get the specified attribute of the package
+  security:
+    - basic_authentication: []
   parameters:
     - $ref: '../components/parameters/project_name.yaml'
     - $ref: '../components/parameters/package_name.yaml'


### PR DESCRIPTION
After reviewing other PRs I realized the `security` part was missing in the PRs I previously opened. So I add it to all of them now. 