### PR TITLE
Refactor maintenance related dev tasks

### DIFF
--- a/src/api/lib/tasks/dev.rake
+++ b/src/api/lib/tasks/dev.rake
@@ -127,15 +127,6 @@ namespace :dev do
 
       # we need to set the user again because some factories set the user back to nil :(
       User.session = admin
-      update_project = create(:update_project, target_project: leap, name: "#{leap.name}:Update")
-      create(
-        :maintenance_project,
-        name: 'MaintenanceProject',
-        title: 'official maintenance space',
-        target_project: update_project,
-        maintainer: admin
-      )
-
       # Create factory dashboard projects
       factory = create(:project, name: 'openSUSE:Factory')
       sworkflow = create(:staging_workflow, project: factory)
@@ -234,8 +225,8 @@ namespace :dev do
       # Create a request with multiple submit actions and diffs
       Rake::Task['dev:requests:request_with_multiple_submit_actions_builds_and_diffs'].invoke
 
-      # Create a request with a couple of maintenance incident request actions
-      Rake::Task['dev:requests:request_with_maintenance_incident_actions'].invoke
+      # Create a maintenance environment with maintenance requests
+      Rake::Task['dev:test_data:maintenance'].invoke
 
       # Create a request with a delete request action
       Rake::Task['dev:requests:request_with_delete_action'].invoke

--- a/src/api/lib/tasks/dev/requests.rake
+++ b/src/api/lib/tasks/dev/requests.rake
@@ -162,45 +162,6 @@ namespace :dev do
       puts "  - Create a couple of repositories in project #{iggy_home_project.name}"
     end
 
-    desc 'Creates a request with maintenance incident actions'
-    task request_with_maintenance_incident_actions: :development_environment do
-      require 'factory_bot'
-      include FactoryBot::Syntax::Methods
-
-      iggy = User.find_by(login: 'Iggy') || create(:staff_user, login: 'Iggy')
-      request = build(
-        :bs_request_with_maintenance_incident_action,
-        creator: iggy
-      )
-
-      maintenance_project = Project.find_by(kind: 'maintenance')
-      release_project = Project.find_by(kind: 'maintenance_release')
-
-      # This is the first maintenance incident action, we reuse the action created by the factory
-      home_iggy_project = RakeSupport.find_or_create_project(iggy.home_project_name, iggy)
-      maintenance_package = create(:package, name: "maintenance_package_#{Faker::Lorem.word}", project: home_iggy_project, commit_user: iggy)
-
-      User.session = iggy
-      request.bs_request_actions.first.tap do |action|
-        action.source_project = home_iggy_project
-        action.source_package = maintenance_package
-        action.target_project = maintenance_project
-        action.target_releaseproject = release_project
-        action.save!
-      end
-
-      # This is the second maintenance incident action
-      another_maintenance_package = create(:package, name: "another_maintenance_package_#{Faker::Lorem.word}", project: home_iggy_project, commit_user: iggy)
-      request.bs_request_actions << create(:bs_request_action,
-                                           type: :maintenance_incident,
-                                           source_project: home_iggy_project,
-                                           source_package: another_maintenance_package,
-                                           target_project: maintenance_project,
-                                           target_releaseproject: release_project)
-
-      puts "* Request with maintenance incident actions #{request.number} has been created."
-    end
-
     # Run this task with: rails dev:requests:request_with_delete_action
     desc 'Creates a request with a delete action'
     task request_with_delete_action: :development_environment do

--- a/src/api/lib/tasks/dev/requests.rake
+++ b/src/api/lib/tasks/dev/requests.rake
@@ -178,7 +178,7 @@ namespace :dev do
 
       # This is the first maintenance incident action, we reuse the action created by the factory
       home_iggy_project = RakeSupport.find_or_create_project(iggy.home_project_name, iggy)
-      maintenance_package = create(:package, name: "maintenance_package_#{Faker::Lorem.word}", project: home_iggy_project)
+      maintenance_package = create(:package, name: "maintenance_package_#{Faker::Lorem.word}", project: home_iggy_project, commit_user: iggy)
 
       User.session = iggy
       request.bs_request_actions.first.tap do |action|
@@ -190,7 +190,7 @@ namespace :dev do
       end
 
       # This is the second maintenance incident action
-      another_maintenance_package = create(:package, name: "another_maintenance_package_#{Faker::Lorem.word}", project: home_iggy_project)
+      another_maintenance_package = create(:package, name: "another_maintenance_package_#{Faker::Lorem.word}", project: home_iggy_project, commit_user: iggy)
       request.bs_request_actions << create(:bs_request_action,
                                            type: :maintenance_incident,
                                            source_project: home_iggy_project,

--- a/src/api/lib/tasks/dev/requests.rake
+++ b/src/api/lib/tasks/dev/requests.rake
@@ -168,8 +168,6 @@ namespace :dev do
       include FactoryBot::Syntax::Methods
 
       iggy = User.find_by(login: 'Iggy') || create(:staff_user, login: 'Iggy')
-      User.session = iggy
-
       request = build(
         :bs_request_with_maintenance_incident_action,
         creator: iggy
@@ -181,6 +179,8 @@ namespace :dev do
       # This is the first maintenance incident action, we reuse the action created by the factory
       home_iggy_project = RakeSupport.find_or_create_project(iggy.home_project_name, iggy)
       maintenance_package = create(:package, name: "maintenance_package_#{Faker::Lorem.word}", project: home_iggy_project)
+
+      User.session = iggy
       request.bs_request_actions.first.tap do |action|
         action.source_project = home_iggy_project
         action.source_package = maintenance_package

--- a/src/api/lib/tasks/dev/test_data/maintenance.rake
+++ b/src/api/lib/tasks/dev/test_data/maintenance.rake
@@ -1,0 +1,63 @@
+namespace :dev do
+  namespace :test_data do
+    require 'factory_bot'
+    include FactoryBot::Syntax::Methods
+
+    def create_maintenance_project(project_name)
+      admin = User.get_default_admin
+      leap = Project.find_by(name: project_name)
+
+      update_project = create(:update_project, target_project: leap, name: "#{leap.name}:Update", commit_user: admin)
+      create(
+        :maintenance_project,
+        name: 'MaintenanceProject',
+        title: 'official maintenance space',
+        target_project: update_project,
+        maintainer: admin,
+        commit_user: admin
+      )
+    end
+
+    def request_with_incident_actions
+      iggy = User.find_by(login: 'Iggy') || create(:staff_user, login: 'Iggy')
+      request = build(
+        :bs_request_with_maintenance_incident_action,
+        creator: iggy
+      )
+
+      maintenance_project = Project.find_by(kind: 'maintenance')
+      release_project = Project.find_by(kind: 'maintenance_release')
+
+      # This is the first maintenance incident action, we reuse the action created by the factory
+      home_iggy_project = RakeSupport.find_or_create_project(iggy.home_project_name, iggy)
+      maintenance_package = create(:package, name: "maintenance_package_#{Faker::Lorem.word}", project: home_iggy_project, commit_user: iggy)
+
+      User.session = iggy
+      request.bs_request_actions.first.tap do |action|
+        action.source_project = home_iggy_project
+        action.source_package = maintenance_package
+        action.target_project = maintenance_project
+        action.target_releaseproject = release_project
+        action.save!
+      end
+
+      # This is the second maintenance incident action
+      another_maintenance_package = create(:package, name: "another_maintenance_package_#{Faker::Lorem.word}", project: home_iggy_project, commit_user: iggy)
+      request.bs_request_actions << create(:bs_request_action,
+                                           type: :maintenance_incident,
+                                           source_project: home_iggy_project,
+                                           source_package: another_maintenance_package,
+                                           target_project: maintenance_project,
+                                           target_releaseproject: release_project)
+
+      puts "* Request with maintenance incident actions #{request.number} has been created."
+    end
+
+    # Run this task with: rails dev:test_data:maintenance
+    desc 'Set a maintenance environment'
+    task maintenance: :development_environment do
+      create_maintenance_project('openSUSE:Leap:15.0')
+      request_with_incident_actions
+    end
+  end
+end


### PR DESCRIPTION
Move maintenance related development Rails tasks to its own task namespace: `dev:maintenance:...`.

Make it easier to add tasks related to maintenance, such as creating different types of requests related to maintenance for the development environtment.

Now we can call:
- `rake dev:test_data:create`

as we did before, and it will add a basic maintenance environment.