### PR TITLE
Make the Previous and Next buttons take the tabs into account

### DIFF
--- a/src/api/app/assets/javascripts/webui/application.js
+++ b/src/api/app/assets/javascripts/webui/application.js
@@ -57,6 +57,7 @@
 //= require webui/collapsible_tooltip.js
 //= require webui/request_show_redesign/add_review.js
 //= require webui/request_show_redesign/build_results.js
+//= require webui/request_show_redesign/bs_request_actions.js
 //= require webui/request_show_redesign/rpm_lint_results.js
 //= require webui/delete_confirmation_dialog.js
 //= require webui/nav_tabs.js

--- a/src/api/app/assets/javascripts/webui/request_show_redesign/bs_request_actions.js
+++ b/src/api/app/assets/javascripts/webui/request_show_redesign/bs_request_actions.js
@@ -1,0 +1,18 @@
+// JavaScript code for the new view under request_show_redesign
+
+function appendAnchorToHref(href) {
+  var HASH_PREFIX = 'tab-pane-';
+  var hashRegexp = new RegExp("#" + HASH_PREFIX + ".+");
+
+  if (document.location.hash.search('#diff_') !== -1 && href.search('#') === -1) {
+    href = href + '#' + HASH_PREFIX + 'changes';
+  }
+  else if (href.search('#') === -1) {
+    href = href + document.location.hash;
+  }
+  else if (document.location.hash.search('#diff_') === -1) {
+    href = href.replace(hashRegexp, document.location.hash);
+  }
+  return href;
+}
+

--- a/src/api/app/assets/javascripts/webui/request_show_redesign/bs_request_actions.js
+++ b/src/api/app/assets/javascripts/webui/request_show_redesign/bs_request_actions.js
@@ -16,3 +16,15 @@ function appendAnchorToHref(href) {
   return href;
 }
 
+function setAnchorToPreviousAndNextButtons() { // jshint ignore:line
+  var previousButton = $('#previous-action-button');
+  var nextButton = $('#next-action-button');
+
+  if (previousButton.length) {
+    previousButton.attr('href', appendAnchorToHref(previousButton.attr('href')));
+  }
+
+  if (nextButton.length) {
+    nextButton.attr('href', appendAnchorToHref(nextButton.attr('href')));
+  }
+}

--- a/src/api/app/views/webui/request/_actions_details.html.haml
+++ b/src/api/app/views/webui/request/_actions_details.html.haml
@@ -62,7 +62,6 @@
 
 - content_for :ready_function do
   :plain
-    var hashRegexp = new RegExp(`\#${HASH_PREFIX}.+`);
 
     $('#request-actions').on('shown.bs.dropdown', function () {
       // Scrolls towards the current request action
@@ -72,15 +71,6 @@
       // Adapts Href according to seleted tab
       $.each($('#request-actions .dropdown-item'), function () {
         var href = $(this).attr('href');
-        if (document.location.hash.search('#diff_') != -1 && href.search('#') == -1) {
-          href = href + '#' + HASH_PREFIX + 'changes';
-        }
-        else if (href.search('#') == -1) {
-          href = href + document.location.hash;
-        }
-        else if (document.location.hash.search('#diff_') == -1) {
-          href = href.replace(hashRegexp, document.location.hash);
-        }
-        $(this).attr('href', href);
+        $(this).attr('href', appendAnchorToHref(href));
       });
     });

--- a/src/api/app/views/webui/request/_actions_details.html.haml
+++ b/src/api/app/views/webui/request/_actions_details.html.haml
@@ -7,7 +7,8 @@
     .input-group.w-auto
       = link_to('Previous', request_show_path(number: bs_request.number, request_action_id: prev_action&.id,
                                               full_diff: diff_limit, diff_to_superseded: diff_to_superseded_id),
-                class: "btn btn-primary btn-sm #{prev_action ? '' : 'disabled'}")
+                class: "btn btn-primary btn-sm #{prev_action ? '' : 'disabled'}",
+                id: 'previous-action-button')
       .dropdown#request-actions
         %button.btn.btn-outline-primary.btn-sm.dropdown-toggle.rounded-0{ 'aria-expanded' => 'false', 'data-bs-toggle' => 'dropdown',
                                                                           :type => 'button', 'data-boundary' => 'viewport' }
@@ -30,7 +31,8 @@
                                                         'aria-current': 'true')
       = link_to('Next', request_show_path(number: bs_request.number, request_action_id: next_action&.id,
                                           full_diff: diff_limit, diff_to_superseded: diff_to_superseded_id),
-                class: "btn btn-primary btn-sm #{next_action ? '' : 'disabled'}")
+                class: "btn btn-primary btn-sm #{next_action ? '' : 'disabled'}",
+                id: 'next-action-button')
 
     - active_action_index = submit_actions.find_index(active_action) + 1
     %span.ms-2 Showing ##{active_action_index} (of #{submit_actions_count})
@@ -62,13 +64,18 @@
 
 - content_for :ready_function do
   :plain
+    // Append anchor to the href of the Previous and Next buttons when the page is loaded or when the tab is changed.
+    setAnchorToPreviousAndNextButtons();
+    $('#request-tabs').find('a[data-bs-toggle="tab"]').on('shown.bs.tab', function(){
+      setAnchorToPreviousAndNextButtons();
+    });
 
     $('#request-actions').on('shown.bs.dropdown', function () {
       // Scrolls towards the current request action
       var currentAction = $('a.dropdown-item.active');
       currentAction[0].scrollIntoView({behavior: "smooth", block: "center"});
 
-      // Adapts Href according to seleted tab
+      // Append anchor to the href of the actions in the dropdown
       $.each($('#request-actions .dropdown-item'), function () {
         var href = $(this).attr('href');
         $(this).attr('href', appendAnchorToHref(href));


### PR DESCRIPTION
When moving through the request actions list, we want to keep seeing the same tab we were in.
i.e. we want to keep seeing the Changes tab to compare the changes of the previous, current and subsequent actions.

To do so, append the corresponding anchor the `href` of the links.

This PR also includes a little refactoring on the JS code that was included in the view, as we need to reuse part of the code now.

**Testing Tips**

- Choose a [request with many actions](https://obs-reviewlab.opensuse.org/saraycp-tab-pane-changes-on-buttons/request/show/9).
- Play around with: changing tabs, clicking on Previous, Next, Dropdown...
- The last selected tab should keep selected and visible.