### PR TITLE
Drop stale doc wording

### DIFF
--- a/src/api/public/apidocs-new/paths/source_project_name_package_name_cmd_getprojectservices.yaml
+++ b/src/api/public/apidocs-new/paths/source_project_name_package_name_cmd_getprojectservices.yaml
@@ -1,7 +1,7 @@
 post:
   summary:  List all services related to a package.
   description: |
-    List all services defined in the project spaces for this package.
+    List all services defined in the project for this package.
 
     Despite using the method `POST`, this endpoint doesn't alter any data.
   security:


### PR DESCRIPTION
A very long time ago the `project spaces` wording was added [here](https://github.com/openSUSE/open-build-service/commit/4f931180b9af49ff2208bd50cda3fe4e28ee9e2e#diff-26ef3c22ebd850f7d723186b4a6c94551409c2a7e25742f7a893a6bbd8695797R707), but currently it lost its meaning, and that's why this PR drops the `spaces` slice. Referring to the `project` is fine and clear.