### PR TITLE
Adjust NotifiedProjects for BsRequestAction comments

### DIFF
--- a/src/api/app/services/notified_projects.rb
+++ b/src/api/app/services/notified_projects.rb
@@ -19,6 +19,8 @@ class NotifiedProjects
         @notifiable.commentable.project
       when 'BsRequest'
         @notifiable.commentable.target_project_objects.distinct
+      when 'BsRequestAction'
+        @notifiable.commentable.bs_request.target_project_objects.distinct
       end
     when 'Package'
       @notifiable.project


### PR DESCRIPTION
We need to retrieve the projects differenly if the commentable is a BsRequestAction object.