### PR TITLE
Add github action to add comments to binary diff for gem file changes

### DIFF
--- a/.github/workflows/diffend_gem_binary_diff.yml
+++ b/.github/workflows/diffend_gem_binary_diff.yml
@@ -1,0 +1,44 @@
+name: Diffend.io gem binary diff links
+on:
+  pull_request:
+    paths:
+      - '**.gem'
+jobs:
+  create_comment_with_diffend_io_links:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Create Diffend.io Links and Comment
+        id: create_diffend_io_links_and_comment
+        run: |
+          # Receive added and removed file names from the git diff, filter out everything besides the gem files and receive
+          # the basename without the gem file extension
+          ADDED_GEMS=( $(git diff --name-only --diff-filter=A origin/${GITHUB_BASE_REF} $GITHUB_SHA | grep .gem$ | xargs basename -s .gem) )
+          REMOVED_GEMS=( $(git diff --name-only --diff-filter=D origin/${GITHUB_BASE_REF} $GITHUB_SHA | grep .gem$ | xargs basename -s .gem) )
+
+          COMMENT_TEXT="Please see the links listed bellow to review the changes applied to the gems:"$'\n'
+
+          for i in "${!ADDED_GEMS[@]}"; do
+            # Receive gem name without version number
+            GEM_NAME=$(echo ${ADDED_GEMS[i]} | rev | cut -d "-" -f2- | rev)
+
+            # Receive added and removed gem version numbers
+            ADDED_GEM_VERSION=$(echo ${ADDED_GEMS[i]} | rev | cut -d "-" -f1 | rev)
+            REMOVED_GEM_VERSION=$(echo ${REMOVED_GEMS[i]} | rev | cut -d "-" -f1 | rev)
+
+            # Create the link to diffend.io
+            DIFFEND_LINK=("https://my.diffend.io/gems/${GEM_NAME}/${REMOVED_GEM_VERSION}/${ADDED_GEM_VERSION}")
+            COMMENT_TEXT+="- [${GEM_NAME} ${REMOVED_GEM_VERSION} -> ${ADDED_GEM_VERSION}](${DIFFEND_LINK})"$'\n'
+          done
+
+          echo "comment_text<<EOF" >> $GITHUB_OUTPUT
+          echo "$COMMENT_TEXT" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+      - name: Add Comment to PR
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          message: |
+            ${{steps.create_diffend_io_links_and_comment.outputs.comment_text}}


### PR DESCRIPTION
Github does not show the diff for changes applied to `.gem` files which we receive throug Depfu PR's. To make it easier to review the changes applied to the gems, this Github Action creates links to the tool diffend.io which provides the diff between the two gem versions and creates a comment with those on the corresponding PR.

Current limitations:

 - Diffend.io only provides diffs from older to newer gem versions, so it does not work when we downgrade gems right now.

Example output from the gh action:
![Screenshot 2023-04-11 at 13-57-32 Test action by krauselukas · Pull Request #3 · krauselukas_open-build-service](https://user-images.githubusercontent.com/22001671/231155934-19231904-4a62-4fff-b6eb-110bef60e0f6.png)

Example link to diff:
https://my.diffend.io/gems/loofah/2.19.1/2.20.0
