### PR TITLE
[backend] implement slow request logging for AJAX requests

### DIFF
--- a/src/backend/BSServerEvents.pm
+++ b/src/backend/BSServerEvents.pm
@@ -50,6 +50,8 @@ sub replrequest_timeout {
   delete $ev->{'fd'};
   delete $ev->{'nfd'};
   delete $ev->{'requestevents'}->{$ev->{'id'}} if $ev->{'requestevents'};
+  my $req = $ev->{'request'};
+  BSServer::log_slow_requests($req->{'conf'}, $req) if $req && $req->{'conf'}->{'slowrequestlog'};
 }
 
 sub replrequest_write {
@@ -68,6 +70,8 @@ sub replrequest_write {
     close($ev->{'fd'});
     close($ev->{'nfd'}) if $ev->{'nfd'};
     delete $ev->{'requestevents'}->{$ev->{'id'}} if $ev->{'requestevents'};
+    my $req = $ev->{'request'};
+    BSServer::log_slow_requests($req->{'conf'}, $req) if $req && $req->{'conf'}->{'slowrequestlog'};
     return;
   }
   if ($r == length($ev->{'replbuf'})) {
@@ -76,6 +80,8 @@ sub replrequest_write {
     close($ev->{'fd'});
     close($ev->{'nfd'}) if $ev->{'nfd'};
     delete $ev->{'requestevents'}->{$ev->{'id'}} if $ev->{'requestevents'};
+    my $req = $ev->{'request'};
+    BSServer::log_slow_requests($req->{'conf'}, $req) if $req && $req->{'conf'}->{'slowrequestlog'};
     return;
   }
   $ev->{'replbuf'} = substr($ev->{'replbuf'}, $r) if $r;
@@ -454,6 +460,8 @@ sub stream_close {
     delete $wev->{'fd'};
     delete $wev->{'readev'};
     delete $wev->{'requestevents'}->{$wev->{'id'}} if $wev->{'requestevents'};
+    my $req = $wev->{'request'};
+    BSServer::log_slow_requests($req->{'conf'}, $req) if $req && $req->{'conf'}->{'slowrequestlog'};
   }
 }
 

--- a/src/backend/BSStdServer.pm
+++ b/src/backend/BSStdServer.pm
@@ -435,6 +435,7 @@ sub server {
     $aconf->{'getrequest_timeout'} = 10 unless exists $aconf->{'getrequest_timeout'};
     $aconf->{'replrequest_timeout'} = 10 unless exists $aconf->{'replrequest_timeout'};
     $aconf->{'run'} ||= \&BSEvents::schedule;
+    $aconf->{'slowrequestlog'} ||= "$BSConfig::logdir/${name}_ajax.slow.log" if $aconf->{'slowrequestthr'};
     $aconf->{'name'} = $name;
     BSDispatch::compile($aconf);
   }

--- a/src/backend/bs_repserver
+++ b/src/backend/bs_repserver
@@ -4564,6 +4564,7 @@ my $conf = {
 my $aconf = {
   'socketpath' => $ajaxsocket,
   'dispatches' => $dispatches_ajax,
+  'slowrequestthr' => 300,
 };
 
 if ($BSConfig::workerreposerver) {

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -7833,6 +7833,7 @@ my $conf = {
 my $aconf = {
   'socketpath' => $ajaxsocket,
   'dispatches' => $dispatches_ajax,
+  'slowrequestthr' => 300,
 };
 
 $conf->{'maxchild'} = $BSConfig::srcserver_maxchild if $BSConfig::srcserver_maxchild;


### PR DESCRIPTION
The threshold is 300s. Slow requests are mostly not a problem (that's what the AJAX process is for), but it is nice to have a place to check if something weird is going on.