### PR TITLE
[backend] split xrpc_isfinished from xrpc_resume

### DIFF
--- a/src/backend/BSSched/RPC.pm
+++ b/src/backend/BSSched/RPC.pm
@@ -321,10 +321,6 @@ sub xrpc_resume_nextrpc {
 sub xrpc_resume {
   my ($rctx, $handle) = @_;
 
-  # check if the rpc is really done
-  my $isfinished = eval { BSRPC::rpc_isfinished($handle) };
-  return unless $@ || $isfinished;
-
   # iswaiting rpc, finish...
   my $iswaiting = $rctx->{'iswaiting'};
   my $iswaiting_server = $rctx->{'iswaiting_server'};
@@ -386,6 +382,12 @@ sub xrpc_nextparams {
   my @next = @{$handle->{'_nextxrpc'} || []};
   unshift @next, $handle if $handle->{'_xrpc_data'};	# waiting because of server load
   return map {$_->{'_xrpc_data'}->[2]} @next;		# map to param argument
+}
+
+sub xrpc_isfinished {
+  my ($rctx, $handle) = @_;
+  my $isfinished = eval { BSRPC::rpc_isfinished($handle) };
+  return $@ || $isfinished ? 1 : 0;
 }
 
 1;

--- a/src/backend/bs_sched
+++ b/src/backend/bs_sched
@@ -872,6 +872,7 @@ eval {
         for my $watcher (@watchers) {
           my $remoteurl = $watcher->{'remoteurl'};
           if (!defined($remoteurl)) {
+	    next unless $gctx->{'rctx'}->xrpc_isfinished($watcher);
             $gctx->{'rctx'}->xrpc_resume($watcher);
             $gotevent = 1;	# force loop restart
           } elsif ($remoteurl eq 'ping') {


### PR DESCRIPTION
This brings rpcs in sync with the watcher handling.