### PR TITLE
Authenticate bugzilla with api_key

### DIFF
--- a/src/api/app/models/issue_tracker.rb
+++ b/src/api/app/models/issue_tracker.rb
@@ -17,7 +17,7 @@ class IssueTracker < ApplicationRecord
   after_save :update_package_meta
 
   # FIXME: issues_updated should not be hidden, but it should also not break our api
-  DEFAULT_RENDER_PARAMS = { except: [:id, :password, :user, :issues_updated], dasherize: true, skip_types: true, skip_instruct: true }.freeze
+  DEFAULT_RENDER_PARAMS = { except: [:id, :password, :user, :issues_updated, :api_key], dasherize: true, skip_types: true, skip_instruct: true }.freeze
 
   before_validation(on: :create) do
     self.issues_updated ||= Time.now

--- a/src/api/app/models/issue_tracker.rb
+++ b/src/api/app/models/issue_tracker.rb
@@ -258,7 +258,8 @@ class IssueTracker < ApplicationRecord
     server.timeout = 300 # 5 minutes timeout
     server.user = user if user
     server.password = password if password
-    server.proxy('Bug')
+    args = api_key ? { 'Bugzilla_login' => user, 'Bugzilla_api_key' => api_key } : {}
+    server.proxy('Bug', args)
   end
 
   # helper method that does a GET request to given <url> and follows

--- a/src/api/config/initializers/filter_parameter_logging.rb
+++ b/src/api/config/initializers/filter_parameter_logging.rb
@@ -4,4 +4,4 @@
 # sensitive information. See the ActiveSupport::ParameterFilter documentation for supported
 # notations and behaviors.
 # FIXME: `string` is a column from the Tokens table, this column should be renamed.
-Rails.application.config.filter_parameters += [:password, :passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn, :scm_token, :string]
+Rails.application.config.filter_parameters += [:password, :passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn, :scm_token, :string, :api_key]

--- a/src/api/db/migrate/20230413080503_add_api_key_to_issue_tracker.rb
+++ b/src/api/db/migrate/20230413080503_add_api_key_to_issue_tracker.rb
@@ -1,0 +1,5 @@
+class AddApiKeyToIssueTracker < ActiveRecord::Migration[7.0]
+  def change
+    add_column :issue_trackers, :api_key, :string
+  end
+end


### PR DESCRIPTION
This is needed because SUSE Bugzilla updated to version 5 without HTTP Basic Authentication. We make sure to authenticate with an api key in addition to the password whenever it's available.