### PR TITLE
Document GET PUT DELETE _pattern files as DEPRECATED

### DIFF
--- a/src/api/public/apidocs-new/OBS-v2.10.50.yaml
+++ b/src/api/public/apidocs-new/OBS-v2.10.50.yaml
@@ -271,6 +271,8 @@ paths:
     $ref: 'paths/source_project_name_meta.yaml'
   /source/{project_name}/_pattern:
     $ref: 'paths/source_project_name_pattern.yaml'
+  /source/{project_name}/_pattern/{file_name}:
+    $ref: 'paths/source_project_name_pattern_file_name.yaml'
   /source/{project_name}/_project:
     $ref: 'paths/source_project_name_project.yaml'
   /source/{project_name}/_pubkey:

--- a/src/api/public/apidocs-new/components/responses/unknown_project_or_file.yaml
+++ b/src/api/public/apidocs-new/components/responses/unknown_project_or_file.yaml
@@ -1,0 +1,17 @@
+description: |
+  Not Found.
+
+  XML Schema used for body validation: [status.xsd](../schema/status.xsd)
+content:
+  application/xml; charset=utf-8:
+    schema:
+      $ref: '../schemas/api_response.yaml'
+    examples:
+      Unknown Project:
+        value:
+          code: unknown_project
+          summary: "Project not found: home:some_project"
+      Unknown File:
+        value:
+          code: unknown_file
+          summary: "File not found: home:some_project/_pattern/some_file"

--- a/src/api/public/apidocs-new/paths/source_project_name_pattern_file_name.yaml
+++ b/src/api/public/apidocs-new/paths/source_project_name_pattern_file_name.yaml
@@ -1,0 +1,90 @@
+get:
+  deprecated: true
+  summary: Read a specified pattern file
+  description: Read a specified pattern file and return the content
+  security:
+    - basic_authentication: []
+  parameters:
+    - $ref: '../components/parameters/project_name.yaml'
+    - $ref: '../components/parameters/file_name.yaml'
+  responses:
+    '200':
+      $ref: '../components/responses/succeeded.yaml'
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '404':
+      $ref: '../components/responses/unknown_project_or_file.yaml'
+  tags:
+    - Sources - Projects
+
+delete:
+  deprecated: true
+  summary: Deletes a specified pattern file.
+  description: Deletes a specified pattern file of a project.
+  security:
+    - basic_authentication: []
+  parameters:
+    - $ref: '../components/parameters/project_name.yaml'
+    - $ref: '../components/parameters/file_name.yaml'
+  responses:
+    '200':
+      $ref: '../components/responses/succeeded.yaml'
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '404':
+      $ref: '../components/responses/unknown_project_or_file.yaml'
+  tags:
+    - Sources - Projects
+
+put:
+  deprecated: true
+  summary: Write a specified pattern file.
+  description: Write a specified pattern file of a project.
+  security:
+    - basic_authentication: []
+  parameters:
+    - $ref: '../components/parameters/project_name.yaml'
+    - $ref: '../components/parameters/file_name.yaml'
+  requestBody:
+    content:
+      plain/text:
+        schema:
+          type: string
+          properties:
+            file:
+              type: string
+              format: binary
+  responses:
+    '200':
+      description:
+        Updates the artifact's file contents
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/revision.yaml'
+          example:
+            rev: 28
+            srcmd5: 6c73fc9ef8d43369f0778564617b4a93
+            time: 1682497725
+            user: Admin
+            comment:
+            requestid:
+    '400':
+      description: |
+        Error: Bad request.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          examples:
+            Bad Request:
+              value:
+                code: validation_failed
+                summary: |
+                  pattern validation error: 1:1: FATAL: Start tag expected, < not found
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '404':
+      $ref: '../components/responses/unknown_project_or_file.yaml'
+  tags:
+    - Sources - Projects


### PR DESCRIPTION
### For reviewers

Access to the documented endpoint in the review-app through
- GET [this link](https://obs-reviewlab.opensuse.org/ncounter-deprecate-pattern-file-api-doc/apidocs-new/index.html#/Sources%20-%20Projects/get_source__project_name___pattern__file_name_)
- PUT [this link](https://obs-reviewlab.opensuse.org/ncounter-deprecate-pattern-file-api-doc/apidocs-new/index.html#/Sources%20-%20Projects/put_source__project_name___pattern__file_name_)
- DELETE [this link](https://obs-reviewlab.opensuse.org/ncounter-deprecate-pattern-file-api-doc/apidocs-new/index.html#/Sources%20-%20Projects/delete_source__project_name___pattern__file_name_)