### PR TITLE
Grant write permission for PR's to gem binary diff link github action

### DIFF
--- a/.github/workflows/diffend_gem_binary_diff.yml
+++ b/.github/workflows/diffend_gem_binary_diff.yml
@@ -6,6 +6,10 @@ on:
 jobs:
   create_comment_with_diffend_io_links:
     runs-on: ubuntu-latest
+    permissions:
+      # In order to allow the creation of the comment on the pull request
+      pull-requests: write
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION
In order to allow the creation of the comment with the links to the binary diffs of the modified ruby gems on a PR, we need to grant the github action write permission on pull requests.