### PR TITLE
Simplify NotificationExcerptComponent

### DIFF
--- a/src/api/app/components/notification_component.html.haml
+++ b/src/api/app/components/notification_component.html.haml
@@ -23,4 +23,4 @@
           = render NotificationActionDescriptionComponent.new(@notification)
       .row.d-none.d-md-block.ps-4
         .col
-          = render NotificationExcerptComponent.new(@notification)
+          = render NotificationExcerptComponent.new(@notification.notifiable)

--- a/src/api/app/components/notification_excerpt_component.rb
+++ b/src/api/app/components/notification_excerpt_component.rb
@@ -2,18 +2,18 @@ class NotificationExcerptComponent < ApplicationComponent
   TRUNCATION_LENGTH = 100
   TRUNCATION_ELLIPSIS_LENGTH = 3 # `...` is the default ellipsis for String#truncate
 
-  def initialize(notification)
+  def initialize(notifiable)
     super
 
-    @notification = notification
+    @notifiable = notifiable
   end
 
   def call
-    text = case @notification.notifiable_type
+    text = case @notifiable.class.name
            when 'BsRequest'
-             @notification.notifiable.description.to_s # description can be nil
+             @notifiable.description.to_s # description can be nil
            when 'Comment'
-             helpers.render_without_markdown(@notification.notifiable.body)
+             helpers.render_without_markdown(@notifiable.body)
            else
              ''
            end

--- a/src/api/spec/components/notification_excerpt_component_spec.rb
+++ b/src/api/spec/components/notification_excerpt_component_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe NotificationExcerptComponent, type: :component do
     let(:notification) { create(:web_notification, :request_created, notifiable: bs_request, subscriber: user) }
 
     it do
-      expect(render_inline(described_class.new(notification))).to have_selector('p', text: '')
+      expect(render_inline(described_class.new(notification.notifiable))).to have_selector('p', text: '')
     end
   end
 
@@ -17,7 +17,7 @@ RSpec.describe NotificationExcerptComponent, type: :component do
     let(:notification) { create(:web_notification, :comment_for_project, notifiable: comment, subscriber: user) }
 
     it do
-      expect(render_inline(described_class.new(notification))).to have_selector('p', text: 'Nice project!')
+      expect(render_inline(described_class.new(notification.notifiable))).to have_selector('p', text: 'Nice project!')
     end
   end
 
@@ -26,7 +26,7 @@ RSpec.describe NotificationExcerptComponent, type: :component do
     let(:notification) { create(:web_notification, :comment_for_project, notifiable: comment, subscriber: user) }
 
     it do
-      expect(render_inline(described_class.new(notification))).to have_text('...')
+      expect(render_inline(described_class.new(notification.notifiable))).to have_text('...')
     end
   end
 end

--- a/src/api/spec/components/previews/notification_excerpt_component_preview.rb
+++ b/src/api/spec/components/previews/notification_excerpt_component_preview.rb
@@ -1,6 +1,19 @@
 class NotificationExcerptComponentPreview < ViewComponent::Preview
-  # Preview at http://HOST:PORT/rails/view_components/notification_excerpt_component/preview
-  def preview
-    render(NotificationExcerptComponent.new(Notification.last))
+  # Preview at http://HOST:PORT/rails/view_components/notification_excerpt_component/with_comment_notifiable
+  def with_comment_notifiable
+    notifiable = Comment.new(body: Faker::Lorem.paragraph_by_chars(number: 200))
+    render(NotificationExcerptComponent.new(notifiable))
+  end
+
+  # Preview at http://HOST:PORT/rails/view_components/notification_excerpt_component/with_request_notifiable
+  def with_request_notifiable
+    notifiable = BsRequest.new(description: Faker::Lorem.paragraph_by_chars(number: 200))
+    render(NotificationExcerptComponent.new(notifiable))
+  end
+
+  # Preview at http://HOST:PORT/rails/view_components/notification_excerpt_component/with_review_notifiable
+  def with_review_notifiable
+    notifiable = Review.new
+    render(NotificationExcerptComponent.new(notifiable))
   end
 end


### PR DESCRIPTION
So the object is passed to the component and not retrieved inside. That makes it possible to not persist any object to use its preview.