### PR TITLE
[WIP] Refactoring prepare_request_data method: split and use only useful chunks for different pages

### DIFF
--- a/src/api/app/components/sourcediff_component.html.haml
+++ b/src/api/app/components/sourcediff_component.html.haml
@@ -1,6 +1,6 @@
 .row
   .col
-    - if @refresh
+    - if @diff_not_cached
       .clearfix.mb-2.text-center
         .btn.btn-outline-primary.cache-refresh{ title: 'Refresh results', onclick: 'loadChanges();' }
           Crunching the latest data. Refresh again in a few seconds

--- a/src/api/app/components/sourcediff_component.rb
+++ b/src/api/app/components/sourcediff_component.rb
@@ -4,13 +4,13 @@ class SourcediffComponent < ApplicationComponent
   delegate :diff_label, to: :helpers
   delegate :diff_data, to: :helpers
 
-  def initialize(bs_request:, action:, index:, refresh:)
+  def initialize(bs_request:, action:, index:, diff_not_cached:)
     super
 
     @bs_request = bs_request
     @action = action
     @index = index
-    @refresh = refresh
+    @diff_not_cached = diff_not_cached
   end
 
   def commentable

--- a/src/api/app/components/sourcediff_tab_component.html.haml
+++ b/src/api/app/components/sourcediff_tab_component.html.haml
@@ -7,7 +7,7 @@
       Release in #{@action[:releaseproject]}
   %hr
   .row
-    - if @refresh
+    - if @diff_not_cached
       .col-lg-12
         .clearfix.mb-2.text-center
           .btn.btn-outline-primary.cache-refresh{ title: 'Refresh results', onclick: "reloadRequestAction(#{@index})" }

--- a/src/api/app/components/sourcediff_tab_component.rb
+++ b/src/api/app/components/sourcediff_tab_component.rb
@@ -1,21 +1,21 @@
 # frozen_string_literal: true
 
 class SourcediffTabComponent < ApplicationComponent
-  attr_accessor :bs_request, :action, :active, :index, :refresh
+  attr_accessor :bs_request, :action, :active, :index, :diff_not_cached
 
   delegate :valid_xml_id, to: :helpers
   delegate :request_action_header, to: :helpers
   delegate :diff_label, to: :helpers
   delegate :diff_data, to: :helpers
 
-  def initialize(bs_request:, action:, active:, index:, refresh:)
+  def initialize(bs_request:, action:, active:, index:, diff_not_cached:)
     super
 
     @bs_request = bs_request
     @action = action
     @active = active
     @index = index
-    @refresh = refresh
+    @diff_not_cached = diff_not_cached
   end
 
   def file_view_path(filename, sourcediff)

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -23,6 +23,8 @@ class Webui::RequestController < Webui::WebuiController
                             if: -> { Flipper.enabled?(:request_show_redesign, User.session) }
   before_action :cache_diff_data, only: [:request_action, :request_action_changes, :show, :build_results, :rpm_lint, :changes, :mentioned_issues]
   before_action :check_beta_user_redirect, only: [:build_results, :rpm_lint, :changes, :mentioned_issues]
+  before_action :check_notifications, only: [:show, :build_results, :rpm_lint, :changes, :mentioned_issues],
+                                      if: -> { Flipper.enabled?(:request_show_redesign, User.session) }
 
   after_action :verify_authorized, only: [:create]
 
@@ -596,7 +598,7 @@ class Webui::RequestController < Webui::WebuiController
     # provided by the action the code goes through
   end
 
-  def prepare_request_data
+  def check_notifications
     return unless User.session && params[:notification_id]
 
     @current_notification = Notification.find(params[:notification_id])

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -21,7 +21,7 @@ class Webui::RequestController < Webui::WebuiController
                               if: -> { Flipper.enabled?(:request_show_redesign, User.session) }
   before_action :tabs_data, only: [:show, :build_results, :rpm_lint, :changes, :mentioned_issues],
                             if: -> { Flipper.enabled?(:request_show_redesign, User.session) }
-  before_action :prepare_request_data, only: [:rpm_lint, :changes, :mentioned_issues],
+  before_action :prepare_request_data, only: [:changes, :mentioned_issues],
                                        if: -> { Flipper.enabled?(:request_show_redesign, User.session) }
   before_action :cache_diff_data, only: [:request_action, :request_action_changes, :show, :build_results, :rpm_lint, :changes, :mentioned_issues]
   before_action :check_beta_user_redirect, only: [:build_results, :rpm_lint, :changes, :mentioned_issues]
@@ -317,6 +317,9 @@ class Webui::RequestController < Webui::WebuiController
 
   def rpm_lint
     redirect_to request_show_path(params[:number], params[:request_action_id]) unless @action[:sprj] || @action[:spkg]
+
+    # Handling build results
+    @staging_project = @bs_request.staging_project.name unless @bs_request.staging_project_id.nil?
 
     @active = 'rpm_lint'
     @ajax_data = {}

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -503,7 +503,9 @@ class Webui::RequestController < Webui::WebuiController
   end
 
   def cache_diff_data
-    return unless (@refresh = @action[:diff_not_cached])
+    return @diff_not_cached = true unless defined?(@action)
+
+    return unless (@diff_not_cached = @action[:diff_not_cached])
 
     bs_request_action = BsRequestAction.find(@action[:id])
     job = Delayed::Job.where('handler LIKE ?', "%job_class: BsRequestActionWebuiInfosJob%#{bs_request_action.to_global_id.uri}%").count

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -544,58 +544,26 @@ class Webui::RequestController < Webui::WebuiController
   end
 
   def header_data
-    # @bs_request
-    # provided by `require_request`
-
-    # @staging_status
     target_project = Project.find_by_name(@bs_request.target_project_name)
     @staging_status = staging_status(@bs_request, target_project) if Staging::Workflow.find_by(project: target_project)
 
-    # @diff_limit
     @diff_limit = params[:full_diff] ? 0 : nil
-    # @diff_to_superseded_id
     @diff_to_superseded_id = params[:diff_to_superseded]
-    # @action
     @action = @bs_request.webui_actions(filelimit: @diff_limit, tarlimit: @diff_limit, diff_to_superseded: @diff_to_superseded,
       diffs: true, action_id: @action_id.to_i, cacheonly: 1).first
 
-    # @active_action
-    # provided by `set_active_action`
-
-    # @supported_actions
-    # provided by `set_supported_actions`
-
     active_action_index = @supported_actions.index(@active_action)
     if active_action_index
-      # @prev_action
       @prev_action = @supported_actions[active_action_index - 1] unless active_action_index.zero?
-      # @next_action
       @next_action = @supported_actions[active_action_index + 1] if active_action_index + 1 < @supported_actions.length
     end
   end
 
   def tabs_data
-    # @bs_request
-    # provided by `require_request`
-
-    # @action
-    # provided by `header_data`
-
-    # @issues
     # Collecting all issues in a hash. Each key is the issue name and the value is a hash containing all the issue details.
+
     @issues = @action.fetch(:sourcediff, []).reduce({}) { |accumulator, sourcediff| accumulator.merge(sourcediff.fetch('issues', {})) }
-
-    # @actions_for_diff
     @actions_for_diff = [:submit, :delete, :maintenance_incident, :maintenance_release]
-
-    # @active_action
-    # provided by `set_active_action`
-
-    # @supported_actions
-    # provided by `set_supported_actions`
-
-    # @active_tab
-    # provided by the action the code goes through
   end
 
   def check_notifications

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -550,13 +550,14 @@ class Webui::RequestController < Webui::WebuiController
     @diff_limit = params[:full_diff] ? 0 : nil
     @diff_to_superseded_id = params[:diff_to_superseded]
     @action = @bs_request.webui_actions(filelimit: @diff_limit, tarlimit: @diff_limit, diff_to_superseded: @diff_to_superseded,
-      diffs: true, action_id: @action_id.to_i, cacheonly: 1).first
+                                        diffs: true, action_id: @action_id.to_i, cacheonly: 1).first
 
     active_action_index = @supported_actions.index(@active_action)
-    if active_action_index
-      @prev_action = @supported_actions[active_action_index - 1] unless active_action_index.zero?
-      @next_action = @supported_actions[active_action_index + 1] if active_action_index + 1 < @supported_actions.length
-    end
+
+    return unless active_action_index
+
+    @prev_action = @supported_actions[active_action_index - 1] unless active_action_index.zero?
+    @next_action = @supported_actions[active_action_index + 1] if active_action_index + 1 < @supported_actions.length
   end
 
   def tabs_data

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -21,8 +21,6 @@ class Webui::RequestController < Webui::WebuiController
                               if: -> { Flipper.enabled?(:request_show_redesign, User.session) }
   before_action :tabs_data, only: [:show, :build_results, :rpm_lint, :changes, :mentioned_issues],
                             if: -> { Flipper.enabled?(:request_show_redesign, User.session) }
-  before_action :prepare_request_data, only: [:mentioned_issues],
-                                       if: -> { Flipper.enabled?(:request_show_redesign, User.session) }
   before_action :cache_diff_data, only: [:request_action, :request_action_changes, :show, :build_results, :rpm_lint, :changes, :mentioned_issues]
   before_action :check_beta_user_redirect, only: [:build_results, :rpm_lint, :changes, :mentioned_issues]
 

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -21,7 +21,7 @@ class Webui::RequestController < Webui::WebuiController
                               if: -> { Flipper.enabled?(:request_show_redesign, User.session) }
   before_action :tabs_data, only: [:show, :build_results, :rpm_lint, :changes, :mentioned_issues],
                             if: -> { Flipper.enabled?(:request_show_redesign, User.session) }
-  before_action :prepare_request_data, only: [:build_results, :rpm_lint, :changes, :mentioned_issues],
+  before_action :prepare_request_data, only: [:rpm_lint, :changes, :mentioned_issues],
                                        if: -> { Flipper.enabled?(:request_show_redesign, User.session) }
   before_action :cache_diff_data, only: [:request_action, :request_action_changes, :show, :build_results, :rpm_lint, :changes, :mentioned_issues]
   before_action :check_beta_user_redirect, only: [:build_results, :rpm_lint, :changes, :mentioned_issues]
@@ -302,6 +302,9 @@ class Webui::RequestController < Webui::WebuiController
 
   def build_results
     redirect_to request_show_path(params[:number], params[:request_action_id]) unless @action[:sprj] || @action[:spkg]
+
+    # Handling build results
+    @staging_project = @bs_request.staging_project.name unless @bs_request.staging_project_id.nil?
 
     @active = 'build_results'
     @project = @staging_project || @action[:sprj]
@@ -591,10 +594,6 @@ class Webui::RequestController < Webui::WebuiController
   end
 
   def prepare_request_data
-
-    # Handling build results
-    @staging_project = @bs_request.staging_project.name unless @bs_request.staging_project_id.nil?
-
     return unless User.session && params[:notification_id]
 
     @current_notification = Notification.find(params[:notification_id])

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -21,7 +21,7 @@ class Webui::RequestController < Webui::WebuiController
                               if: -> { Flipper.enabled?(:request_show_redesign, User.session) }
   before_action :tabs_data, only: [:show, :build_results, :rpm_lint, :changes, :mentioned_issues],
                             if: -> { Flipper.enabled?(:request_show_redesign, User.session) }
-  before_action :prepare_request_data, only: [:changes, :mentioned_issues],
+  before_action :prepare_request_data, only: [:mentioned_issues],
                                        if: -> { Flipper.enabled?(:request_show_redesign, User.session) }
   before_action :cache_diff_data, only: [:request_action, :request_action_changes, :show, :build_results, :rpm_lint, :changes, :mentioned_issues]
   before_action :check_beta_user_redirect, only: [:build_results, :rpm_lint, :changes, :mentioned_issues]
@@ -332,6 +332,8 @@ class Webui::RequestController < Webui::WebuiController
     redirect_to request_show_path(params[:number], params[:request_action_id]) unless @action[:type].in?(@actions_for_diff)
 
     @active = 'changes'
+
+    should_refresh(@action)
   end
 
   def mentioned_issues

--- a/src/api/app/views/webui/request/_request_tabs.html.haml
+++ b/src/api/app/views/webui/request/_request_tabs.html.haml
@@ -1,4 +1,3 @@
--# TODO: Remove the anchor-tag parameter once all the tabs are converted to pages
 .border-bottom
   %ul.nav.scrollable-tabs.border-0#request-tabs
     %li.nav-item.scrollable-tab-link

--- a/src/api/app/views/webui/request/changes.html.haml
+++ b/src/api/app/views/webui/request/changes.html.haml
@@ -14,7 +14,7 @@
                   active_action: @active_action, actions_count: @supported_actions.count, active: @active }
     .container.p-4
       .tab-content.sourcediff
-        = render SourcediffComponent.new(bs_request: @bs_request, action: @action, index: 0, refresh: @refresh)
+        = render SourcediffComponent.new(bs_request: @bs_request, action: @action, index: 0, diff_not_cached: @diff_not_cached)
   = render DeleteConfirmationDialogComponent.new(modal_id: 'delete-comment-modal',
                                                  method: :delete,
                                                  options: { modal_title: 'Delete comment?', remote: true })

--- a/src/api/app/views/webui/request/request_action.js.erb
+++ b/src/api/app/views/webui/request/request_action.js.erb
@@ -1,1 +1,1 @@
-$('.tab-content.sourcediff').append("<%= escape_javascript(render(SourcediffTabComponent.new(bs_request: @bs_request, action: @action, active: @active, index: @index, refresh: @refresh))) %>");
+$('.tab-content.sourcediff').append("<%= escape_javascript(render(SourcediffTabComponent.new(bs_request: @bs_request, action: @action, active: @active, index: @index, diff_not_cached: @diff_not_cached))) %>");

--- a/src/api/app/views/webui/request/request_action_changes.js.erb
+++ b/src/api/app/views/webui/request/request_action_changes.js.erb
@@ -1,1 +1,1 @@
-$('.tab-content.sourcediff').html("<%= escape_javascript(render(SourcediffComponent.new(bs_request: @bs_request, action: @action, index: 0, refresh: @refresh))) %>");
+$('.tab-content.sourcediff').html("<%= escape_javascript(render(SourcediffComponent.new(bs_request: @bs_request, action: @action, index: 0, diff_not_cached: @diff_not_cached))) %>");

--- a/src/api/spec/components/previews/sourcediff_tab_component_preview.rb
+++ b/src/api/spec/components/previews/sourcediff_tab_component_preview.rb
@@ -4,6 +4,6 @@ class SourcediffTabComponentPreview < ViewComponent::Preview
     bs_request = BsRequest.last
     opts = { filelimit: nil, tarlimit: nil, diff_to_superseded: nil, diffs: true, cacheonly: 1 }
     action = bs_request.send(:action_details, opts, xml: bs_request.bs_request_actions.last)
-    render(SourcediffTabComponent.new(bs_request: bs_request, action: action, active: action[:name], index: 0, refresh: action[:diff_not_cached]))
+    render(SourcediffTabComponent.new(bs_request: bs_request, action: action, active: action[:name], index: 0, diff_not_cached: action[:diff_not_cached]))
   end
 end

--- a/src/api/spec/components/sourcediff_tab_component_spec.rb
+++ b/src/api/spec/components/sourcediff_tab_component_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe SourcediffTabComponent, type: :component, vcr: true do
     before do
       User.session = create(:user)
       action = bs_request.send(:action_details, opts, xml: bs_request.bs_request_actions.last)
-      render_inline(described_class.new(bs_request: bs_request, action: action, active: action[:name], index: 0, refresh: action[:diff_not_cached]))
+      render_inline(described_class.new(bs_request: bs_request, action: action, active: action[:name], index: 0, diff_not_cached: action[:diff_not_cached]))
     end
 
     it do


### PR DESCRIPTION
This is a follow-up of the split into different pages of a `Request` page tabs: it was one big page before, now pages are:
- `show` (aka `conversation`)
- `build results`
- `rpm lint`
- `changes`
- `mentioned issues`

The refactoring is about to split up all the data of the former single page to differentiate what is used in which page only.

The refactoring starts from a giant function `prepare_request_data`, and it results into:
- `header_data` : the method that prepares the data for the Request header page, which is always the same for all the pages
- `tabs_data` : the method that prepares the data for the partial that is responsible of showing the right tab, select the active one, etc
- the related and not shared data for each page are instantiated into the proper action method
- few other methods to handle few things left not really bounded to the action method

### Reviewers
- **commit-by-commit** is suggested
- no behavior differences are expected