### PR TITLE
Fix tests: time on utc, not local zone

### DIFF
--- a/src/api/spec/components/bs_request_activity_timeline_component_spec.rb
+++ b/src/api/spec/components/bs_request_activity_timeline_component_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe BsRequestActivityTimelineComponent, type: :component do
   let(:bs_request) { create(:bs_request_with_submit_action) }
   let!(:history_element) { create(:history_element_request_accepted, op_object_id: bs_request.id) }
-  let!(:comment) { create(:comment_request, commentable: bs_request, created_at: Time.zone.yesterday) }
+  let!(:comment) { create(:comment_request, commentable: bs_request, created_at: Time.now.utc - 1.day) }
 
   it 'shows the comment first, as it is an older timeline item' do
     expect(render_inline(described_class.new(bs_request: bs_request))).to have_selector('.timeline-item:first-child', text: 'wrote')

--- a/src/api/spec/components/bs_request_comment_component_spec.rb
+++ b/src/api/spec/components/bs_request_comment_component_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe BsRequestCommentComponent, type: :component do
   let(:commentable) { create(:bs_request_with_submit_action) }
-  let(:comment_a) { create(:comment_request, commentable: commentable, body: 'Comment A', created_at: Time.zone.yesterday) }
+  let(:comment_a) { create(:comment_request, commentable: commentable, body: 'Comment A', created_at: Time.now.utc - 1.day) }
 
   before do
     render_inline(described_class.new(comment: comment_a, commentable: commentable, level: 1))

--- a/src/api/spec/components/bs_request_history_element_component_spec.rb
+++ b/src/api/spec/components/bs_request_history_element_component_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe BsRequestHistoryElementComponent, type: :component do
   end
 
   context 'for any kind of history elements' do
-    let(:element) { create(:history_element_request_accepted, user: user, created_at: Time.zone.yesterday) }
+    let(:element) { create(:history_element_request_accepted, user: user, created_at: Time.now.utc - 1.day) }
 
     it 'displays an avatar' do
       expect(rendered_content).to have_selector("img[title='#{user.realname}']", count: 1)


### PR DESCRIPTION
[Time component](https://github.com/openSUSE/open-build-service/blob/master/src/api/app/components/fuzzy_time_component.rb#L12) uses time on `utc` to compare datetimes, so tests should uses `utc` as well otherwise during the day the tests might be flacky due to local different time zones.