### PR TITLE
Performance improvements for beta request show 

### DIFF
--- a/src/api/app/components/diff_component.html.haml
+++ b/src/api/app/components/diff_component.html.haml
@@ -29,4 +29,11 @@
                            locals: { comment: Comment.new, commentable: commentable, diff_ref: id })
             - else
               .comments-list
-                = render(partial: 'webui/request/add_inline_comment', locals: { commentable: commentable, diff_ref: id })
+                -# rubocop:disable ViewComponent/AvoidGlobalState
+                - if User.session
+                  = link_to(request_inline_comment_path(commentable.bs_request, commentable, id),
+                            class: 'btn btn-sm btn-primary line-new-comment', remote: true, title: 'Add comment') do
+                    %i.fas.fa-comment-medical
+                    .visually-hidden
+                      Add comment
+                -# rubocop:enable ViewComponent/AvoidGlobalState


### PR DESCRIPTION
Removing the partial improves performance significantly:

With partial, the rendering time is ~8.6 seconds
Without partial, the rendering time is ~2.8 seconds

This is the package we have used to test: https://build.opensuse.org/package/show/openSUSE:Factory/python-django-axes