### PR TITLE
Remove creation of the foreign key on notified_projects project_id

### DIFF
--- a/src/api/.database_consistency.todo.yml
+++ b/src/api/.database_consistency.todo.yml
@@ -2090,6 +2090,9 @@ NotifiedProject:
   notification:
     ForeignKeyChecker:
       enabled: false
+  project:
+    ForeignKeyChecker:
+      enabled: false
   index_notified_projects_on_notification_id:
     RedundantIndexChecker:
       enabled: false

--- a/src/api/app/models/notified_project.rb
+++ b/src/api/app/models/notified_project.rb
@@ -20,7 +20,3 @@ end
 #  index_notified_projects_on_notification_id_and_project_id  (notification_id,project_id) UNIQUE
 #  index_notified_projects_on_project_id                      (project_id)
 #
-# Foreign Keys
-#
-#  fk_rails_...  (project_id => projects.id)
-#

--- a/src/api/db/migrate/20230414151119_add_projects_id_notified_projects_project_id_fk.rb
+++ b/src/api/db/migrate/20230414151119_add_projects_id_notified_projects_project_id_fk.rb
@@ -1,5 +1,0 @@
-class AddProjectsIdNotifiedProjectsProjectIdFk < ActiveRecord::Migration[7.0]
-  def change
-    add_foreign_key :notified_projects, :projects, column: :project_id, primary_key: :id
-  end
-end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_14_151119) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_14_085150) do
   create_table "architectures", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "name", null: false, collation: "utf8mb3_general_ci"
     t.boolean "available", default: false
@@ -1183,7 +1183,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_14_151119) do
   add_foreign_key "kiwi_packages", "kiwi_package_groups", column: "package_group_id"
   add_foreign_key "maintained_projects", "projects", column: "maintenance_project_id", name: "maintained_projects_ibfk_2"
   add_foreign_key "maintained_projects", "projects", name: "maintained_projects_ibfk_1"
-  add_foreign_key "notified_projects", "projects"
   add_foreign_key "package_issues", "issues", name: "package_issues_ibfk_2"
   add_foreign_key "package_issues", "packages", name: "package_issues_ibfk_1"
   add_foreign_key "package_kinds", "packages", name: "package_kinds_ibfk_1"


### PR DESCRIPTION
There are some rows on production's notified_projects that reference missing projects in projects table. We need to figure out what to do with those records and how to prevent that from happening again before enforcing this foreign key index.

Fixes #14163