### PR TITLE
Resolve and replace swagger yaml during build process

### DIFF
--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -164,6 +164,10 @@ BuildRequires:  perl-YAML-LibYAML
 BuildRequires:  procps
 BuildRequires:  perl(Devel::Cover)
 BuildRequires:  perl(Test::Simple) > 1
+# for the resolve_swagger_yaml.rb script
+BuildRequires:  rubygem-hana
+BuildRequires:  rubygem-json_refs
+# /for the resolve_swagger_yaml.rb script
 PreReq:         /usr/sbin/useradd /usr/sbin/groupadd
 BuildArch:      noarch
 Requires(pre):  obs-common
@@ -491,6 +495,12 @@ make
 %sysusers_generate_pre dist/system-user-obsrun.conf obsrun system-user-obsrun.conf
 %sysusers_generate_pre dist/system-user-obsservicerun.conf obsservicerun system-user-obsservicerun.conf
 %endif
+
+# combine swagger yaml files to one big yaml file by resolving all references
+# and replace the development version
+pushd /dist
+ruby resolve_swagger_yaml.rb -i %{__obs_api_prefix}/public/apidocs-new/OBS-v2.10.50.yaml -o %{__obs_api_prefix}/public/apidocs-new/OBS-v2.10.50.yaml -f
+popd
 
 %install
 export DESTDIR=$RPM_BUILD_ROOT


### PR DESCRIPTION
In order to speed up the loading time of the OpenAPI documentation, we replace the development version of the yaml files with one big yaml file by resolving all references, during the build process.

DO NOT MERGE: This PR depends on https://github.com/openSUSE/open-build-service/pull/14240 to be merged and we have to submit the two rubygems first to the OBS:Server:Unstable project in order to run the script during the build.

- [x] Merge PR #14240 
- [x] Link rubygem-json_refs to Unstable
- [x] Link rubygem-hana to Unstable