### PR TITLE
Make sure TimeComponent receives a Time object

### DIFF
--- a/src/api/app/views/webui/request/_action_text.html.haml
+++ b/src/api/app/views/webui/request/_action_text.html.haml
@@ -45,4 +45,4 @@
       %p.mb-0.mt-0.small
         by
         = details['user']
-        = render TimeComponent.new(time: details['time'].to_i)
+        = render TimeComponent.new(time: Time.zone.at(details['time'].to_i))


### PR DESCRIPTION
Fixes #14109.

We checked all the TimeComponent calls to make sure they always receive a Time object. We only found this ocurrence to be modified.