### PR TITLE
Redirect to old show view if user is not in beta

### DIFF
--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -12,6 +12,7 @@ class Webui::RequestController < Webui::WebuiController
   before_action :set_superseded_request, only: [:show, :request_action, :request_action_changes, :conversation]
   before_action :check_ajax, only: :sourcediff
   before_action :prepare_request_data, only: [:show, :conversation], if: -> { Flipper.enabled?(:request_show_redesign, User.session) }
+  before_action :check_beta_user_redirect, only: [:conversation]
 
   after_action :verify_authorized, only: [:create]
 
@@ -292,6 +293,10 @@ class Webui::RequestController < Webui::WebuiController
   end
 
   private
+
+  def check_beta_user_redirect
+    redirect_to request_show_path(params[:number], params[:request_action_id]) unless Flipper.enabled?(:request_show_redesign, User.session)
+  end
 
   def addreview_opts
     opts = {}


### PR DESCRIPTION
Actions related to the beta show should not be accessible for not logged-in users. This PR redirects not logged in users to ols show view.

Fixes #14273