### PR TITLE
Don't show the specification file explorer in the Swager-UI interface

### DIFF
--- a/src/api/public/apidocs-new/swagger-initializer.js
+++ b/src/api/public/apidocs-new/swagger-initializer.js
@@ -14,7 +14,7 @@ window.onload = function() {
     plugins: [
       SwaggerUIBundle.plugins.DownloadUrl
     ],
-    layout: "StandaloneLayout"
+    showExplorer: false,
   });
 
   //</editor-fold>


### PR DESCRIPTION
We only have one specification to show, so we don't need a specification explorer form.

**Before:**

![Screenshot from 2023-05-03 15-52-15](https://user-images.githubusercontent.com/24919/235936386-6b9a3211-2388-4b02-9c34-c17b3342033c.png)


**After:**

![Screenshot from 2023-05-03 15-52-25](https://user-images.githubusercontent.com/24919/235936420-b792bfe7-e58e-4491-bf8b-e118420905ab.png)

## For reviewers

Browse this [link](https://obs-reviewlab.opensuse.org/eduardoj-apidocs_newdont_show_explorer/apidocs-new/index.html) of the review app.
