### PR TITLE
[backend] set repo to broken if there is an error in the project config

### DIFF
--- a/src/backend/BSRepServer/Checker.pm
+++ b/src/backend/BSRepServer/Checker.pm
@@ -108,6 +108,7 @@ sub setup {
   die("no repo $repoid in project $projid?\n") unless $repo;
   $ctx->{'repo'} = $repo;
   my $bconf = $ctx->getconfig($projid, $repoid, $myarch, $ctx->{'prpsearchpath'});
+  die("project config: $bconf->{'parse_error'}\n") if $bconf->{'parse_error'} && !$BSConfig::ignore_project_config_errors;
   $ctx->{'conf'} = $bconf;
   my $crosshostarch;
   if ($repo->{'hostsystem'}) {
@@ -116,6 +117,7 @@ sub setup {
   die("crosshostarch mismatch\n") if ($repo->{'crosshostarch'} || '') ne ($crosshostarch || '');
   if ($crosshostarch && $crosshostarch ne $myarch) {
     my $bconf_host = $ctx->getconfig($projid, $repoid, $crosshostarch, $ctx->{'prpsearchpath_host'});
+    die("cross project config: $bconf_host->{'parse_error'}\n") if $bconf_host->{'parse_error'} && !$BSConfig::ignore_project_config_errors;
     $ctx->{'conf_host'} = $bconf_host;
   }
   my $pdatas = $projpacks->{$projid}->{'package'};

--- a/src/backend/BSSched/Checker.pm
+++ b/src/backend/BSSched/Checker.pm
@@ -304,6 +304,7 @@ sub setup {
     return ('broken', "no config ($lastprojid)");
   }
   $ctx->{'conf'} = $bconf;
+  return ('broken', "project config: $bconf->{'parse_error'}") if $bconf->{'parse_error'} && !$BSConfig::ignore_project_config_errors;
   if ($bconf->{'hostarch'} && !$BSCando::knownarch{$bconf->{'hostarch'}}) {
     return ('broken', "bad hostarch ($bconf->{'hostarch'})");
   }
@@ -400,6 +401,7 @@ sub setup {
       my $lastprojid = (split('/', $prpsearchpath_host->[-1]))[0];
       return ('broken', "no config ($lastprojid)");
     }
+    return ('broken', "cross project config: $bconf_host->{'parse_error'}") if $bconf_host->{'parse_error'} && !$BSConfig::ignore_project_config_errors;
     if ($bconf_host->{'hostarch'} && $bconf_host->{'hostarch'} ne $bconf->{'hostarch'}) {
       return ('broken', "$bconf->{'hostarch'} is not native");
     }

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -1746,6 +1746,10 @@ sub getprojpack {
 	      $rinfo->{'error'} = $conf->{'error'};
 	      next;
 	    }
+	    if ($conf->{'parse_error'} && !$BSConfig::ignore_project_config_errors && $cgi->{'buildinfo'}) {
+	      $rinfo->{'error'} = $conf->{'parse_error'};
+	      next;
+	    }
 	    if ($repo->{'hostsystem'}) {
 	      $repo->{'crosshostarch'} = $conf->{'hostarch'} || $arch;
 	      my $path = $expandedrepos{"$projid/$repoid/hostsystem"};
@@ -1780,6 +1784,10 @@ sub getprojpack {
 		$conf = $bconfs{"$repoid/$arch"};
 		if ($conf->{'error'}) {
 		  $rinfo->{'error'} = $conf->{'error'};
+		  next;
+		}
+		if ($conf->{'parse_error'} && !$BSConfig::ignore_project_config_errors && $cgi->{'buildinfo'}) {
+		  $rinfo->{'error'} = $conf->{'parse_error'};
 		  next;
 		}
 		if ($conf->{'hostarch'} && $conf->{'hostarch'} ne $arch) {


### PR DESCRIPTION
This can be disabled by setting $BSConfig::ignore_project_config_errors