### PR TITLE
Reference legacy and new documentation to each other

### DIFF
--- a/docs/api/api/api.txt
+++ b/docs/api/api/api.txt
@@ -2,6 +2,8 @@
 
 Version: 2.9
 
+  The most recent API documentation is reachable at https://api.opensuse.org/apidocs-new/index.html
+
   Only authenticated users are allowed to access the API. Authentication is done
   by sending a Basic HTTP Authorisation header.
 

--- a/src/api/public/apidocs-new/OBS-v2.10.50.yaml
+++ b/src/api/public/apidocs-new/OBS-v2.10.50.yaml
@@ -63,6 +63,8 @@ info:
 
     For command-line users, we recommend using [osc](https://github.com/openSUSE/osc) with its _api_ command to interact with the API.
     It's as simple as this example: `osc api /about` (_about_ is one of the endpoints documented below)
+
+    The legacy API documentation is reachable [here](https://api.opensuse.org/apidocs/index).
   version: '2.10.50'
   title: Open Build Service API
   contact:


### PR DESCRIPTION
This PR adds:
- A link in the [legacy API documentation](https://build.opensuse.org/apidocs/index) pointing to the [new one](https://build.opensuse.org/apidocs-new/index.html)
- A link in the [new API documentation](https://build.opensuse.org/apidocs-new/index.html) pointing to the [old one](https://build.opensuse.org/apidocs/index)