### PR TITLE
Fix build on tumbleweed

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -12,7 +12,10 @@ APACHE_CONFDIR_VHOST=$(APACHE_CONFDIR)/vhosts.d
 APACHE_VHOST_CONF=obs-apache24.conf
 APACHE_LOGDIR=/var/log/apache2
 
-OBS_RUBY_BIN=/usr/bin/ruby.ruby3.1
-OBS_BUNDLE_BIN=/usr/bin/bundle.ruby3.1
-OBS_RAKE_BIN=/usr/bin/rake.ruby3.1
 OBS_RUBY_ABI_VERSION=3.1.0
+OBS_RUBY_SUFFIX=".ruby3.1"
+
+OBS_RUBY_BIN=/usr/bin/ruby$(OBS_RUBY_SUFFIX)
+OBS_GEM_BIN=/usr/bin/gem$(OBS_RUBY_SUFFIX)
+OBS_BUNDLE_BIN=/usr/bin/bundle$(OBS_RUBY_SUFFIX)
+OBS_RAKE_BIN=/usr/bin/rake$(OBS_RUBY_SUFFIX)

--- a/dist/obs-bundled-gems.spec
+++ b/dist/obs-bundled-gems.spec
@@ -16,7 +16,8 @@
 #
 
 %if 0%{?suse_version}
-%define __obs_ruby_interpreter /usr/bin/ruby.ruby3.1
+%define __obs_ruby_suffix      ruby3.1
+%define __obs_ruby_interpreter /usr/bin/ruby.%{__obs_ruby_suffix}
 %define rack_version %(%{__obs_ruby_interpreter} -r rack -e "puts Rack::RELEASE")
 %define rake_version %(%{__obs_ruby_interpreter} -r rake -e "puts Rake::VERSION")
 %define ruby_abi_version %(%{__obs_ruby_interpreter} -r rbconfig -e 'print RbConfig::CONFIG["ruby_version"]')
@@ -121,14 +122,14 @@ EOF
 # all operations here since bundle does not decouple compile and install
 pushd %{_sourcedir}/open-build-service-*/src/api
 export GEM_HOME=~/.gems
-bundle config build.ffi --enable-system-libffi
-bundle config build.nokogiri --use-system-libraries
-bundle config build.sassc --disable-march-tune-native
-bundle config build.nio4r --with-cflags='%{optflags} -Wno-return-type'
-bundle config force_ruby_platform true
-bundle config set --local path %{buildroot}%_libdir/obs-api/
+bundle.%{__obs_ruby_suffix} config build.ffi --enable-system-libffi
+bundle.%{__obs_ruby_suffix} config build.nokogiri --use-system-libraries
+bundle.%{__obs_ruby_suffix} config build.sassc --disable-march-tune-native
+bundle.%{__obs_ruby_suffix} config build.nio4r --with-cflags='%{optflags} -Wno-return-type'
+bundle.%{__obs_ruby_suffix} config force_ruby_platform true
+bundle.%{__obs_ruby_suffix} config set --local path %{buildroot}%_libdir/obs-api/
 
-bundle install --local
+bundle.%{__obs_ruby_suffix} install --local
 popd
 
 %if 0%{?suse_version}

--- a/src/api/Makefile
+++ b/src/api/Makefile
@@ -73,13 +73,13 @@ test_unit:
 	# rspec runs independently
 
 test_rake:
-	$(eval SYSTEM_RAKE_VERSION:=$(shell basename `gem.ruby3.1 which -g rake | sed 's,/lib/rake.rb$$,,'`))
-	$(eval BUNDLE_RAKE_VERSION:=$(shell basename `bundle show rake`))
+	$(eval SYSTEM_RAKE_VERSION:=$(shell basename `$(OBS_GEM_BIN) which -g rake | sed 's,/lib/rake.rb$$,,'`))
+	$(eval BUNDLE_RAKE_VERSION:=$(shell basename `$(OBS_BUNDLE_BIN) show rake`))
 	@if [ "$(SYSTEM_RAKE_VERSION)" != "$(BUNDLE_RAKE_VERSION)" ]; then echo "rake version mismatch! System: $(SYSTEM_RAKE_VERSION) / Bundle: $(BUNDLE_RAKE_VERSION)"; exit 1; fi
 
 test_rack:
-	$(eval SYSTEM_RACK_VERSION:=$(shell basename `gem.ruby3.1 which -g rack | sed 's,/lib/rack.rb$$,,'`))
-	$(eval BUNDLE_RACK_VERSION:=$(shell basename `bundle show rack`))
+	$(eval SYSTEM_RACK_VERSION:=$(shell basename `$(OBS_GEM_BIN) which -g rack | sed 's,/lib/rack.rb$$,,'`))
+	$(eval BUNDLE_RACK_VERSION:=$(shell basename `$(OBS_BUNDLE_BIN) show rack`))
 	@if [ "$(SYSTEM_RACK_VERSION)" != "$(BUNDLE_RACK_VERSION)" ]; then echo "rack version mismatch! System: $(SYSTEM_RACK_VERSION) / Bundle: $(BUNDLE_RACK_VERSION)"; exit 1; fi
 
 clean:


### PR DESCRIPTION
without consistently using the ruby suffix it tried to build the gems for ruby 3.2 while only 3.1 was available.