### PR TITLE
Correct popover offset values

### DIFF
--- a/src/api/app/components/build_result_for_architecture_component.html.haml
+++ b/src/api/app/components/build_result_for_architecture_component.html.haml
@@ -3,7 +3,7 @@
                                                     'bs-toggle': 'popover',
                                                     'bs-html': 'true',
                                                     'bs-content': help,
-                                                    'bs-offset': 50 } }
+                                                    'bs-offset': '50,0' } }
   .d-flex.align-items-baseline.mb-sm-2
     %span.fw-bold
       = result.architecture


### PR DESCRIPTION
[Bootstrap 4.6](https://getbootstrap.com/docs/4.6/components/popovers/#options) accepted one number for the popover's offset.
[Bootstrap 5+](https://getbootstrap.com/docs/5.2/components/popovers/#options) requires two values in string or array format.

**Reviewing Tips**

- Add at least one repository to the project involved in a request.
- Enable beta.
- Go to the request tab in the beta request show page.
- See the popover when you hover one of the results.

You should see something like this:
![popover](https://user-images.githubusercontent.com/2581944/230064493-6c29efdf-0a72-4df4-9662-c0c4cc5ec0cc.png)
