### PR TITLE
[backend] improved testing bdep

### DIFF
--- a/src/backend/t/0160-BSSched-BuildJob-KiwiProduct.t
+++ b/src/backend/t/0160-BSSched-BuildJob-KiwiProduct.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 7;                      # last test to print
+use Test::More tests => 1735.;                      # last test to print
 use Data::Dumper;
 use FindBin;
 use BSUtil;

--- a/src/backend/t/0170-BSSched-BuildJob-Package.t
+++ b/src/backend/t/0170-BSSched-BuildJob-Package.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 9;			# last test to print
+use Test::More tests => 114;			# last test to print
 use Data::Dumper;
 use FindBin;
 use BSUtil;

--- a/src/backend/t/0360-BSRepServer-BuildInfo-Package.t
+++ b/src/backend/t/0360-BSRepServer-BuildInfo-Package.t
@@ -11,7 +11,7 @@ use Test::OBS::Utils;
 use Test::OBS;
 use Test::Mock::BSRepServer::Checker;
 
-use Test::More tests => 3;                      # last test to print
+use Test::More tests => 208;                      # last test to print
 
 use BSUtil;
 use BSXML;

--- a/src/backend/t/0370-BSRepServer-BuildInfo-KiwiImage.t
+++ b/src/backend/t/0370-BSRepServer-BuildInfo-KiwiImage.t
@@ -11,7 +11,7 @@ use Test::OBS::Utils;
 use Test::OBS;
 use Test::Mock::BSRepServer::Checker;
 
-use Test::More tests => 3;                      # last test to print
+use Test::More tests => 1074;                      # last test to print
 
 use BSUtil;
 use BSXML;

--- a/src/backend/t/0380-BSRepServer-BuildInfo-KiwiProduct.t
+++ b/src/backend/t/0380-BSRepServer-BuildInfo-KiwiProduct.t
@@ -11,7 +11,7 @@ use Test::OBS::Utils;
 use Test::OBS;
 use Test::Mock::BSRepServer::Checker;
 
-use Test::More tests => 2;                      # last test to print
+use Test::More tests => 1576;                      # last test to print
 
 use BSUtil;
 use BSXML;

--- a/src/backend/t/lib/Test/OBS.pm
+++ b/src/backend/t/lib/Test/OBS.pm
@@ -19,6 +19,7 @@ package Test::OBS;
 
 use strict;
 use warnings;
+use Data::Dumper;
 
 use Exporter;
 @Test::OBS::ISA       = ("Exporter");
@@ -34,13 +35,25 @@ sub bdepkey {
 
 sub cmp_buildinfo {
   my ($got, $expected, $comment) = @_;
+  #print Dumper($got->{bdep});
 
   delete $_->{'hdrmd5'} for @{$got->{'bdep'} || []};
   $got->{'bdep'}       = [ sort {bdepkey($a) cmp bdepkey($b)} @{$got->{'bdep'} || []} ];
   $expected->{'bdep'}  = [ sort {bdepkey($a) cmp bdepkey($b)} @{$expected->{'bdep'} || []} ];
   $got->{subpack}      = [ sort { $a cmp $b }  @{ $got->{subpack}  || []} ];
   $expected->{subpack} = [ sort { $a cmp $b } @{ $expected->{subpack}  || []} ];
-  is_deeply($got, $expected, $comment);
+  my $got_bdeps = scalar @{$got->{bdep}};
+  my $exp_bdeps = scalar @{$expected->{bdep}};
+  ok($got_bdeps == $exp_bdeps, 'equal number of bdeps');
+  my $c1=0;
+  while ($c1<$got_bdeps) {
+    is_deeply($got->{bdep}->[$c1], $expected->{bdep}->[$c1], "$comment bdep $c1") || print Dumper($got->{bdep}->[$c1], $expected->{bdep}->[$c1]);
+    $c1++;
+  }
+  delete $got->{bdep};
+  delete $expected->{bdep};
+
+  is_deeply($got, $expected, "$comment");
 }
 
 1;


### PR DESCRIPTION
With this commit we split the testing of bdeps in the BuildInfo testing into single tests and print got/expected if the test fails. This makes debugging of issues easier in future.