### PR TITLE
Use a link in legacy API docs to point to the new API documentation

### DIFF
--- a/docs/api/api/api.txt
+++ b/docs/api/api/api.txt
@@ -2,7 +2,7 @@
 
 Version: 2.9
 
-  The most recent API documentation is reachable at https://api.opensuse.org/apidocs-new/index.html
+  The most recent API documentation is reachable at [https://api.opensuse.org/apidocs-new/](https://api.opensuse.org/apidocs-new/index.html)
 
   Only authenticated users are allowed to access the API. Authentication is done
   by sending a Basic HTTP Authorisation header.

--- a/docs/api/restility/lib/rest_htmlprinter.rb
+++ b/docs/api/restility/lib/rest_htmlprinter.rb
@@ -83,7 +83,13 @@ class HtmlPrinter < Printer
   def print_text text
     @html.p do |p|
       text.text.each do |t|
-        p.span(t)
+        if %r{(.*)\[([^\[\]]+)\]\((https?:\/\/[^()]+)\)(.*)} =~ t
+          # line contains a link
+          p.span { |span| span.text!($1); span.a($2, href: $3); span.text!($4) }
+        else
+          p.span(t)
+        end
+
         p.br
       end
     end


### PR DESCRIPTION
**Before:**

![Screenshot from 2023-04-21 15-48-42](https://user-images.githubusercontent.com/24919/233652984-51cbde88-c77b-4125-a68a-181bb79b2ef3.png)

**After:**

![Screenshot from 2023-04-21 15-49-08](https://user-images.githubusercontent.com/24919/233653006-1469d897-207e-4066-b965-7a20946f4e4e.png)

Related to #14196.

## For reviewers

In development environment:
- checkout this branch
- enter the `frontend`  container: `docker-compose run --rm --service-ports frontend bash`
- `cd /obs`
- `make -C docs/api/api apidocs`
- browse the file locally (not from the rails puma server) `$LOCAL_REPOSITORY_DIRECTORY/docs/api/html/index.html`