### PR TITLE
Show supported action types

### DIFF
--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -23,17 +23,17 @@ class Webui::RequestController < Webui::WebuiController
       @diff_to_superseded_id = params[:diff_to_superseded]
 
       # Handling request actions
-      action_id = params[:request_action_id] || @bs_request.bs_request_actions.first.id
-      @action = @bs_request.webui_actions(filelimit: @diff_limit, tarlimit: @diff_limit, diff_to_superseded: @diff_to_superseded,
-                                          diffs: true, action_id: action_id.to_i, cacheonly: 1).first
-      actions = @bs_request.bs_request_actions
-      @active_action = actions.find(action_id)
+      @actions = @bs_request.bs_request_actions
       # Change supported_actions below into actions here when all actions are supported
-      supported_actions = actions.where(type: [:add_role, :submit])
-      active_action_index = supported_actions.index(@active_action)
+      @supported_actions = @actions.where(type: [:add_role, :submit])
+      @action_id = params[:request_action_id] || @supported_actions.first&.id || @actions.first.id
+      @active_action = @actions.find(@action_id)
+      @action = @bs_request.webui_actions(filelimit: @diff_limit, tarlimit: @diff_limit, diff_to_superseded: @diff_to_superseded,
+                                          diffs: true, action_id: @action_id.to_i, cacheonly: 1).first
+      active_action_index = @supported_actions.index(@active_action)
       if active_action_index
-        @prev_action = supported_actions[active_action_index - 1] unless active_action_index.zero?
-        @next_action = supported_actions[active_action_index + 1] if active_action_index + 1 < supported_actions.length
+        @prev_action = @supported_actions[active_action_index - 1] unless active_action_index.zero?
+        @next_action = @supported_actions[active_action_index + 1] if active_action_index + 1 < @supported_actions.length
       end
 
       target_project = Project.find_by_name(@bs_request.target_project_name)

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -5,10 +5,10 @@ class Webui::RequestController < Webui::WebuiController
   # requests do not really add much value for our page rank :)
   before_action :lockout_spiders
   before_action :require_request, only: [:changerequest, :show, :request_action, :request_action_changes, :inline_comment]
-  before_action :set_actions, only: [:show], if: -> { Flipper.enabled?(:request_show_redesign, User.session) }
-  before_action :set_supported_actions, only: [:show], if: -> { Flipper.enabled?(:request_show_redesign, User.session) }
-  before_action :set_action_id, only: [:show], if: -> { Flipper.enabled?(:request_show_redesign, User.session) }
-  before_action :set_active_action, only: [:show], if: -> { Flipper.enabled?(:request_show_redesign, User.session) }
+  before_action :set_actions, only: [:inline_comment, :show], if: -> { Flipper.enabled?(:request_show_redesign, User.session) }
+  before_action :set_supported_actions, only: [:inline_comment, :show], if: -> { Flipper.enabled?(:request_show_redesign, User.session) }
+  before_action :set_action_id, only: [:inline_comment, :show], if: -> { Flipper.enabled?(:request_show_redesign, User.session) }
+  before_action :set_active_action, only: [:inline_comment, :show], if: -> { Flipper.enabled?(:request_show_redesign, User.session) }
   before_action :set_superseded_request, only: [:show, :request_action, :request_action_changes]
   before_action :check_ajax, only: :sourcediff
 
@@ -329,10 +329,6 @@ class Webui::RequestController < Webui::WebuiController
   end
 
   def inline_comment
-    # Handling request actions
-    action_id = params[:request_action_id] || @bs_request.bs_request_actions.first.id
-    @active_action = @bs_request.bs_request_actions.find(action_id)
-
     @line = params[:line]
     respond_to do |format|
       format.js

--- a/src/api/app/views/webui/request/beta_show.html.haml
+++ b/src/api/app/views/webui/request/beta_show.html.haml
@@ -74,8 +74,8 @@
       .mt-4
         -# action description, prev + dropdown select + next
         = render partial: 'actions_details', locals: { bs_request: @bs_request, action: @action, active_action: @active_action,
-                                                     prev_action: @prev_action, next_action: @next_action,
-                                                     diff_to_superseded_id: @diff_to_superseded_id, diff_limit: @diff_limit }
+                                                       prev_action: @prev_action, next_action: @next_action,
+                                                       diff_to_superseded_id: @diff_to_superseded_id, diff_limit: @diff_limit }
 
     .border-bottom
       %ul.nav.nav-tabs.scrollable-tabs.border-0#request-tabs{ role: 'tablist' }


### PR DESCRIPTION
Before, in a multiaction submit request, a supported action was not shown if it was the only action supported and it was not the first action.

Now, in those conditions above mentioned, show the supported action.

For example, for a multiaction submit request where a Delete action is the only supported action, and also the last action (I was doing tests in my development environment, and the Delete action will be soonish supported), this is how it looked like before:

![Screenshot from 2023-03-27 11-25-20](https://user-images.githubusercontent.com/24919/227902812-f7096a7a-d8a6-4575-b7e7-af15dd251994.png)

And this is after:

![Screenshot from 2023-03-27 11-24-49](https://user-images.githubusercontent.com/24919/227902744-86dca058-2635-4427-950f-b9ffe874081b.png)
