### PR TITLE
BsRequest state as a hint in the watchlist

### DIFF
--- a/src/api/app/components/bs_request_state_badge_component.rb
+++ b/src/api/app/components/bs_request_state_badge_component.rb
@@ -7,7 +7,10 @@ class BsRequestStateBadgeComponent < ApplicationComponent
   end
 
   def call
-    tag.span(@bs_request.state,
-             class: ['badge', "bg-#{helpers.request_badge_color(@bs_request.state)}", @css_class])
+    content_tag(
+      :span,
+      tag.i(class: 'fas fa-code-pull-request me-1').concat(@bs_request.state),
+      class: ['badge', "bg-#{helpers.request_badge_color(@bs_request.state)}", @css_class]
+    )
   end
 end

--- a/src/api/app/components/watched_items_list_component.html.haml
+++ b/src/api/app/components/watched_items_list_component.html.haml
@@ -38,7 +38,7 @@
         - name = "##{item.number} #{helpers.request_type_of_action(item)}"
         .d-flex.flex-row.flex-wrap.align-items-baseline.collapsible-tooltip-parent
           = link_to(request_show_path(item.number), class: 'text-word-break-all') do
-            %i.fas.fa-code-pull-request.me-1
+            = render BsRequestStateBadgeComponent.new(bs_request: item)
             = name
           %i.fa.fa-question-circle.text-light.px-2.collapsible-tooltip{ title: 'Click to keep it open' }
           = link_to('#', class: 'text-light ms-auto',
@@ -51,7 +51,6 @@
         .extended-info.mt-2.mb-3.collapsed
           .triangle.left
           .extended-info-content
-            = render BsRequestStateBadgeComponent.new(bs_request: item, css_class: 'mt-2 ms-2')
             %p.px-2.pt-2= render(BsRequestActionSourceAndTargetComponent.new(item))
 - else
   %p.text-muted= empty_list_text


### PR DESCRIPTION
Feature to address https://github.com/openSUSE/open-build-service/issues/13187

This PR helps to find out what is the current state of a request in the watchlist without going into details of each, and take decisions afterwards (like deleting or keeping in the watchlist, going to the request page details, etc).

## Test & Review
- Go to this [request](https://obs-reviewlab.opensuse.org/ncounter-request-status-watch-list/request/show/4) in the `review-app`
- Add it to the watchlist by hitting the top-right button [Watch]
- Open the watchlist from the top-right navigation bar
- Check out the request in the watchlist with the badge color and text

## Before
![Screenshot from 2023-04-06 16-03-07](https://user-images.githubusercontent.com/7080830/230401553-19b0ae25-2e44-42f9-b703-25066f3715ab.png)

## After

![Screenshot from 2023-04-06 16-02-36](https://user-images.githubusercontent.com/7080830/230401570-85ced4c5-18f4-4516-b0f8-294ff17ae12d.png)
