### PR TITLE
Redirect to proper path instead of rendering partial

### DIFF
--- a/src/api/app/controllers/webui/users/tokens_controller.rb
+++ b/src/api/app/controllers/webui/users/tokens_controller.rb
@@ -105,7 +105,7 @@ class Webui::Users::TokensController < Webui::WebuiController
     # Check if only project_name or only package_name are present
     if @extra_params[:project_name].present? ^ @extra_params[:package_name].present?
       flash[:error] = 'When providing an optional package, both Project name and Package name must be provided.'
-      render :new and return
+      redirect_to new_token_path and return
     end
 
     # If both project_name and package_name are present, check if this is an existing package
@@ -113,11 +113,11 @@ class Webui::Users::TokensController < Webui::WebuiController
       @package = Package.get_by_project_and_name(@extra_params[:project_name], @extra_params[:package_name])
     rescue Project::UnknownObjectError
       flash[:error] = "When providing an optional package, the package must exist. Project '#{elide(@extra_params[:project_name])}' does not exist."
-      render :new
+      redirect_to new_token_path
     rescue Package::UnknownObjectError
       flash[:error] = 'When providing an optional package, the package must exist. ' \
                       "Package '#{elide(@extra_params[:project_name])}/#{elide(@extra_params[:package_name])}' does not exist."
-      render :new
+      redirect_to new_token_path
     end
   end
 end


### PR DESCRIPTION
Fix https://github.com/openSUSE/open-build-service/issues/14081

Handle [this error](https://errbit.opensuse.org/apps/5620ca2bdc71fa00b1000000/problems/6402111584bf46052b8464d4) better.

During token creation, before executing the `:create` method, the code-path goes through [`set_package`](https://github.com/openSUSE/open-build-service/blob/master/src/api//app/controllers/webui/users/tokens_controller.rb#L112) and it may happen that the project or the package don't exist. If so, lines [108](https://github.com/openSUSE/open-build-service/blob/master/src/api//app/controllers/webui/users/tokens_controller.rb#L108) or [116](https://github.com/openSUSE/open-build-service/blob/master/src/api//app/controllers/webui/users/tokens_controller.rb#L116) or [120](https://github.com/openSUSE/open-build-service/blob/master/src/api//app/controllers/webui/users/tokens_controller.rb#L120) get hit and render `:new` partial without initializing the `@token` variable, as it is supposed to happen in `new_token_path` instead. Only the rendering leads to ```undefined method `new_record?' for nil:NilClass``` due to [this check](https://github.com/openSUSE/open-build-service/blob/master/src/api//app/views/webui/users/tokens/new.html.haml#L10). Redirecting to [`new_token_path`](https://github.com/openSUSE/open-build-service/blob/master/src/api//app/controllers/webui/users/tokens_controller.rb#L16) would be better so `@token` get initialized.


## Review APP
- go to [my/tokens/new](https://obs-reviewlab.opensuse.org/ncounter-redirect-token-new/my/tokens/new)
- enter non existing project and or package names like `abcdefghijk`
- hit `create` token
- see the flash message in the `new` page instead of the rails error page


## Before
![token-error-not-handled](https://user-images.githubusercontent.com/7080830/228511008-89d6bab8-4993-4f54-b295-02053e937941.png)

## After
![token-error-handling](https://user-images.githubusercontent.com/7080830/228511024-1a5534fc-0be0-4a8f-b654-3167e085aae3.png)
