### PR TITLE
Clarify variable meaning

### DIFF
--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -26,7 +26,7 @@ class Webui::RequestController < Webui::WebuiController
   def show
     # TODO: Remove this `if` condition, and the `else` clause once request_show_redesign is rolled out
     if Flipper.enabled?(:request_show_redesign, User.session)
-      @active = 'conversation'
+      @active_tab = 'conversation'
       render :beta_show
     else
       @diff_limit = params[:full_diff] ? 0 : nil
@@ -293,7 +293,7 @@ class Webui::RequestController < Webui::WebuiController
   def build_results
     redirect_to request_show_path(params[:number], params[:request_action_id]) unless @action[:sprj] || @action[:spkg]
 
-    @active = 'build_results'
+    @active_tab = 'build_results'
     @project = @staging_project || @action[:sprj]
     @buildable = @action[:spkg] || @project
 
@@ -305,7 +305,7 @@ class Webui::RequestController < Webui::WebuiController
   def rpm_lint
     redirect_to request_show_path(params[:number], params[:request_action_id]) unless @action[:sprj] || @action[:spkg]
 
-    @active = 'rpm_lint'
+    @active_tab = 'rpm_lint'
     @ajax_data = {}
     @ajax_data['project'] = @action[:sprj] if @action[:sprj]
     @ajax_data['package'] = @action[:spkg] if @action[:spkg]
@@ -315,13 +315,13 @@ class Webui::RequestController < Webui::WebuiController
   def changes
     redirect_to request_show_path(params[:number], params[:request_action_id]) unless @action[:type].in?(@actions_for_diff)
 
-    @active = 'changes'
+    @active_tab = 'changes'
   end
 
   def mentioned_issues
     redirect_to request_show_path(params[:number], params[:request_action_id]) unless @action[:type].in?(@actions_for_diff)
 
-    @active = 'mentioned_issues'
+    @active_tab = 'mentioned_issues'
   end
 
   private

--- a/src/api/app/views/webui/request/_request_tabs.html.haml
+++ b/src/api/app/views/webui/request/_request_tabs.html.haml
@@ -3,21 +3,21 @@
   %ul.nav.scrollable-tabs.border-0#request-tabs
     %li.nav-item.scrollable-tab-link
       = link_to('Conversation', request_show_path(bs_request.number, actions_count > 1 ? active_action : nil),
-                class: "nav-link text-nowrap #{active == 'conversation' ? 'active' : ''}")
+                class: "nav-link text-nowrap #{active_tab == 'conversation' ? 'active' : ''}")
     - if action[:sprj] || action[:spkg]
       %li.nav-item.scrollable-tab-link.active
         = link_to('Build Results', request_build_results_path(bs_request.number, actions_count > 1 ? active_action : nil),
-                  class: "nav-link text-nowrap #{active == 'build_results' ? 'active' : ''}")
+                  class: "nav-link text-nowrap #{active_tab == 'build_results' ? 'active' : ''}")
       %li.nav-item.scrollable-tab-link
         = link_to('RPM Lint', request_rpm_lint_path(bs_request.number, actions_count > 1 ? active_action : nil),
-                  class: "nav-link text-nowrap #{active == 'rpm_lint' ? 'active' : ''}")
+                  class: "nav-link text-nowrap #{active_tab == 'rpm_lint' ? 'active' : ''}")
     - if action[:type].in?(actions_for_diff)
       %li.nav-item.scrollable-tab-link
         = link_to('Changes', request_changes_path(bs_request.number, actions_count > 1 ? active_action : nil),
-                  class: "nav-link text-nowrap #{active == 'changes' ? 'active' : ''}")
+                  class: "nav-link text-nowrap #{active_tab == 'changes' ? 'active' : ''}")
     - if action[:type].in?(actions_for_diff)
       %li.nav-item.scrollable-tab-link
         = link_to(request_mentioned_issues_path(bs_request.number, actions_count > 1 ? active_action : nil),
-                  class: "nav-link text-nowrap #{active == 'mentioned_issues' ? 'active' : ''}") do
+                  class: "nav-link text-nowrap #{active_tab == 'mentioned_issues' ? 'active' : ''}") do
           Mentioned Issues
           %span.badge.bg-primary.align-text-top= issues.size

--- a/src/api/app/views/webui/request/beta_show.html.haml
+++ b/src/api/app/views/webui/request/beta_show.html.haml
@@ -13,7 +13,7 @@
                   diff_to_superseded_id: @diff_to_superseded_id, diff_limit: @diff_limit, page_name: '' }
     = render partial: 'request_tabs',
         locals: { actions_for_diff: @actions_for_diff, bs_request: @bs_request, action: @action, issues: @issues,
-                  active_action: @active_action, actions_count: @supported_actions.count, active: @active }
+                  active_action: @active_action, actions_count: @supported_actions.count, active_tab: @active_tab }
     .container.p-4
       .row
         .col-md-12

--- a/src/api/app/views/webui/request/build_results.html.haml
+++ b/src/api/app/views/webui/request/build_results.html.haml
@@ -11,7 +11,7 @@
                   diff_to_superseded_id: @diff_to_superseded_id, diff_limit: @diff_limit, page_name: 'request_build_results' }
     = render partial: 'request_tabs',
         locals: { actions_for_diff: @actions_for_diff, bs_request: @bs_request, action: @action, issues: @issues,
-                  active_action: @active_action, actions_count: @supported_actions.count, active: @active }
+                  active_action: @active_action, actions_count: @supported_actions.count, active_tab: @active_tab }
     .container.p-4
       - if @buildable
         .build-results-content{ data: @ajax_data }

--- a/src/api/app/views/webui/request/changes.html.haml
+++ b/src/api/app/views/webui/request/changes.html.haml
@@ -11,7 +11,7 @@
                   diff_to_superseded_id: @diff_to_superseded_id, diff_limit: @diff_limit, page_name: 'request_changes' }
     = render partial: 'request_tabs',
         locals: { actions_for_diff: @actions_for_diff, bs_request: @bs_request, action: @action, issues: @issues,
-                  active_action: @active_action, actions_count: @supported_actions.count, active: @active }
+                  active_action: @active_action, actions_count: @supported_actions.count, active_tab: @active_tab }
     .container.p-4
       .tab-content.sourcediff
         = render SourcediffComponent.new(bs_request: @bs_request, action: @action, index: 0, refresh: @refresh)

--- a/src/api/app/views/webui/request/mentioned_issues.html.haml
+++ b/src/api/app/views/webui/request/mentioned_issues.html.haml
@@ -11,7 +11,7 @@
                   diff_to_superseded_id: @diff_to_superseded_id, diff_limit: @diff_limit, page_name: 'request_mentioned_issues' }
     = render partial: 'request_tabs',
         locals: { actions_for_diff: @actions_for_diff, bs_request: @bs_request, action: @action, issues: @issues,
-                  active_action: @active_action, actions_count: @supported_actions.count, active: @active }
+                  active_action: @active_action, actions_count: @supported_actions.count, active_tab: @active_tab }
     .container.p-4
       - if @issues.empty?
         %p No issues are mentioned for this request action.

--- a/src/api/app/views/webui/request/rpm_lint.html.haml
+++ b/src/api/app/views/webui/request/rpm_lint.html.haml
@@ -11,7 +11,7 @@
                   diff_to_superseded_id: @diff_to_superseded_id, diff_limit: @diff_limit, page_name: 'request_rpm_lint' }
     = render partial: 'request_tabs',
         locals: { actions_for_diff: @actions_for_diff, bs_request: @bs_request, action: @action, issues: @issues,
-                  active_action: @active_action, actions_count: @supported_actions.count, active: @active }
+                  active_action: @active_action, actions_count: @supported_actions.count, active_tab: @active_tab }
     .container.p-4
       - if @action[:spkg]
         .rpm-lint-content{ data: @ajax_data }


### PR DESCRIPTION
`active` could be anything, especially for multiactions request could be the active action, but in this case it was for `active_tab`, therefore the renaming of the variable.