### PR TITLE
Disable swagger.io's online validator link

### DIFF
--- a/src/api/public/apidocs-new/swagger-initializer.js
+++ b/src/api/public/apidocs-new/swagger-initializer.js
@@ -4,6 +4,7 @@ window.onload = function() {
   // the following lines will be replaced by docker/configurator, when it runs in a docker-container
   window.ui = SwaggerUIBundle({
     url: "OBS-v2.10.50.yaml",
+    validatorUrl: "none",
     dom_id: '#swagger-ui',
     deepLinking: true,
     presets: [


### PR DESCRIPTION
We don't potentially need it, and it performs a requests outside the domain where the documentation is installed.

Before:

![Screenshot from 2023-04-05 11-59-34](https://user-images.githubusercontent.com/24919/230048513-21eba7d0-3768-4203-bc7c-cb940e785333.png)

After:

![Screenshot from 2023-04-05 11-59-43](https://user-images.githubusercontent.com/24919/230048554-8427d615-7af6-4f3c-9544-9e17dc45f20b.png)

## For reviewers

The build-test.o.o instance was monkey patched. Access the new API documentation there to see it working.

This cannot be checked in the development enviroment.