### PR TITLE
Remove `POST /build/:project/:repository/:arch` API endpoint

### DIFF
--- a/src/api/config/routes/api_routes.rb
+++ b/src/api/config/routes/api_routes.rb
@@ -373,7 +373,8 @@ OBSApi::Application.routes.draw do
   delete 'build/:project/:repository/:arch/:package/:filename' => 'build/file#destroy', constraints: cons
   match 'build/:project/:repository/:arch/_builddepinfo' => 'build#builddepinfo', via: [:get, :post], constraints: cons
   get 'build/:project/:repository/_buildconfig' => 'build#index', constraints: cons
-  match 'build/:project/:repository/:arch(/:package)' => 'build#index', constraints: cons, via: [:get, :post]
+  match 'build/:project/:repository/:arch/:package' => 'build#index', constraints: cons, via: [:get, :post]
+  get 'build/:project/:repository/:arch' => 'build#index', constraints: cons
   get 'build/_result' => 'build#scmresult', constraints: cons
   get 'build/:project/_result' => 'build#result', constraints: cons
   get 'build/:project/:repository' => 'build#index', constraints: cons


### PR DESCRIPTION
The Rails controller errors with empty package not found. There isn't any defined in the backend, in `bs_srvserver`.