### PR TITLE
Split github action workflows into two separate workflows

### DIFF
--- a/.github/workflows/comment_diffend_io_links_to_pr.yml
+++ b/.github/workflows/comment_diffend_io_links_to_pr.yml
@@ -1,0 +1,24 @@
+name: Add Comment with Diffend.io Links to PR
+on:
+  workflow_run:
+    workflows: ['Create Diffend.io Links and Comment Text']
+    types:
+      - completed
+permissions:
+  contents: read
+jobs:
+  comment_diffend_io_links_to_pr:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Download artifacts
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: ${{ github.event.workflow_run.workflow_id }}
+          workflow_conclusion: success
+      - name: Add Comment to PR
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          filePath: comment_text/comment_text.txt
+          pr_number: ${{ github.event.workflow_run.pull_requests[0].number }}

--- a/.github/workflows/create_diffend_io_links.yml
+++ b/.github/workflows/create_diffend_io_links.yml
@@ -1,4 +1,4 @@
-name: Diffend.io gem binary diff links
+name: Create Diffend.io Links and Comment Text
 on:
   pull_request:
     paths:
@@ -7,19 +7,14 @@ permissions:
   contents: read
 
 jobs:
-  create_comment_with_diffend_io_links:
+  create_diffend_io_links_and_comment_text:
     runs-on: ubuntu-latest
-    permissions:
-      # In order to allow the creation of the comment on the pull request
-      pull-requests: write
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Create Diffend.io Links and Comment
-        id: create_diffend_io_links_and_comment
+      - name: Create Diffend.io Links and Comment Text
         run: |
           # Receive added and removed file names from the git diff, filter out everything besides the gem files and receive
           # the basename without the gem file extension
@@ -41,11 +36,10 @@ jobs:
             COMMENT_TEXT+="- [${GEM_NAME} ${REMOVED_GEM_VERSION} -> ${ADDED_GEM_VERSION}](${DIFFEND_LINK})"$'\n'
           done
 
-          echo "comment_text<<EOF" >> $GITHUB_OUTPUT
-          echo "$COMMENT_TEXT" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-      - name: Add Comment to PR
-        uses: thollander/actions-comment-pull-request@v2
+          mkdir ./artifacts
+          echo "$COMMENT_TEXT" > ./artifacts/comment_text.txt
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
         with:
-          message: |
-            ${{steps.create_diffend_io_links_and_comment.outputs.comment_text}}
+          name: comment_text
+          path: artifacts/comment_text.txt


### PR DESCRIPTION
In order to allow the creation of comments on PR's that are
coming from forks, we would need to use the `:pull_request_target`
event over the `:pull_request` event. Since the `:pull_request_target`
event comes with more permissions on the target repo, its not recommended to
checkout the code coming from an untrusted fork.
Therefore the gh action workflow is now split into two separate
workflows.
One workflow keeps working on the `:pull_request` event and checksout
the code to perform the diff operation in order to receive gem
name, version etc. Afterwards the informations are saved as artifacts.
The second workflow listens for the `workflow_run` event and gets
triggered after the first one finished successfully, then downloads
the artifacts and finally creates the comment (the `:workflow_run`
event has permission to comment on the PR).

For reference https://securitylab.github.com/research/github-actions-preventing-pwn-requests/