### PR TITLE
Refactor request refresh logic

### DIFF
--- a/src/api/app/components/sourcediff_component.html.haml
+++ b/src/api/app/components/sourcediff_component.html.haml
@@ -1,6 +1,6 @@
 .row
   .col
-    - if @refresh
+    - if @diff_not_cached
       .clearfix.mb-2.text-center
         .btn.btn-outline-primary.cache-refresh{ title: 'Refresh results', onclick: 'loadChanges();' }
           Crunching the latest data. Refresh again in a few seconds

--- a/src/api/app/components/sourcediff_component.html.haml
+++ b/src/api/app/components/sourcediff_component.html.haml
@@ -1,6 +1,6 @@
 .row
   .col
-    - if @diff_not_cached
+    - if @action[:diff_not_cached]
       .clearfix.mb-2.text-center
         .btn.btn-outline-primary.cache-refresh{ title: 'Refresh results', onclick: 'loadChanges();' }
           Crunching the latest data. Refresh again in a few seconds

--- a/src/api/app/components/sourcediff_component.rb
+++ b/src/api/app/components/sourcediff_component.rb
@@ -4,13 +4,13 @@ class SourcediffComponent < ApplicationComponent
   delegate :diff_label, to: :helpers
   delegate :diff_data, to: :helpers
 
-  def initialize(bs_request:, action:, index:, refresh:)
+  def initialize(bs_request:, action:, index:, diff_not_cached:)
     super
 
     @bs_request = bs_request
     @action = action
     @index = index
-    @refresh = refresh
+    @diff_not_cached = diff_not_cached
   end
 
   def commentable

--- a/src/api/app/components/sourcediff_component.rb
+++ b/src/api/app/components/sourcediff_component.rb
@@ -4,13 +4,12 @@ class SourcediffComponent < ApplicationComponent
   delegate :diff_label, to: :helpers
   delegate :diff_data, to: :helpers
 
-  def initialize(bs_request:, action:, index:, diff_not_cached:)
+  def initialize(bs_request:, action:, index:)
     super
 
     @bs_request = bs_request
     @action = action
     @index = index
-    @diff_not_cached = diff_not_cached
   end
 
   def commentable

--- a/src/api/app/components/sourcediff_tab_component.html.haml
+++ b/src/api/app/components/sourcediff_tab_component.html.haml
@@ -7,7 +7,7 @@
       Release in #{@action[:releaseproject]}
   %hr
   .row
-    - if @diff_not_cached
+    - if @action[:diff_not_cached]
       .col-lg-12
         .clearfix.mb-2.text-center
           .btn.btn-outline-primary.cache-refresh{ title: 'Refresh results', onclick: "reloadRequestAction(#{@index})" }

--- a/src/api/app/components/sourcediff_tab_component.html.haml
+++ b/src/api/app/components/sourcediff_tab_component.html.haml
@@ -7,7 +7,7 @@
       Release in #{@action[:releaseproject]}
   %hr
   .row
-    - if @refresh
+    - if @diff_not_cached
       .col-lg-12
         .clearfix.mb-2.text-center
           .btn.btn-outline-primary.cache-refresh{ title: 'Refresh results', onclick: "reloadRequestAction(#{@index})" }

--- a/src/api/app/components/sourcediff_tab_component.rb
+++ b/src/api/app/components/sourcediff_tab_component.rb
@@ -1,21 +1,21 @@
 # frozen_string_literal: true
 
 class SourcediffTabComponent < ApplicationComponent
-  attr_accessor :bs_request, :action, :active, :index, :refresh
+  attr_accessor :bs_request, :action, :active, :index, :diff_not_cached
 
   delegate :valid_xml_id, to: :helpers
   delegate :request_action_header, to: :helpers
   delegate :diff_label, to: :helpers
   delegate :diff_data, to: :helpers
 
-  def initialize(bs_request:, action:, active:, index:, refresh:)
+  def initialize(bs_request:, action:, active:, index:, diff_not_cached:)
     super
 
     @bs_request = bs_request
     @action = action
     @active = active
     @index = index
-    @refresh = refresh
+    @diff_not_cached = diff_not_cached
   end
 
   def file_view_path(filename, sourcediff)

--- a/src/api/app/components/sourcediff_tab_component.rb
+++ b/src/api/app/components/sourcediff_tab_component.rb
@@ -1,21 +1,20 @@
 # frozen_string_literal: true
 
 class SourcediffTabComponent < ApplicationComponent
-  attr_accessor :bs_request, :action, :active, :index, :diff_not_cached
+  attr_accessor :bs_request, :action, :active, :index
 
   delegate :valid_xml_id, to: :helpers
   delegate :request_action_header, to: :helpers
   delegate :diff_label, to: :helpers
   delegate :diff_data, to: :helpers
 
-  def initialize(bs_request:, action:, active:, index:, diff_not_cached:)
+  def initialize(bs_request:, action:, active:, index:)
     super
 
     @bs_request = bs_request
     @action = action
     @active = active
     @index = index
-    @diff_not_cached = diff_not_cached
   end
 
   def file_view_path(filename, sourcediff)

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -19,6 +19,8 @@ class Webui::RequestController < Webui::WebuiController
   before_action :check_ajax, only: :sourcediff
   before_action :prepare_request_data, only: [:show, :build_results, :rpm_lint, :changes, :mentioned_issues],
                                        if: -> { Flipper.enabled?(:request_show_redesign, User.session) }
+  before_action :cache_diff_data, only: [:show, :build_results, :rpm_lint, :changes, :mentioned_issues],
+                                  if: -> { Flipper.enabled?(:request_show_redesign, User.session) }
   before_action :check_beta_user_redirect, only: [:build_results, :rpm_lint, :changes, :mentioned_issues]
 
   after_action :verify_authorized, only: [:create]
@@ -186,11 +188,7 @@ class Webui::RequestController < Webui::WebuiController
     @diff_to_superseded_id = params[:diff_to_superseded]
     @refresh = @action[:diff_not_cached]
 
-    if @refresh
-      bs_request_action = BsRequestAction.find(@action[:id])
-      job = Delayed::Job.where('handler LIKE ?', "%job_class: BsRequestActionWebuiInfosJob%#{bs_request_action.to_global_id.uri}%").count
-      BsRequestActionWebuiInfosJob.perform_later(bs_request_action) if job.zero?
-    end
+    cache_diff_data
 
     respond_to do |format|
       format.js
@@ -515,6 +513,14 @@ class Webui::RequestController < Webui::WebuiController
     }
   end
 
+  def cache_diff_data
+    return unless (@refresh = @action[:diff_not_cached])
+
+    bs_request_action = BsRequestAction.find(@action[:id])
+    job = Delayed::Job.where('handler LIKE ?', "%job_class: BsRequestActionWebuiInfosJob%#{bs_request_action.to_global_id.uri}%").count
+    BsRequestActionWebuiInfosJob.perform_later(bs_request_action) if job.zero?
+  end
+
   def prepare_request_data
     @is_author = @bs_request.creator == User.possibly_nobody.login
     @is_target_maintainer = @bs_request.is_target_maintainer?(User.session)
@@ -537,7 +543,6 @@ class Webui::RequestController < Webui::WebuiController
     target_project = Project.find_by_name(@bs_request.target_project_name)
     @request_reviews = @bs_request.reviews.for_non_staging_projects(target_project)
     @staging_status = staging_status(@bs_request, target_project) if Staging::Workflow.find_by(project: target_project)
-    @refresh = @action[:diff_not_cached]
 
     # Collecting all issues in a hash. Each key is the issue name and the value is a hash containing all the issue details.
     @issues = @action.fetch(:sourcediff, []).reduce({}) { |accumulator, sourcediff| accumulator.merge(sourcediff.fetch('issues', {})) }
@@ -555,12 +560,6 @@ class Webui::RequestController < Webui::WebuiController
     # Handling build results
     @staging_project = @bs_request.staging_project.name unless @bs_request.staging_project_id.nil?
     @actions_for_diff = [:submit, :delete, :maintenance_incident, :maintenance_release]
-
-    if @refresh
-      bs_request_action = BsRequestAction.find(@action[:id])
-      job = Delayed::Job.where('handler LIKE ?', "%job_class: BsRequestActionWebuiInfosJob%#{bs_request_action.to_global_id.uri}%").count
-      BsRequestActionWebuiInfosJob.perform_later(bs_request_action) if job.zero?
-    end
 
     return unless User.session && params[:notification_id]
 

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -162,9 +162,9 @@ class Webui::RequestController < Webui::WebuiController
     @active = @action[:name]
     @not_full_diff = BsRequest.truncated_diffs?(@actions)
     @diff_to_superseded_id = params[:diff_to_superseded]
-    @refresh = @action[:diff_not_cached]
+    @diff_not_cached = @action[:diff_not_cached]
 
-    if @refresh
+    if @diff_not_cached
       bs_request_action = BsRequestAction.find(@action[:id])
       job = Delayed::Job.where('handler LIKE ?', "%job_class: BsRequestActionWebuiInfosJob%#{bs_request_action.to_global_id.uri}%").count
       BsRequestActionWebuiInfosJob.perform_later(bs_request_action) if job.zero?
@@ -186,7 +186,7 @@ class Webui::RequestController < Webui::WebuiController
     @not_full_diff = BsRequest.truncated_diffs?(@actions)
     # TODO: Check if @diff_to_superseded_id is really needed
     @diff_to_superseded_id = params[:diff_to_superseded]
-    @refresh = @action[:diff_not_cached]
+    @diff_not_cached = @action[:diff_not_cached]
 
     cache_diff_data
 
@@ -514,7 +514,7 @@ class Webui::RequestController < Webui::WebuiController
   end
 
   def cache_diff_data
-    return unless (@refresh = @action[:diff_not_cached])
+    return unless (@diff_not_cached = @action[:diff_not_cached])
 
     bs_request_action = BsRequestAction.find(@action[:id])
     job = Delayed::Job.where('handler LIKE ?', "%job_class: BsRequestActionWebuiInfosJob%#{bs_request_action.to_global_id.uri}%").count

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -162,9 +162,8 @@ class Webui::RequestController < Webui::WebuiController
     @active = @action[:name]
     @not_full_diff = BsRequest.truncated_diffs?(@actions)
     @diff_to_superseded_id = params[:diff_to_superseded]
-    @diff_not_cached = @action[:diff_not_cached]
 
-    if @diff_not_cached
+    if @action[:diff_not_cached]
       bs_request_action = BsRequestAction.find(@action[:id])
       job = Delayed::Job.where('handler LIKE ?', "%job_class: BsRequestActionWebuiInfosJob%#{bs_request_action.to_global_id.uri}%").count
       BsRequestActionWebuiInfosJob.perform_later(bs_request_action) if job.zero?
@@ -186,7 +185,6 @@ class Webui::RequestController < Webui::WebuiController
     @not_full_diff = BsRequest.truncated_diffs?(@actions)
     # TODO: Check if @diff_to_superseded_id is really needed
     @diff_to_superseded_id = params[:diff_to_superseded]
-    @diff_not_cached = @action[:diff_not_cached]
 
     cache_diff_data
 
@@ -514,7 +512,7 @@ class Webui::RequestController < Webui::WebuiController
   end
 
   def cache_diff_data
-    return unless (@diff_not_cached = @action[:diff_not_cached])
+    return unless @action[:diff_not_cached]
 
     bs_request_action = BsRequestAction.find(@action[:id])
     job = Delayed::Job.where('handler LIKE ?', "%job_class: BsRequestActionWebuiInfosJob%#{bs_request_action.to_global_id.uri}%").count

--- a/src/api/app/views/webui/request/changes.html.haml
+++ b/src/api/app/views/webui/request/changes.html.haml
@@ -14,7 +14,7 @@
                   active_action: @active_action, actions_count: @supported_actions.count, active_tab: @active_tab }
     .container.p-4
       .tab-content.sourcediff
-        = render SourcediffComponent.new(bs_request: @bs_request, action: @action, index: 0, refresh: @refresh)
+        = render SourcediffComponent.new(bs_request: @bs_request, action: @action, index: 0, diff_not_cached: @diff_not_cached)
   = render DeleteConfirmationDialogComponent.new(modal_id: 'delete-comment-modal',
                                                  method: :delete,
                                                  options: { modal_title: 'Delete comment?', remote: true })

--- a/src/api/app/views/webui/request/changes.html.haml
+++ b/src/api/app/views/webui/request/changes.html.haml
@@ -14,7 +14,7 @@
                   active_action: @active_action, actions_count: @supported_actions.count, active_tab: @active_tab }
     .container.p-4
       .tab-content.sourcediff
-        = render SourcediffComponent.new(bs_request: @bs_request, action: @action, index: 0, diff_not_cached: @diff_not_cached)
+        = render SourcediffComponent.new(bs_request: @bs_request, action: @action, index: 0)
   = render DeleteConfirmationDialogComponent.new(modal_id: 'delete-comment-modal',
                                                  method: :delete,
                                                  options: { modal_title: 'Delete comment?', remote: true })

--- a/src/api/app/views/webui/request/request_action.js.erb
+++ b/src/api/app/views/webui/request/request_action.js.erb
@@ -1,1 +1,1 @@
-$('.tab-content.sourcediff').append("<%= escape_javascript(render(SourcediffTabComponent.new(bs_request: @bs_request, action: @action, active: @active, index: @index, diff_not_cached: @diff_not_cached))) %>");
+$('.tab-content.sourcediff').append("<%= escape_javascript(render(SourcediffTabComponent.new(bs_request: @bs_request, action: @action, active: @active, index: @index))) %>");

--- a/src/api/app/views/webui/request/request_action.js.erb
+++ b/src/api/app/views/webui/request/request_action.js.erb
@@ -1,1 +1,1 @@
-$('.tab-content.sourcediff').append("<%= escape_javascript(render(SourcediffTabComponent.new(bs_request: @bs_request, action: @action, active: @active, index: @index, refresh: @refresh))) %>");
+$('.tab-content.sourcediff').append("<%= escape_javascript(render(SourcediffTabComponent.new(bs_request: @bs_request, action: @action, active: @active, index: @index, diff_not_cached: @diff_not_cached))) %>");

--- a/src/api/app/views/webui/request/request_action_changes.js.erb
+++ b/src/api/app/views/webui/request/request_action_changes.js.erb
@@ -1,1 +1,1 @@
-$('.tab-content.sourcediff').html("<%= escape_javascript(render(SourcediffComponent.new(bs_request: @bs_request, action: @action, index: 0, refresh: @refresh))) %>");
+$('.tab-content.sourcediff').html("<%= escape_javascript(render(SourcediffComponent.new(bs_request: @bs_request, action: @action, index: 0, diff_not_cached: @diff_not_cached))) %>");

--- a/src/api/app/views/webui/request/request_action_changes.js.erb
+++ b/src/api/app/views/webui/request/request_action_changes.js.erb
@@ -1,1 +1,1 @@
-$('.tab-content.sourcediff').html("<%= escape_javascript(render(SourcediffComponent.new(bs_request: @bs_request, action: @action, index: 0, diff_not_cached: @diff_not_cached))) %>");
+$('.tab-content.sourcediff').html("<%= escape_javascript(render(SourcediffComponent.new(bs_request: @bs_request, action: @action, index: 0))) %>");

--- a/src/api/spec/components/previews/sourcediff_component_preview.rb
+++ b/src/api/spec/components/previews/sourcediff_component_preview.rb
@@ -4,6 +4,6 @@ class SourcediffComponentPreview < ViewComponent::Preview
     bs_request = BsRequest.last
     opts = { filelimit: nil, tarlimit: nil, diff_to_superseded: nil, diffs: true, cacheonly: 1 }
     action = bs_request.send(:action_details, opts, xml: bs_request.bs_request_actions.last)
-    render(SourcediffComponent.new(bs_request: bs_request, action: action, index: 0, refresh: action[:diff_not_cached]))
+    render(SourcediffComponent.new(bs_request: bs_request, action: action, index: 0))
   end
 end

--- a/src/api/spec/components/previews/sourcediff_tab_component_preview.rb
+++ b/src/api/spec/components/previews/sourcediff_tab_component_preview.rb
@@ -4,6 +4,6 @@ class SourcediffTabComponentPreview < ViewComponent::Preview
     bs_request = BsRequest.last
     opts = { filelimit: nil, tarlimit: nil, diff_to_superseded: nil, diffs: true, cacheonly: 1 }
     action = bs_request.send(:action_details, opts, xml: bs_request.bs_request_actions.last)
-    render(SourcediffTabComponent.new(bs_request: bs_request, action: action, active: action[:name], index: 0, diff_not_cached: action[:diff_not_cached]))
+    render(SourcediffTabComponent.new(bs_request: bs_request, action: action, active: action[:name], index: 0))
   end
 end

--- a/src/api/spec/components/previews/sourcediff_tab_component_preview.rb
+++ b/src/api/spec/components/previews/sourcediff_tab_component_preview.rb
@@ -4,6 +4,6 @@ class SourcediffTabComponentPreview < ViewComponent::Preview
     bs_request = BsRequest.last
     opts = { filelimit: nil, tarlimit: nil, diff_to_superseded: nil, diffs: true, cacheonly: 1 }
     action = bs_request.send(:action_details, opts, xml: bs_request.bs_request_actions.last)
-    render(SourcediffTabComponent.new(bs_request: bs_request, action: action, active: action[:name], index: 0, refresh: action[:diff_not_cached]))
+    render(SourcediffTabComponent.new(bs_request: bs_request, action: action, active: action[:name], index: 0, diff_not_cached: action[:diff_not_cached]))
   end
 end

--- a/src/api/spec/components/sourcediff_component_spec.rb
+++ b/src/api/spec/components/sourcediff_component_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe SourcediffComponent, type: :component, vcr: true do
   context 'with a request with a submit action' do
     before do
       action = bs_request.send(:action_details, bs_request_opts, xml: bs_request.bs_request_actions.last)
-      render_inline(described_class.new(bs_request: bs_request, action: action, index: 0, refresh: action[:diff_not_cached]))
+      render_inline(described_class.new(bs_request: bs_request, action: action, index: 0))
     end
 
     it 'renders the diff' do

--- a/src/api/spec/components/sourcediff_tab_component_spec.rb
+++ b/src/api/spec/components/sourcediff_tab_component_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe SourcediffTabComponent, type: :component, vcr: true do
     before do
       User.session = create(:user)
       action = bs_request.send(:action_details, opts, xml: bs_request.bs_request_actions.last)
-      render_inline(described_class.new(bs_request: bs_request, action: action, active: action[:name], index: 0, diff_not_cached: action[:diff_not_cached]))
+      render_inline(described_class.new(bs_request: bs_request, action: action, active: action[:name], index: 0))
     end
 
     it do

--- a/src/api/spec/components/sourcediff_tab_component_spec.rb
+++ b/src/api/spec/components/sourcediff_tab_component_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe SourcediffTabComponent, type: :component, vcr: true do
     before do
       User.session = create(:user)
       action = bs_request.send(:action_details, opts, xml: bs_request.bs_request_actions.last)
-      render_inline(described_class.new(bs_request: bs_request, action: action, active: action[:name], index: 0, refresh: action[:diff_not_cached]))
+      render_inline(described_class.new(bs_request: bs_request, action: action, active: action[:name], index: 0, diff_not_cached: action[:diff_not_cached]))
     end
 
     it do


### PR DESCRIPTION
The logic of that piece of code is to check if the `diff` changes are already computed and cached, or it triggers the async job to fetch them.
The refactoring makes all the access to the request page (no matter which tab) to hit that method so the `diff` will be fetched in advance. The refactoring also renames the `@refresh` variable into some more explicit flag with the name of `@diff_not_cached`, which is in line with the id of the hash retrieved from the backend job.