### PR TITLE
Allow retrieving deleted maintainers

### DIFF
--- a/src/api/app/mixins/has_relationships.rb
+++ b/src/api/app/mixins/has_relationships.rb
@@ -75,7 +75,7 @@ module HasRelationships
   end
 
   def maintainers
-    direct_users = relationships.with_users_and_roles_query.maintainers.pluck('users.login').map! { |user| User.find_by_login!(user) }
+    direct_users = relationships.with_users_and_roles_query.maintainers.pluck('users.login').map! { |user| User.find_by_login(user) }
     users_in_groups = relationships.with_groups_and_roles_query.maintainers.pluck('groups.title')
                                    .map! { |title| Group.find_by_title!(title).users }.flatten
     (direct_users + users_in_groups).uniq

--- a/src/api/spec/cassettes/Project/_maintainers/returns_all_the_users_but_user_2_only_once.yml
+++ b/src/api/spec/cassettes/Project/_maintainers/returns_all_the_users_but_user_2_only_once.yml
@@ -1,0 +1,81 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE_41/_meta?user=user_1
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE_41">
+          <title>Brandy of the Damned</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '108'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE_41">
+          <title>Brandy of the Damned</title>
+          <description></description>
+        </project>
+  recorded_at: Wed, 10 May 2023 14:10:59 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_2/_meta?user=user_2
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_2">
+          <title/>
+          <description/>
+          <person userid="user_2" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '134'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_2">
+          <title></title>
+          <description></description>
+          <person userid="user_2" role="maintainer"/>
+        </project>
+  recorded_at: Wed, 10 May 2023 14:10:59 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Project/_maintainers/when_one_of_the_users_is_deleted/still_returns_the_deleted_user.yml
+++ b/src/api/spec/cassettes/Project/_maintainers/when_one_of_the_users_is_deleted/still_returns_the_deleted_user.yml
@@ -1,0 +1,81 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE_41/_meta?user=user_9
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE_41">
+          <title>The Violent Bear It Away</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '112'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE_41">
+          <title>The Violent Bear It Away</title>
+          <description></description>
+        </project>
+  recorded_at: Wed, 10 May 2023 14:11:00 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_10/_meta?user=user_10
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_10">
+          <title/>
+          <description/>
+          <person userid="user_10" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '136'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_10">
+          <title></title>
+          <description></description>
+          <person userid="user_10" role="maintainer"/>
+        </project>
+  recorded_at: Wed, 10 May 2023 14:11:00 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Project/_maintainers/when_the_group_is_deleted/returns_the_deleted_user_but_not_the_deleted_group_s_user.yml
+++ b/src/api/spec/cassettes/Project/_maintainers/when_the_group_is_deleted/returns_the_deleted_user_but_not_the_deleted_group_s_user.yml
@@ -1,0 +1,81 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE_41/_meta?user=user_5
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE_41">
+          <title>The Mermaids Singing</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '108'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE_41">
+          <title>The Mermaids Singing</title>
+          <description></description>
+        </project>
+  recorded_at: Wed, 10 May 2023 14:11:00 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_6/_meta?user=user_6
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_6">
+          <title/>
+          <description/>
+          <person userid="user_6" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '134'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_6">
+          <title></title>
+          <description></description>
+          <person userid="user_6" role="maintainer"/>
+        </project>
+  recorded_at: Wed, 10 May 2023 14:11:00 GMT
+recorded_with: VCR 6.1.0


### PR DESCRIPTION
Until now, retrieving projects' maintainers that were deleted made the code crash.

Deleted users are displayed everywhere in the application (groups' members, projects' users etc). They are visible but on a special state, "deleted". So there is no reason to stop displaying them in the list of maintainers.

Fixes: #14302

**Reviewing Tips**

- Create two users
- Make them maintainers of a project
- Delete one of them from Configuration > Manage Users
- Check that `project.maintainers` returns the same users, including the deleted one, without crashing.

TODO:

- [x] Specs for `maintainers` method