### PR TITLE
Bug fix: make sure loadChanges receives parameters to build url properly

### DIFF
--- a/src/api/app/assets/javascripts/webui/request.js
+++ b/src/api/app/assets/javascripts/webui/request.js
@@ -185,10 +185,9 @@ function loadDiffs(element){
   });
 }
 
-function loadChanges() { // jshint ignore:line
+function loadChanges(requestNumber, requestActionId) { // jshint ignore:line
   $('.loading-diff').removeClass('invisible');
-  var element = $('#changes-tab');
-  var url = '/request/' + element.data('request-number') + '/request_action/' + element.data('request-action-id') + '/changes';
+  var url = '/request/' + requestNumber + '/request_action/' + requestActionId + '/changes';
   $.ajax({
     url: url,
     success: function() {

--- a/src/api/app/components/sourcediff_component.html.haml
+++ b/src/api/app/components/sourcediff_component.html.haml
@@ -2,7 +2,7 @@
   .col
     - if @refresh
       .clearfix.mb-2.text-center
-        .btn.btn-outline-primary.cache-refresh{ title: 'Refresh results', onclick: 'loadChanges();' }
+        .btn.btn-outline-primary.cache-refresh{ title: 'Refresh results', onclick: "loadChanges(#{@bs_request.number}, #{@action[:id]});" }
           Crunching the latest data. Refresh again in a few seconds
           %i.fas.fa-sync-alt{ id: "cache#{@index}-reload" }
     - else


### PR DESCRIPTION
Since the conversion from tabs to separate pages, in the request page the `#changes-tab` id got dropped. Therefore the `loadChanges` is no longer able to fetch the parameters (`request number` and `action id`) properly.

The bug fix passes those parameters on calling the function instead of delegating to the function the search and read of those parameters relying on some other element.