### PR TITLE
Set minimum github token permission for gh action workflow

### DIFF
--- a/.github/workflows/diffend_gem_binary_diff.yml
+++ b/.github/workflows/diffend_gem_binary_diff.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
     paths:
       - '**.gem'
+permissions:
+  contents: read
+
 jobs:
   create_comment_with_diffend_io_links:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Set the toplevel permission of the used github token to a minimum for the github action workflow and only grant necessary permissions on a job level to increase security.

Reported by https://github.com/openSUSE/open-build-service/security/code-scanning/29