### PR TITLE
[backend] bs_worker: make file writing fatal

### DIFF
--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -1279,7 +1279,7 @@ sub link_or_copy {
       warn("syswrite $to: $!\n");
       unlink($to);
       close F;
-      return undef;
+      die("FATAL: unable to write file: $to");
     }
   }
   close(F);


### PR DESCRIPTION
To catch such failures:

fetching sources, getsources: syswrite: No space left on device