### PR TITLE
Enable `Rails/HttpStatus` cop in rubocop main conf and remove offenses

### DIFF
--- a/src/api/.rubocop.yml
+++ b/src/api/.rubocop.yml
@@ -428,10 +428,6 @@ Rails/Exit:
 Rails/HasAndBelongsToMany:
   Enabled: false
 
-# FIXME: Disabled due to a bug in Rubocop. Once it is fixed in this PR (https://github.com/bbatsov/rubocop/pull/5707), it could be enabled again
-Rails/HttpStatus:
-  Enabled: false
-
 # Checks for the use of output calls like puts and print
 Rails/Output:
   Exclude:

--- a/src/api/app/controllers/application_controller.rb
+++ b/src/api/app/controllers/application_controller.rb
@@ -181,14 +181,14 @@ class ApplicationController < ActionController::Base
     @errorcode = 'ok'
     @summary = 'Ok'
     @data = opt[:data] if opt[:data]
-    render template: 'status', status: 200
+    render template: 'status', status: :ok
   end
 
   def render_invoked(opt = {})
     @errorcode = 'invoked'
     @summary = 'Job invoked'
     @data = opt[:data] if opt[:data]
-    render template: 'status', status: 200
+    render template: 'status', status: :ok
   end
 
   # Passes control to subroutines determined by action and a request parameter. By

--- a/src/api/app/controllers/build/file_controller.rb
+++ b/src/api/app/controllers/build/file_controller.rb
@@ -111,7 +111,7 @@ module Build
         'Content-Length' => fsize
       )
 
-      render status: 200, text: proc { |_, output|
+      render status: :ok, text: proc { |_, output|
         backend_request = Net::HTTP::Get.new(path)
         Net::HTTP.start(CONFIG['source_host'], CONFIG['source_port']) do |http|
           http.request(backend_request) do |response|

--- a/src/api/app/controllers/concerns/backend_proxy.rb
+++ b/src/api/app/controllers/concerns/backend_proxy.rb
@@ -81,7 +81,7 @@ module BackendProxy
       logger.debug "[backend] VOLLEY(mod_xforward): #{path}"
       headers['X-Forward'] = "#{CONFIG['source_protocol'] || 'http'}://#{CONFIG['source_host']}:#{CONFIG['source_port']}#{path}"
       headers['Cache-Control'] = 'no-transform' # avoid compression
-      head(200)
+      head(:ok)
       @skip_validation = true
       return true
     end
@@ -92,7 +92,7 @@ module BackendProxy
       headers['X-Rewrite-URI'] = path
       headers['X-Rewrite-Host'] = CONFIG['x_rewrite_host']
       headers['Cache-Control'] = 'no-transform' # avoid compression
-      head(200)
+      head(:ok)
       @skip_validation = true
       return true
     end
@@ -102,7 +102,7 @@ module BackendProxy
       logger.debug "[backend] VOLLEY(nginx): #{path}"
       headers['X-Accel-Redirect'] = "#{CONFIG['use_nginx_redirect']}/http/#{CONFIG['source_host']}:#{CONFIG['source_port']}#{path}"
       headers['Cache-Control'] = 'no-transform' # avoid compression
-      head(200)
+      head(:ok)
       @skip_validation = true
       return true
     end

--- a/src/api/app/controllers/concerns/rescue_authorization_handler.rb
+++ b/src/api/app/controllers/concerns/rescue_authorization_handler.rb
@@ -13,13 +13,13 @@ module RescueAuthorizationHandler
             redirect_back(fallback_location: root_path)
           end
         end
-        format.json { render json: { errorcode: authorization_errorcode(exception), summary: authorization_message(exception) }, status: 403 }
-        format.js { render json: { errorcode: authorization_errorcode(exception), summary: authorization_message(exception) }, status: 403 }
+        format.json { render json: { errorcode: authorization_errorcode(exception), summary: authorization_message(exception) }, status: :forbidden }
+        format.js { render json: { errorcode: authorization_errorcode(exception), summary: authorization_message(exception) }, status: :forbidden }
         # Consider everything else an XML request...
         format.any do
           @errorcode = authorization_errorcode(exception)
           @summary = authorization_message(exception)
-          render template: 'status', status: 403, formats: [:xml]
+          render template: 'status', status: :forbidden, formats: [:xml]
         end
       end
     end

--- a/src/api/app/controllers/concerns/webui/rescue_handler.rb
+++ b/src/api/app/controllers/concerns/webui/rescue_handler.rb
@@ -14,7 +14,7 @@ module Webui::RescueHandler
                 end
 
       if request.xhr?
-        render json: { error: message }, status: 400
+        render json: { error: message }, status: :bad_request
       else
         flash[:error] = message
         redirect_back(fallback_location: root_path)
@@ -36,7 +36,7 @@ module Webui::RescueHandler
     class MissingParameterError < RuntimeError; end
     rescue_from MissingParameterError do |exception|
       logger.debug "#{exception.class.name} #{exception.message} #{exception.backtrace.join('\n')}"
-      render file: Rails.public_path.join('404.html'), status: 404, layout: false, formats: [:html]
+      render file: Rails.public_path.join('404.html'), status: :not_found, layout: false, formats: [:html]
     end
   end
 end

--- a/src/api/app/controllers/person_controller.rb
+++ b/src/api/app/controllers/person_controller.rb
@@ -274,7 +274,7 @@ class PersonController < ApplicationController
       logger.debug 'No user logged in, permission to changing password denied'
       @errorcode = 401
       @summary = 'No user logged in, permission to changing password denied'
-      render template: 'error', status: 401
+      render template: 'error', status: :unauthorized
       return
     end
 

--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -684,7 +684,7 @@ class Webui::PackageController < Webui::WebuiController
     @meta_xml = Xmlhash.parse(params[:meta])
   rescue Suse::ValidationError => e
     flash.now[:error] = "Error while saving the Meta file: #{e}."
-    render layout: false, status: 400, partial: 'layouts/webui/flash', object: flash
+    render layout: false, status: :bad_request, partial: 'layouts/webui/flash', object: flash
   end
 
   def package_files(rev = nil, expand = nil)

--- a/src/api/app/controllers/webui/projects/meta_controller.rb
+++ b/src/api/app/controllers/webui/projects/meta_controller.rb
@@ -30,7 +30,7 @@ module Webui
         meta_validator.call
         if meta_validator.errors?
           flash.now[:error] = meta_validator.errors
-          render layout: false, status: 400, partial: 'layouts/webui/flash', object: flash
+          render layout: false, status: :bad_request, partial: 'layouts/webui/flash', object: flash
         else
           @request_data = meta_validator.request_data
         end

--- a/src/api/app/controllers/webui/webui_controller.rb
+++ b/src/api/app/controllers/webui/webui_controller.rb
@@ -91,7 +91,7 @@ class Webui::WebuiController < ActionController::Base
     else
       # Demand kerberos negotiation
       response.headers['WWW-Authenticate'] = 'Negotiate'
-      render :new, status: 401
+      render :new, status: :unauthorized
       nil
     end
   end


### PR DESCRIPTION
The cop got disabled in the past due to some bug. Meanwhile its functional, so we can enable it and remove the offenses.