### PR TITLE
Add missing index on notified_project's project_id

### DIFF
--- a/src/api/.database_consistency.todo.yml
+++ b/src/api/.database_consistency.todo.yml
@@ -2090,9 +2090,6 @@ NotifiedProject:
   notification:
     ForeignKeyChecker:
       enabled: false
-  project:
-    ForeignKeyChecker:
-      enabled: false
   index_notified_projects_on_notification_id:
     RedundantIndexChecker:
       enabled: false

--- a/src/api/app/models/notified_project.rb
+++ b/src/api/app/models/notified_project.rb
@@ -12,10 +12,15 @@ end
 #  id              :bigint           not null, primary key
 #  created_at      :datetime         not null
 #  notification_id :bigint           not null, indexed, indexed => [project_id]
-#  project_id      :integer          not null, indexed => [notification_id]
+#  project_id      :integer          not null, indexed => [notification_id], indexed
 #
 # Indexes
 #
 #  index_notified_projects_on_notification_id                 (notification_id)
 #  index_notified_projects_on_notification_id_and_project_id  (notification_id,project_id) UNIQUE
+#  index_notified_projects_on_project_id                      (project_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (project_id => projects.id)
 #

--- a/src/api/db/migrate/20230414085150_add_notified_projects_project_id_index.rb
+++ b/src/api/db/migrate/20230414085150_add_notified_projects_project_id_index.rb
@@ -1,0 +1,5 @@
+class AddNotifiedProjectsProjectIdIndex < ActiveRecord::Migration[7.0]
+  def change
+    add_index :notified_projects, :project_id
+  end
+end

--- a/src/api/db/migrate/20230414151119_add_projects_id_notified_projects_project_id_fk.rb
+++ b/src/api/db/migrate/20230414151119_add_projects_id_notified_projects_project_id_fk.rb
@@ -1,0 +1,5 @@
+class AddProjectsIdNotifiedProjectsProjectIdFk < ActiveRecord::Migration[7.0]
+  def change
+    add_foreign_key :notified_projects, :projects, column: :project_id, primary_key: :id
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_13_080503) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_14_151119) do
   create_table "architectures", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "name", null: false, collation: "utf8mb3_general_ci"
     t.boolean "available", default: false
@@ -703,6 +703,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_13_080503) do
     t.datetime "created_at", null: false
     t.index ["notification_id", "project_id"], name: "index_notified_projects_on_notification_id_and_project_id", unique: true
     t.index ["notification_id"], name: "index_notified_projects_on_notification_id"
+    t.index ["project_id"], name: "index_notified_projects_on_project_id"
   end
 
   create_table "package_issues", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
@@ -1182,6 +1183,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_13_080503) do
   add_foreign_key "kiwi_packages", "kiwi_package_groups", column: "package_group_id"
   add_foreign_key "maintained_projects", "projects", column: "maintenance_project_id", name: "maintained_projects_ibfk_2"
   add_foreign_key "maintained_projects", "projects", name: "maintained_projects_ibfk_1"
+  add_foreign_key "notified_projects", "projects"
   add_foreign_key "package_issues", "issues", name: "package_issues_ibfk_2"
   add_foreign_key "package_issues", "packages", name: "package_issues_ibfk_1"
   add_foreign_key "package_kinds", "packages", name: "package_kinds_ibfk_1"

--- a/src/api/spec/db/data/backfill_notified_projects_spec.rb
+++ b/src/api/spec/db/data/backfill_notified_projects_spec.rb
@@ -39,13 +39,16 @@ RSpec.describe BackfillNotifiedProjects, type: :migration, vcr: true do
     end
 
     it 'backfills the notifications_projects table with all projects from existing notifications' do
-      expect(NotifiedProject.pluck(:project_id)).to eq([
+      expected = NotifiedProject.pluck(:project_id)
+      actual = [
         bs_request_with_submit_action.target_project_objects.distinct.map(&:id),
         user_review.bs_request.target_project_objects.distinct.map(&:id),
         comment_project.commentable.id,
         comment_package.commentable.project_id,
         comment_request.commentable.target_project_objects.distinct.map(&:id)
-      ].flatten!)
+      ].flatten!
+
+      expect(expected).to match_array(actual)
     end
   end
 end


### PR DESCRIPTION
The second slowest query in the slow log report that you can find in the attached [Trello card](https://trello.com/c/94X2HYZT/2215-not-indexed-queries) examines a lot of rows.

```
# Query 2: 0 QPS, 0x concurrency, ID 0x62E363BA6ED76266A41605B6B8D6CAC0 at byte 161791658
# This item is included in the report because it matches --limit.
# Scores: V/M = 0.00
# Time range: all events occurred at 2021-12-06 13:42:58
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          0       1
# Exec time     20     16s     16s     16s     16s     16s       0     16s
# Lock time      0    97us    97us    97us    97us    97us       0    97us
# Rows sent      0       0       0       0       0       0       0       0
# Rows examine  49  54.15M  54.15M  54.15M  54.15M  54.15M       0  54.15M
# Rows affecte   0       0       0       0       0       0       0       0
# Bytes sent     0     373     373     373     373     373       0     373
# Query size     0     101     101     101     101     101       0     101
# String:
# Databases    frontend
# Hosts        ibs-proxy-1.ibsmgmt.suse.de
# Users        obs
# Query_time distribution
#   1us
#  10us
# 100us
#   1ms
#  10ms
# 100ms
#    1s
#  10s+  ################################################################
# Tables
#    SHOW TABLE STATUS FROM `frontend` LIKE 'notified_projects'\G
#    SHOW CREATE TABLE `frontend`.`notified_projects`\G
# EXPLAIN /*!50100 PARTITIONS*/
SELECT `notified_projects`.* FROM `notified_projects` WHERE `notified_projects`.`project_id` = 474649\G
```

Maybe we are not hitting any index for that query:
```
MariaDB [api_development]> explain SELECT `notified_projects`.* FROM `notified_projects` WHERE `notified_projects`.`project_id` = 24;
+------+-------------+-------------------+------+---------------+------+---------+------+------+-------------+
| id   | select_type | table             | type | possible_keys | key  | key_len | ref  | rows | Extra       |
+------+-------------+-------------------+------+---------------+------+---------+------+------+-------------+
|    1 | SIMPLE      | notified_projects | ALL  | NULL          | NULL | NULL    | NULL | 11   | Using where |
+------+-------------+-------------------+------+---------------+------+---------+------+------+-------------+
```
Great, this query is doing a full table scan (no possible keys listed and no key used after all). After the creation of the index, you can see that it hits the newly created index and the number of rows scanned are lower:
```
MariaDB [api_development]> explain SELECT `notified_projects`.* FROM `notified_projects` WHERE `notified_projects`.`project_id` = 24;
+------+-------------+-------------------+------+---------------------------------------+---------------------------------------+---------+-------+------+-------+
| id   | select_type | table             | type | possible_keys                         | key                                   | key_len | ref   | rows | Extra |
+------+-------------+-------------------+------+---------------------------------------+---------------------------------------+---------+-------+------+-------+
|    1 | SIMPLE      | notified_projects | ref  | index_notified_projects_on_project_id | index_notified_projects_on_project_id | 4       | const | 1    |       |
+------+-------------+-------------------+------+---------------------------------------+---------------------------------------+---------+-------+------+-------+
```