### PR TITLE
Remove POST /build/{project_name}/{repository_name}/_buildconfig API route

### DIFF
--- a/src/api/config/routes/api_routes.rb
+++ b/src/api/config/routes/api_routes.rb
@@ -372,7 +372,7 @@ OBSApi::Application.routes.draw do
   put 'build/:project/:repository/:arch/:package/:filename' => 'build/file#update', constraints: cons
   delete 'build/:project/:repository/:arch/:package/:filename' => 'build/file#destroy', constraints: cons
   match 'build/:project/:repository/:arch/_builddepinfo' => 'build#builddepinfo', via: [:get, :post], constraints: cons
-  match 'build/:project/:repository/_buildconfig' => 'build#index', constraints: cons, via: [:get, :post]
+  get 'build/:project/:repository/_buildconfig' => 'build#index', constraints: cons
   match 'build/:project/:repository/:arch(/:package)' => 'build#index', constraints: cons, via: [:get, :post]
   get 'build/_result' => 'build#scmresult', constraints: cons
   get 'build/:project/_result' => 'build#result', constraints: cons


### PR DESCRIPTION
... from the frontend router

It always fails with a 404 error and it is not defined in the backend. See: https://github.com/openSUSE/open-build-service/blob/f8f8c2331da85ea844f0ec81f8b883e3ae123491/src/backend/bs_srcserver#L7726