### PR TITLE
Hand over PR number between gh action workflows through artifacts

### DIFF
--- a/.github/workflows/comment_diffend_io_links_to_pr.yml
+++ b/.github/workflows/comment_diffend_io_links_to_pr.yml
@@ -17,8 +17,11 @@ jobs:
         with:
           workflow: ${{ github.event.workflow_run.workflow_id }}
           workflow_conclusion: success
+      - name: Fetch PR number from artifacts
+        run: |
+          echo "pr_number=$(cat comment_text_and_pr_number/pr_number.txt)" >> $GITHUB_ENV
       - name: Add Comment to PR
         uses: thollander/actions-comment-pull-request@v2
         with:
-          filePath: comment_text/comment_text.txt
-          pr_number: ${{ github.event.workflow_run.pull_requests[0].number }}
+          filePath: comment_text_and_pr_number/comment_text.txt
+          pr_number: ${{ env.pr_number }}

--- a/.github/workflows/create_diffend_io_links.yml
+++ b/.github/workflows/create_diffend_io_links.yml
@@ -38,8 +38,9 @@ jobs:
 
           mkdir ./artifacts
           echo "$COMMENT_TEXT" > ./artifacts/comment_text.txt
+          echo ${{ github.event.number }} > ./artifacts/pr_number.txt
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: comment_text
-          path: artifacts/comment_text.txt
+          name: comment_text_and_pr_number
+          path: artifacts/


### PR DESCRIPTION
The PR number is not available in the payload of the `workflow_run` event, when the PR is coming from a fork. To workaround that problem I write the PR number to the artifacts in the first workflow that gets triggered from the `pull_request` event (where the pr number is available) and fetch it in the following one from there.