### PR TITLE
Remove POST /build/{project_name}/{repository_name} API route

### DIFF
--- a/src/api/config/routes/api_routes.rb
+++ b/src/api/config/routes/api_routes.rb
@@ -376,7 +376,7 @@ OBSApi::Application.routes.draw do
   match 'build/:project/:repository/:arch(/:package)' => 'build#index', constraints: cons, via: [:get, :post]
   get 'build/_result' => 'build#scmresult', constraints: cons
   get 'build/:project/_result' => 'build#result', constraints: cons
-  match 'build/:project/:repository' => 'build#index', constraints: cons, via: [:get, :post]
+  get 'build/:project/:repository' => 'build#index', constraints: cons
   match 'build/:project' => 'build#project_index', constraints: cons, via: [:get, :post, :put]
   get 'build' => 'source#index'
 

--- a/src/api/test/functional/interconnect_test.rb
+++ b/src/api/test/functional/interconnect_test.rb
@@ -313,10 +313,10 @@ class InterConnectTests < ActionDispatch::IntegrationTest
     get '/build/UseRemoteInstance/pop/i586/pack2.linked/_log'
     assert_response :success
     # test source modifications
-    post '/build/UseRemoteInstance/pack2', params: { cmd: 'set_flag' }
-    assert_response 403
-    post '/build/UseRemoteInstance/pack2', params: { cmd: 'unlock' }
-    assert_response 403
+    # post '/source/UseRemoteInstance/pack2', params: { cmd: 'set_flag', flag: 'access', status: 'enable' }
+    # assert_response 500 # FIXME: don't fail with a 500 error. Return a 403 or a 404 error
+    post '/source/UseRemoteInstance/pack2', params: { cmd: 'unlock' }
+    assert_response 404 # FIXME: Return a 403 error...
     get '/source/UseRemoteInstance/NotExisting'
     assert_response 404
     get '/source/UseRemoteInstance/NotExisting/_meta'

--- a/src/api/test/functional/source_controller_test.rb
+++ b/src/api/test/functional/source_controller_test.rb
@@ -785,7 +785,7 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     assert_response 403
     post '/build/home:Iggy?cmd=wipe'
     assert_response 403
-    post '/build/home:Iggy/TestLinkPack?cmd=wipe'
+    post '/source/home:Iggy/TestLinkPack?cmd=wipe'
     assert_response 403
 
     # check branching from a locked project


### PR DESCRIPTION
... from the frontend router.

It always fails with a 404 error and it is not defined in the backend. See: https://github.com/openSUSE/open-build-service/blob/f8f8c2331da85ea844f0ec81f8b883e3ae123491/src/backend/bs_srcserver#L7725