### PR TITLE
[backend] BSContar: split normalize_layer from create_layer_data

### DIFF
--- a/src/backend/BSPublisher/Container.pm
+++ b/src/backend/BSPublisher/Container.pm
@@ -351,11 +351,8 @@ sub create_container_dist_info {
     my $layer_ent = $tar{$layer_file};
     die("file $layer_file not included in tar\n") unless $layer_ent;
     my $lcomp = shift @layer_comp;
-    my $comp;
-    $comp = 'gzip' if $lcomp && $lcomp eq 'gzip';
-    $comp = 'zstd' if $lcomp && ($lcomp eq 'zstd' || $lcomp =~ /^zstd:/);
-    my $layer_data;
-    ($layer_ent, $layer_data) = BSContar::create_layer_data($layer_ent, $oci, $comp, undef, $lcomp);
+    ($layer_ent, $lcomp) = BSContar::normalize_layer($layer_ent, $oci, $lcomp);
+    my $layer_data = BSContar::create_layer_data($layer_ent, $oci, $lcomp);
     push @layer_data, $layer_data;
   }
   my $mani = BSContar::create_dist_manifest_data($config_data, \@layer_data, $oci);

--- a/src/backend/BSPublisher/Registry.pm
+++ b/src/backend/BSPublisher/Registry.pm
@@ -692,10 +692,8 @@ sub push_containers {
 	}
 	my $layer_ent = $tar{$layer_file};
 	die("File $layer_file not included in tar\n") unless $layer_ent;
-	my $comp = 'gzip';
-	$comp = 'zstd' if $lcomp && ($lcomp eq 'zstd' || $lcomp =~ /^zstd:/);
-	my $layer_data;
-	($layer_ent, $layer_data) = BSContar::create_layer_data($layer_ent, $oci, $comp, $comp, $lcomp);
+	$lcomp = 'gzip' unless $oci && $lcomp && ($lcomp eq 'zstd' || $lcomp =~ /^zstd:/);
+	my $layer_data = BSContar::create_layer_data($layer_ent, $oci, $lcomp);
 	push @layer_data, $layer_data;
 	$layer_datas{$layer_file} = $layer_data;
 

--- a/src/backend/bs_regpush
+++ b/src/backend/bs_regpush
@@ -782,10 +782,10 @@ for my $tarfile (@tarfiles) {
     }
     my $layer_ent = $tar{$layer_file};
     die("File $layer_file not included in tar\n") unless $layer_ent;
-
+    # normalize layer
+    ($layer_ent, $lcomp) = BSContar::normalize_layer($layer_ent, $oci, undef, undef, $lcomp);
     # create layer data
-    my $layer_data;
-    ($layer_ent, $layer_data) = BSContar::create_layer_data($layer_ent, $oci, undef, undef, $lcomp);
+    my $layer_data = BSContar::create_layer_data($layer_ent, $oci, $lcomp);
     push @layer_data, $layer_data;
     $layer_datas{$layer_file} = $layer_data;
 


### PR DESCRIPTION
Mixing those two was a bad idea. It's much cleaner now.