### PR TITLE
Use fuubar for rubocop progress report

### DIFF
--- a/src/api/Rakefile
+++ b/src/api/Rakefile
@@ -14,7 +14,7 @@ unless Rails.env.production?
   require 'haml_lint/rake_task'
 
   RuboCop::RakeTask.new(:rubocop) do |task|
-    task.options = ['-D', '-F', '--fail-level', 'convention']
+    task.options = ['-D', '-F', '--fail-level', 'convention', '--format', 'fuubar']
   end
 
   HamlLint::RakeTask.new

--- a/src/api/lib/tasks/dev/lint.rake
+++ b/src/api/lib/tasks/dev/lint.rake
@@ -29,13 +29,13 @@ namespace :dev do
 
       desc 'Run the ruby linter in rails'
       task :rails do
-        sh 'rubocop', '--fail-fast', '--display-style-guide', '--fail-level', 'convention', '--ignore_parent_exclusion'
+        sh 'rubocop', '--fail-fast', '--display-style-guide', '--fail-level', 'convention', '--ignore_parent_exclusion', '--format', 'fuubar'
       end
 
       desc 'Run the ruby linter in root'
       task :root do
         Dir.chdir('../..') do
-          sh 'rubocop', '--fail-fast', '--display-style-guide', '--fail-level', 'convention'
+          sh 'rubocop', '--fail-fast', '--display-style-guide', '--fail-level', 'convention', '--format', 'fuubar'
         end
       end
 


### PR DESCRIPTION
Following #14182, this PR makes Rubocop use fuubar progress formatter also.

It would be nice to make `haml-lint` to use fuubar as well, but I found no way of doing it...