### PR TITLE
Document the validation checks

### DIFF
--- a/src/api/public/apidocs-new/OBS-v2.10.50.yaml
+++ b/src/api/public/apidocs-new/OBS-v2.10.50.yaml
@@ -66,6 +66,10 @@ info:
     For command-line users, we recommend using [osc](https://github.com/openSUSE/osc) with its _api_ command to interact with the API.
     It's as simple as this example: `osc api /about` (_about_ is one of the endpoints documented below)
 
+    In order to make sure complex requests and responses are in the expected format, a validation check is executed on sending and receiving commands.
+    All validation formats in use are available in `.xsd` and `.rng` files listed [here](https://github.com/openSUSE/open-build-service/tree/master/docs/api/api).
+    In case a defined format is not respected, a validation error is reported.
+
     The legacy API documentation is reachable [here](https://api.opensuse.org/apidocs/index).
   version: '2.10.50'
   title: Open Build Service API


### PR DESCRIPTION
Let the API doc user know about validation checks definitions.