### PR TITLE
Rearrange CircleCI linters steps

### DIFF
--- a/.circleci/conditional_config.yml
+++ b/.circleci/conditional_config.yml
@@ -167,11 +167,6 @@ jobs:
     steps:
       - attach_workspace:
          at: .
-      - run:
-          name: Run rubocop
-          working_directory: src/api
-          command: bundle exec rake dev:lint:rubocop:all
-      - *save_rubocop_cache
       - when:
           condition: << pipeline.parameters.run-javascripts-linter >>
           steps:
@@ -208,6 +203,11 @@ jobs:
           command: |
             bundle exec rake db:setup
             bundle exec database_consistency -c .database_consistency.todo.yml
+      - run:
+          name: Run rubocop
+          working_directory: src/api
+          command: bundle exec rake dev:lint:rubocop:all
+      - *save_rubocop_cache
 
   rspec:
     parallelism: 3


### PR DESCRIPTION
RuboCop linter tests take longer than other linters.

Move them to the last position of the sequence of linters. This way, linters fail sooner because the linters that take less time are run first, and therefore, CI steps fail sooner on average when we encounter a linter offense and we use less test cycles.