### PR TITLE
Improve request state badge component

### DIFF
--- a/src/api/app/assets/stylesheets/webui/colors.scss
+++ b/src/api/app/assets/stylesheets/webui/colors.scss
@@ -1,3 +1,7 @@
 .bg-gray-800 {
   background-color: $gray-800;
 }
+
+.bg-dismissed {
+  background-color: $gray-500;
+}

--- a/src/api/app/assets/stylesheets/webui/requests.scss
+++ b/src/api/app/assets/stylesheets/webui/requests.scss
@@ -44,6 +44,10 @@
   height: 400px;
 }
 
+.fa-stack-slash {
+  left: -2px;
+}
+
 @include media-breakpoint-up(sm) {
   .order-sm-1 {
     order: 1;

--- a/src/api/app/components/bs_request_state_badge_component.rb
+++ b/src/api/app/components/bs_request_state_badge_component.rb
@@ -9,7 +9,7 @@ class BsRequestStateBadgeComponent < ApplicationComponent
   def call
     content_tag(
       :span,
-      tag.i(class: 'fas fa-code-pull-request me-1').concat(@bs_request.state),
+      icon_state_tag.concat(@bs_request.state),
       class: ['badge', "bg-#{decode_state_color(@bs_request.state)}", @css_class]
     )
   end
@@ -18,14 +18,45 @@ class BsRequestStateBadgeComponent < ApplicationComponent
     case state
     when :review, :new
       'secondary'
-    when :declined, :revoke
+    when :declined
       'danger'
     when :superseded
       'warning'
     when :accepted
       'success'
+    when :revoked
+      'dismissed'
     else
       'dark'
+    end
+  end
+
+  def decode_state_icon(state)
+    case state
+    when :new
+      'code-branch'
+    when :review, :declined, :revoked
+      'code-pull-request'
+    when :superseded
+      'code-compare'
+    when :accepted
+      'code-merge'
+    else
+      'code-fork'
+    end
+  end
+
+  def icon_state_tag
+    if [:declined, :revoked].include?(@bs_request.state)
+      content_tag(
+        :span,
+        tag.i(class: "fas fa-#{decode_state_icon(@bs_request.state)}").concat(
+          tag.i(class: 'fas fa-slash fa-stack-1x fa-stack-slash top-icon')
+        ),
+        class: 'position-relative me-1'
+      )
+    else
+      tag.i(class: "fas fa-#{decode_state_icon(@bs_request.state)} me-1")
     end
   end
 end

--- a/src/api/app/components/bs_request_state_badge_component.rb
+++ b/src/api/app/components/bs_request_state_badge_component.rb
@@ -10,7 +10,22 @@ class BsRequestStateBadgeComponent < ApplicationComponent
     content_tag(
       :span,
       tag.i(class: 'fas fa-code-pull-request me-1').concat(@bs_request.state),
-      class: ['badge', "bg-#{helpers.request_badge_color(@bs_request.state)}", @css_class]
+      class: ['badge', "bg-#{decode_state_color(@bs_request.state)}", @css_class]
     )
+  end
+
+  def decode_state_color(state)
+    case state
+    when :review, :new
+      'secondary'
+    when :declined, :revoke
+      'danger'
+    when :superseded
+      'warning'
+    when :accepted
+      'success'
+    else
+      'dark'
+    end
   end
 end

--- a/src/api/app/helpers/webui/notification_helper.rb
+++ b/src/api/app/helpers/webui/notification_helper.rb
@@ -6,21 +6,6 @@ module Webui::NotificationHelper
     link_to("Show #{less_or_more}", my_notifications_path(parameters))
   end
 
-  def request_badge_color(state)
-    case state
-    when :review, :new
-      'secondary'
-    when :declined, :revoke
-      'danger'
-    when :superseded
-      'warning'
-    when :accepted
-      'success'
-    else
-      'dark'
-    end
-  end
-
   private
 
   def mark_as_read_or_unread_button(notification)

--- a/src/api/app/views/webui/request/_show_overview.html.haml
+++ b/src/api/app/views/webui/request/_show_overview.html.haml
@@ -1,7 +1,7 @@
 %h3
   Request #{bs_request.number}
-  %span.badge.ms-1{ class: "bg-#{request_badge_color(bs_request.state)}" }
-    = bs_request.state
+  %small
+    = render BsRequestStateBadgeComponent.new(bs_request: bs_request, css_class: 'ms-1')
   - if User.session
     .d-inline.ms-2#watchlist-icon-wrapper
       = render WatchlistIconComponent.new(user: User.session!, bs_request: bs_request, current_object: bs_request)

--- a/src/api/app/views/webui/request/beta_show.html.haml
+++ b/src/api/app/views/webui/request/beta_show.html.haml
@@ -30,8 +30,7 @@
         Request #{@bs_request.number}
         -# state badge
         %small
-          .badge.ms-2{ class: "bg-#{request_badge_color(@bs_request.state)}" }
-            = @bs_request.state
+          = render BsRequestStateBadgeComponent.new(bs_request: @bs_request, css_class: 'ms-2')
       -# watch button
       - if User.session
         .d-inline.align-bottom.ms-1#watchlist-icon-wrapper

--- a/src/api/app/views/webui/request/beta_show.html.haml
+++ b/src/api/app/views/webui/request/beta_show.html.haml
@@ -47,7 +47,7 @@
         -# superseded
         - if @bs_request.superseded_by.present?
           %li
-            %mark.text-nowrap.text-light{ class: "bg-#{request_badge_color(@bs_request.state)}" } Superseded
+            %mark.text-nowrap.text-light{ class: "bg-#{BsRequestStateBadgeComponent.decode_state_color(@bs_request.state)}" } Superseded
             by
             = link_to "##{@bs_request.superseded_by}", number: @bs_request.superseded_by
         -# superseding statement


### PR DESCRIPTION
Follow-up of https://github.com/openSUSE/open-build-service/pull/14118 

Make use of the badge component everywhere is possible
Add a different `code-pull-request` icon next to the `bs_request` status text in the badge

## After
### Review
![after-component-beta](https://user-images.githubusercontent.com/7080830/230411999-9a5b600b-d77c-499f-b871-ae150ca22487.png)

### Accepted
![merge-icon](https://user-images.githubusercontent.com/7080830/230418805-ba0fbe28-176a-458a-84a8-a7f881bbe370.png)

### Superseded
![superseded-badge](https://user-images.githubusercontent.com/7080830/230421321-2494210d-391f-42ab-aafc-ab11eefddf68.png)

### Watchlist

![full-set](https://user-images.githubusercontent.com/7080830/231394180-cd0a0024-3897-4d3d-8f76-878c56c7d3ec.png)
