### PR TITLE
Refactor maintenance test data rake task as functions

### DIFF
--- a/src/api/lib/tasks/dev.rake
+++ b/src/api/lib/tasks/dev.rake
@@ -77,6 +77,8 @@ namespace :dev do
       include FactoryBot::Syntax::Methods
       require 'active_support/testing/time_helpers'
       include ActiveSupport::Testing::TimeHelpers
+      require 'tasks/dev/test_data/maintenance'
+      include TestData::Maintenance
 
       Rails.cache.clear
       Rake::Task['db:reset'].invoke
@@ -226,7 +228,8 @@ namespace :dev do
       Rake::Task['dev:requests:request_with_multiple_submit_actions_builds_and_diffs'].invoke
 
       # Create a maintenance environment with maintenance requests
-      Rake::Task['dev:test_data:maintenance'].invoke
+      create_maintenance_project('openSUSE:Leap:15.0')
+      request_with_incident_actions
 
       # Create a request with a delete request action
       Rake::Task['dev:requests:request_with_delete_action'].invoke

--- a/src/api/lib/tasks/dev/test_data/maintenance.rb
+++ b/src/api/lib/tasks/dev/test_data/maintenance.rb
@@ -1,5 +1,5 @@
-namespace :dev do
-  namespace :test_data do
+module TestData
+  module Maintenance
     def create_maintenance_project(project_name)
       admin = User.get_default_admin
       leap = Project.find_by(name: project_name)
@@ -48,13 +48,6 @@ namespace :dev do
                                            target_releaseproject: release_project)
 
       puts "* Request with maintenance incident actions #{request.number} has been created."
-    end
-
-    # Run this task with: rails dev:test_data:maintenance
-    desc 'Set a maintenance environment'
-    task maintenance: :development_environment do
-      create_maintenance_project('openSUSE:Leap:15.0')
-      request_with_incident_actions
     end
   end
 end


### PR DESCRIPTION
This rake task makes no sense to be called alone by itself. So it's best to refactor it as plain functions.