### PR TITLE
Support `maintenance_incident` request actions in beta

### DIFF
--- a/src/api/app/assets/stylesheets/webui/requests.scss
+++ b/src/api/app/assets/stylesheets/webui/requests.scss
@@ -20,6 +20,13 @@
   }
 }
 
+.bg-maintenance {
+  background-color: $orange;
+  > a {
+    color: $white;
+  }
+}
+
 .req-description-box {
   word-break: break-all;
   white-space: pre-line;

--- a/src/api/app/components/sourcediff_component.rb
+++ b/src/api/app/components/sourcediff_component.rb
@@ -29,6 +29,9 @@ class SourcediffComponent < ApplicationComponent
   end
 
   def target_package
+    # For not accepted maintenance incident requests, the package is not there.
+    return nil unless @action[:tpkg]
+
     Package.get_by_project_and_name(@action[:tprj], @action[:tpkg], { follow_multibuild: true })
   rescue Package::UnknownObjectError
   end

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -480,7 +480,7 @@ class Webui::RequestController < Webui::WebuiController
 
   def set_supported_actions
     # Change supported_actions below into actions here when all actions are supported
-    @supported_actions = @actions.where(type: [:add_role, :change_devel, :delete, :submit])
+    @supported_actions = @actions.where(type: [:add_role, :change_devel, :delete, :submit, :maintenance_incident])
   end
 
   def set_action_id

--- a/src/api/app/helpers/webui/request_helper.rb
+++ b/src/api/app/helpers/webui/request_helper.rb
@@ -117,64 +117,69 @@ module Webui::RequestHelper
   def request_action_header(action, creator)
     source_project_hash = { project: action[:sprj], package: action[:spkg], trim_to: nil }
 
-    case action[:type]
-    when :submit
-      'Submit %{source_container} to %{target_container}' % {
-        source_container: project_or_package_link(source_project_hash),
-        target_container: project_or_package_link(project: action[:tprj], package: action[:tpkg])
-      }
-    when :delete
-      target_repository = "repository #{link_to(action[:trepo], repositories_path(project: action[:tprj], repository: action[:trepo]))} for " if action[:trepo]
+    description = case action[:type]
+                  when :submit
+                    'Submit %{source_container} to %{target_container}' % {
+                      source_container: project_or_package_link(source_project_hash),
+                      target_container: project_or_package_link(project: action[:tprj], package: action[:tpkg])
+                    }
+                  when :delete
+                    target_repository = "repository #{link_to(action[:trepo], repositories_path(project: action[:tprj], repository: action[:trepo]))} for " if action[:trepo]
 
-      'Delete %{target_repository}%{target_container}' % {
-        target_repository: target_repository,
-        target_container: project_or_package_link(project: action[:tprj], package: action[:tpkg])
-      }
-    when :add_role, :set_bugowner
-      '%{creator} wants %{requester} to %{task} for %{target_container}' % {
-        creator: user_with_realname_and_icon(creator),
-        requester: requester_str(creator, action[:user], action[:group]),
-        task: creator_intentions(action[:role]),
-        target_container: project_or_package_link(project: action[:tprj], package: action[:tpkg])
-      }
-    when :change_devel
-      # TODO: leave only the content of the if part when request_show_redesign is rolled out.
-      if Flipper.enabled?(:request_show_redesign, User.session)
-        'Set %{source_container} to be devel project/package of %{target_container}' % {
-          source_container: project_or_package_link(source_project_hash),
-          target_container: project_or_package_link(project: action[:tprj], package: action[:tpkg])
-        }
-      else
-        'Set the devel project to %{source_container} for %{target_container}' % {
-          source_container: project_or_package_link(source_project_hash),
-          target_container: project_or_package_link(project: action[:tprj], package: action[:tpkg])
-        }
-      end
-    when :maintenance_incident
-      source_project_hash.update(homeproject: creator)
+                    'Delete %{target_repository}%{target_container}' % {
+                      target_repository: target_repository,
+                      target_container: project_or_package_link(project: action[:tprj], package: action[:tpkg])
+                    }
+                  when :add_role, :set_bugowner
+                    '%{creator} wants %{requester} to %{task} for %{target_container}' % {
+                      creator: user_with_realname_and_icon(creator),
+                      requester: requester_str(creator, action[:user], action[:group]),
+                      task: creator_intentions(action[:role]),
+                      target_container: project_or_package_link(project: action[:tprj], package: action[:tpkg])
+                    }
+                  when :change_devel
+                    'Set the devel project to %{source_container} for %{target_container}' % {
+                      source_container: project_or_package_link(source_project_hash),
+                      target_container: project_or_package_link(project: action[:tprj], package: action[:tpkg])
+                    }
+                  when :maintenance_incident
+                    source_project_hash.update(homeproject: creator)
+                    'Submit update from %{source_container} to %{target_container}' % {
+                      source_container: project_or_package_link(source_project_hash),
+                      target_container: project_or_package_link(project: action[:tprj], package: action[:tpkg])
+                    }
+                  when :maintenance_release
+                    'Maintenance release %{source_container} to %{target_container}' % {
+                      source_container: project_or_package_link(source_project_hash),
+                      target_container: project_or_package_link(project: action[:tprj], package: action[:tpkg])
+                    }
+                  when :release
+                    'Release %{source_container} to %{target_container}' % {
+                      source_container: project_or_package_link(source_project_hash),
+                      target_container: project_or_package_link(project: action[:tprj], package: action[:tpkg])
+                    }
+                  end
 
-      if Flipper.enabled?(:request_show_redesign, User.session)
-        'Submit update from %{source_container} to %{target_container}' % {
-          source_container: project_or_package_link(source_project_hash),
-          target_container: project_or_package_link(project: action[:tprj], package: action[:tpkg], trim_to: nil)
-        }
-      else
-        'Submit update from %{source_container} to %{target_container}' % {
-          source_container: project_or_package_link(source_project_hash),
-          target_container: project_or_package_link(project: action[:tprj], package: action[:tpkg])
-        }
-      end
-    when :maintenance_release
-      'Maintenance release %{source_container} to %{target_container}' % {
-        source_container: project_or_package_link(source_project_hash),
-        target_container: project_or_package_link(project: action[:tprj], package: action[:tpkg])
-      }
-    when :release
-      'Release %{source_container} to %{target_container}' % {
-        source_container: project_or_package_link(source_project_hash),
-        target_container: project_or_package_link(project: action[:tprj], package: action[:tpkg])
-      }
-    end.html_safe
+    # TODO: merge these extra conditions when request_show_redesign is rolled out.
+    if Flipper.enabled?(:request_show_redesign, User.session)
+      description = case action[:type]
+                    when :change_devel
+                      'Set %{source_container} to be devel project/package of %{target_container}' % {
+                        source_container: project_or_package_link(source_project_hash),
+                        target_container: project_or_package_link(project: action[:tprj], package: action[:tpkg])
+                      }
+                    when :maintenance_incident
+                      source_project_hash.update(homeproject: creator)
+                      'Submit update from %{source_container} to %{target_container}' % {
+                        source_container: project_or_package_link(source_project_hash),
+                        target_container: project_or_package_link(project: action[:tprj], package: action[:tpkg], trim_to: nil)
+                      }
+                    else
+                      description
+                    end
+    end
+
+    description.html_safe
   end
   # rubocop:enable Style/FormatString
 

--- a/src/api/app/helpers/webui/request_helper.rb
+++ b/src/api/app/helpers/webui/request_helper.rb
@@ -152,10 +152,18 @@ module Webui::RequestHelper
       end
     when :maintenance_incident
       source_project_hash.update(homeproject: creator)
-      'Submit update from %{source_container} to %{target_container}' % {
-        source_container: project_or_package_link(source_project_hash),
-        target_container: project_or_package_link(project: action[:tprj], package: action[:tpkg])
-      }
+
+      if Flipper.enabled?(:request_show_redesign, User.session)
+        'Submit update from %{source_container} to %{target_container}' % {
+          source_container: project_or_package_link(source_project_hash),
+          target_container: project_or_package_link(project: action[:tprj], package: action[:tpkg], trim_to: nil)
+        }
+      else
+        'Submit update from %{source_container} to %{target_container}' % {
+          source_container: project_or_package_link(source_project_hash),
+          target_container: project_or_package_link(project: action[:tprj], package: action[:tpkg])
+        }
+      end
     when :maintenance_release
       'Maintenance release %{source_container} to %{target_container}' % {
         source_container: project_or_package_link(source_project_hash),

--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -862,6 +862,11 @@ class BsRequest < ApplicationRecord
     bs_request_actions&.first&.target_project.to_s
   end
 
+  # It is considered an "incident request" if it has at least one maintenance_incident action
+  def maintenance_incident_request?
+    bs_request_actions.where(type: 'maintenance_incident').any?
+  end
+
   def auto_accept
     # do not run for processed requests. Ignoring review on purpose since this
     # must also work when people do not react anymore

--- a/src/api/app/views/webui/request/_action_text.html.haml
+++ b/src/api/app/views/webui/request/_action_text.html.haml
@@ -29,16 +29,21 @@
           Delete #{project_or_package_text(action.target_project, action.target_package)}
         - when 'change_devel'
           Set #{project_or_package_text(action.source_project, action.source_package)}
+        - when 'maintenance_incident'
+          Incident #{action.source_package}
         - else
           = action.name
 
     -# delete and set_bugowner are actions on the target repo, so they don't need to mention where they are coming from
     - unless %w[delete set_bugowner].include?(action.type)
       %p.mb-0.mt-0.small
-        - if action.type == 'add_role'
+        - case action.type
+        - when 'add_role'
           Add #{action.person_name} as #{action.role} of #{project_or_package_text(action.target_project, action.target_package)}
-        - elsif action.type == 'change_devel'
+        - when 'change_devel'
           as development package of #{action.target_project}/#{action.target_package}
+        - when 'maintenance_incident'
+          from #{action.source_project} to #{action.target_project}
         - else
           from #{project_or_package_text(action.source_project, action.source_package)}
     - if details

--- a/src/api/app/views/webui/request/_actions_details.html.haml
+++ b/src/api/app/views/webui/request/_actions_details.html.haml
@@ -42,7 +42,9 @@
     %span#action-seen-by-user-wrapper
       = render ActionSeenByUserComponent.new(action: active_action, user: User.session!)
 
-.fst-italic= request_action_header(action, bs_request.creator)
+%p.fst-italic= request_action_header(action, bs_request.creator)
+- if active_action.target_releaseproject
+  %p.fst-italic Release in #{project_or_package_link(project: active_action.target_releaseproject)}
 
 - if active_action.type == 'add_role'
   :ruby

--- a/src/api/app/views/webui/request/_request_header.html.haml
+++ b/src/api/app/views/webui/request/_request_header.html.haml
@@ -51,6 +51,12 @@
         %mark.text-dark.alert-warning.ps-2.pe-2.text-nowrap{ title: bs_request.accept_at }
           auto accepted
           = render TimeComponent.new(time: bs_request.accept_at)
+    -# Maintenance Incident Request
+    - if bs_request.maintenance_incident_request?
+      %li
+        This is a
+        %mark.text-light.bg-maintenance.text-nowrap.text Maintenance Incident
+        request
   .mt-4
     -# action description, prev + dropdown select + next
         TODO: once we support all types of actions, we have to send @actions instead of @supported_actions

--- a/src/api/app/views/webui/request/_request_tabs.html.haml
+++ b/src/api/app/views/webui/request/_request_tabs.html.haml
@@ -3,7 +3,7 @@
     %li.nav-item.scrollable-tab-link
       = link_to('Conversation', request_show_path(bs_request.number, actions_count > 1 ? active_action : nil),
                 class: "nav-link text-nowrap #{active_tab == 'conversation' ? 'active' : ''}")
-    - if action[:sprj] || action[:spkg]
+    - if (action[:sprj] || action[:spkg]) && !(action[:type] == :maintenance_incident && action[:spkg] == 'patchinfo')
       %li.nav-item.scrollable-tab-link.active
         = link_to('Build Results', request_build_results_path(bs_request.number, actions_count > 1 ? active_action : nil),
                   class: "nav-link text-nowrap #{active_tab == 'build_results' ? 'active' : ''}")


### PR DESCRIPTION
Adapt the beta request show view to display maintenance incident requests.

**Before:**

![Screenshot 2023-05-25 at 12-10-41 Request 13 (accepted)](https://github.com/openSUSE/open-build-service/assets/2581944/19aed9c7-92fc-45ea-8434-4f47cb7d29f6)


**Now:**

- At the top of the page, it is highlighted that the request is a Maintenance Incident Request.
- The names of the projects and packages are not trimmed.
- Display a link to the target release, if present.
- The dropdown's action text only displays the relevant information

Not accepted request. Target is openSUSE:Maintenance.

![Screenshot 2023-05-25 at 12-09-47 Open Build Service](https://github.com/openSUSE/open-build-service/assets/2581944/df7369f3-1495-4485-b098-f9dfcc0ee6b2)

![Screenshot 2023-05-25 at 12-09-56 Open Build Service](https://github.com/openSUSE/open-build-service/assets/2581944/c58e5a2d-df4b-464a-a269-aaaf702f9ea1)

Accepted request. Target is openSUSE:Maintenance:0.

![Screenshot 2023-05-25 at 12-09-09 Open Build Service](https://github.com/openSUSE/open-build-service/assets/2581944/a7014c51-a43b-4863-af90-f9c9e8465fe5)

![Screenshot 2023-05-25 at 12-09-25 Open Build Service](https://github.com/openSUSE/open-build-service/assets/2581944/de77c631-dcce-4e2c-a558-381358950925)

**Reviewing Tips**
Run `bundle exec rake dev:test_data:create` to set up all the data you need. Requests with numbers between 11 and 14 are incident ones.

NOTE: specs will be covered in another PR.
