### PR TITLE
Fix `update_project` factory

### DIFF
--- a/src/api/spec/factories/project.rb
+++ b/src/api/spec/factories/project.rb
@@ -167,6 +167,7 @@ FactoryBot.define do
       end
 
       after(:create) do |update_project, evaluator|
+        create(:maintained_attrib, project: update_project)
         create(:update_project_attrib, project: evaluator.target_project, update_project: update_project)
         if evaluator.target_project
           create(:build_flag, status: 'disable', project: evaluator.target_project)


### PR DESCRIPTION
Allow to search for maintained packages (`osc maintained`) and create maintenance branches (`osc mbranch`) in the development environment.

**Before:**
```bash
> osc -A http://localhost:3000 maintained apache2
BuildService API error: no packages found by search criteria
>
```

**After:**
```bash
> osc -A http://localhost:3000 maintained apache2
openSUSE:Leap:15.0:Update/apache2
>
```

**References:**
- https://openbuildservice.org/help/manuals/obs-user-guide/cha.obs.maintenance_setup.html#id-1.5.10.12.10.3
- https://en.opensuse.org/openSUSE:Package_maintenance#Find_the_package_that_you_need_to_work_with