### PR TITLE
Replace Expectations with Assertions in spider tests

### DIFF
--- a/src/api/test/functional/webui/spider_test.rb
+++ b/src/api/test/functional/webui/spider_test.rb
@@ -164,7 +164,7 @@ class Webui::SpiderTest < Webui::IntegrationTest
     crawl
     ActiveRecord::Base.clear_active_connections!
 
-    @pages_visited.keys.length.must_be :>, 800
+    assert_operator(@pages_visited.keys.length, :>, 800)
   end
 
   def test_spider_as_admin
@@ -175,6 +175,6 @@ class Webui::SpiderTest < Webui::IntegrationTest
     crawl
     ActiveRecord::Base.clear_active_connections!
 
-    @pages_visited.keys.length.must_be :>, 1200
+    assert_operator(@pages_visited.keys.length, :>, 1200)
   end
 end


### PR DESCRIPTION
Prevent from throwing this warning in spider tests:
```
DEPRECATED: global use of must_be from test/functional/webui/spider_test.rb:167. Use _(obj).must_be instead. This will fail in Minitest 6.
```

## For reviewers

Take a look at the spider tests log of this pull request. The string with the deprecation warning does not appear.