### PR TITLE
Fix `Style/StringConcatenation` rubocop offense in `test_consistency_helper` and `maintenance_test.rb`

### DIFF
--- a/src/api/.rubocop.yml
+++ b/src/api/.rubocop.yml
@@ -325,7 +325,6 @@ Style/StringConcatenation:
     - 'test/functional/issue_controller_test.rb'
     - 'test/functional/issue_trackers_controller_test.rb'
     - 'test/functional/kgraft_maintenance_test.rb'
-    - 'test/functional/maintenance_test.rb'
     - 'test/functional/person_controller_test.rb'
     - 'test/functional/product_test.rb'
     - 'test/functional/public_controller_test.rb'
@@ -341,7 +340,6 @@ Style/StringConcatenation:
     - 'test/functional/trigger_controller_test.rb'
     - 'test/functional/zzz_post_consistency_test.rb'
     - 'test/integration/last_events_test.rb'
-    - 'test/test_consistency_helper.rb'
 
 ##################### Metrics ##################################
 

--- a/src/api/test/functional/maintenance_test.rb
+++ b/src/api/test/functional/maintenance_test.rb
@@ -2,7 +2,7 @@
 # rubocop:disable Metrics/AbcSize
 # rubocop:disable Metrics/MethodLength
 # rubocop:disable Metrics/ClassLength
-require File.expand_path(File.dirname(__FILE__) + '/..') + '/test_helper'
+require_relative '../test_helper'
 require 'source_controller'
 
 class MaintenanceTests < ActionDispatch::IntegrationTest
@@ -958,32 +958,32 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     assert_response :success
 
     # correct branched ?
-    get '/source/' + incident_project + '/pack2.BaseDistro2.0_LinkedUpdateProject/_link'
+    get "/source/#{incident_project}/pack2.BaseDistro2.0_LinkedUpdateProject/_link"
     assert_response :success
     assert_xml_tag(tag: 'link', attributes: { project: 'BaseDistro2.0:LinkedUpdateProject', package: 'pack2' })
-    get '/source/' + incident_project
+    get "/source/#{incident_project}"
     assert_response :success
     assert_xml_tag(tag: 'directory', attributes: { count: '3' })
     assert_xml_tag(tag: 'entry', attributes: { name: 'pack2.BaseDistro2.0_LinkedUpdateProject' })
     assert_xml_tag(tag: 'entry', attributes: { name: 'pack2.linked.BaseDistro2.0_LinkedUpdateProject' })
     assert_xml_tag(tag: 'entry', attributes: { name: 'pack2.BaseDistro3' })
-    get '/source/' + incident_project + '/_meta'
+    get "/source/#{incident_project}/_meta"
     assert_response :success
     assert_xml_tag(tag: 'path', attributes: { project: 'BaseDistro2.0:LinkedUpdateProject', repository: 'BaseDistro2LinkedUpdateProject_repo' })
     assert_xml_tag(tag: 'releasetarget', attributes: { project: 'BaseDistro2.0:LinkedUpdateProject', repository: 'BaseDistro2LinkedUpdateProject_repo', trigger: 'maintenance' })
     assert_xml_tag(tag: 'releasetarget', attributes: { project: 'BaseDistro3', repository: 'BaseDistro3_repo', trigger: 'maintenance' })
     # correct vrev ?
-    get '/source/' + incident_project + '/pack2.BaseDistro2.0_LinkedUpdateProject?expand=1'
+    get "/source/#{incident_project}/pack2.BaseDistro2.0_LinkedUpdateProject?expand=1"
     assert_response :success
     assert_xml_tag(tag: 'directory', attributes: { vrev: '4.2' })
     # validate package meta
-    get '/source/' + incident_project + '/pack2.BaseDistro2.0_LinkedUpdateProject/_meta'
+    get "/source/#{incident_project}/pack2.BaseDistro2.0_LinkedUpdateProject/_meta"
     assert_response :success
     assert_xml_tag(parent: { tag: 'build' }, tag: 'enable', attributes: { repository: 'BaseDistro2.0_LinkedUpdateProject' })
-    get '/source/' + incident_project + '/pack2.linked.BaseDistro2.0_LinkedUpdateProject/_meta'
+    get "/source/#{incident_project}/pack2.linked.BaseDistro2.0_LinkedUpdateProject/_meta"
     assert_response :success
     assert_xml_tag(parent: { tag: 'build' }, tag: 'enable', attributes: { repository: 'BaseDistro2.0_LinkedUpdateProject' })
-    get '/source/' + incident_project + '/pack2.BaseDistro3/_meta'
+    get "/source/#{incident_project}/pack2.BaseDistro3/_meta"
     assert_response :success
     assert_xml_tag(parent: { tag: 'build' }, tag: 'enable', attributes: { repository: 'BaseDistro3' })
     # set lock disabled to check later the valid result when enabling
@@ -994,10 +994,10 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
 
     # create some changes, including issue tracker references
     travel(1.second)
-    put '/source/' + incident_project + '/pack2.BaseDistro2.0_LinkedUpdateProject/dummy.changes', params: 'DUMMY bnc#1042'
+    put "/source/#{incident_project}/pack2.BaseDistro2.0_LinkedUpdateProject/dummy.changes", params: 'DUMMY bnc#1042'
     assert_response :success
     travel(1.second)
-    post '/source/' + incident_project + '/pack2.BaseDistro2.0_LinkedUpdateProject?unified=1&cmd=diff&filelimit=0&expand=1'
+    post "/source/#{incident_project}/pack2.BaseDistro2.0_LinkedUpdateProject?unified=1&cmd=diff&filelimit=0&expand=1"
     assert_response :success
     assert_match(/DUMMY bnc#1042/, @response.body)
     get "/source/#{incident_project}/pack2.BaseDistro2.0_LinkedUpdateProject?view=issues"
@@ -1025,12 +1025,12 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     assert_xml_tag(tag: 'data', attributes: { name: 'targetpackage' }, content: 'patchinfo')
     assert_xml_tag(tag: 'data', attributes: { name: 'targetproject' }, content: incident_project)
     # add reader role for adrian
-    get '/source/' + incident_project + '/_meta'
+    get "/source/#{incident_project}/_meta"
     assert_response :success
     meta = Nokogiri::XML(@response.body, &:strict).root
     meta.add_child('<person userid="adrian" role="reader"/>')
     travel(1.second)
-    put '/source/' + incident_project + '/_meta', params: meta.to_xml
+    put "/source/#{incident_project}/_meta", params: meta.to_xml
     assert_response :success
     get "/source/#{incident_project}/patchinfo/_patchinfo"
     assert_response :success
@@ -1073,7 +1073,7 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
 
     # add another issue and update patchinfo
     travel(1.second)
-    put '/source/' + incident_project + '/pack2.BaseDistro2.0_LinkedUpdateProject/dummy.changes', params: 'DUMMY bnc#1042 cve-2009-0815 bnc#4201'
+    put "/source/#{incident_project}/pack2.BaseDistro2.0_LinkedUpdateProject/dummy.changes", params: 'DUMMY bnc#1042 cve-2009-0815 bnc#4201'
     assert_response :success
     get "/source/#{incident_project}/pack2.BaseDistro2.0_LinkedUpdateProject?view=issues"
     assert_response :success
@@ -1143,12 +1143,12 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
                    tag: 'status', attributes: { package: 'pack2.BaseDistro3', code: 'scheduled' }
 
     # try to create release request too early
-    post '/request?cmd=create', params: '<request>
-                                   <action type="maintenance_release">
-                                     <source project="' + incident_project + '" />
+    post '/request?cmd=create', params: "<request>
+                                   <action type='maintenance_release'>
+                                     <source project='#{incident_project}' />
                                    </action>
-                                   <state name="new" />
-                                 </request>'
+                                   <state name='new' />
+                                 </request>"
     assert_response 400
     assert_xml_tag tag: 'status', attributes: { code: 'build_not_finished' }
     # upload build result as a worker would do
@@ -1180,12 +1180,12 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     assert_xml_tag parent: { tag: 'result', attributes: { repository: 'BaseDistro2.0_LinkedUpdateProject', arch: 'i586', state: 'unpublished' } },
                    tag: 'status', attributes: { package: 'patchinfo', code: 'broken' }
     # try to create release request nevertheless
-    post '/request?cmd=create&addrevision=1', params: '<request>
-                                   <action type="maintenance_release">
-                                     <source project="' + incident_project + '" />
+    post '/request?cmd=create&addrevision=1', params: "<request>
+                                   <action type='maintenance_release'>
+                                     <source project='#{incident_project}' />
                                    </action>
-                                   <state name="new" />
-                                 </request>'
+                                   <state name='new' />
+                                 </request>"
     assert_response 400
     assert_xml_tag(tag: 'status', attributes: { code: 'build_not_finished' })
     assert_match(/patchinfo patchinfo is broken/, @response.body)
@@ -1243,12 +1243,12 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     pi.add_child('<binary>does not exist</binary>')
     put "/source/#{incident_project}/patchinfo/_patchinfo", params: pi.to_xml
     assert_response :success
-    post '/request?cmd=create&addrevision=1', params: '<request>
-                                   <action type="maintenance_release">
-                                     <source project="' + incident_project + '" />
+    post '/request?cmd=create&addrevision=1', params: "<request>
+                                   <action type='maintenance_release'>
+                                     <source project='#{incident_project}'/>
                                    </action>
-                                   <state name="new" />
-                                 </request>'
+                                   <state name='new'/>
+                                 </request>"
     assert_response 400
     assert_match(/last patchinfo patchinfo is not yet build/, @response.body)
 
@@ -1260,12 +1260,12 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     run_scheduler('i586')
 
     # publisher run did not happen yet
-    post '/request?cmd=create&addrevision=1', params: '<request>
-                                   <action type="maintenance_release">
-                                     <source project="' + incident_project + '" />
+    post '/request?cmd=create&addrevision=1', params: "<request>
+                                   <action type='maintenance_release'>
+                                     <source project='#{incident_project}'/>
                                    </action>
-                                   <state name="new" />
-                                 </request>'
+                                   <state name='new'/>
+                                 </request>"
     assert_response 400
     assert_match(/did not finish the publish yet/, @response.body)
 
@@ -1288,12 +1288,12 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
                    attributes: { project: incident_project, package: 'pack2.BaseDistro3' })
 
     # create release request for real
-    post '/request?cmd=create&addrevision=1', params: '<request>
-                                   <action type="maintenance_release">
-                                     <source project="' + incident_project + '" />
+    post '/request?cmd=create&addrevision=1', params: "<request>
+                                   <action type='maintenance_release'>
+                                     <source project='#{incident_project}'/>
                                    </action>
-                                   <state name="new" />
-                                 </request>'
+                                   <state name='new'/>
+                                 </request>"
     assert_response :success
     assert_no_xml_tag(tag: 'source', attributes: { package: 'pack2.0', rev: nil })
     assert_no_xml_tag(tag: 'source', attributes: { package: 'pack2.linked.0', rev: nil })
@@ -1302,12 +1302,12 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     assert_no_xml_tag(tag: 'target', attributes: { project: 'BaseDistro2.0:LinkedUpdateProject', package: 'pack2' })
     assert_no_xml_tag(tag: 'target', attributes: { project: 'BaseDistro3', package: 'pack2' })
     assert_no_xml_tag(tag: 'target', attributes: { project: incident_project })
-    assert_xml_tag(tag: 'target', attributes: { project: 'BaseDistro2.0:LinkedUpdateProject', package: 'pack2.' + incident_id })
-    assert_xml_tag(tag: 'target', attributes: { project: 'BaseDistro2.0:LinkedUpdateProject', package: 'pack2.linked.' + incident_id })
-    assert_xml_tag(tag: 'target', attributes: { project: 'BaseDistro2.0:LinkedUpdateProject', package: 'packNew.' + incident_id })
-    assert_xml_tag(tag: 'target', attributes: { project: 'BaseDistro2.0:LinkedUpdateProject', package: 'patchinfo.' + incident_id })
-    assert_xml_tag(tag: 'target', attributes: { project: 'BaseDistro3', package: 'pack2.' + incident_id })
-    assert_xml_tag(tag: 'target', attributes: { project: 'BaseDistro3', package: 'patchinfo.' + incident_id })
+    assert_xml_tag(tag: 'target', attributes: { project: 'BaseDistro2.0:LinkedUpdateProject', package: "pack2.#{incident_id}" })
+    assert_xml_tag(tag: 'target', attributes: { project: 'BaseDistro2.0:LinkedUpdateProject', package: "pack2.linked.#{incident_id}" })
+    assert_xml_tag(tag: 'target', attributes: { project: 'BaseDistro2.0:LinkedUpdateProject', package: "packNew.#{incident_id}" })
+    assert_xml_tag(tag: 'target', attributes: { project: 'BaseDistro2.0:LinkedUpdateProject', package: "patchinfo.#{incident_id}" })
+    assert_xml_tag(tag: 'target', attributes: { project: 'BaseDistro3', package: "pack2.#{incident_id}" })
+    assert_xml_tag(tag: 'target', attributes: { project: 'BaseDistro3', package: "patchinfo.#{incident_id}" })
     assert_xml_tag(tag: 'review', attributes: { by_group: 'test_group' })
     assert_xml_tag(tag: 'review', attributes: { by_user: 'fred' }) # BaseDistro2:Update pack2
     assert_xml_tag(tag: 'priority', content: 'important') # from patchinfo rating
@@ -1360,23 +1360,23 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
 
     # incident project not visible for tom
     login_tom
-    post '/request?cmd=create&addrevision=1', params: '<request>
-                                   <action type="maintenance_incident">
-                                     <source project="kde4" package="kdelibs" />
-                                     <target project="' + incident_project + '" releaseproject="BaseDistro2.0:LinkedUpdateProject" />
+    post '/request?cmd=create&addrevision=1', params: "<request>
+                                   <action type='maintenance_incident'>
+                                     <source project='kde4' package='kdelibs'/>
+                                     <target project='#{incident_project}' releaseproject='BaseDistro2.0:LinkedUpdateProject'/>
                                    </action>
-                                   <state name="new" />
-                                 </request>'
+                                   <state name='new'/>
+                                 </request>"
     assert_response 404
     # new incident request accept is blocked, but decline works
     login_adrian
-    post '/request?cmd=create&addrevision=1', params: '<request>
-                                   <action type="maintenance_incident">
-                                     <source project="BaseDistro3" package="pack2" />
-                                     <target project="' + incident_project + '" releaseproject="BaseDistro2.0:LinkedUpdateProject" />
+    post '/request?cmd=create&addrevision=1', params: "<request>
+                                   <action type='maintenance_incident'>
+                                     <source project='BaseDistro3' package='pack2'/>
+                                     <target project='#{incident_project}' releaseproject='BaseDistro2.0:LinkedUpdateProject'/>
                                    </action>
-                                   <state name="new" />
-                                 </request>'
+                                   <state name='new' />
+                                 </request>"
     assert_response :success
     node = Xmlhash.parse(@response.body)
     assert node['id']

--- a/src/api/test/test_consistency_helper.rb
+++ b/src/api/test/test_consistency_helper.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.dirname(__FILE__) + '/..') + '/test/test_helper'
+require_relative './test_helper'
 require 'source_controller'
 
 #


### PR DESCRIPTION
* Use `require_relative` over concatenating the path to the `test_helper` manually
* Adapt to use string interpolation for everything else