### PR TITLE
[dist] add reconnect: true to database.yaml.template

### DIFF
--- a/src/api/config/database.yml.example
+++ b/src/api/config/database.yml.example
@@ -15,6 +15,7 @@ production:
   collation: utf8mb4_unicode_ci
   timeout: 15
   pool: 30
+  reconnect: true
 
 development:
   adapter: mysql2
@@ -25,6 +26,7 @@ development:
   collation: utf8mb4_unicode_ci
   timeout: 15
   pool: 30
+  reconnect: true
   
 # Warning: The database defined as 'test' will be erased and
 # re-generated from your development database when you run 'rails'.
@@ -38,4 +40,5 @@ test:
   collation: utf8mb4_unicode_ci
   timeout: 15
   pool: 30
+  reconnect: true
 


### PR DESCRIPTION
Our single host installations lack this and run into trouble with the delayed jobs on database update.