### PR TITLE
Retrieve maintainers if target_project is present

### DIFF
--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -555,11 +555,7 @@ class Webui::RequestController < Webui::WebuiController
     @package_maintainers = target_package_maintainers
 
     # retrieve a list of all project maintainers
-    @project_maintainers = if Project.deleted?(@bs_request.target_project_name)
-                             []
-                           else
-                             target_project.maintainers
-                           end
+    @project_maintainers = target_project&.maintainers || []
 
     # search for a project, where the user is not a package maintainer but a project maintainer and show
     # a hint if that package has some package maintainers (issue#1970)


### PR DESCRIPTION
Make sure `target_project` exists before retrieving its maintainers.

Sometimes `Project.deleted?(@bs_request.target_project_name)` returned false, it means the project is not deleted. But right after the check, when trying to access `target_project.maintainers`,  `target_project` happens to be nil.

The errors tracked in Errbit match exactly the same date and time when a Deletion request was accepted (so when the project was deleted).

My conclusion is that `Project.deleted?` needs a while to reflect reality as it relies on some data in the backend (`_history` file with `deleted: 1`) that probably takes longer to be set. So there is a mismatch for a moment.

Anyway, whatever the reason is, I've refactored the code to not rely on `Project.deleted?` but to always check for the presence of `target_project` before trying to retrieve `maintainers`.

Fixes https://github.com/openSUSE/open-build-service/issues/13994