### PR TITLE
Fix flickering test in MaintenanceTests minitests

### DIFF
--- a/src/api/test/functional/maintenance_test.rb
+++ b/src/api/test/functional/maintenance_test.rb
@@ -2410,7 +2410,7 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     assert_response :success
     assert_xml_tag tag: 'status', attributes: { package: 'pack2', code: 'succeeded' }
 
-    travel(1.second)
+    sleep(1) # to ensure that the timestamp becomes newer
     post '/source/CopyOfBaseDistro3?cmd=copy&oproject=BaseDistro3&withhistory=1&withbinaries=1&nodelay=1'
     assert_response :success
     get '/source/CopyOfBaseDistro3/_meta'


### PR DESCRIPTION
Our minitest suite errors with this message:
```
MaintenanceTests
  test_OBS_BranchTarget                                           PASS (1.04s)
  test_branch_from_service_pack_WIP                               PASS (2.00s)
  test_branch_package                                             PASS (3.07s)
  test_branch_package_with_local_link                             PASS (2.21s)
  test_copy_from_origin_with_modification_has_write_permission_check PASS (0.17s)
  test_copy_project_for_release                                   PASS (3.63s)
  test_copy_project_for_release_using_makeoriginolder             PASS (1.69s)
  test_copy_project_for_release_with_history                      PASS (1.68s)
  test_copy_project_with_history_and_binaries                     FAIL (1.59s)
        Expected "1681474478" to not be equal to "1681474478".
        test/functional/maintenance_test.rb:2446:in `test_copy_project_with_history_and_binaries'
        test/test_helper.rb:99:in `block in __run'
        test/test_helper.rb:99:in `map'
        test/test_helper.rb:99:in `__run'
```

We want to test that the timestamps don't get copied. We cannot use time helpers - the timestamps to be checked are created in the backend, so they are not affected by the Rails time helpers.

Revert the change introduced in #14053.