### PR TITLE
Bring back repository status help

### DIFF
--- a/src/api/app/helpers/webui/webui_helper.rb
+++ b/src/api/app/helpers/webui/webui_helper.rb
@@ -93,7 +93,7 @@ module Webui::WebuiHelper
 
     repo_state_class = repository_state_class(outdated, status)
 
-    tag.i('', class: "repository-state-#{repo_state_class} #{html_class} fas fa-#{repo_status_icon(status)}")
+    tag.i('', class: "repository-state-#{repo_state_class} #{html_class} fas fa-#{repo_status_icon(status)}", title: description)
   end
 
   def repository_info(status)

--- a/src/api/app/models/buildresult.rb
+++ b/src/api/app/models/buildresult.rb
@@ -85,6 +85,7 @@ class Buildresult
         repository: result['repository'],
         architecture: result['arch'],
         code: result['code'],
+        details: result['details'],
         state: state
       )
 

--- a/src/api/app/views/webui/project/_buildstatus.html.haml
+++ b/src/api/app/views/webui/project/_buildstatus.html.haml
@@ -28,7 +28,7 @@
           - build_results.sort_by(&:architecture).each do |build_result|
             .d-flex.flex-row.flex-nowrap.py-1
               .repository-state
-                = repository_status_icon(status: build_result.state)
+                = repository_status_icon(status: build_result.state, details: build_result.details)
                 %span.ms-1
                   = link_to(build_result.architecture, { action: :monitor,
                                                   "#{valid_xml_id("repo_#{repository}")}": 1,


### PR DESCRIPTION
This has been lost in 0b22ee5fbda2f22e73b86f3dbcd2b3617028efab

It was especially confusing if you have a broken repository that did not build anything yet. Because then you can't get to the repository status help anywhere, just the icon.

![buildresults](https://github.com/openSUSE/open-build-service/assets/514785/1a04557f-3ccd-47c9-98f4-c084476f7538)
