### PR TITLE
Improve line parameter route constraint

### DIFF
--- a/src/api/app/lib/routes_helper/routes_constraints.rb
+++ b/src/api/app/lib/routes_helper/routes_constraints.rb
@@ -22,7 +22,7 @@ module RoutesHelper
       staging_project_name: %r{[^/]*},
       staging_project_copy_name: %r{[^/]*},
       request_action_id: /\d*/,
-      line: /diff_\d*_n\d*/
+      line: /diff_\d+_n\d+/
     }.freeze
   end
 end


### PR DESCRIPTION
We can replace the `*` by the `+`. We don't need to take in account the case of not having a digit.

This is a follow-up to 4383013d3e.