### PR TITLE
Fine tune methods to create maintenance setup

### DIFF
--- a/src/api/lib/tasks/dev.rake
+++ b/src/api/lib/tasks/dev.rake
@@ -228,8 +228,7 @@ namespace :dev do
       Rake::Task['dev:requests:request_with_multiple_submit_actions_builds_and_diffs'].invoke
 
       # Create a maintenance environment with maintenance requests
-      create_maintenance_project('openSUSE:Leap:15.0')
-      request_with_incident_actions
+      create_maintenance_setup
 
       # Create a request with a delete request action
       Rake::Task['dev:requests:request_with_delete_action'].invoke

--- a/src/api/lib/tasks/dev/test_data/maintenance.rb
+++ b/src/api/lib/tasks/dev/test_data/maintenance.rb
@@ -1,3 +1,14 @@
+# Running `dev:test_data:maintenance` as part of the `rails dev:test_data`
+# will create all the elements related to maintenance:
+
+# - Maintained project (GA Project): i.e. openSUSE:Leap:15.4
+# - Update Project: i.e. openSUSE:Leap:15.4:Update
+# - User's branch of the Update Project: i.e. home:Iggy:branches:openSUSE:Leap:15.4:Update
+# - Maintenance Project: i.e. openSUSE:Maintenance
+# - Incident Project: i.e. openSUSE:Maintenance:100
+# - Maintenance Incident Request.
+# - Maintenance Release Request.
+
 module TestData
   module Maintenance
     def create_maintenance_project(project_name)

--- a/src/api/lib/tasks/dev/test_data/maintenance.rb
+++ b/src/api/lib/tasks/dev/test_data/maintenance.rb
@@ -13,17 +13,23 @@ module TestData
   module Maintenance
     def create_maintenance_project(project_name)
       admin = User.get_default_admin
-      leap = Project.find_by(name: project_name)
+      update_project = Project.find_by(name: "#{project_name}:Update")
 
-      update_project = create(:update_project, target_project: leap, name: "#{leap.name}:Update", commit_user: admin)
       create(
         :maintenance_project,
-        name: 'MaintenanceProject',
-        title: 'official maintenance space',
+        name: 'openSUSE:Maintenance',
+        title: 'official openSUSE maintenance space',
         target_project: update_project,
         maintainer: admin,
         commit_user: admin
       )
+    end
+
+    def create_update_project(project_name)
+      admin = User.get_default_admin
+
+      leap = Project.find_by(name: project_name)
+      create(:update_project, target_project: leap, name: "#{leap.name}:Update", commit_user: admin)
     end
 
     def request_with_incident_actions
@@ -33,32 +39,40 @@ module TestData
         creator: iggy
       )
 
-      maintenance_project = Project.find_by(kind: 'maintenance')
-      release_project = Project.find_by(kind: 'maintenance_release')
+      maintenance_project = Project.find_by(kind: 'maintenance') # i.e openSUSE:Maintenance
+      update_project = Project.find_by(kind: 'maintenance_release') # i.e openSUSE:Leap:15.4:Update
 
-      # This is the first maintenance incident action, we reuse the action created by the factory
-      home_iggy_project = RakeSupport.find_or_create_project(iggy.home_project_name, iggy)
-      maintenance_package = create(:package, name: "maintenance_package_#{Faker::Lorem.word}", project: home_iggy_project, commit_user: iggy)
+      update_project_branch = RakeSupport.find_or_create_project(iggy.branch_project_name(update_project.name), iggy) # i.e. home:Iggy:branches:openSUSE:Leap:15.4:Update
+      maintenance_package = create(:package, name: "maintenance_package_#{Faker::Lorem.word}", project: update_project_branch, commit_user: iggy)
 
+      # This is the first maintenance incident action
       User.session = iggy
       request.bs_request_actions.first.tap do |action|
-        action.source_project = home_iggy_project
+        action.source_project = update_project_branch
         action.source_package = maintenance_package
         action.target_project = maintenance_project
-        action.target_releaseproject = release_project
+        action.target_releaseproject = update_project
         action.save!
       end
 
       # This is the second maintenance incident action
-      another_maintenance_package = create(:package, name: "another_maintenance_package_#{Faker::Lorem.word}", project: home_iggy_project, commit_user: iggy)
+      another_maintenance_package = create(:package, name: "another_maintenance_package_#{Faker::Lorem.word}", project: update_project_branch, commit_user: iggy)
       request.bs_request_actions << create(:bs_request_action,
                                            type: :maintenance_incident,
-                                           source_project: home_iggy_project,
+                                           source_project: update_project_branch,
                                            source_package: another_maintenance_package,
                                            target_project: maintenance_project,
-                                           target_releaseproject: release_project)
+                                           target_releaseproject: update_project)
 
-      puts "* Request with maintenance incident actions #{request.number} has been created."
+      puts "* Request #{request.number} with maintenance incident actions has been created."
+    end
+
+    def create_maintenance_setup
+      leap = create(:project, name: 'openSUSE:Leap:15.4')
+      create(:repository, project: leap, name: 'openSUSE_Tumbleweed', architectures: ['x86_64'])
+      create_maintenance_project('openSUSE:Leap:15.4')
+      create_update_project('openSUSE:Leap:15.4')
+      request_with_incident_actions
     end
   end
 end

--- a/src/api/spec/factories/maintained_project.rb
+++ b/src/api/spec/factories/maintained_project.rb
@@ -1,3 +1,7 @@
+# Create a relationship between an update project and a maintenance project. Example:
+#   project: openSUSE:Leap:15.4:Update
+#   maintenance_project: openSUSE:Maintenance
+
 FactoryBot.define do
   factory :maintained_project do
     project


### PR DESCRIPTION
Adapt methods to create maintenance setup to set projects' names that better reflect reality and use terminology we are more familiar with.

**Reviewing Tips**

Run `bundle exec rake dev:test_data:create` to make sure it doesn't crash.
Then check the data is there: 

- openSUSE:Leap:15.4
- openSUSE:Maintenance
- openSUSE:Leap:15.4:Update
- home:Iggy:branches:openSUSE:Leap:15.4:Update
- Outgoing request from home:Iggy:branches:openSUSE:Leap:15.4:Update
