### PR TITLE
Show Delete request actions in the action dropdown

### DIFF
--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -494,7 +494,7 @@ class Webui::RequestController < Webui::WebuiController
 
   def set_supported_actions
     # Change supported_actions below into actions here when all actions are supported
-    @supported_actions = @actions.where(type: [:add_role, :submit])
+    @supported_actions = @actions.where(type: [:add_role, :delete, :submit])
   end
 
   def set_action_id

--- a/src/api/app/views/webui/request/_action_text.html.haml
+++ b/src/api/app/views/webui/request/_action_text.html.haml
@@ -23,6 +23,8 @@
         %span.me-2 ##{action_index + 1}
         - if action.type == 'add_role'
           #{action.type.titleize}
+        - elsif action.type == 'delete'
+          Delete #{project_or_package_text(action.target_project, action.target_package)}
         - else
           = action.name
     -# add_role, delete and set_bugowner are actions on the target repo, so they don't need to mention where they are coming from

--- a/src/api/lib/tasks/dev/requests.rake
+++ b/src/api/lib/tasks/dev/requests.rake
@@ -65,6 +65,15 @@ namespace :dev do
       bs_req_action = build(:bs_request_action, action_attributes)
       bs_req_action.save! if bs_req_action.valid?
 
+      create(:bs_request_action_delete,
+             target_project: target_project,
+             bs_request: request)
+
+      create(:bs_request_action_delete,
+             target_project: target_project,
+             target_package: target_package_a,
+             bs_request: request)
+
       puts "* Request #{request.number} contains multiple actions and mentioned issues."
       puts 'To start the builds confirm or perfom the following steps:'
       puts '- Create the interconnect with openSUSE.org'

--- a/src/api/spec/features/webui/requests/delete_actions_spec.rb
+++ b/src/api/spec/features/webui/requests/delete_actions_spec.rb
@@ -1,0 +1,28 @@
+require 'browser_helper'
+
+RSpec.describe 'Request with delete actions', beta: true do
+  let(:submitter) { create(:confirmed_user, :with_home, login: 'submitter') }
+  let(:receiver) { create(:confirmed_user, :with_home, login: 'receiver') }
+  let(:target_project) { receiver.home_project }
+  let(:target_package) { create(:package, name: 'package_1', project: target_project) }
+  let(:request) { create(:delete_bs_request, creator: submitter, target_project: target_project) }
+  let!(:delete_package_action) do
+    create(:bs_request_action_delete,
+           bs_request: request,
+           target_project: target_project,
+           target_package: target_package)
+  end
+
+  before do
+    login receiver
+    visit request_show_path(request.number)
+  end
+
+  it 'shows delete actions' do
+    expect(page).to have_text('Showing #1 (of 2)').and(have_text("Delete project #{target_project}"))
+
+    click_link('Next')
+
+    expect(page).to have_text('Showing #2 (of 2)').and(have_text("Delete package #{target_project} / #{target_package}"))
+  end
+end


### PR DESCRIPTION
![Screenshot from 2023-03-30 14-14-15](https://user-images.githubusercontent.com/24919/228832556-bef9b3e1-8139-474d-a415-4474a07b2ee6.png)


## For reviewers

- Link to a request with multiple actions, being the last two of them delete actions, in the review app, [here](https://obs-reviewlab.opensuse.org/eduardoj-featuredisplay_delete_request_actions/request/show/9).
- Link to a request with two unsupported actions and one delete action in the review app, [here](https://obs-reviewlab.opensuse.org/eduardoj-featuredisplay_delete_request_actions/request/show/11).