### PR TITLE
Mention dismissed reviews in request conversation timeline

### DIFF
--- a/src/api/app/components/bs_request_activity_timeline_component.html.haml
+++ b/src/api/app/components/bs_request_activity_timeline_component.html.haml
@@ -5,4 +5,5 @@
         = render BsRequestCommentComponent.new(comment: comment_or_history_element, level: 1, commentable: comment_or_history_element.commentable,
                                                diff: diff_for_ref(comment_or_history_element))
     - else
-      = render BsRequestHistoryElementComponent.new(element: comment_or_history_element)
+      = render BsRequestHistoryElementComponent.new(element: comment_or_history_element,
+                                                    request_reviews_for_non_staging_projects: request_reviews_for_non_staging_projects)

--- a/src/api/app/components/bs_request_activity_timeline_component.rb
+++ b/src/api/app/components/bs_request_activity_timeline_component.rb
@@ -4,9 +4,9 @@
 # It merges the BsRequestCommentComponent and the BsRequestHistoryElement to
 # provide a merged timeline of events.
 class BsRequestActivityTimelineComponent < ApplicationComponent
-  attr_reader :bs_request, :creator, :timeline
+  attr_reader :bs_request, :creator, :timeline, :request_reviews_for_non_staging_projects
 
-  def initialize(bs_request:)
+  def initialize(bs_request:, request_reviews_for_non_staging_projects: [])
     super
     @bs_request = bs_request
     @creator = User.find_by_login(bs_request.creator) || User.nobody
@@ -20,6 +20,7 @@ class BsRequestActivityTimelineComponent < ApplicationComponent
       @bs_request.comments.without_parent.includes(:user) +
       @bs_request.history_elements.includes(:user)
     ).compact.sort_by(&:created_at)
+    @request_reviews_for_non_staging_projects = request_reviews_for_non_staging_projects
   end
 
   def diff_for_ref(comment)

--- a/src/api/app/components/bs_request_history_element_component.html.haml
+++ b/src/api/app/components/bs_request_history_element_component.html.haml
@@ -11,6 +11,8 @@
       %strong
         = element.action_target
       = element.user_action_suffix
+    - elsif element.instance_of?(HistoryElement::RequestAccepted) && pending_reviews?
+      #{element.user_action} and dismissed pending reviews
     - else
       = element.user_action
     = link_to("#status-history-#{element.id}", title: l(element.created_at.utc), name: "status-history-#{element.id}") do

--- a/src/api/app/components/bs_request_history_element_component.rb
+++ b/src/api/app/components/bs_request_history_element_component.rb
@@ -3,12 +3,13 @@
 # It is used in the beta view of the request show page, under the Overview tab,
 # merged with the BsRequestCommentComponent.
 class BsRequestHistoryElementComponent < ApplicationComponent
-  attr_reader :element
+  attr_reader :element, :request_reviews_for_non_staging_projects
 
-  def initialize(element:)
+  def initialize(element:, request_reviews_for_non_staging_projects: [])
     super
 
     @element = element
+    @request_reviews_for_non_staging_projects = request_reviews_for_non_staging_projects
   end
 
   private
@@ -33,5 +34,11 @@ class BsRequestHistoryElementComponent < ApplicationComponent
 
   def css_for_comment
     element_with_comment_from_human? ? 'comment-bubble comment-bubble-content' : ''
+  end
+
+  def pending_reviews?
+    return true if request_reviews_for_non_staging_projects.select(&:new?).any?
+
+    false
   end
 end

--- a/src/api/app/views/webui/request/beta_show.html.haml
+++ b/src/api/app/views/webui/request/beta_show.html.haml
@@ -66,9 +66,11 @@
                   %span.collapser
                     Collapse history from superseded request ##{superseding_request.number}
               .collapse.mb-4#collapse-superseding
-                = render BsRequestActivityTimelineComponent.new(bs_request: superseding_request)
+                = render BsRequestActivityTimelineComponent.new(bs_request: superseding_request,
+                                                                request_reviews_for_non_staging_projects: @request_reviews)
 
-            = render BsRequestActivityTimelineComponent.new(bs_request: @bs_request)
+            = render BsRequestActivityTimelineComponent.new(bs_request: @bs_request,
+                                                            request_reviews_for_non_staging_projects: @request_reviews)
 
           .comment_new
             = render partial: 'webui/comment/new', locals: { commentable: @bs_request }

--- a/src/api/spec/components/bs_request_history_element_component_spec.rb
+++ b/src/api/spec/components/bs_request_history_element_component_spec.rb
@@ -2,9 +2,10 @@ require 'rails_helper'
 
 RSpec.describe BsRequestHistoryElementComponent, type: :component do
   let(:user) { create(:confirmed_user) }
+  let(:reviews) { [] }
 
   before do
-    render_inline(described_class.new(element: element))
+    render_inline(described_class.new(element: element, request_reviews_for_non_staging_projects: reviews))
   end
 
   context 'for any kind of history elements' do
@@ -36,6 +37,14 @@ RSpec.describe BsRequestHistoryElementComponent, type: :component do
 
     it 'describes the element action' do
       expect(rendered_content).to have_text('accepted request')
+    end
+
+    context 'with pending reviews' do
+      let(:reviews) { build_list(:review, 2, state: 'new') }
+
+      it 'describes the element action and mentions dismissed reviews' do
+        expect(rendered_content).to have_text('accepted request and dismissed pending reviews')
+      end
     end
   end
 


### PR DESCRIPTION
Make it more obvious when a user accepted a request, despite
open/pending reviews by extending the text shown for the
`HistoryElement::RequestAccepted` in the conversation timeline
mentioning that the user dismissed pending reviews.

![screenshot_dismissed_reviews](https://github.com/openSUSE/open-build-service/assets/22001671/9e31f5a4-211e-4ff4-9870-fb49a3211863)

How to test:

1. Create a submit request
2. Add a review for another user/group
3. Accept the request despite the pending review
4. See the note about the dismissed reviews in the conversations timeline