### PR TITLE
Default ajax feedback in case of error 

### DIFF
--- a/src/api/app/assets/javascripts/webui/application.js
+++ b/src/api/app/assets/javascripts/webui/application.js
@@ -70,3 +70,4 @@
 //= require Chart.bundle
 //= require webui/report.js
 //= require webui/canned_responses.js
+//= require webui/network.js

--- a/src/api/app/assets/javascripts/webui/flash.js
+++ b/src/api/app/assets/javascripts/webui/flash.js
@@ -6,52 +6,22 @@ $(window).scroll(function() {
   }
 });
 
-// function to toggle visibility to the additional flash message information
-function toggleMoreInfo(element, collapsibleContent) {
-  collapsibleContent.classList.toggle("d-none");
-  element.textContent = collapsibleContent.classList.contains('d-none') ? 'more info' : 'less info';
-}
-
 // Create a flash error message on the fly receiving
 // a generic error message and the detailed response of an ajax call
-function generateFlashError(xhdr, message) {
+function generateFlashError(message) { // jshint ignore:line
   var row = document.createElement("div");
   row.className = "row";
 
-  var col = document.createElement("div");
-  col.className = "col-12";
-  row.appendChild(col);
-
-  var alert = document.createElement("div");
-  alert.className = "alert alert-dismissible fade show alert-error";
-  alert.textContent = message;
-  col.appendChild(alert);
-
-  var icon = document.createElement("i");
-  icon.className = "fas";
-  alert.appendChild(icon);
-
-  var moreInfoLink = document.createElement("button");
-  moreInfoLink.className = "btn btn-link alert-link";
-  moreInfoLink.textContent = "more info";
-  alert.appendChild(moreInfoLink);
-
-  var moreInfo = document.createElement("div");
-  moreInfo.className = "moreInfo d-none";
-  moreInfoLink.onclick = () => toggleMoreInfo(moreInfoLink, moreInfo);
-  alert.appendChild(moreInfo);
-
-  var moreInfoContent = document.createElement("div");
-  moreInfoContent.className = "more-info-content";
-  moreInfoContent.textContent = xhdr.responseText;
-  moreInfo.appendChild(moreInfoContent);
-
-  var closeButton = document.createElement("button");
-  closeButton.className = "btn btn-close float-end";
-  closeButton.setAttribute("type", "button");
-  closeButton.setAttribute("data-bs-dismiss", "alert");
-  closeButton.setAttribute("aria-label", "Close");
-  alert.appendChild(closeButton);
+  row.innerHTML =
+    `
+      <div class='col-12'>
+        <div class='alert alert-dismissible fade show alert-error'>
+          ${message}
+          <i class='fas'></i>
+          <button class='btn btn-close float-end' type='button' data-bs-dismiss='alert' aria-label='Close' />
+        </div>
+      </div>
+    `;
 
   return row;
 }

--- a/src/api/app/assets/javascripts/webui/flash.js
+++ b/src/api/app/assets/javascripts/webui/flash.js
@@ -5,3 +5,53 @@ $(window).scroll(function() {
     $('.flash-and-announcement').removeClass('sticking');
   }
 });
+
+// function to toggle visibility to the additional flash message information
+function toggleMoreInfo(element, collapsibleContent) {
+  collapsibleContent.classList.toggle("d-none");
+  element.textContent = collapsibleContent.classList.contains('d-none') ? 'more info' : 'less info';
+}
+
+// Create a flash error message on the fly receiving
+// a generic error message and the detailed response of an ajax call
+function generateFlashError(xhdr, message) {
+  var row = document.createElement("div");
+  row.className = "row";
+
+  var col = document.createElement("div");
+  col.className = "col-12";
+  row.appendChild(col);
+
+  var alert = document.createElement("div");
+  alert.className = "alert alert-dismissible fade show alert-error";
+  alert.textContent = message;
+  col.appendChild(alert);
+
+  var icon = document.createElement("i");
+  icon.className = "fas";
+  alert.appendChild(icon);
+
+  var moreInfoLink = document.createElement("button");
+  moreInfoLink.className = "btn btn-link alert-link";
+  moreInfoLink.textContent = "more info";
+  alert.appendChild(moreInfoLink);
+
+  var moreInfo = document.createElement("div");
+  moreInfo.className = "moreInfo d-none";
+  moreInfoLink.onclick = () => toggleMoreInfo(moreInfoLink, moreInfo);
+  alert.appendChild(moreInfo);
+
+  var moreInfoContent = document.createElement("div");
+  moreInfoContent.className = "more-info-content";
+  moreInfoContent.textContent = xhdr.responseText;
+  moreInfo.appendChild(moreInfoContent);
+
+  var closeButton = document.createElement("button");
+  closeButton.className = "btn btn-close float-end";
+  closeButton.setAttribute("type", "button");
+  closeButton.setAttribute("data-bs-dismiss", "alert");
+  closeButton.setAttribute("aria-label", "Close");
+  alert.appendChild(closeButton);
+
+  return row;
+}

--- a/src/api/app/assets/javascripts/webui/network.js
+++ b/src/api/app/assets/javascripts/webui/network.js
@@ -1,3 +1,3 @@
 $(document).on( "ajaxError", function(event, xhdr, settings, thrownError) {
-  $('#flash').show().append(generateFlashError(xhdr, `An issue occurred while loading '${settings.url}': '${thrownError}'. Please try again or reload the page.`));
+  $('#flash').show().append(generateFlashError(`An issue occurred while loading '${settings.url}': '${thrownError}'. Please try again or reload the page.`)); // jshint ignore:line
 });

--- a/src/api/app/assets/javascripts/webui/network.js
+++ b/src/api/app/assets/javascripts/webui/network.js
@@ -1,0 +1,3 @@
+$(document).on( "ajaxError", function(event, xhdr, settings, thrownError) {
+  $('#flash').show().append(generateFlashError(xhdr, `An issue occurred while loading '${settings.url}': '${thrownError}'. Please try again or reload the page.`));
+});


### PR DESCRIPTION
`AJAX` calls handle the `success` case of the request lifecycle, but they don't handle the `error` scenario often (the case when something goes wrong during the request). By design `AJAX` calls are async and silent, thus there is a chance the user cannot see if the call completed or failed eventually.

This PR introduces a global `AJAX` setting to set a default fallback in case the async request returns an error, and this is to present a message to the user about what happened.

![image](https://github.com/openSUSE/open-build-service/assets/7080830/d90b8a5f-24a1-46af-a227-180e8ec93ada)

