### PR TITLE
Make sure the regex finds matches for diff_ref

### DIFF
--- a/src/api/app/components/bs_request_activity_timeline_component.rb
+++ b/src/api/app/components/bs_request_activity_timeline_component.rb
@@ -23,9 +23,9 @@ class BsRequestActivityTimelineComponent < ApplicationComponent
   end
 
   def diff_for_ref(comment)
-    return unless comment.diff_ref
+    return unless (ref = comment.diff_ref&.match(/diff_([0-9]+)/))
 
-    file_index = comment.diff_ref.match(/diff_([0-9]*)/).captures.first
+    file_index = ref.captures.first
     sourcediff = @diffs.find { |d| d[:id] == comment.commentable.id }[:sourcediff].first
     filename = sourcediff.dig('filenames', file_index.to_i)
     sourcediff.dig('files', filename)

--- a/src/api/spec/cassettes/Bootstrap_Requests_Submissions/submit_package/when_under_the_beta_program/a_request_that_has_a_broken_comment/displays_the_comment_in_the_timeline.yml
+++ b/src/api/spec/cassettes/Bootstrap_Requests_Submissions/submit_package/when_under_the_beta_program/a_request_that_has_a_broken_comment/displays_the_comment_in_the_timeline.yml
@@ -1,0 +1,171 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/source/home:madam_submitter/Quebec
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 6b7c085d-64dc-47fc-93b8-5b6407499516
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '293'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="Quebec" rev="28" vrev="28" srcmd5="d76a6fd277e6ebf6bb8cbda14afa6d78">
+          <entry name="_config" md5="682cf9003bf24f28c5c19c95208d7a8b" size="54" mtime="1677245940"/>
+          <entry name="somefile.txt" md5="67bd297eb27e7505ea64aee12da615c0" size="65" mtime="1677245940"/>
+        </directory>
+  recorded_at: Tue, 04 Apr 2023 10:33:37 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/home:madam_submitter/Quebec?cacheonly=1&cmd=diff&expand=1&filelimit=10000&opackage=Quebec&oproject=home:mr_receiver&tarlimit=10000&view=xml&withissues=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      X-Request-Id:
+      - 6b7c085d-64dc-47fc-93b8-5b6407499516
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '1181'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="ade1b7c366b44f95397d2f8e1b705e88">
+          <old project="home:mr_receiver" package="Quebec" rev="18" srcmd5="569b45f589ff92f838a032f7d1d958bd"/>
+          <new project="home:madam_submitter" package="Quebec" rev="28" srcmd5="d76a6fd277e6ebf6bb8cbda14afa6d78"/>
+          <files>
+            <file state="changed">
+              <old name="_config" md5="113b773589d8fd6068f58e75638c656b" size="66"/>
+              <new name="_config" md5="682cf9003bf24f28c5c19c95208d7a8b" size="54"/>
+              <diff lines="5">@@ -1,1 +1,1 @@
+        -Explicabo fugiat ipsum. Aut in et. Laboriosam voluptas doloremque.
+        \ No newline at end of file
+        +Minus ut minima. Voluptates quas illum. Et vel fugiat.
+        \ No newline at end of file
+        </diff>
+            </file>
+            <file state="changed">
+              <old name="somefile.txt" md5="dfcc14a9d4b3d4a8ea7866a439633db6" size="66"/>
+              <new name="somefile.txt" md5="67bd297eb27e7505ea64aee12da615c0" size="65"/>
+              <diff lines="5">@@ -1,1 +1,1 @@
+        -Excepturi quisquam et. Praesentium porro vel. Magni quibusdam eos.
+        \ No newline at end of file
+        +Ut voluptatum provident. Quia placeat veniam. Modi recusandae et.
+        \ No newline at end of file
+        </diff>
+            </file>
+          </files>
+          <issues>
+          </issues>
+        </sourcediff>
+  recorded_at: Tue, 04 Apr 2023 10:33:37 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:mr_receiver/Quebec
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 6b7c085d-64dc-47fc-93b8-5b6407499516
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '293'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="Quebec" rev="18" vrev="18" srcmd5="569b45f589ff92f838a032f7d1d958bd">
+          <entry name="_config" md5="113b773589d8fd6068f58e75638c656b" size="66" mtime="1677245935"/>
+          <entry name="somefile.txt" md5="dfcc14a9d4b3d4a8ea7866a439633db6" size="66" mtime="1677245935"/>
+        </directory>
+  recorded_at: Tue, 04 Apr 2023 10:33:37 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:madam_submitter/_result?package=Quebec&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 5a0e02a2-c40a-426e-8b1f-d1d7f9a634dd
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Tue, 04 Apr 2023 10:33:37 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/features/webui/requests/submissions_spec.rb
+++ b/src/api/spec/features/webui/requests/submissions_spec.rb
@@ -164,6 +164,24 @@ RSpec.describe 'Bootstrap_Requests_Submissions', js: true, vcr: true do
           expect(page).to have_text(comment.body)
         end
       end
+
+      describe 'a request that has a broken comment' do
+        let(:bs_request) do
+          create(:bs_request_with_submit_action,
+                 creator: receiver,
+                 target_project: target_project,
+                 target_package: target_package,
+                 source_project: source_project,
+                 source_package: source_package)
+        end
+        let!(:comment) { create(:comment, commentable: bs_request, diff_ref: '') }
+
+        it 'displays the comment in the timeline' do
+          login submitter
+          visit request_show_path(bs_request)
+          expect(page).to have_text(comment.body)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Before if the diff_ref didn't match the regex, the page would not render, now the regex is tried first so we know if the string we get in diff_ref matches.

https://errbit.opensuse.org/apps/5620ca2bdc71fa00b1000000/problems/642bf86284bf4604fe227a8e