### PR TITLE
Further optimize getting commented lines by avoiding ruby logic

### DIFF
--- a/src/api/app/components/diff_list_component.rb
+++ b/src/api/app/components/diff_list_component.rb
@@ -8,7 +8,7 @@ class DiffListComponent < ApplicationComponent
     @diff_list = diff_list
     @view_id = view_id
     @commentable = commentable
-    @commented_lines = commentable ? commentable.comments.map(&:diff_ref).uniq.compact : []
+    @commented_lines = commentable ? commentable.comments.where.not(diff_ref: nil).select(:diff_ref).distinct.pluck(:diff_ref) : []
   end
 
   def badge_for_state(state)


### PR DESCRIPTION
I worked a bit more on this, and decided to forego the ruby logic entirely, only using activerecord to get an optimized query. This here results in
```sql
SELECT DISTINCT `comments`.`diff_ref` FROM `comments` WHERE `comments`.`commentable_id` = id AND `comments`.`commentable_type` = 'BsRequestAction' AND `comments`.`diff_ref` IS NOT NULL
```
which is faster than mapping, uniqing and compacting the records manually