### PR TITLE
Fix sorting of files in the changes tab

### DIFF
--- a/src/api/app/components/sourcediff_component.html.haml
+++ b/src/api/app/components/sourcediff_component.html.haml
@@ -23,7 +23,8 @@
             %h4
               #{diff_label(sourcediff['new'])} – #{diff_label(sourcediff['old'])}
           - if sourcediff['filenames'].present?
-            = render(DiffListComponent.new(diff_list: sourcediff['files'], view_id: @action[:spkg], commentable:))
+            - diff_list = sourcediff['files'].sort_by { |k, _v| sourcediff['filenames'].find_index(k) }.to_h
+            = render(DiffListComponent.new(diff_list:, view_id: @action[:spkg], commentable:))
           - else
             .mb-2
               %p.lead


### PR DESCRIPTION
The sorting there was incorrect compared to the old diffs, this makes the sorting correct.