### PR TITLE
Set proper collapsed state on loading

### DIFF
--- a/src/api/app/components/diff_list_component.html.haml
+++ b/src/api/app/components/diff_list_component.html.haml
@@ -1,15 +1,17 @@
 - diff_list.each_with_index do |(name, file_info), file_index|
   - state = file_info['state']
+  - expanded = expand?(name, state)
   .accordion.mb-2{ id: "diff-list-#{name.parameterize}" }
     .accordion-item
       %h2.accordion-header
         %button.accordion-button.text-bg-light{ type: 'button', data: { 'bs-toggle': 'collapse',
                                                                         'bs-target': "#diff-item-#{name.parameterize}" },
-                                                aria: { expanded: 'true', controls: "diff-item-#{name.parameterize}" } }
+                                                aria: { expanded: 'true', controls: "diff-item-#{name.parameterize}" },
+                                                class: expanded ? '' : 'collapsed' }
           - if (old_file = file_info['old'])
             = changed_filename(old_file['name'], name, state)
           - else
             = name
           %span.badge.ms-1{ class: badge_for_state(state) }= state.capitalize
-      .accordion-collapse.collapse{ class: expand?(name, state) ? 'show' : '', id: "diff-item-#{name.parameterize}", 'data-object': view_id }
+      .accordion-collapse.collapse{ class: expanded ? 'show' : '', id: "diff-item-#{name.parameterize}", 'data-object': view_id }
         = render(DiffComponent.new(diff: file_info.dig('diff', '_content'), file_index:, commentable:))


### PR DESCRIPTION
Set the proper state of collapsed/not collapsed to show the proper arrow up/down in the Request#changes tab.

## Before
![collapsed-before](https://user-images.githubusercontent.com/7080830/226064952-ee602977-81aa-44d6-92ca-df5442ec9677.png)


## After
![collapsed-after](https://user-images.githubusercontent.com/7080830/226064961-2a27b663-d851-4adf-84ac-5396240e1877.png)

