### PR TITLE
Tag hyperlinks with nofollow

### DIFF
--- a/src/api/app/helpers/webui/markdown_helper.rb
+++ b/src/api/app/helpers/webui/markdown_helper.rb
@@ -8,7 +8,7 @@ module Webui::MarkdownHelper
                                            autolink: true,
                                            no_intra_emphasis: true,
                                            fenced_code_blocks: true, disable_indented_code_blocks: true)
-    ActionController::Base.helpers.sanitize(@md_parser.render(content.dup.to_s))
+    ActionController::Base.helpers.sanitize(@md_parser.render(content.dup.to_s), scrubber: Loofah::Scrubbers::NoFollow.new)
   end
 
   def render_without_markdown(content)

--- a/src/api/spec/helpers/webui/markdown_helper_spec.rb
+++ b/src/api/spec/helpers/webui/markdown_helper_spec.rb
@@ -4,35 +4,35 @@ RSpec.describe Webui::MarkdownHelper do
   describe '#render_as_markdown' do
     it 'renders markdown links to html links' do
       expect(render_as_markdown('[my link](https://github.com/openSUSE/open-build-service/issues/5091)')).to eq(
-        "<p><a href=\"https://github.com/openSUSE/open-build-service/issues/5091\">my link</a></p>\n"
+        "<p><a href=\"https://github.com/openSUSE/open-build-service/issues/5091\" rel=\"nofollow\">my link</a></p>\n"
       )
     end
 
     it 'adds the OBS domain to relative links' do
       expect(render_as_markdown('[my link](/here)')).to eq(
-        "<p><a href=\"#{Configuration.obs_url}/here\">my link</a></p>\n"
+        "<p><a href=\"#{Configuration.obs_url}/here\" rel=\"nofollow\">my link</a></p>\n"
       )
     end
 
     it 'detects all the mentions to users' do
       expect(render_as_markdown('@alfie @milo and @Admin, please review. Also you, @test1 and @user.name.')).to eq(
-        '<p><a href="https://unconfigured.openbuildservice.org/users/alfie">@alfie</a> ' \
-        '<a href="https://unconfigured.openbuildservice.org/users/milo">@milo</a> ' \
-        'and <a href="https://unconfigured.openbuildservice.org/users/Admin">@Admin</a>, ' \
-        'please review. Also you, <a href="https://unconfigured.openbuildservice.org/users/test1">@test1</a> ' \
-        "and <a href=\"https://unconfigured.openbuildservice.org/users/user.name\">@user.name</a>.</p>\n"
+        '<p><a href="https://unconfigured.openbuildservice.org/users/alfie" rel="nofollow">@alfie</a> ' \
+        '<a href="https://unconfigured.openbuildservice.org/users/milo" rel="nofollow">@milo</a> ' \
+        'and <a href="https://unconfigured.openbuildservice.org/users/Admin" rel="nofollow">@Admin</a>, ' \
+        'please review. Also you, <a href="https://unconfigured.openbuildservice.org/users/test1" rel="nofollow">@test1</a> ' \
+        "and <a href=\"https://unconfigured.openbuildservice.org/users/user.name\" rel=\"nofollow\">@user.name</a>.</p>\n"
       )
     end
 
     it "doesn't render users inside the text of html links" do
       expect(render_as_markdown('Group [openSUSE Leap 15.0 Incidents@DVD-Incidents](https://openqa.opensuse.org/tests/overview)')).to eq(
-        "<p>Group <a href=\"https://openqa.opensuse.org/tests/overview\">openSUSE Leap 15.0 Incidents@DVD-Incidents</a></p>\n"
+        "<p>Group <a href=\"https://openqa.opensuse.org/tests/overview\" rel=\"nofollow\">openSUSE Leap 15.0 Incidents@DVD-Incidents</a></p>\n"
       )
     end
 
     it 'does not crash due to invalid URIs' do
       expect(render_as_markdown("anbox[400000+22d000]\r\n(the number)")).to eq(
-        "<p>anbox<a href=\"the%20number\">400000+22d000</a></p>\n"
+        "<p>anbox<a href=\"the%20number\" rel=\"nofollow\">400000+22d000</a></p>\n"
       )
     end
 
@@ -60,7 +60,7 @@ RSpec.describe Webui::MarkdownHelper do
 
     it 'does remove dangerous html from inside the links' do
       expect(render_as_markdown('[<script></script>](https://build.opensuse.org)')).to eq(
-        "<p><a href=\"https://build.opensuse.org\">&amp;lt;script&amp;gt;&amp;lt;/script&amp;gt;</a></p>\n"
+        "<p><a href=\"https://build.opensuse.org\" rel=\"nofollow\">&amp;lt;script&amp;gt;&amp;lt;/script&amp;gt;</a></p>\n"
       )
     end
 

--- a/src/api/spec/mailers/event_mailer_spec.rb
+++ b/src/api/spec/mailers/event_mailer_spec.rb
@@ -78,8 +78,8 @@ RSpec.describe EventMailer, vcr: true do
       end
 
       it 'renders links absolute' do
-        expected_html = "<p>Hey <a href=\"https://build.example.com/users/#{receiver.login}\">@#{receiver.login}</a> "
-        expected_html += 'how are things? Look at <a href="https://build.example.com/project/show/apache">bug</a> please.'
+        expected_html = "<p>Hey <a href=\"https://build.example.com/users/#{receiver.login}\" rel=\"nofollow\">@#{receiver.login}</a> "
+        expected_html += 'how are things? Look at <a href="https://build.example.com/project/show/apache" rel="nofollow">bug</a> please.'
         expect(mail.html_part.to_s).to include(expected_html)
       end
 


### PR DESCRIPTION
Bots are spamming us with hyperlinks to unrelated sites to increase their pages' score in search engines. By adding rel="nofollow", this will be disincentivised.

Fixes #14189 