### PR TITLE
Use pundit policy for `handle_request?` in request beta view components

### DIFF
--- a/src/api/app/components/accordion_reviews_component.rb
+++ b/src/api/app/components/accordion_reviews_component.rb
@@ -1,21 +1,20 @@
 class AccordionReviewsComponent < ApplicationComponent
-  def initialize(request_reviews, request_state, can_handle_request:)
+  def initialize(request_reviews, bs_request)
     super
 
-    @can_handle_request = can_handle_request
     @accepted_reviews = request_reviews.select(&:accepted?)
     @accepted_reviews_count = @accepted_reviews.size
     @pending_reviews = request_reviews.select(&:new?)
     @pending_reviews_count = @pending_reviews.size
     @declined_reviews = request_reviews.select(&:declined?)
     @declined_reviews_count = @declined_reviews.size
-    @request_state = request_state
+    @bs_request = bs_request
   end
 
   def render?
-    @can_handle_request &&
+    policy(@bs_request).handle_request? &&
       (@accepted_reviews_count + @pending_reviews_count + @declined_reviews_count).positive? &&
       # Declined is not really a final state, since the request can always be reopened...
-      (BsRequest::FINAL_REQUEST_STATES.exclude?(@request_state) || @request_state == :declined)
+      (BsRequest::FINAL_REQUEST_STATES.exclude?(@bs_request.state) || @bs_request.state == :declined)
   end
 end

--- a/src/api/app/components/request_decision_component.rb
+++ b/src/api/app/components/request_decision_component.rb
@@ -9,7 +9,7 @@ class RequestDecisionComponent < ApplicationComponent
   end
 
   def render?
-    can_handle_request?
+    policy(@bs_request).handle_request?
   end
 
   def single_action_request
@@ -29,10 +29,6 @@ class RequestDecisionComponent < ApplicationComponent
   end
 
   # TODO: Move all those "can_*" checks to a pundit policy
-  def can_handle_request?
-    @bs_request.state.in?([:new, :review, :declined]) && (@is_target_maintainer || @is_author)
-  end
-
   def can_revoke_request?
     @is_author && @bs_request.state.in?([:new, :review, :declined])
   end

--- a/src/api/app/views/webui/request/beta_show.html.haml
+++ b/src/api/app/views/webui/request/beta_show.html.haml
@@ -98,8 +98,7 @@
                 %strong auto-accepted
                 = render TimeComponent.new(time: @bs_request.accept_at)
 
-          = render AccordionReviewsComponent.new(@request_reviews, @bs_request.state, can_handle_request: policy(@bs_request).handle_request?)
-
+          = render AccordionReviewsComponent.new(@request_reviews, @bs_request)
           = render RequestDecisionComponent.new(bs_request: @bs_request, action: @action,
                                                 is_target_maintainer: @is_target_maintainer,
                                                 is_author: @is_author)


### PR DESCRIPTION
We already have a pundit policy for this, no need to add this logic again to the view component.

Extracted out of https://github.com/openSUSE/open-build-service/pull/14318 to ease review