### PR TITLE
Move xml response example to a xml section in new API documentation

### DIFF
--- a/src/api/public/apidocs-new/paths/source_project_name_package_name_cmd_servicediff.yaml
+++ b/src/api/public/apidocs-new/paths/source_project_name_package_name_cmd_servicediff.yaml
@@ -29,6 +29,79 @@
             No Changes:
               description: If the last run of services didn't change the sources, return empty.
               value: |
+            Without any value for view parameter:
+              value: |
+                new:
+                ----
+                  _service:obs_scm:obs-api-testsuite-rspec.spec
+
+                spec files:
+                -----------
+
+                ++++++ new spec file:
+                --- _service:obs_scm:obs-api-testsuite-rspec.spec
+                +++ _service:obs_scm:obs-api-testsuite-rspec.spec
+                @@ -0,0 +1,73 @@
+                +#
+                +# spec file for package obs-api-testsuite-rspec
+                +#
+                +
+                +
+                +Name:           obs-api-testsuite-rspec
+                +Version:        2.10~pre
+                +Release:        0
+                +Summary:        The Open Build Service -- RSpec test suite
+                +License:        GPL-2.0-only OR GPL-3.0-only
+                +Group:          Productivity/Networking/Web/Utilities
+                +Url:            http://www.openbuildservice.org
+                +Source0:        open-build-service-%version.tar.xz
+                +BuildRequires:  obs-api-testsuite-deps
+                +# rspec specific dependencies
+                +BuildRequires:  chromedriver
+                +BuildRequires:  xorg-x11-fonts
+                +BuildRoot:      %{_tmppath}/%{name}-%{version}-build
+                +%if 0%{?disable_obs_frontend_test_suite} || 0%{?disable_obs_test_suite}
+                +ExclusiveArch:  nothere
+                +%else
+                +ExclusiveArch:  x86_64
+                +%endif
+                +
+                +
+                +%description
+                +Running the RSpec test suite of the OBS frontend independently
+                +of packaging the application
+                +
+                +%prep
+                +%setup -q -n open-build-service-%{version}
+                +
+                +%build
+                +# run in build environment
+                +pushd src/backend/
+                +rm -rf build
+                +ln -sf /usr/lib/build build
+                +popd
+                +
+                +pushd src/api
+                +# configure to the bundled gems
+                +bundle --local --path %_libdir/obs-api/
+                +
+                +./script/prepare_spec_tests.sh
+                +
+                +export RAILS_ENV=test
+                +bin/rake db:setup
+                +bin/rails assets:precompile
+                +
+                +bin/rspec -f d --exclude-pattern 'spec/db/**/*_spec.rb'
+                +
+                +# now migration tests (if they fail they create tons of follow up errors, so run them last)
+                +bin/rspec -f d -P 'spec/db/**/*_spec.rb'
+                +
+                +%install
+                +
+                +# no result
+                +%files
+                +
+                +%changelog
             With view=unified:
               value: |
                 Index: _service:obs_scm:obs-api-testsuite-rspec.spec

--- a/src/api/public/apidocs-new/paths/source_project_name_package_name_cmd_servicediff.yaml
+++ b/src/api/public/apidocs-new/paths/source_project_name_package_name_cmd_servicediff.yaml
@@ -64,6 +64,17 @@
                 +version: 2.11~alpha.20221007T165328.9f99a31a
                 +mtime: 1665154408
                 +commit: 9f99a31afe0ab435c1dd1d02be5f52fe4425b00f
+        text/xml:
+          schema:
+            type: object
+            properties:
+              name:
+                key: string
+                xml:
+                  attribute: true
+            xml:
+              name: sourcediff
+          examples:
             # Representing a `sourcediff` xml with a schema is not possible.
             # The `diff` element has both: content and an attribute (`lines`).
             # OpenAPI specification 3.0 doesn't allow to represent XML elements with both content and attributes.


### PR DESCRIPTION
Make clear that this response returns a `xml/plain` Content-type header.

Also, add example for an empty `view` parameter. This was forgotten to be included in the previous documentation iteration.