### PR TITLE
Display links to source and target files in diffs

### DIFF
--- a/src/api/app/components/diff_component.html.haml
+++ b/src/api/app/components/diff_component.html.haml
@@ -5,7 +5,25 @@
       .line-container{ id: }
         %div{ class: "line #{line.state}" }>
           - case line.state
-          - when 'comment', 'range'
+          - when 'range'
+            - if source_file
+              = link_to(source_file, title: 'See original file') do
+                .number.p-0.text-center.link-danger<
+                  %i.fas.fa-file-arrow-down
+            - else
+              %a
+                .number
+            - if target_file
+              = link_to(target_file, title: 'See changed file') do
+                .number.p-0.text-center.link-success<
+                  %i.fas.fa-file-arrow-up
+            - else
+              %a
+                .number
+            .value<
+              .text-muted.ms-3
+                = line.content
+          - when 'comment'
             .offset
               .text-muted.text
                 = line.content

--- a/src/api/app/components/diff_component.html.haml
+++ b/src/api/app/components/diff_component.html.haml
@@ -14,7 +14,7 @@
               %a
                 .number
             - if target_file
-              = link_to(target_file, title: 'See changed file') do
+              = link_to(target_file, title: 'See submitted file') do
                 .number.p-0.text-center.link-success<
                   %i.fas.fa-file-arrow-up
             - else

--- a/src/api/app/components/diff_component.rb
+++ b/src/api/app/components/diff_component.rb
@@ -1,15 +1,17 @@
 # frozen_string_literal: true
 
 class DiffComponent < ApplicationComponent
-  attr_reader :diff, :file_index, :commentable, :commented_lines, :range
+  attr_reader :diff, :file_index, :commentable, :commented_lines, :range, :source_file, :target_file
 
-  def initialize(diff:, file_index: nil, commentable: nil, commented_lines: [], range: (0..))
+  def initialize(diff:, file_index: nil, commentable: nil, commented_lines: [], range: (0..), source_file: nil, target_file: nil)
     super
     @diff = parse_diff(diff)
     @file_index = file_index
     @commentable = commentable
     @commented_lines = commented_lines
     @range = range
+    @source_file = source_file
+    @target_file = target_file
   end
 
   def render?

--- a/src/api/app/components/diff_list_component.html.haml
+++ b/src/api/app/components/diff_list_component.html.haml
@@ -1,6 +1,8 @@
 - diff_list.each_with_index do |(name, file_info), file_index|
-  - state = file_info['state']
-  - expanded = expand?(name, state, file_index)
+  :ruby
+    state = file_info['state']
+    old_filename = file_info.dig('old', 'name')
+    expanded = expand?(name, state, file_index)
   .accordion.mb-2{ id: "diff-list-#{name.parameterize}" }
     .accordion-item
       %h2.accordion-header
@@ -8,6 +10,7 @@
                                                                         'bs-target': "#diff-item-#{name.parameterize}" },
                                                 aria: { expanded: 'true', controls: "diff-item-#{name.parameterize}" },
                                                 class: expanded ? '' : 'collapsed' }
-          = render(DiffSubjectComponent.new(state:, old_filename: file_info.dig('old', 'name'), new_filename: name))
+          = render(DiffSubjectComponent.new(state:, old_filename:, new_filename: name))
       .accordion-collapse.collapse{ class: expanded ? 'show' : '', id: "diff-item-#{name.parameterize}", 'data-object': view_id }
-        = render(DiffComponent.new(diff: file_info.dig('diff', '_content'), file_index:, commentable:, commented_lines:))
+        = render(DiffComponent.new(diff: file_info.dig('diff', '_content'), file_index:, commentable:, commented_lines:,
+                                   source_file: source_file(old_filename), target_file: target_file(name)))

--- a/src/api/app/components/diff_list_component.rb
+++ b/src/api/app/components/diff_list_component.rb
@@ -1,14 +1,17 @@
 # frozen_string_literal: true
 
 class DiffListComponent < ApplicationComponent
-  attr_reader :diff_list, :view_id, :commentable, :commented_lines
+  attr_reader :diff_list, :view_id, :commentable, :commented_lines, :source_package, :target_package, :source_rev
 
-  def initialize(diff_list:, view_id: nil, commentable: nil)
+  def initialize(diff_list:, view_id: nil, commentable: nil, source_package: nil, target_package: nil, source_rev: nil)
     super
     @diff_list = diff_list
     @view_id = view_id
     @commentable = commentable
     @commented_lines = commentable ? commentable.comments.where.not(diff_ref: nil).select(:diff_ref).distinct.pluck(:diff_ref) : []
+    @source_package = source_package
+    @target_package = target_package
+    @source_rev = source_rev
   end
 
   # We expand the diff if the changeset:
@@ -23,5 +26,19 @@ class DiffListComponent < ApplicationComponent
       (filename == '_patchinfo' || filename.ends_with?('.spec', '.changes'))
 
     commented_lines.any? { |cl| cl.split('_')[1].to_i == file_index }
+  end
+
+  def source_file(filename)
+    return nil unless @source_package
+    return nil unless @source_package.file_exists?(filename, { rev: @source_rev }.compact)
+
+    package_view_file_path(@source_package.project, @source_package, filename, rev: @source_rev)
+  end
+
+  def target_file(filename)
+    return nil unless @target_package
+    return nil unless @target_package.file_exists?(filename)
+
+    package_view_file_path(@target_package.project, @target_package, filename)
   end
 end

--- a/src/api/app/components/diff_list_component.rb
+++ b/src/api/app/components/diff_list_component.rb
@@ -30,15 +30,15 @@ class DiffListComponent < ApplicationComponent
 
   def source_file(filename)
     return nil unless @source_package
-    return nil unless @source_package.file_exists?(filename, { rev: @source_rev }.compact)
+    return nil unless @source_package.file_exists?(filename, { rev: @source_rev, expand: 1 }.compact)
 
-    package_view_file_path(@source_package.project, @source_package, filename, rev: @source_rev)
+    package_view_file_path(@source_package.project, @source_package, filename, rev: @source_rev, expand: 1)
   end
 
   def target_file(filename)
     return nil unless @target_package
-    return nil unless @target_package.file_exists?(filename)
+    return nil unless @target_package.file_exists?(filename, expand: 1)
 
-    package_view_file_path(@target_package.project, @target_package, filename)
+    package_view_file_path(@target_package.project, @target_package, filename, expand: 1)
   end
 end

--- a/src/api/app/components/sourcediff_component.html.haml
+++ b/src/api/app/components/sourcediff_component.html.haml
@@ -24,7 +24,8 @@
               #{diff_label(sourcediff['new'])} – #{diff_label(sourcediff['old'])}
           - if sourcediff['filenames'].present?
             - diff_list = sourcediff['files'].sort_by { |k, _v| sourcediff['filenames'].find_index(k) }.to_h
-            = render(DiffListComponent.new(diff_list:, view_id: @action[:spkg], commentable:))
+            = render(DiffListComponent.new(diff_list:, view_id: @action[:spkg], commentable:, source_package:,
+                                           target_package:, source_rev: @action[:srev]))
           - else
             .mb-2
               %p.lead

--- a/src/api/app/components/sourcediff_component.rb
+++ b/src/api/app/components/sourcediff_component.rb
@@ -22,4 +22,12 @@ class SourcediffComponent < ApplicationComponent
     diff_params = diff_data(@action[:type], sourcediff)
     package_view_file_path(diff_params.merge(filename: filename))
   end
+
+  def source_package
+    Package.find_by_project_and_name(@action[:sprj], @action[:spkg])
+  end
+
+  def target_package
+    Package.find_by_project_and_name(@action[:tprj], @action[:tpkg])
+  end
 end

--- a/src/api/app/components/sourcediff_component.rb
+++ b/src/api/app/components/sourcediff_component.rb
@@ -24,10 +24,10 @@ class SourcediffComponent < ApplicationComponent
   end
 
   def source_package
-    Package.find_by_project_and_name(@action[:sprj], @action[:spkg])
+    Package.get_by_project_and_name(@action[:sprj], @action[:spkg], { follow_multibuild: true })
   end
 
   def target_package
-    Package.find_by_project_and_name(@action[:tprj], @action[:tpkg])
+    Package.get_by_project_and_name(@action[:tprj], @action[:tpkg], { follow_multibuild: true })
   end
 end

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -1330,8 +1330,8 @@ class Package < ApplicationRecord
     true
   end
 
-  def file_exists?(filename, expand: 0)
-    dir_hash.key?('entry') && [dir_hash(expand: expand)['entry']].flatten.any? { |item| item['name'] == filename }
+  def file_exists?(filename, opts = {})
+    dir_hash(opts).key?('entry') && [dir_hash(opts)['entry']].flatten.any? { |item| item['name'] == filename }
   end
 
   def has_icon?

--- a/src/api/spec/cassettes/ImageTemplates/branching/branch_Kiwi_image_template.yml
+++ b/src/api/spec/cassettes/ImageTemplates/branching/branch_Kiwi_image_template.yml
@@ -39,7 +39,7 @@ http_interactions:
           <description></description>
           <person userid="tom" role="maintainer"/>
         </project>
-  recorded_at: Tue, 01 Feb 2022 14:52:39 GMT
+  recorded_at: Thu, 18 May 2023 11:49:52 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/_meta?user=user_6
@@ -47,7 +47,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         <project name="my_project">
-          <title>The Glory and the Dream</title>
+          <title>Have His Carcase</title>
           <description/>
         </project>
     headers:
@@ -69,15 +69,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '110'
+      - '103'
     body:
       encoding: UTF-8
       string: |
         <project name="my_project">
-          <title>The Glory and the Dream</title>
+          <title>Have His Carcase</title>
           <description></description>
         </project>
-  recorded_at: Tue, 01 Feb 2022 14:52:40 GMT
+  recorded_at: Thu, 18 May 2023 11:49:52 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/first_package/_meta?user=user_7
@@ -86,7 +86,352 @@ http_interactions:
       string: |
         <package name="first_package" project="my_project">
           <title>a</title>
-          <description>Corporis cumque necessitatibus voluptatem.</description>
+          <description>Quae aliquam beatae in.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '135'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="first_package" project="my_project">
+          <title>a</title>
+          <description>Quae aliquam beatae in.</description>
+        </package>
+  recorded_at: Thu, 18 May 2023 11:49:52 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/my_project/first_package/_config
+    body:
+      encoding: UTF-8
+      string: Quasi fugiat quod. Nobis delectus exercitationem. Maxime sunt inventore.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="9" vrev="9">
+          <srcmd5>ea1957524ec0c0324203a78796e39e0d</srcmd5>
+          <version>unknown</version>
+          <time>1684410592</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Thu, 18 May 2023 11:49:52 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/my_project/first_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Rerum saepe occaecati. Deleniti et consectetur. Perferendis incidunt
+        quis.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="10" vrev="10">
+          <srcmd5>5088c94aac17a0aef4b66b50bc9e450d</srcmd5>
+          <version>unknown</version>
+          <time>1684410592</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Thu, 18 May 2023 11:49:52 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/my_project/second_package/_meta?user=user_8
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="second_package" project="my_project">
+          <title>c</title>
+          <description>Dolorum ut est dicta.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '134'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="second_package" project="my_project">
+          <title>c</title>
+          <description>Dolorum ut est dicta.</description>
+        </package>
+  recorded_at: Thu, 18 May 2023 11:49:52 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/my_project/second_package/_config
+    body:
+      encoding: UTF-8
+      string: Ipsam tempore accusantium. Hic molestias officia. Explicabo sapiente
+        et.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="9" vrev="9">
+          <srcmd5>31cd799c7cd8805c6e31d5a0a5ddb3ff</srcmd5>
+          <version>unknown</version>
+          <time>1684410592</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Thu, 18 May 2023 11:49:52 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/my_project/second_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Odio asperiores sint. Voluptatibus omnis beatae. Nesciunt mollitia aliquid.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="10" vrev="10">
+          <srcmd5>b65424aabad564d81ed9ae5429949807</srcmd5>
+          <version>unknown</version>
+          <time>1684410592</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Thu, 18 May 2023 11:49:52 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/my_project/third_package/_meta?user=user_9
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="third_package" project="my_project">
+          <title>b</title>
+          <description>Officia aperiam natus aut.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '138'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="third_package" project="my_project">
+          <title>b</title>
+          <description>Officia aperiam natus aut.</description>
+        </package>
+  recorded_at: Thu, 18 May 2023 11:49:52 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/my_project/third_package/_config
+    body:
+      encoding: UTF-8
+      string: Reiciendis aut ad. Perspiciatis asperiores reiciendis. Commodi repellat
+        et.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="9" vrev="9">
+          <srcmd5>f67fb0c2cfef097ef7d92e0c84d8dc4d</srcmd5>
+          <version>unknown</version>
+          <time>1684410592</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Thu, 18 May 2023 11:49:52 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/my_project/third_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Blanditiis voluptatibus assumenda. Placeat id eum. Tempora quos iusto.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="10" vrev="10">
+          <srcmd5>1658e81f9e644cd5edc299ebbb2fb0a7</srcmd5>
+          <version>unknown</version>
+          <time>1684410592</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Thu, 18 May 2023 11:49:52 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/my_project/package_with_kiwi_image/_meta?user=user_10
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="my_project">
+          <title>Eyeless in Gaza</title>
+          <description>Maxime et est eos.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -111,353 +456,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <package name="first_package" project="my_project">
-          <title>a</title>
-          <description>Corporis cumque necessitatibus voluptatem.</description>
-        </package>
-  recorded_at: Tue, 01 Feb 2022 14:52:40 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/my_project/first_package/_config
-    body:
-      encoding: UTF-8
-      string: Est molestiae voluptatem. Deleniti eos labore. Ut aperiam deleniti.
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '207'
-    body:
-      encoding: UTF-8
-      string: |
-        <revision rev="7" vrev="7">
-          <srcmd5>89763736fdcdd457814b3f7570a9d02c</srcmd5>
-          <version>unknown</version>
-          <time>1643727160</time>
-          <user>unknown</user>
-          <comment></comment>
-          <requestid/>
-        </revision>
-  recorded_at: Tue, 01 Feb 2022 14:52:40 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/my_project/first_package/somefile.txt
-    body:
-      encoding: UTF-8
-      string: Tempora ut iure. Quidem dolores dolorem. Quo sapiente qui.
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '207'
-    body:
-      encoding: UTF-8
-      string: |
-        <revision rev="8" vrev="8">
-          <srcmd5>a2925d3e9de0ecf32a047850b66246c5</srcmd5>
-          <version>unknown</version>
-          <time>1643727160</time>
-          <user>unknown</user>
-          <comment></comment>
-          <requestid/>
-        </revision>
-  recorded_at: Tue, 01 Feb 2022 14:52:41 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/my_project/second_package/_meta?user=user_8
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="second_package" project="my_project">
-          <title>c</title>
-          <description>Labore ratione quia vel.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '137'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="second_package" project="my_project">
-          <title>c</title>
-          <description>Labore ratione quia vel.</description>
-        </package>
-  recorded_at: Tue, 01 Feb 2022 14:52:41 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/my_project/second_package/_config
-    body:
-      encoding: UTF-8
-      string: Fugit dolor quo. Distinctio consequatur dolorum. Ea quos quis.
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '207'
-    body:
-      encoding: UTF-8
-      string: |
-        <revision rev="7" vrev="7">
-          <srcmd5>5784542c08c57e741a7f2a1f32356e3c</srcmd5>
-          <version>unknown</version>
-          <time>1643727161</time>
-          <user>unknown</user>
-          <comment></comment>
-          <requestid/>
-        </revision>
-  recorded_at: Tue, 01 Feb 2022 14:52:41 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/my_project/second_package/somefile.txt
-    body:
-      encoding: UTF-8
-      string: Et natus eaque. Est animi totam. Odit temporibus quos.
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '207'
-    body:
-      encoding: UTF-8
-      string: |
-        <revision rev="8" vrev="8">
-          <srcmd5>2d365fd1d9c63ebdb14dc96a4743e2c7</srcmd5>
-          <version>unknown</version>
-          <time>1643727161</time>
-          <user>unknown</user>
-          <comment></comment>
-          <requestid/>
-        </revision>
-  recorded_at: Tue, 01 Feb 2022 14:52:41 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/my_project/third_package/_meta?user=user_9
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="third_package" project="my_project">
-          <title>b</title>
-          <description>Beatae omnis ullam reiciendis.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '142'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="third_package" project="my_project">
-          <title>b</title>
-          <description>Beatae omnis ullam reiciendis.</description>
-        </package>
-  recorded_at: Tue, 01 Feb 2022 14:52:41 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/my_project/third_package/_config
-    body:
-      encoding: UTF-8
-      string: Voluptas neque autem. Cupiditate dignissimos sit. Autem sunt libero.
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '207'
-    body:
-      encoding: UTF-8
-      string: |
-        <revision rev="7" vrev="7">
-          <srcmd5>d1d95ee333d1a60e4f854fcb0f31cfc2</srcmd5>
-          <version>unknown</version>
-          <time>1643727162</time>
-          <user>unknown</user>
-          <comment></comment>
-          <requestid/>
-        </revision>
-  recorded_at: Tue, 01 Feb 2022 14:52:42 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/my_project/third_package/somefile.txt
-    body:
-      encoding: UTF-8
-      string: Iure odio tempore. Quos veritatis neque. Libero dolores dolorem.
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '207'
-    body:
-      encoding: UTF-8
-      string: |
-        <revision rev="8" vrev="8">
-          <srcmd5>1ff26bdb3cc047ba8a22cb63ab7a27d4</srcmd5>
-          <version>unknown</version>
-          <time>1643727162</time>
-          <user>unknown</user>
-          <comment></comment>
-          <requestid/>
-        </revision>
-  recorded_at: Tue, 01 Feb 2022 14:52:42 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/my_project/package_with_kiwi_image/_meta?user=user_10
-    body:
-      encoding: UTF-8
-      string: |
         <package name="package_with_kiwi_image" project="my_project">
-          <title>In Dubious Battle</title>
-          <description>Delectus libero est sint.</description>
+          <title>Eyeless in Gaza</title>
+          <description>Maxime et est eos.</description>
         </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '163'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="package_with_kiwi_image" project="my_project">
-          <title>In Dubious Battle</title>
-          <description>Delectus libero est sint.</description>
-        </package>
-  recorded_at: Tue, 01 Feb 2022 14:52:42 GMT
+  recorded_at: Thu, 18 May 2023 11:49:52 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/package_with_kiwi_image/package_with_kiwi_image.kiwi
@@ -491,15 +494,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="4" vrev="4">
+        <revision rev="5" vrev="5">
           <srcmd5>801c545be09c1c468ff2d99b40415aac</srcmd5>
           <version>0.0.1</version>
-          <time>1643727162</time>
+          <time>1684410593</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Tue, 01 Feb 2022 14:52:42 GMT
+  recorded_at: Thu, 18 May 2023 11:49:53 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/package_with_kiwi_image/_meta?user=user_10
@@ -507,8 +510,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="my_project">
-          <title>In Dubious Battle</title>
-          <description>Delectus libero est sint.</description>
+          <title>Eyeless in Gaza</title>
+          <description>Maxime et est eos.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -529,15 +532,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '163'
+      - '154'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="my_project">
-          <title>In Dubious Battle</title>
-          <description>Delectus libero est sint.</description>
+          <title>Eyeless in Gaza</title>
+          <description>Maxime et est eos.</description>
         </package>
-  recorded_at: Tue, 01 Feb 2022 14:52:42 GMT
+  recorded_at: Thu, 18 May 2023 11:49:53 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/package_with_kiwi_image
@@ -567,10 +570,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_kiwi_image" rev="4" vrev="4" srcmd5="801c545be09c1c468ff2d99b40415aac">
-          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1643726947"/>
+        <directory name="package_with_kiwi_image" rev="5" vrev="5" srcmd5="801c545be09c1c468ff2d99b40415aac">
+          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1677064926"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:52:42 GMT
+  recorded_at: Thu, 18 May 2023 11:49:53 GMT
 - request:
     method: put
     uri: http://backend:5352/source/my_project/_project/_attribute?meta=1&user=tom
@@ -604,13 +607,13 @@ http_interactions:
       encoding: UTF-8
       string: |
         <revision rev="12">
-          <srcmd5>fcec2e61834d1b5b31aecf86078fedcb</srcmd5>
-          <time>1643727163</time>
+          <srcmd5>303f2c4f95ec878c87a831fe2b51c6c1</srcmd5>
+          <time>1684410593</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Tue, 01 Feb 2022 14:52:43 GMT
+  recorded_at: Thu, 18 May 2023 11:49:53 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/first_package
@@ -619,7 +622,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - a2970fc6-e4d9-40cb-8cca-6b7b798ddceb
+      - 575ddf42-eb1f-416f-9c5b-b65d855e7a54
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -638,24 +641,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '298'
+      - '300'
     body:
       encoding: UTF-8
       string: |
-        <directory name="first_package" rev="8" vrev="8" srcmd5="a2925d3e9de0ecf32a047850b66246c5">
-          <entry name="_config" md5="a4000e2689fb03037f94848ba82695f1" size="67" mtime="1643727160"/>
-          <entry name="somefile.txt" md5="3ad0d79df53e78b331189e4d857433db" size="58" mtime="1643727160"/>
+        <directory name="first_package" rev="10" vrev="10" srcmd5="5088c94aac17a0aef4b66b50bc9e450d">
+          <entry name="_config" md5="ed1885e0850271e888665ba820e7aa84" size="72" mtime="1684410592"/>
+          <entry name="somefile.txt" md5="42aa02acd6daf819be320dcb85a64c21" size="74" mtime="1684410592"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:52:43 GMT
+  recorded_at: Thu, 18 May 2023 11:49:53 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/my_project/first_package?expand=0
+    uri: http://backend:5352/source/my_project/first_package
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - a2970fc6-e4d9-40cb-8cca-6b7b798ddceb
+      - 575ddf42-eb1f-416f-9c5b-b65d855e7a54
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -674,15 +677,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '298'
+      - '300'
     body:
       encoding: UTF-8
       string: |
-        <directory name="first_package" rev="8" vrev="8" srcmd5="a2925d3e9de0ecf32a047850b66246c5">
-          <entry name="_config" md5="a4000e2689fb03037f94848ba82695f1" size="67" mtime="1643727160"/>
-          <entry name="somefile.txt" md5="3ad0d79df53e78b331189e4d857433db" size="58" mtime="1643727160"/>
+        <directory name="first_package" rev="10" vrev="10" srcmd5="5088c94aac17a0aef4b66b50bc9e450d">
+          <entry name="_config" md5="ed1885e0850271e888665ba820e7aa84" size="72" mtime="1684410592"/>
+          <entry name="somefile.txt" md5="42aa02acd6daf819be320dcb85a64c21" size="74" mtime="1684410592"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:52:43 GMT
+  recorded_at: Thu, 18 May 2023 11:49:53 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/second_package
@@ -691,7 +694,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - a2970fc6-e4d9-40cb-8cca-6b7b798ddceb
+      - 575ddf42-eb1f-416f-9c5b-b65d855e7a54
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -710,24 +713,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '299'
+      - '301'
     body:
       encoding: UTF-8
       string: |
-        <directory name="second_package" rev="8" vrev="8" srcmd5="2d365fd1d9c63ebdb14dc96a4743e2c7">
-          <entry name="_config" md5="60114eddf7932a2850786060acb2ee89" size="62" mtime="1643727161"/>
-          <entry name="somefile.txt" md5="9f290108d689cc138a8ea44882219b21" size="54" mtime="1643727161"/>
+        <directory name="second_package" rev="10" vrev="10" srcmd5="b65424aabad564d81ed9ae5429949807">
+          <entry name="_config" md5="75173dce82b81bdbf11d6187b639a643" size="72" mtime="1684410592"/>
+          <entry name="somefile.txt" md5="a74444e54a7f077ce79f1ee0cf903b80" size="75" mtime="1684410592"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:52:43 GMT
+  recorded_at: Thu, 18 May 2023 11:49:53 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/my_project/second_package?expand=0
+    uri: http://backend:5352/source/my_project/second_package
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - a2970fc6-e4d9-40cb-8cca-6b7b798ddceb
+      - 575ddf42-eb1f-416f-9c5b-b65d855e7a54
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -746,15 +749,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '299'
+      - '301'
     body:
       encoding: UTF-8
       string: |
-        <directory name="second_package" rev="8" vrev="8" srcmd5="2d365fd1d9c63ebdb14dc96a4743e2c7">
-          <entry name="_config" md5="60114eddf7932a2850786060acb2ee89" size="62" mtime="1643727161"/>
-          <entry name="somefile.txt" md5="9f290108d689cc138a8ea44882219b21" size="54" mtime="1643727161"/>
+        <directory name="second_package" rev="10" vrev="10" srcmd5="b65424aabad564d81ed9ae5429949807">
+          <entry name="_config" md5="75173dce82b81bdbf11d6187b639a643" size="72" mtime="1684410592"/>
+          <entry name="somefile.txt" md5="a74444e54a7f077ce79f1ee0cf903b80" size="75" mtime="1684410592"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:52:43 GMT
+  recorded_at: Thu, 18 May 2023 11:49:53 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/third_package
@@ -763,7 +766,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - a2970fc6-e4d9-40cb-8cca-6b7b798ddceb
+      - 575ddf42-eb1f-416f-9c5b-b65d855e7a54
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -782,24 +785,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '298'
+      - '300'
     body:
       encoding: UTF-8
       string: |
-        <directory name="third_package" rev="8" vrev="8" srcmd5="1ff26bdb3cc047ba8a22cb63ab7a27d4">
-          <entry name="_config" md5="b0daa9112283fdbe24d0d98a87fe7d6c" size="68" mtime="1643727161"/>
-          <entry name="somefile.txt" md5="21a0db9e281c9802b73430b37d77c1c8" size="64" mtime="1643727162"/>
+        <directory name="third_package" rev="10" vrev="10" srcmd5="1658e81f9e644cd5edc299ebbb2fb0a7">
+          <entry name="_config" md5="d89911953af8957fe486b15d99f2b55d" size="75" mtime="1684410592"/>
+          <entry name="somefile.txt" md5="acc7cc23a7bd3a774b9ad61c4dbe4edc" size="70" mtime="1684410592"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:52:43 GMT
+  recorded_at: Thu, 18 May 2023 11:49:53 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/my_project/third_package?expand=0
+    uri: http://backend:5352/source/my_project/third_package
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - a2970fc6-e4d9-40cb-8cca-6b7b798ddceb
+      - 575ddf42-eb1f-416f-9c5b-b65d855e7a54
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -818,15 +821,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '298'
+      - '300'
     body:
       encoding: UTF-8
       string: |
-        <directory name="third_package" rev="8" vrev="8" srcmd5="1ff26bdb3cc047ba8a22cb63ab7a27d4">
-          <entry name="_config" md5="b0daa9112283fdbe24d0d98a87fe7d6c" size="68" mtime="1643727161"/>
-          <entry name="somefile.txt" md5="21a0db9e281c9802b73430b37d77c1c8" size="64" mtime="1643727162"/>
+        <directory name="third_package" rev="10" vrev="10" srcmd5="1658e81f9e644cd5edc299ebbb2fb0a7">
+          <entry name="_config" md5="d89911953af8957fe486b15d99f2b55d" size="75" mtime="1684410592"/>
+          <entry name="somefile.txt" md5="acc7cc23a7bd3a774b9ad61c4dbe4edc" size="70" mtime="1684410592"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:52:43 GMT
+  recorded_at: Thu, 18 May 2023 11:49:53 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/package_with_kiwi_image
@@ -835,7 +838,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - a2970fc6-e4d9-40cb-8cca-6b7b798ddceb
+      - 575ddf42-eb1f-416f-9c5b-b65d855e7a54
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -858,19 +861,19 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_kiwi_image" rev="4" vrev="4" srcmd5="801c545be09c1c468ff2d99b40415aac">
-          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1643726947"/>
+        <directory name="package_with_kiwi_image" rev="5" vrev="5" srcmd5="801c545be09c1c468ff2d99b40415aac">
+          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1677064926"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:52:43 GMT
+  recorded_at: Thu, 18 May 2023 11:49:53 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/my_project/package_with_kiwi_image?expand=0
+    uri: http://backend:5352/source/my_project/package_with_kiwi_image
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - a2970fc6-e4d9-40cb-8cca-6b7b798ddceb
+      - 575ddf42-eb1f-416f-9c5b-b65d855e7a54
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -893,10 +896,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_kiwi_image" rev="4" vrev="4" srcmd5="801c545be09c1c468ff2d99b40415aac">
-          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1643726947"/>
+        <directory name="package_with_kiwi_image" rev="5" vrev="5" srcmd5="801c545be09c1c468ff2d99b40415aac">
+          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1677064926"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:52:43 GMT
+  recorded_at: Thu, 18 May 2023 11:49:53 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom/_result?code=unresolvable&view=status
@@ -905,7 +908,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 6d2b5910-5251-4ed9-9a39-e67641fcdd05
+      - 314af733-ed32-432c-b19a-d28b98a91f96
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -930,7 +933,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Tue, 01 Feb 2022 14:52:44 GMT
+  recorded_at: Thu, 18 May 2023 11:49:54 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom/_keyinfo?donotcreatecert=1&withsslcert=1
@@ -939,7 +942,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 6d2b5910-5251-4ed9-9a39-e67641fcdd05
+      - 314af733-ed32-432c-b19a-d28b98a91f96
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -958,11 +961,39 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '11'
+      - '1639'
     body:
       encoding: UTF-8
-      string: "<keyinfo/>\n"
-  recorded_at: Tue, 01 Feb 2022 14:52:44 GMT
+      string: |
+        <keyinfo project="home:tom">
+          <pubkey keyid="cfaa8e084a26fafa" userid="home:tom OBS Project &lt;home:tom@private&gt;" algo="rsa" keysize="2048" expires="1741880605" fingerprint="5c29 f588 f5b8 c2c4 6069 ff08 cfaa 8e08 4a26 fafa">-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+        mQENBGO0TR0BCADlQ4FwIb9gBi9DUkkC7MvIpu1QI6n1yLdv93X53Tc4kRmE0F5v
+        LD3qihj+ENLuF+CpK15JXzM5pwswcO/UzNs1pJjEDBef8Bw10RTQZy88qGdwaEbH
+        v+LZnt/8UzH1DfTccN/7ana/ZnZFDkztHq1syw2VL+dK2w+JcA7xmD4SzD4DBhgJ
+        UfxvZT9prdXbr8GyIqYdInDqnmexdeYZCaVJlcLlIHI/z2k9/Yfofnu4tA0GBXVJ
+        MnRfkdLEyRPaVNMBz8ITw+5naiv+pj9jV3dKKxaMblCMPOPoUWrT8hEUZyravYtR
+        uiKjl/4nCePyRypatKJUL6i1i93UoF2JGI0BABEBAAG0J2hvbWU6dG9tIE9CUyBQ
+        cm9qZWN0IDxob21lOnRvbUBwcml2YXRlPokBVAQTAQgAPhYhBFwp9Yj1uMLEYGn/
+        CM+qjghKJvr6BQJjtE0dAhsDBQkEHrAABQsJCAcCBhUKCQgLAgQWAgMBAh4BAheA
+        AAoJEM+qjghKJvr6+pwIAN/0N8BgUOIUpsx2oOx7z5+CoJb9kEBgeIZeQ/HSvfYR
+        0Lec22ztbuNehj0OpP6inL7lfREThEKlc0u/wKMB9VgtsVyQfUrEuDQUQyxU4SvO
+        JWdo05+nSfX5x7tU33uMc9YPy/VfJs/E0boJJuwR/OexCa4U96Qz2fQnj2WHgt3t
+        SXUMkxbUd3RU24PCdfJnDq/hl75tx8uI01f/IcIimEoHLsNPotPGELnstHKrMpUp
+        gjkWouCSq4VlE8Wrr8kvsf+/lD4rOqCTTcSqs6Pj9ytEDr6pYZGMj0gmGrSWd25G
+        o1YyY/rmenLKH9WQJ4f8AojkVnqt9YVzxgwXvMu42biJATMEEwEIAB0WIQQGTN2V
+        wCe8seo248C/9fknuEcc6wUCY7RNHgAKCRC/9fknuEcc6xEkCACvwrBh1UlV9EM/
+        p5hqlzT+VOlcXSAtLRfAElPtyYY0mleof0+AxDM32z2cPiGieUOAW/HK7eXHJCb2
+        uYosjrO1D8CLUPZ9DM0X5bLicxux2JBtbxV0F9kkEc+p0a+jbi/sE8Ao0vStZD5r
+        cJoUSEiglRKS+uC+VsJbqpDhL7+w7lvL9ItG5uszkTukLb7eMlpi6yve3WWapEiN
+        eXyF09dSJbe0B9wOB8ilw8qOmmCEVElug0044fxq+0Aam6LXCfuC8BEx8YqmGnED
+        jYotxAOCpnQ01KzF4PbGogHn8G86s0btjiayWfed3Cs42O1UC9i+USPe0D2L5lXg
+        QDgCOz2L
+        =nUQx
+        -----END PGP PUBLIC KEY BLOCK-----
+        </pubkey>
+        </keyinfo>
+  recorded_at: Thu, 18 May 2023 11:49:54 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom/_result?view=summary
@@ -971,7 +1002,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 2746a820-060e-4d4d-95b5-75f0123b09a1
+      - 7b0296d8-a06d-4215-a550-89d9ea5b937a
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -996,7 +1027,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Tue, 01 Feb 2022 14:52:44 GMT
+  recorded_at: Thu, 18 May 2023 11:49:54 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/first_package
@@ -1005,7 +1036,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - cc25ca77-f400-48db-b167-f8b38ae2abd4
+      - 04b164a2-038c-4a31-9d9d-99b776de5150
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1024,24 +1055,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '298'
+      - '300'
     body:
       encoding: UTF-8
       string: |
-        <directory name="first_package" rev="8" vrev="8" srcmd5="a2925d3e9de0ecf32a047850b66246c5">
-          <entry name="_config" md5="a4000e2689fb03037f94848ba82695f1" size="67" mtime="1643727160"/>
-          <entry name="somefile.txt" md5="3ad0d79df53e78b331189e4d857433db" size="58" mtime="1643727160"/>
+        <directory name="first_package" rev="10" vrev="10" srcmd5="5088c94aac17a0aef4b66b50bc9e450d">
+          <entry name="_config" md5="ed1885e0850271e888665ba820e7aa84" size="72" mtime="1684410592"/>
+          <entry name="somefile.txt" md5="42aa02acd6daf819be320dcb85a64c21" size="74" mtime="1684410592"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:52:44 GMT
+  recorded_at: Thu, 18 May 2023 11:49:54 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/my_project/first_package?expand=0
+    uri: http://backend:5352/source/my_project/first_package
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - cc25ca77-f400-48db-b167-f8b38ae2abd4
+      - 04b164a2-038c-4a31-9d9d-99b776de5150
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1060,15 +1091,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '298'
+      - '300'
     body:
       encoding: UTF-8
       string: |
-        <directory name="first_package" rev="8" vrev="8" srcmd5="a2925d3e9de0ecf32a047850b66246c5">
-          <entry name="_config" md5="a4000e2689fb03037f94848ba82695f1" size="67" mtime="1643727160"/>
-          <entry name="somefile.txt" md5="3ad0d79df53e78b331189e4d857433db" size="58" mtime="1643727160"/>
+        <directory name="first_package" rev="10" vrev="10" srcmd5="5088c94aac17a0aef4b66b50bc9e450d">
+          <entry name="_config" md5="ed1885e0850271e888665ba820e7aa84" size="72" mtime="1684410592"/>
+          <entry name="somefile.txt" md5="42aa02acd6daf819be320dcb85a64c21" size="74" mtime="1684410592"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:52:44 GMT
+  recorded_at: Thu, 18 May 2023 11:49:54 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/second_package
@@ -1077,7 +1108,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - cc25ca77-f400-48db-b167-f8b38ae2abd4
+      - 04b164a2-038c-4a31-9d9d-99b776de5150
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1096,24 +1127,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '299'
+      - '301'
     body:
       encoding: UTF-8
       string: |
-        <directory name="second_package" rev="8" vrev="8" srcmd5="2d365fd1d9c63ebdb14dc96a4743e2c7">
-          <entry name="_config" md5="60114eddf7932a2850786060acb2ee89" size="62" mtime="1643727161"/>
-          <entry name="somefile.txt" md5="9f290108d689cc138a8ea44882219b21" size="54" mtime="1643727161"/>
+        <directory name="second_package" rev="10" vrev="10" srcmd5="b65424aabad564d81ed9ae5429949807">
+          <entry name="_config" md5="75173dce82b81bdbf11d6187b639a643" size="72" mtime="1684410592"/>
+          <entry name="somefile.txt" md5="a74444e54a7f077ce79f1ee0cf903b80" size="75" mtime="1684410592"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:52:44 GMT
+  recorded_at: Thu, 18 May 2023 11:49:54 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/my_project/second_package?expand=0
+    uri: http://backend:5352/source/my_project/second_package
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - cc25ca77-f400-48db-b167-f8b38ae2abd4
+      - 04b164a2-038c-4a31-9d9d-99b776de5150
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1132,15 +1163,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '299'
+      - '301'
     body:
       encoding: UTF-8
       string: |
-        <directory name="second_package" rev="8" vrev="8" srcmd5="2d365fd1d9c63ebdb14dc96a4743e2c7">
-          <entry name="_config" md5="60114eddf7932a2850786060acb2ee89" size="62" mtime="1643727161"/>
-          <entry name="somefile.txt" md5="9f290108d689cc138a8ea44882219b21" size="54" mtime="1643727161"/>
+        <directory name="second_package" rev="10" vrev="10" srcmd5="b65424aabad564d81ed9ae5429949807">
+          <entry name="_config" md5="75173dce82b81bdbf11d6187b639a643" size="72" mtime="1684410592"/>
+          <entry name="somefile.txt" md5="a74444e54a7f077ce79f1ee0cf903b80" size="75" mtime="1684410592"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:52:44 GMT
+  recorded_at: Thu, 18 May 2023 11:49:55 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/third_package
@@ -1149,7 +1180,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - cc25ca77-f400-48db-b167-f8b38ae2abd4
+      - 04b164a2-038c-4a31-9d9d-99b776de5150
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1168,24 +1199,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '298'
+      - '300'
     body:
       encoding: UTF-8
       string: |
-        <directory name="third_package" rev="8" vrev="8" srcmd5="1ff26bdb3cc047ba8a22cb63ab7a27d4">
-          <entry name="_config" md5="b0daa9112283fdbe24d0d98a87fe7d6c" size="68" mtime="1643727161"/>
-          <entry name="somefile.txt" md5="21a0db9e281c9802b73430b37d77c1c8" size="64" mtime="1643727162"/>
+        <directory name="third_package" rev="10" vrev="10" srcmd5="1658e81f9e644cd5edc299ebbb2fb0a7">
+          <entry name="_config" md5="d89911953af8957fe486b15d99f2b55d" size="75" mtime="1684410592"/>
+          <entry name="somefile.txt" md5="acc7cc23a7bd3a774b9ad61c4dbe4edc" size="70" mtime="1684410592"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:52:44 GMT
+  recorded_at: Thu, 18 May 2023 11:49:55 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/my_project/third_package?expand=0
+    uri: http://backend:5352/source/my_project/third_package
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - cc25ca77-f400-48db-b167-f8b38ae2abd4
+      - 04b164a2-038c-4a31-9d9d-99b776de5150
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1204,15 +1235,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '298'
+      - '300'
     body:
       encoding: UTF-8
       string: |
-        <directory name="third_package" rev="8" vrev="8" srcmd5="1ff26bdb3cc047ba8a22cb63ab7a27d4">
-          <entry name="_config" md5="b0daa9112283fdbe24d0d98a87fe7d6c" size="68" mtime="1643727161"/>
-          <entry name="somefile.txt" md5="21a0db9e281c9802b73430b37d77c1c8" size="64" mtime="1643727162"/>
+        <directory name="third_package" rev="10" vrev="10" srcmd5="1658e81f9e644cd5edc299ebbb2fb0a7">
+          <entry name="_config" md5="d89911953af8957fe486b15d99f2b55d" size="75" mtime="1684410592"/>
+          <entry name="somefile.txt" md5="acc7cc23a7bd3a774b9ad61c4dbe4edc" size="70" mtime="1684410592"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:52:44 GMT
+  recorded_at: Thu, 18 May 2023 11:49:55 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/package_with_kiwi_image
@@ -1221,7 +1252,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - cc25ca77-f400-48db-b167-f8b38ae2abd4
+      - 04b164a2-038c-4a31-9d9d-99b776de5150
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1244,19 +1275,19 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_kiwi_image" rev="4" vrev="4" srcmd5="801c545be09c1c468ff2d99b40415aac">
-          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1643726947"/>
+        <directory name="package_with_kiwi_image" rev="5" vrev="5" srcmd5="801c545be09c1c468ff2d99b40415aac">
+          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1677064926"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:52:44 GMT
+  recorded_at: Thu, 18 May 2023 11:49:55 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/my_project/package_with_kiwi_image?expand=0
+    uri: http://backend:5352/source/my_project/package_with_kiwi_image
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - cc25ca77-f400-48db-b167-f8b38ae2abd4
+      - 04b164a2-038c-4a31-9d9d-99b776de5150
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1279,10 +1310,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_kiwi_image" rev="4" vrev="4" srcmd5="801c545be09c1c468ff2d99b40415aac">
-          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1643726947"/>
+        <directory name="package_with_kiwi_image" rev="5" vrev="5" srcmd5="801c545be09c1c468ff2d99b40415aac">
+          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1677064926"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:52:44 GMT
+  recorded_at: Thu, 18 May 2023 11:49:55 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/package_with_kiwi_image?expand=1
@@ -1291,7 +1322,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 29833207-8d04-4028-bc81-7c3ad1bbe88e
+      - cbbf124b-4082-470a-85a4-7247afbe3ff3
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1314,19 +1345,19 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_kiwi_image" rev="4" vrev="4" srcmd5="801c545be09c1c468ff2d99b40415aac">
-          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1643726947"/>
+        <directory name="package_with_kiwi_image" rev="5" vrev="5" srcmd5="801c545be09c1c468ff2d99b40415aac">
+          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1677064926"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:52:44 GMT
+  recorded_at: Thu, 18 May 2023 11:49:56 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/my_project/package_with_kiwi_image?rev=4
+    uri: http://backend:5352/source/my_project/package_with_kiwi_image?rev=5
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - 29833207-8d04-4028-bc81-7c3ad1bbe88e
+      - cbbf124b-4082-470a-85a4-7247afbe3ff3
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1349,10 +1380,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_kiwi_image" rev="4" vrev="4" srcmd5="801c545be09c1c468ff2d99b40415aac">
-          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1643726947"/>
+        <directory name="package_with_kiwi_image" rev="5" vrev="5" srcmd5="801c545be09c1c468ff2d99b40415aac">
+          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1677064926"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:52:44 GMT
+  recorded_at: Thu, 18 May 2023 11:49:56 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22package_with_kiwi_image%22%20and%20linkinfo/@project=%22my_project%22%20and%20@project=%22my_project%22)
@@ -1386,7 +1417,7 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Tue, 01 Feb 2022 14:52:44 GMT
+  recorded_at: Thu, 18 May 2023 11:49:56 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:my_project/_meta?user=tom
@@ -1400,7 +1431,7 @@ http_interactions:
         </project>
     headers:
       X-Request-Id:
-      - 29833207-8d04-4028-bc81-7c3ad1bbe88e
+      - cbbf124b-4082-470a-85a4-7247afbe3ff3
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1428,7 +1459,7 @@ http_interactions:
           <description>This project was created for package package_with_kiwi_image via attribute OBS:Maintained</description>
           <person userid="tom" role="maintainer"/>
         </project>
-  recorded_at: Tue, 01 Feb 2022 14:52:45 GMT
+  recorded_at: Thu, 18 May 2023 11:49:56 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:my_project/_project/_attribute?meta=1&user=tom
@@ -1437,12 +1468,12 @@ http_interactions:
       string: |
         <attributes>
           <attribute name="AutoCleanup" namespace="OBS">
-            <value>2022-02-15 14:52:45 +0000</value>
+            <value>2023-06-01 11:49:56 +0000</value>
           </attribute>
         </attributes>
     headers:
       X-Request-Id:
-      - 29833207-8d04-4028-bc81-7c3ad1bbe88e
+      - cbbf124b-4082-470a-85a4-7247afbe3ff3
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1465,14 +1496,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="11">
-          <srcmd5>188b016ca9969bf43c7fc16a245d0609</srcmd5>
-          <time>1643727165</time>
+        <revision rev="14">
+          <srcmd5>7e9f52c9cd5c3435ba488956d34fd480</srcmd5>
+          <time>1684410596</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Tue, 01 Feb 2022 14:52:45 GMT
+  recorded_at: Thu, 18 May 2023 11:49:56 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:my_project/package_with_kiwi_image/_meta?user=tom
@@ -1480,8 +1511,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="home:tom:branches:my_project">
-          <title>In Dubious Battle</title>
-          <description>Delectus libero est sint.</description>
+          <title>Eyeless in Gaza</title>
+          <description>Maxime et est eos.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1502,15 +1533,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '181'
+      - '172'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="home:tom:branches:my_project">
-          <title>In Dubious Battle</title>
-          <description>Delectus libero est sint.</description>
+          <title>Eyeless in Gaza</title>
+          <description>Maxime et est eos.</description>
         </package>
-  recorded_at: Tue, 01 Feb 2022 14:52:45 GMT
+  recorded_at: Thu, 18 May 2023 11:49:56 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:my_project/package_with_kiwi_image?cmd=branch&noservice=1&opackage=package_with_kiwi_image&oproject=my_project&orev=801c545be09c1c468ff2d99b40415aac&user=tom
@@ -1542,15 +1573,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="2" vrev="2">
+        <revision rev="1" vrev="1">
           <srcmd5>00d929e44f732106a7aa255543b32f11</srcmd5>
           <version>unknown</version>
-          <time>1643727165</time>
+          <time>1684410596</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Tue, 01 Feb 2022 14:52:45 GMT
+  recorded_at: Thu, 18 May 2023 11:49:56 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:my_project/package_with_kiwi_image/_meta?user=tom
@@ -1558,8 +1589,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="home:tom:branches:my_project">
-          <title>In Dubious Battle</title>
-          <description>Delectus libero est sint.</description>
+          <title>Eyeless in Gaza</title>
+          <description>Maxime et est eos.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1580,15 +1611,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '181'
+      - '172'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="home:tom:branches:my_project">
-          <title>In Dubious Battle</title>
-          <description>Delectus libero est sint.</description>
+          <title>Eyeless in Gaza</title>
+          <description>Maxime et est eos.</description>
         </package>
-  recorded_at: Tue, 01 Feb 2022 14:52:45 GMT
+  recorded_at: Thu, 18 May 2023 11:49:56 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/package_with_kiwi_image
@@ -1618,12 +1649,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_kiwi_image" rev="2" vrev="2" srcmd5="00d929e44f732106a7aa255543b32f11">
+        <directory name="package_with_kiwi_image" rev="1" vrev="1" srcmd5="00d929e44f732106a7aa255543b32f11">
           <linkinfo project="my_project" package="package_with_kiwi_image" rev="801c545be09c1c468ff2d99b40415aac" srcmd5="801c545be09c1c468ff2d99b40415aac" baserev="801c545be09c1c468ff2d99b40415aac" xsrcmd5="067709a3aecd96cf74107fa909e67564" lsrcmd5="00d929e44f732106a7aa255543b32f11"/>
-          <entry name="_link" md5="4e48143c1ab3ebf7faf55f7286d870d4" size="157" mtime="1643726954"/>
-          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1643726947"/>
+          <entry name="_link" md5="4e48143c1ab3ebf7faf55f7286d870d4" size="157" mtime="1684410596"/>
+          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1677064926"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:52:45 GMT
+  recorded_at: Thu, 18 May 2023 11:49:56 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/package_with_kiwi_image?view=info
@@ -1632,7 +1663,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 29833207-8d04-4028-bc81-7c3ad1bbe88e
+      - cbbf124b-4082-470a-85a4-7247afbe3ff3
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1655,11 +1686,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="package_with_kiwi_image" rev="2" vrev="2" srcmd5="067709a3aecd96cf74107fa909e67564" lsrcmd5="00d929e44f732106a7aa255543b32f11" verifymd5="801c545be09c1c468ff2d99b40415aac">
+        <sourceinfo package="package_with_kiwi_image" rev="1" vrev="1" srcmd5="067709a3aecd96cf74107fa909e67564" lsrcmd5="00d929e44f732106a7aa255543b32f11" verifymd5="801c545be09c1c468ff2d99b40415aac">
           <filename>package_with_kiwi_image.kiwi</filename>
           <linked project="my_project" package="package_with_kiwi_image"/>
         </sourceinfo>
-  recorded_at: Tue, 01 Feb 2022 14:52:45 GMT
+  recorded_at: Thu, 18 May 2023 11:49:56 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/package_with_kiwi_image
@@ -1668,7 +1699,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 29833207-8d04-4028-bc81-7c3ad1bbe88e
+      - cbbf124b-4082-470a-85a4-7247afbe3ff3
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1691,12 +1722,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_kiwi_image" rev="2" vrev="2" srcmd5="00d929e44f732106a7aa255543b32f11">
+        <directory name="package_with_kiwi_image" rev="1" vrev="1" srcmd5="00d929e44f732106a7aa255543b32f11">
           <linkinfo project="my_project" package="package_with_kiwi_image" rev="801c545be09c1c468ff2d99b40415aac" srcmd5="801c545be09c1c468ff2d99b40415aac" baserev="801c545be09c1c468ff2d99b40415aac" xsrcmd5="067709a3aecd96cf74107fa909e67564" lsrcmd5="00d929e44f732106a7aa255543b32f11"/>
-          <entry name="_link" md5="4e48143c1ab3ebf7faf55f7286d870d4" size="157" mtime="1643726954"/>
-          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1643726947"/>
+          <entry name="_link" md5="4e48143c1ab3ebf7faf55f7286d870d4" size="157" mtime="1684410596"/>
+          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1677064926"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:52:45 GMT
+  recorded_at: Thu, 18 May 2023 11:49:56 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:my_project/package_with_kiwi_image?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -1728,14 +1759,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="affe0613e7178bea8d035bba86acc7a4">
+        <sourcediff key="caf8cbce974dbd11633db6e2292d67f4">
           <old project="home:tom:branches:my_project" package="package_with_kiwi_image" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:tom:branches:my_project" package="package_with_kiwi_image" rev="2" srcmd5="00d929e44f732106a7aa255543b32f11"/>
+          <new project="home:tom:branches:my_project" package="package_with_kiwi_image" rev="1" srcmd5="00d929e44f732106a7aa255543b32f11"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Tue, 01 Feb 2022 14:52:45 GMT
+  recorded_at: Thu, 18 May 2023 11:49:56 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:my_project/package_with_kiwi_image?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -1767,12 +1798,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="9efbe5ebc49e20d2162122b7302dfbce">
+        <sourcediff key="61314a7684fea950242ee620b53e480e">
           <old project="my_project" package="package_with_kiwi_image" rev="801c545be09c1c468ff2d99b40415aac" srcmd5="801c545be09c1c468ff2d99b40415aac"/>
           <new project="home:tom:branches:my_project" package="package_with_kiwi_image" rev="067709a3aecd96cf74107fa909e67564" srcmd5="067709a3aecd96cf74107fa909e67564"/>
           <files/>
         </sourcediff>
-  recorded_at: Tue, 01 Feb 2022 14:52:45 GMT
+  recorded_at: Thu, 18 May 2023 11:49:56 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:my_project/_meta?user=tom
@@ -1789,7 +1820,7 @@ http_interactions:
         </project>
     headers:
       X-Request-Id:
-      - 29833207-8d04-4028-bc81-7c3ad1bbe88e
+      - cbbf124b-4082-470a-85a4-7247afbe3ff3
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1820,7 +1851,7 @@ http_interactions:
             <disable/>
           </publish>
         </project>
-  recorded_at: Tue, 01 Feb 2022 14:52:46 GMT
+  recorded_at: Thu, 18 May 2023 11:49:56 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/package_with_kiwi_image
@@ -1829,7 +1860,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 29833207-8d04-4028-bc81-7c3ad1bbe88e
+      - cbbf124b-4082-470a-85a4-7247afbe3ff3
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1852,12 +1883,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_kiwi_image" rev="2" vrev="2" srcmd5="00d929e44f732106a7aa255543b32f11">
+        <directory name="package_with_kiwi_image" rev="1" vrev="1" srcmd5="00d929e44f732106a7aa255543b32f11">
           <linkinfo project="my_project" package="package_with_kiwi_image" rev="801c545be09c1c468ff2d99b40415aac" srcmd5="801c545be09c1c468ff2d99b40415aac" baserev="801c545be09c1c468ff2d99b40415aac" xsrcmd5="067709a3aecd96cf74107fa909e67564" lsrcmd5="00d929e44f732106a7aa255543b32f11"/>
-          <entry name="_link" md5="4e48143c1ab3ebf7faf55f7286d870d4" size="157" mtime="1643726954"/>
-          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1643726947"/>
+          <entry name="_link" md5="4e48143c1ab3ebf7faf55f7286d870d4" size="157" mtime="1684410596"/>
+          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1677064926"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:52:46 GMT
+  recorded_at: Thu, 18 May 2023 11:49:56 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/package_with_kiwi_image
@@ -1866,7 +1897,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 6a34bcf8-6d96-430d-903c-5fff425bd1d0
+      - 9115083e-7d94-480b-8ee7-7eba9a6f8751
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1889,12 +1920,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_kiwi_image" rev="2" vrev="2" srcmd5="00d929e44f732106a7aa255543b32f11">
+        <directory name="package_with_kiwi_image" rev="1" vrev="1" srcmd5="00d929e44f732106a7aa255543b32f11">
           <linkinfo project="my_project" package="package_with_kiwi_image" rev="801c545be09c1c468ff2d99b40415aac" srcmd5="801c545be09c1c468ff2d99b40415aac" baserev="801c545be09c1c468ff2d99b40415aac" xsrcmd5="067709a3aecd96cf74107fa909e67564" lsrcmd5="00d929e44f732106a7aa255543b32f11"/>
-          <entry name="_link" md5="4e48143c1ab3ebf7faf55f7286d870d4" size="157" mtime="1643726954"/>
-          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1643726947"/>
+          <entry name="_link" md5="4e48143c1ab3ebf7faf55f7286d870d4" size="157" mtime="1684410596"/>
+          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1677064926"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:52:47 GMT
+  recorded_at: Thu, 18 May 2023 11:49:56 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/package_with_kiwi_image/package_with_kiwi_image.kiwi
@@ -1928,7 +1959,7 @@ http_interactions:
         \   <preferences>\n      <version>0.0.1</version>\n      <type image=\"oem\"
         primary=\"true\" boot=\"oemboot/suse-13.2\"/>\n    </preferences>\n  </image>\n
         \ "
-  recorded_at: Tue, 01 Feb 2022 14:52:47 GMT
+  recorded_at: Thu, 18 May 2023 11:49:59 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/package_with_kiwi_image
@@ -1937,7 +1968,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 6a34bcf8-6d96-430d-903c-5fff425bd1d0
+      - 9115083e-7d94-480b-8ee7-7eba9a6f8751
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1960,12 +1991,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_kiwi_image" rev="2" vrev="2" srcmd5="00d929e44f732106a7aa255543b32f11">
+        <directory name="package_with_kiwi_image" rev="1" vrev="1" srcmd5="00d929e44f732106a7aa255543b32f11">
           <linkinfo project="my_project" package="package_with_kiwi_image" rev="801c545be09c1c468ff2d99b40415aac" srcmd5="801c545be09c1c468ff2d99b40415aac" baserev="801c545be09c1c468ff2d99b40415aac" xsrcmd5="067709a3aecd96cf74107fa909e67564" lsrcmd5="00d929e44f732106a7aa255543b32f11"/>
-          <entry name="_link" md5="4e48143c1ab3ebf7faf55f7286d870d4" size="157" mtime="1643726954"/>
-          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1643726947"/>
+          <entry name="_link" md5="4e48143c1ab3ebf7faf55f7286d870d4" size="157" mtime="1684410596"/>
+          <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1677064926"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:52:47 GMT
+  recorded_at: Thu, 18 May 2023 11:49:59 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:my_project/package_with_kiwi_image/_meta?user=tom
@@ -1973,8 +2004,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="home:tom:branches:my_project">
-          <title>In Dubious Battle</title>
-          <description>Delectus libero est sint.</description>
+          <title>Eyeless in Gaza</title>
+          <description>Maxime et est eos.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -1995,15 +2026,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '181'
+      - '172'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="home:tom:branches:my_project">
-          <title>In Dubious Battle</title>
-          <description>Delectus libero est sint.</description>
+          <title>Eyeless in Gaza</title>
+          <description>Maxime et est eos.</description>
         </package>
-  recorded_at: Tue, 01 Feb 2022 14:52:47 GMT
+  recorded_at: Thu, 18 May 2023 11:49:59 GMT
 - request:
     method: put
     uri: http://backend:5352/source/home:tom:branches:my_project/package_with_kiwi_image/_meta?user=tom
@@ -2011,8 +2042,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="home:tom:branches:my_project">
-          <title>In Dubious Battle</title>
-          <description>Delectus libero est sint.</description>
+          <title>Eyeless in Gaza</title>
+          <description>Maxime et est eos.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -2033,13 +2064,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '181'
+      - '172'
     body:
       encoding: UTF-8
       string: |
         <package name="package_with_kiwi_image" project="home:tom:branches:my_project">
-          <title>In Dubious Battle</title>
-          <description>Delectus libero est sint.</description>
+          <title>Eyeless in Gaza</title>
+          <description>Maxime et est eos.</description>
         </package>
-  recorded_at: Tue, 01 Feb 2022 14:52:47 GMT
-recorded_with: VCR 6.0.0
+  recorded_at: Thu, 18 May 2023 11:49:59 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/ImageTemplates/branching/branch_image_template.yml
+++ b/src/api/spec/cassettes/ImageTemplates/branching/branch_image_template.yml
@@ -1,6 +1,544 @@
 ---
 http_interactions:
 - request:
+    method: put
+    uri: http://backend:5352/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '128'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer"/>
+        </project>
+  recorded_at: Thu, 18 May 2023 11:49:40 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/my_project/_meta?user=user_1
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="my_project">
+          <title>In Dubious Battle</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '104'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="my_project">
+          <title>In Dubious Battle</title>
+          <description></description>
+        </project>
+  recorded_at: Thu, 18 May 2023 11:49:40 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/my_project/first_package/_meta?user=user_2
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="first_package" project="my_project">
+          <title>a</title>
+          <description>Voluptas aperiam iure similique.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '144'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="first_package" project="my_project">
+          <title>a</title>
+          <description>Voluptas aperiam iure similique.</description>
+        </package>
+  recorded_at: Thu, 18 May 2023 11:49:40 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/my_project/first_package/_config
+    body:
+      encoding: UTF-8
+      string: Quia corrupti sint. Reiciendis animi consequatur. Eligendi tenetur quia.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="7" vrev="7">
+          <srcmd5>2265b1ed461af3197720a25b50b7ca3c</srcmd5>
+          <version>unknown</version>
+          <time>1684410580</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Thu, 18 May 2023 11:49:40 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/my_project/first_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Commodi recusandae illo. Quisquam sed iste. Quia dolores ratione.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="8" vrev="8">
+          <srcmd5>63a573c9bdd2d5c01e9caa0cc00e71ae</srcmd5>
+          <version>unknown</version>
+          <time>1684410580</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Thu, 18 May 2023 11:49:40 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/my_project/second_package/_meta?user=user_3
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="second_package" project="my_project">
+          <title>c</title>
+          <description>Minus et sapiente et.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '134'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="second_package" project="my_project">
+          <title>c</title>
+          <description>Minus et sapiente et.</description>
+        </package>
+  recorded_at: Thu, 18 May 2023 11:49:40 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/my_project/second_package/_config
+    body:
+      encoding: UTF-8
+      string: Itaque impedit et. Molestias quisquam ab. Et impedit exercitationem.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="7" vrev="7">
+          <srcmd5>5fcf13e7db7a4716667614c960dd8caa</srcmd5>
+          <version>unknown</version>
+          <time>1684410580</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Thu, 18 May 2023 11:49:41 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/my_project/second_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Eum unde magnam. Vitae quae molestias. Rem dicta blanditiis.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="8" vrev="8">
+          <srcmd5>7d091fa836670ad9e58065521548e09c</srcmd5>
+          <version>unknown</version>
+          <time>1684410581</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Thu, 18 May 2023 11:49:41 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/my_project/third_package/_meta?user=user_4
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="third_package" project="my_project">
+          <title>b</title>
+          <description>Iusto eius enim magni.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '134'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="third_package" project="my_project">
+          <title>b</title>
+          <description>Iusto eius enim magni.</description>
+        </package>
+  recorded_at: Thu, 18 May 2023 11:49:41 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/my_project/third_package/_config
+    body:
+      encoding: UTF-8
+      string: Rerum delectus sed. Repudiandae molestias a. Qui dolor ipsa.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="7" vrev="7">
+          <srcmd5>5d6ae99f29a1b87798ca506a76269849</srcmd5>
+          <version>unknown</version>
+          <time>1684410581</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Thu, 18 May 2023 11:49:41 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/my_project/third_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Temporibus et blanditiis. Cumque aperiam aut. Adipisci et tempore.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="8" vrev="8">
+          <srcmd5>3678d49f4584dfc0c29ec25859e54c79</srcmd5>
+          <version>unknown</version>
+          <time>1684410581</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Thu, 18 May 2023 11:49:41 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/my_project/package_with_kiwi_image/_meta?user=user_5
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="my_project">
+          <title>Antic Hay</title>
+          <description>Natus qui ducimus et.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '151'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="my_project">
+          <title>Antic Hay</title>
+          <description>Natus qui ducimus et.</description>
+        </package>
+  recorded_at: Thu, 18 May 2023 11:49:41 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/my_project/package_with_kiwi_image/package_with_kiwi_image.kiwi
+    body:
+      encoding: UTF-8
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n  <image schemaversion=\"6.2\"
+        name=\"suse-13.2-live\">\n    <description type=\"system\">\n    </description>\n
+        \   <preferences>\n      <version>0.0.1</version>\n      <type image=\"oem\"
+        primary=\"true\" boot=\"oemboot/suse-13.2\"/>\n    </preferences>\n  </image>\n
+        \ "
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '205'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="4" vrev="4">
+          <srcmd5>801c545be09c1c468ff2d99b40415aac</srcmd5>
+          <version>0.0.1</version>
+          <time>1684410581</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Thu, 18 May 2023 11:49:41 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/my_project/package_with_kiwi_image/_meta?user=user_5
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="my_project">
+          <title>Antic Hay</title>
+          <description>Natus qui ducimus et.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '151'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_kiwi_image" project="my_project">
+          <title>Antic Hay</title>
+          <description>Natus qui ducimus et.</description>
+        </package>
+  recorded_at: Thu, 18 May 2023 11:49:41 GMT
+- request:
     method: get
     uri: http://backend:5352/source/my_project/package_with_kiwi_image
     body:
@@ -29,10 +567,50 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_kiwi_image" rev="3" vrev="3" srcmd5="801c545be09c1c468ff2d99b40415aac">
+        <directory name="package_with_kiwi_image" rev="4" vrev="4" srcmd5="801c545be09c1c468ff2d99b40415aac">
           <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1677064926"/>
         </directory>
-  recorded_at: Fri, 24 Feb 2023 13:03:32 GMT
+  recorded_at: Thu, 18 May 2023 11:49:41 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/my_project/_project/_attribute?meta=1&user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <attributes>
+          <attribute name="ImageTemplates" namespace="OBS"/>
+        </attributes>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '166'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="10">
+          <srcmd5>6256d54b1876aa627babd0b7a0c7872a</srcmd5>
+          <time>1684410581</time>
+          <user>tom</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Thu, 18 May 2023 11:49:41 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/first_package
@@ -41,7 +619,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - ca7dd789-a244-4c57-8616-3c6ed2dde8f8
+      - 17b72a88-dda3-48d8-85e3-8f9ec457915c
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -64,20 +642,20 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="first_package" rev="6" vrev="6" srcmd5="75636523146b8634e20e82e205dcc741">
-          <entry name="_config" md5="f69d35d06f7b54d8c8aaa84af2681cb3" size="58" mtime="1677088677"/>
-          <entry name="somefile.txt" md5="0f2416116d94550631676b18b16d5a2b" size="67" mtime="1677088677"/>
+        <directory name="first_package" rev="8" vrev="8" srcmd5="63a573c9bdd2d5c01e9caa0cc00e71ae">
+          <entry name="_config" md5="739535ed2ca0b9feb299f8da2502d8be" size="72" mtime="1684410580"/>
+          <entry name="somefile.txt" md5="d45db0d967e37f65544337564cc4de0c" size="65" mtime="1684410580"/>
         </directory>
-  recorded_at: Fri, 24 Feb 2023 13:03:32 GMT
+  recorded_at: Thu, 18 May 2023 11:49:45 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/my_project/first_package?expand=0
+    uri: http://backend:5352/source/my_project/first_package
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - ca7dd789-a244-4c57-8616-3c6ed2dde8f8
+      - 17b72a88-dda3-48d8-85e3-8f9ec457915c
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -100,11 +678,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="first_package" rev="6" vrev="6" srcmd5="75636523146b8634e20e82e205dcc741">
-          <entry name="_config" md5="f69d35d06f7b54d8c8aaa84af2681cb3" size="58" mtime="1677088677"/>
-          <entry name="somefile.txt" md5="0f2416116d94550631676b18b16d5a2b" size="67" mtime="1677088677"/>
+        <directory name="first_package" rev="8" vrev="8" srcmd5="63a573c9bdd2d5c01e9caa0cc00e71ae">
+          <entry name="_config" md5="739535ed2ca0b9feb299f8da2502d8be" size="72" mtime="1684410580"/>
+          <entry name="somefile.txt" md5="d45db0d967e37f65544337564cc4de0c" size="65" mtime="1684410580"/>
         </directory>
-  recorded_at: Fri, 24 Feb 2023 13:03:32 GMT
+  recorded_at: Thu, 18 May 2023 11:49:45 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/second_package
@@ -113,7 +691,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - ca7dd789-a244-4c57-8616-3c6ed2dde8f8
+      - 17b72a88-dda3-48d8-85e3-8f9ec457915c
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -136,20 +714,20 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="second_package" rev="6" vrev="6" srcmd5="055f157b268ebdbaff27e03a1d2060ee">
-          <entry name="_config" md5="5601a0d621508ca7f3e41db9cdfcb91d" size="56" mtime="1677088677"/>
-          <entry name="somefile.txt" md5="a2af3efd0634fb08044de0b592af6250" size="59" mtime="1677088677"/>
+        <directory name="second_package" rev="8" vrev="8" srcmd5="7d091fa836670ad9e58065521548e09c">
+          <entry name="_config" md5="09d6e680a08aea1aa39804599c811a6c" size="68" mtime="1684410580"/>
+          <entry name="somefile.txt" md5="23b7b51ce46759f38d1d2ba242e124f2" size="60" mtime="1684410581"/>
         </directory>
-  recorded_at: Fri, 24 Feb 2023 13:03:32 GMT
+  recorded_at: Thu, 18 May 2023 11:49:45 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/my_project/second_package?expand=0
+    uri: http://backend:5352/source/my_project/second_package
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - ca7dd789-a244-4c57-8616-3c6ed2dde8f8
+      - 17b72a88-dda3-48d8-85e3-8f9ec457915c
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -172,11 +750,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="second_package" rev="6" vrev="6" srcmd5="055f157b268ebdbaff27e03a1d2060ee">
-          <entry name="_config" md5="5601a0d621508ca7f3e41db9cdfcb91d" size="56" mtime="1677088677"/>
-          <entry name="somefile.txt" md5="a2af3efd0634fb08044de0b592af6250" size="59" mtime="1677088677"/>
+        <directory name="second_package" rev="8" vrev="8" srcmd5="7d091fa836670ad9e58065521548e09c">
+          <entry name="_config" md5="09d6e680a08aea1aa39804599c811a6c" size="68" mtime="1684410580"/>
+          <entry name="somefile.txt" md5="23b7b51ce46759f38d1d2ba242e124f2" size="60" mtime="1684410581"/>
         </directory>
-  recorded_at: Fri, 24 Feb 2023 13:03:32 GMT
+  recorded_at: Thu, 18 May 2023 11:49:45 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/third_package
@@ -185,7 +763,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - ca7dd789-a244-4c57-8616-3c6ed2dde8f8
+      - 17b72a88-dda3-48d8-85e3-8f9ec457915c
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -208,20 +786,20 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="third_package" rev="6" vrev="6" srcmd5="0032d4845c61e59d70b2702c1bb70560">
-          <entry name="_config" md5="76ae07b1bd4804a788458d5ed12e9556" size="71" mtime="1677088677"/>
-          <entry name="somefile.txt" md5="ca168ef2f03c136c4762e9e0310db712" size="55" mtime="1677088677"/>
+        <directory name="third_package" rev="8" vrev="8" srcmd5="3678d49f4584dfc0c29ec25859e54c79">
+          <entry name="_config" md5="561ae18d2ae0326875a132a184142a11" size="60" mtime="1684410581"/>
+          <entry name="somefile.txt" md5="045c590a12881c5eb95caa2777ab3137" size="66" mtime="1684410581"/>
         </directory>
-  recorded_at: Fri, 24 Feb 2023 13:03:32 GMT
+  recorded_at: Thu, 18 May 2023 11:49:45 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/my_project/third_package?expand=0
+    uri: http://backend:5352/source/my_project/third_package
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - ca7dd789-a244-4c57-8616-3c6ed2dde8f8
+      - 17b72a88-dda3-48d8-85e3-8f9ec457915c
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -244,11 +822,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="third_package" rev="6" vrev="6" srcmd5="0032d4845c61e59d70b2702c1bb70560">
-          <entry name="_config" md5="76ae07b1bd4804a788458d5ed12e9556" size="71" mtime="1677088677"/>
-          <entry name="somefile.txt" md5="ca168ef2f03c136c4762e9e0310db712" size="55" mtime="1677088677"/>
+        <directory name="third_package" rev="8" vrev="8" srcmd5="3678d49f4584dfc0c29ec25859e54c79">
+          <entry name="_config" md5="561ae18d2ae0326875a132a184142a11" size="60" mtime="1684410581"/>
+          <entry name="somefile.txt" md5="045c590a12881c5eb95caa2777ab3137" size="66" mtime="1684410581"/>
         </directory>
-  recorded_at: Fri, 24 Feb 2023 13:03:32 GMT
+  recorded_at: Thu, 18 May 2023 11:49:45 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/package_with_kiwi_image
@@ -257,7 +835,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - ca7dd789-a244-4c57-8616-3c6ed2dde8f8
+      - 17b72a88-dda3-48d8-85e3-8f9ec457915c
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -280,19 +858,19 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_kiwi_image" rev="3" vrev="3" srcmd5="801c545be09c1c468ff2d99b40415aac">
+        <directory name="package_with_kiwi_image" rev="4" vrev="4" srcmd5="801c545be09c1c468ff2d99b40415aac">
           <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1677064926"/>
         </directory>
-  recorded_at: Fri, 24 Feb 2023 13:03:32 GMT
+  recorded_at: Thu, 18 May 2023 11:49:45 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/my_project/package_with_kiwi_image?expand=0
+    uri: http://backend:5352/source/my_project/package_with_kiwi_image
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - ca7dd789-a244-4c57-8616-3c6ed2dde8f8
+      - 17b72a88-dda3-48d8-85e3-8f9ec457915c
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -315,10 +893,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_kiwi_image" rev="3" vrev="3" srcmd5="801c545be09c1c468ff2d99b40415aac">
+        <directory name="package_with_kiwi_image" rev="4" vrev="4" srcmd5="801c545be09c1c468ff2d99b40415aac">
           <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1677064926"/>
         </directory>
-  recorded_at: Fri, 24 Feb 2023 13:03:32 GMT
+  recorded_at: Thu, 18 May 2023 11:49:45 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom/_result?code=unresolvable&view=status
@@ -327,7 +905,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 18ce42c7-6d16-4580-9af2-fa4498e406d4
+      - 28f13683-1dc2-478f-9dc7-11e8f50f4ed1
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -352,7 +930,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Fri, 24 Feb 2023 13:03:33 GMT
+  recorded_at: Thu, 18 May 2023 11:49:48 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom/_keyinfo?donotcreatecert=1&withsslcert=1
@@ -361,7 +939,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 18ce42c7-6d16-4580-9af2-fa4498e406d4
+      - 28f13683-1dc2-478f-9dc7-11e8f50f4ed1
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -412,7 +990,7 @@ http_interactions:
         -----END PGP PUBLIC KEY BLOCK-----
         </pubkey>
         </keyinfo>
-  recorded_at: Fri, 24 Feb 2023 13:03:33 GMT
+  recorded_at: Thu, 18 May 2023 11:49:48 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom/_result?view=summary
@@ -421,7 +999,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 389d8361-5ac1-4fe5-b1e0-7b889680a4b8
+      - 825ac5cb-e99d-4ad9-83bc-2c38166b19af
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -446,7 +1024,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Fri, 24 Feb 2023 13:03:33 GMT
+  recorded_at: Thu, 18 May 2023 11:49:48 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/first_package
@@ -455,7 +1033,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 295d1422-f7dd-4816-b817-a802a9930b9e
+      - af518ceb-4882-4ccb-bc24-6c1d2bcf2ea5
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -478,20 +1056,20 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="first_package" rev="6" vrev="6" srcmd5="75636523146b8634e20e82e205dcc741">
-          <entry name="_config" md5="f69d35d06f7b54d8c8aaa84af2681cb3" size="58" mtime="1677088677"/>
-          <entry name="somefile.txt" md5="0f2416116d94550631676b18b16d5a2b" size="67" mtime="1677088677"/>
+        <directory name="first_package" rev="8" vrev="8" srcmd5="63a573c9bdd2d5c01e9caa0cc00e71ae">
+          <entry name="_config" md5="739535ed2ca0b9feb299f8da2502d8be" size="72" mtime="1684410580"/>
+          <entry name="somefile.txt" md5="d45db0d967e37f65544337564cc4de0c" size="65" mtime="1684410580"/>
         </directory>
-  recorded_at: Fri, 24 Feb 2023 13:03:33 GMT
+  recorded_at: Thu, 18 May 2023 11:49:49 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/my_project/first_package?expand=0
+    uri: http://backend:5352/source/my_project/first_package
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - 295d1422-f7dd-4816-b817-a802a9930b9e
+      - af518ceb-4882-4ccb-bc24-6c1d2bcf2ea5
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -514,11 +1092,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="first_package" rev="6" vrev="6" srcmd5="75636523146b8634e20e82e205dcc741">
-          <entry name="_config" md5="f69d35d06f7b54d8c8aaa84af2681cb3" size="58" mtime="1677088677"/>
-          <entry name="somefile.txt" md5="0f2416116d94550631676b18b16d5a2b" size="67" mtime="1677088677"/>
+        <directory name="first_package" rev="8" vrev="8" srcmd5="63a573c9bdd2d5c01e9caa0cc00e71ae">
+          <entry name="_config" md5="739535ed2ca0b9feb299f8da2502d8be" size="72" mtime="1684410580"/>
+          <entry name="somefile.txt" md5="d45db0d967e37f65544337564cc4de0c" size="65" mtime="1684410580"/>
         </directory>
-  recorded_at: Fri, 24 Feb 2023 13:03:33 GMT
+  recorded_at: Thu, 18 May 2023 11:49:49 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/second_package
@@ -527,7 +1105,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 295d1422-f7dd-4816-b817-a802a9930b9e
+      - af518ceb-4882-4ccb-bc24-6c1d2bcf2ea5
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -550,20 +1128,20 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="second_package" rev="6" vrev="6" srcmd5="055f157b268ebdbaff27e03a1d2060ee">
-          <entry name="_config" md5="5601a0d621508ca7f3e41db9cdfcb91d" size="56" mtime="1677088677"/>
-          <entry name="somefile.txt" md5="a2af3efd0634fb08044de0b592af6250" size="59" mtime="1677088677"/>
+        <directory name="second_package" rev="8" vrev="8" srcmd5="7d091fa836670ad9e58065521548e09c">
+          <entry name="_config" md5="09d6e680a08aea1aa39804599c811a6c" size="68" mtime="1684410580"/>
+          <entry name="somefile.txt" md5="23b7b51ce46759f38d1d2ba242e124f2" size="60" mtime="1684410581"/>
         </directory>
-  recorded_at: Fri, 24 Feb 2023 13:03:33 GMT
+  recorded_at: Thu, 18 May 2023 11:49:49 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/my_project/second_package?expand=0
+    uri: http://backend:5352/source/my_project/second_package
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - 295d1422-f7dd-4816-b817-a802a9930b9e
+      - af518ceb-4882-4ccb-bc24-6c1d2bcf2ea5
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -586,11 +1164,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="second_package" rev="6" vrev="6" srcmd5="055f157b268ebdbaff27e03a1d2060ee">
-          <entry name="_config" md5="5601a0d621508ca7f3e41db9cdfcb91d" size="56" mtime="1677088677"/>
-          <entry name="somefile.txt" md5="a2af3efd0634fb08044de0b592af6250" size="59" mtime="1677088677"/>
+        <directory name="second_package" rev="8" vrev="8" srcmd5="7d091fa836670ad9e58065521548e09c">
+          <entry name="_config" md5="09d6e680a08aea1aa39804599c811a6c" size="68" mtime="1684410580"/>
+          <entry name="somefile.txt" md5="23b7b51ce46759f38d1d2ba242e124f2" size="60" mtime="1684410581"/>
         </directory>
-  recorded_at: Fri, 24 Feb 2023 13:03:33 GMT
+  recorded_at: Thu, 18 May 2023 11:49:49 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/third_package
@@ -599,7 +1177,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 295d1422-f7dd-4816-b817-a802a9930b9e
+      - af518ceb-4882-4ccb-bc24-6c1d2bcf2ea5
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -622,20 +1200,20 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="third_package" rev="6" vrev="6" srcmd5="0032d4845c61e59d70b2702c1bb70560">
-          <entry name="_config" md5="76ae07b1bd4804a788458d5ed12e9556" size="71" mtime="1677088677"/>
-          <entry name="somefile.txt" md5="ca168ef2f03c136c4762e9e0310db712" size="55" mtime="1677088677"/>
+        <directory name="third_package" rev="8" vrev="8" srcmd5="3678d49f4584dfc0c29ec25859e54c79">
+          <entry name="_config" md5="561ae18d2ae0326875a132a184142a11" size="60" mtime="1684410581"/>
+          <entry name="somefile.txt" md5="045c590a12881c5eb95caa2777ab3137" size="66" mtime="1684410581"/>
         </directory>
-  recorded_at: Fri, 24 Feb 2023 13:03:33 GMT
+  recorded_at: Thu, 18 May 2023 11:49:49 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/my_project/third_package?expand=0
+    uri: http://backend:5352/source/my_project/third_package
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - 295d1422-f7dd-4816-b817-a802a9930b9e
+      - af518ceb-4882-4ccb-bc24-6c1d2bcf2ea5
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -658,11 +1236,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="third_package" rev="6" vrev="6" srcmd5="0032d4845c61e59d70b2702c1bb70560">
-          <entry name="_config" md5="76ae07b1bd4804a788458d5ed12e9556" size="71" mtime="1677088677"/>
-          <entry name="somefile.txt" md5="ca168ef2f03c136c4762e9e0310db712" size="55" mtime="1677088677"/>
+        <directory name="third_package" rev="8" vrev="8" srcmd5="3678d49f4584dfc0c29ec25859e54c79">
+          <entry name="_config" md5="561ae18d2ae0326875a132a184142a11" size="60" mtime="1684410581"/>
+          <entry name="somefile.txt" md5="045c590a12881c5eb95caa2777ab3137" size="66" mtime="1684410581"/>
         </directory>
-  recorded_at: Fri, 24 Feb 2023 13:03:33 GMT
+  recorded_at: Thu, 18 May 2023 11:49:49 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/package_with_kiwi_image
@@ -671,7 +1249,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 295d1422-f7dd-4816-b817-a802a9930b9e
+      - af518ceb-4882-4ccb-bc24-6c1d2bcf2ea5
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -694,19 +1272,19 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_kiwi_image" rev="3" vrev="3" srcmd5="801c545be09c1c468ff2d99b40415aac">
+        <directory name="package_with_kiwi_image" rev="4" vrev="4" srcmd5="801c545be09c1c468ff2d99b40415aac">
           <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1677064926"/>
         </directory>
-  recorded_at: Fri, 24 Feb 2023 13:03:33 GMT
+  recorded_at: Thu, 18 May 2023 11:49:49 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/my_project/package_with_kiwi_image?expand=0
+    uri: http://backend:5352/source/my_project/package_with_kiwi_image
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - 295d1422-f7dd-4816-b817-a802a9930b9e
+      - af518ceb-4882-4ccb-bc24-6c1d2bcf2ea5
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -729,10 +1307,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_kiwi_image" rev="3" vrev="3" srcmd5="801c545be09c1c468ff2d99b40415aac">
+        <directory name="package_with_kiwi_image" rev="4" vrev="4" srcmd5="801c545be09c1c468ff2d99b40415aac">
           <entry name="package_with_kiwi_image.kiwi" md5="1c5276faed68b141541d9ecaf6a2f3b6" size="289" mtime="1677064926"/>
         </directory>
-  recorded_at: Fri, 24 Feb 2023 13:03:33 GMT
+  recorded_at: Thu, 18 May 2023 11:49:49 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/second_package?expand=1
@@ -741,7 +1319,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 979b27b2-5f45-4bca-b552-1618be4715f3
+      - 8de66a45-e61c-4273-811b-37d45da83566
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -764,20 +1342,20 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="second_package" rev="6" vrev="6" srcmd5="055f157b268ebdbaff27e03a1d2060ee">
-          <entry name="_config" md5="5601a0d621508ca7f3e41db9cdfcb91d" size="56" mtime="1677088677"/>
-          <entry name="somefile.txt" md5="a2af3efd0634fb08044de0b592af6250" size="59" mtime="1677088677"/>
+        <directory name="second_package" rev="8" vrev="8" srcmd5="7d091fa836670ad9e58065521548e09c">
+          <entry name="_config" md5="09d6e680a08aea1aa39804599c811a6c" size="68" mtime="1684410580"/>
+          <entry name="somefile.txt" md5="23b7b51ce46759f38d1d2ba242e124f2" size="60" mtime="1684410581"/>
         </directory>
-  recorded_at: Fri, 24 Feb 2023 13:03:34 GMT
+  recorded_at: Thu, 18 May 2023 11:49:50 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/my_project/second_package?rev=6
+    uri: http://backend:5352/source/my_project/second_package?rev=8
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - 979b27b2-5f45-4bca-b552-1618be4715f3
+      - 8de66a45-e61c-4273-811b-37d45da83566
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -800,11 +1378,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="second_package" rev="6" vrev="6" srcmd5="055f157b268ebdbaff27e03a1d2060ee">
-          <entry name="_config" md5="5601a0d621508ca7f3e41db9cdfcb91d" size="56" mtime="1677088677"/>
-          <entry name="somefile.txt" md5="a2af3efd0634fb08044de0b592af6250" size="59" mtime="1677088677"/>
+        <directory name="second_package" rev="8" vrev="8" srcmd5="7d091fa836670ad9e58065521548e09c">
+          <entry name="_config" md5="09d6e680a08aea1aa39804599c811a6c" size="68" mtime="1684410580"/>
+          <entry name="somefile.txt" md5="23b7b51ce46759f38d1d2ba242e124f2" size="60" mtime="1684410581"/>
         </directory>
-  recorded_at: Fri, 24 Feb 2023 13:03:34 GMT
+  recorded_at: Thu, 18 May 2023 11:49:50 GMT
 - request:
     method: post
     uri: http://backend:5352/search/package/id?match=(linkinfo/@package=%22second_package%22%20and%20linkinfo/@project=%22my_project%22%20and%20@project=%22my_project%22)
@@ -838,10 +1416,134 @@ http_interactions:
       string: |
         <collection>
         </collection>
-  recorded_at: Fri, 24 Feb 2023 13:03:34 GMT
+  recorded_at: Thu, 18 May 2023 11:49:50 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom:branches:my_project/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom:branches:my_project">
+          <title>Branch project for package second_package</title>
+          <description>This project was created for package second_package via attribute OBS:Maintained</description>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      X-Request-Id:
+      - 8de66a45-e61c-4273-811b-37d45da83566
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '269'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom:branches:my_project">
+          <title>Branch project for package second_package</title>
+          <description>This project was created for package second_package via attribute OBS:Maintained</description>
+          <person userid="tom" role="maintainer"/>
+        </project>
+  recorded_at: Thu, 18 May 2023 11:49:50 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom:branches:my_project/_project/_attribute?meta=1&user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <attributes>
+          <attribute name="AutoCleanup" namespace="OBS">
+            <value>2023-06-01 11:49:50 +0000</value>
+          </attribute>
+        </attributes>
+    headers:
+      X-Request-Id:
+      - 8de66a45-e61c-4273-811b-37d45da83566
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '166'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="11">
+          <srcmd5>8c49a2e4d47d07c13800527f0259d2d6</srcmd5>
+          <time>1684410590</time>
+          <user>tom</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Thu, 18 May 2023 11:49:50 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom:branches:my_project/custom_name/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="custom_name" project="home:tom:branches:my_project">
+          <title>c</title>
+          <description>Minus et sapiente et.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '149'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="custom_name" project="home:tom:branches:my_project">
+          <title>c</title>
+          <description>Minus et sapiente et.</description>
+        </package>
+  recorded_at: Thu, 18 May 2023 11:49:50 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/home:tom:branches:my_project/custom_name?cmd=branch&noservice=1&opackage=second_package&oproject=my_project&orev=055f157b268ebdbaff27e03a1d2060ee&user=tom
+    uri: http://backend:5352/source/home:tom:branches:my_project/custom_name?cmd=branch&noservice=1&opackage=second_package&oproject=my_project&orev=7d091fa836670ad9e58065521548e09c&user=tom
     body:
       encoding: UTF-8
       string: ''
@@ -870,15 +1572,53 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="5" vrev="5">
-          <srcmd5>5ac8d6cfb41d4d42c0d7e7ef6fcaa273</srcmd5>
+        <revision rev="6" vrev="6">
+          <srcmd5>e196019a6d32d2024c34dd71ca9ddfcd</srcmd5>
           <version>unknown</version>
-          <time>1677243814</time>
+          <time>1684410590</time>
           <user>tom</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Fri, 24 Feb 2023 13:03:34 GMT
+  recorded_at: Thu, 18 May 2023 11:49:50 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom:branches:my_project/custom_name/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="custom_name" project="home:tom:branches:my_project">
+          <title>c</title>
+          <description>Minus et sapiente et.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '149'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="custom_name" project="home:tom:branches:my_project">
+          <title>c</title>
+          <description>Minus et sapiente et.</description>
+        </package>
+  recorded_at: Thu, 18 May 2023 11:49:50 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/custom_name
@@ -908,13 +1648,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="custom_name" rev="5" vrev="5" srcmd5="5ac8d6cfb41d4d42c0d7e7ef6fcaa273">
-          <linkinfo project="my_project" package="second_package" rev="055f157b268ebdbaff27e03a1d2060ee" srcmd5="055f157b268ebdbaff27e03a1d2060ee" baserev="055f157b268ebdbaff27e03a1d2060ee" xsrcmd5="c7a21355aaa4b47f244f7156ac8c88f3" lsrcmd5="5ac8d6cfb41d4d42c0d7e7ef6fcaa273"/>
-          <entry name="_config" md5="5601a0d621508ca7f3e41db9cdfcb91d" size="56" mtime="1677088677"/>
-          <entry name="_link" md5="4cf56ebd40df356acef06107b749a37d" size="182" mtime="1677088687"/>
-          <entry name="somefile.txt" md5="a2af3efd0634fb08044de0b592af6250" size="59" mtime="1677088677"/>
+        <directory name="custom_name" rev="6" vrev="6" srcmd5="e196019a6d32d2024c34dd71ca9ddfcd">
+          <linkinfo project="my_project" package="second_package" rev="7d091fa836670ad9e58065521548e09c" srcmd5="7d091fa836670ad9e58065521548e09c" baserev="7d091fa836670ad9e58065521548e09c" xsrcmd5="50b049d063dda2f82b87fac70f47c8f8" lsrcmd5="e196019a6d32d2024c34dd71ca9ddfcd"/>
+          <entry name="_config" md5="09d6e680a08aea1aa39804599c811a6c" size="68" mtime="1684410580"/>
+          <entry name="_link" md5="a5bffb62f7c05e1f683137f1bcea5780" size="182" mtime="1684410590"/>
+          <entry name="somefile.txt" md5="23b7b51ce46759f38d1d2ba242e124f2" size="60" mtime="1684410581"/>
         </directory>
-  recorded_at: Fri, 24 Feb 2023 13:03:34 GMT
+  recorded_at: Thu, 18 May 2023 11:49:50 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/custom_name?view=info
@@ -923,7 +1663,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 979b27b2-5f45-4bca-b552-1618be4715f3
+      - 8de66a45-e61c-4273-811b-37d45da83566
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -946,11 +1686,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="custom_name" rev="5" vrev="5" srcmd5="c7a21355aaa4b47f244f7156ac8c88f3" lsrcmd5="5ac8d6cfb41d4d42c0d7e7ef6fcaa273" verifymd5="055f157b268ebdbaff27e03a1d2060ee">
+        <sourceinfo package="custom_name" rev="6" vrev="6" srcmd5="50b049d063dda2f82b87fac70f47c8f8" lsrcmd5="e196019a6d32d2024c34dd71ca9ddfcd" verifymd5="7d091fa836670ad9e58065521548e09c">
           <error>bad build configuration, no build type defined or detected</error>
           <linked project="my_project" package="second_package"/>
         </sourceinfo>
-  recorded_at: Fri, 24 Feb 2023 13:03:34 GMT
+  recorded_at: Thu, 18 May 2023 11:49:50 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/custom_name
@@ -959,7 +1699,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 979b27b2-5f45-4bca-b552-1618be4715f3
+      - 8de66a45-e61c-4273-811b-37d45da83566
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -982,13 +1722,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="custom_name" rev="5" vrev="5" srcmd5="5ac8d6cfb41d4d42c0d7e7ef6fcaa273">
-          <linkinfo project="my_project" package="second_package" rev="055f157b268ebdbaff27e03a1d2060ee" srcmd5="055f157b268ebdbaff27e03a1d2060ee" baserev="055f157b268ebdbaff27e03a1d2060ee" xsrcmd5="c7a21355aaa4b47f244f7156ac8c88f3" lsrcmd5="5ac8d6cfb41d4d42c0d7e7ef6fcaa273"/>
-          <entry name="_config" md5="5601a0d621508ca7f3e41db9cdfcb91d" size="56" mtime="1677088677"/>
-          <entry name="_link" md5="4cf56ebd40df356acef06107b749a37d" size="182" mtime="1677088687"/>
-          <entry name="somefile.txt" md5="a2af3efd0634fb08044de0b592af6250" size="59" mtime="1677088677"/>
+        <directory name="custom_name" rev="6" vrev="6" srcmd5="e196019a6d32d2024c34dd71ca9ddfcd">
+          <linkinfo project="my_project" package="second_package" rev="7d091fa836670ad9e58065521548e09c" srcmd5="7d091fa836670ad9e58065521548e09c" baserev="7d091fa836670ad9e58065521548e09c" xsrcmd5="50b049d063dda2f82b87fac70f47c8f8" lsrcmd5="e196019a6d32d2024c34dd71ca9ddfcd"/>
+          <entry name="_config" md5="09d6e680a08aea1aa39804599c811a6c" size="68" mtime="1684410580"/>
+          <entry name="_link" md5="a5bffb62f7c05e1f683137f1bcea5780" size="182" mtime="1684410590"/>
+          <entry name="somefile.txt" md5="23b7b51ce46759f38d1d2ba242e124f2" size="60" mtime="1684410581"/>
         </directory>
-  recorded_at: Fri, 24 Feb 2023 13:03:34 GMT
+  recorded_at: Thu, 18 May 2023 11:49:50 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:my_project/custom_name?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -1020,14 +1760,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="64ca9c073627bfe548e36dc9843f1726">
+        <sourcediff key="f935aac6bb47e7c03ba331697f72d644">
           <old project="home:tom:branches:my_project" package="custom_name" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:tom:branches:my_project" package="custom_name" rev="5" srcmd5="5ac8d6cfb41d4d42c0d7e7ef6fcaa273"/>
+          <new project="home:tom:branches:my_project" package="custom_name" rev="6" srcmd5="e196019a6d32d2024c34dd71ca9ddfcd"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Fri, 24 Feb 2023 13:03:34 GMT
+  recorded_at: Thu, 18 May 2023 11:49:50 GMT
 - request:
     method: post
     uri: http://backend:5352/source/home:tom:branches:my_project/custom_name?cmd=linkdiff&linkrev=base&onlyissues=1&view=xml
@@ -1050,23 +1790,71 @@ http_interactions:
     headers:
       Content-Type:
       - text/xml
-      Content-Length:
-      - '387'
       Cache-Control:
       - no-cache
       Connection:
       - close
+      Content-Length:
+      - '387'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="febdeec98e20860e05beadebe46d869a">
-          <old project="my_project" package="second_package" rev="055f157b268ebdbaff27e03a1d2060ee" srcmd5="055f157b268ebdbaff27e03a1d2060ee"/>
-          <new project="home:tom:branches:my_project" package="custom_name" rev="c7a21355aaa4b47f244f7156ac8c88f3" srcmd5="c7a21355aaa4b47f244f7156ac8c88f3"/>
+        <sourcediff key="068a2209949035877b0277e7838f6288">
+          <old project="my_project" package="second_package" rev="7d091fa836670ad9e58065521548e09c" srcmd5="7d091fa836670ad9e58065521548e09c"/>
+          <new project="home:tom:branches:my_project" package="custom_name" rev="50b049d063dda2f82b87fac70f47c8f8" srcmd5="50b049d063dda2f82b87fac70f47c8f8"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Fri, 24 Feb 2023 13:03:34 GMT
+  recorded_at: Thu, 18 May 2023 11:49:50 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom:branches:my_project/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom:branches:my_project">
+          <title>Branch project for package second_package</title>
+          <description>This project was created for package second_package via attribute OBS:Maintained</description>
+          <person userid="tom" role="maintainer"/>
+          <publish>
+            <disable/>
+          </publish>
+        </project>
+    headers:
+      X-Request-Id:
+      - 8de66a45-e61c-4273-811b-37d45da83566
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '309'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom:branches:my_project">
+          <title>Branch project for package second_package</title>
+          <description>This project was created for package second_package via attribute OBS:Maintained</description>
+          <person userid="tom" role="maintainer"/>
+          <publish>
+            <disable/>
+          </publish>
+        </project>
+  recorded_at: Thu, 18 May 2023 11:49:50 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/custom_name
@@ -1075,7 +1863,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 979b27b2-5f45-4bca-b552-1618be4715f3
+      - 8de66a45-e61c-4273-811b-37d45da83566
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1098,13 +1886,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="custom_name" rev="5" vrev="5" srcmd5="5ac8d6cfb41d4d42c0d7e7ef6fcaa273">
-          <linkinfo project="my_project" package="second_package" rev="055f157b268ebdbaff27e03a1d2060ee" srcmd5="055f157b268ebdbaff27e03a1d2060ee" baserev="055f157b268ebdbaff27e03a1d2060ee" xsrcmd5="c7a21355aaa4b47f244f7156ac8c88f3" lsrcmd5="5ac8d6cfb41d4d42c0d7e7ef6fcaa273"/>
-          <entry name="_config" md5="5601a0d621508ca7f3e41db9cdfcb91d" size="56" mtime="1677088677"/>
-          <entry name="_link" md5="4cf56ebd40df356acef06107b749a37d" size="182" mtime="1677088687"/>
-          <entry name="somefile.txt" md5="a2af3efd0634fb08044de0b592af6250" size="59" mtime="1677088677"/>
+        <directory name="custom_name" rev="6" vrev="6" srcmd5="e196019a6d32d2024c34dd71ca9ddfcd">
+          <linkinfo project="my_project" package="second_package" rev="7d091fa836670ad9e58065521548e09c" srcmd5="7d091fa836670ad9e58065521548e09c" baserev="7d091fa836670ad9e58065521548e09c" xsrcmd5="50b049d063dda2f82b87fac70f47c8f8" lsrcmd5="e196019a6d32d2024c34dd71ca9ddfcd"/>
+          <entry name="_config" md5="09d6e680a08aea1aa39804599c811a6c" size="68" mtime="1684410580"/>
+          <entry name="_link" md5="a5bffb62f7c05e1f683137f1bcea5780" size="182" mtime="1684410590"/>
+          <entry name="somefile.txt" md5="23b7b51ce46759f38d1d2ba242e124f2" size="60" mtime="1684410581"/>
         </directory>
-  recorded_at: Fri, 24 Feb 2023 13:03:34 GMT
+  recorded_at: Thu, 18 May 2023 11:49:50 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/second_package?view=info
@@ -1113,7 +1901,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 3cc3e491-8848-4e3e-9f96-be68527dec1b
+      - dff25c3b-48b0-4638-83dc-be448ab4cf1e
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1136,10 +1924,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="second_package" rev="6" vrev="6" srcmd5="055f157b268ebdbaff27e03a1d2060ee" verifymd5="055f157b268ebdbaff27e03a1d2060ee">
+        <sourceinfo package="second_package" rev="8" vrev="8" srcmd5="7d091fa836670ad9e58065521548e09c" verifymd5="7d091fa836670ad9e58065521548e09c">
           <error>bad build configuration, no build type defined or detected</error>
         </sourceinfo>
-  recorded_at: Fri, 24 Feb 2023 13:03:34 GMT
+  recorded_at: Thu, 18 May 2023 11:49:50 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/second_package
@@ -1148,7 +1936,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 3cc3e491-8848-4e3e-9f96-be68527dec1b
+      - dff25c3b-48b0-4638-83dc-be448ab4cf1e
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1171,11 +1959,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="second_package" rev="6" vrev="6" srcmd5="055f157b268ebdbaff27e03a1d2060ee">
-          <entry name="_config" md5="5601a0d621508ca7f3e41db9cdfcb91d" size="56" mtime="1677088677"/>
-          <entry name="somefile.txt" md5="a2af3efd0634fb08044de0b592af6250" size="59" mtime="1677088677"/>
+        <directory name="second_package" rev="8" vrev="8" srcmd5="7d091fa836670ad9e58065521548e09c">
+          <entry name="_config" md5="09d6e680a08aea1aa39804599c811a6c" size="68" mtime="1684410580"/>
+          <entry name="somefile.txt" md5="23b7b51ce46759f38d1d2ba242e124f2" size="60" mtime="1684410581"/>
         </directory>
-  recorded_at: Fri, 24 Feb 2023 13:03:34 GMT
+  recorded_at: Thu, 18 May 2023 11:49:50 GMT
 - request:
     method: post
     uri: http://backend:5352/source/my_project/second_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -1198,23 +1986,23 @@ http_interactions:
     headers:
       Content-Type:
       - text/xml
-      Content-Length:
-      - '310'
       Cache-Control:
       - no-cache
       Connection:
       - close
+      Content-Length:
+      - '310'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="bbea7b25ea4d75abbabf50477c4bbfec">
+        <sourcediff key="0cbd4d28bdc94fd677c7e4092cd67923">
           <old project="my_project" package="second_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="my_project" package="second_package" rev="6" srcmd5="055f157b268ebdbaff27e03a1d2060ee"/>
+          <new project="my_project" package="second_package" rev="8" srcmd5="7d091fa836670ad9e58065521548e09c"/>
           <files/>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Fri, 24 Feb 2023 13:03:34 GMT
+  recorded_at: Thu, 18 May 2023 11:49:50 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/custom_name
@@ -1223,7 +2011,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 3cc3e491-8848-4e3e-9f96-be68527dec1b
+      - dff25c3b-48b0-4638-83dc-be448ab4cf1e
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1246,16 +2034,16 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="custom_name" rev="5" vrev="5" srcmd5="5ac8d6cfb41d4d42c0d7e7ef6fcaa273">
-          <linkinfo project="my_project" package="second_package" rev="055f157b268ebdbaff27e03a1d2060ee" srcmd5="055f157b268ebdbaff27e03a1d2060ee" baserev="055f157b268ebdbaff27e03a1d2060ee" xsrcmd5="c7a21355aaa4b47f244f7156ac8c88f3" lsrcmd5="5ac8d6cfb41d4d42c0d7e7ef6fcaa273"/>
-          <entry name="_config" md5="5601a0d621508ca7f3e41db9cdfcb91d" size="56" mtime="1677088677"/>
-          <entry name="_link" md5="4cf56ebd40df356acef06107b749a37d" size="182" mtime="1677088687"/>
-          <entry name="somefile.txt" md5="a2af3efd0634fb08044de0b592af6250" size="59" mtime="1677088677"/>
+        <directory name="custom_name" rev="6" vrev="6" srcmd5="e196019a6d32d2024c34dd71ca9ddfcd">
+          <linkinfo project="my_project" package="second_package" rev="7d091fa836670ad9e58065521548e09c" srcmd5="7d091fa836670ad9e58065521548e09c" baserev="7d091fa836670ad9e58065521548e09c" xsrcmd5="50b049d063dda2f82b87fac70f47c8f8" lsrcmd5="e196019a6d32d2024c34dd71ca9ddfcd"/>
+          <entry name="_config" md5="09d6e680a08aea1aa39804599c811a6c" size="68" mtime="1684410580"/>
+          <entry name="_link" md5="a5bffb62f7c05e1f683137f1bcea5780" size="182" mtime="1684410590"/>
+          <entry name="somefile.txt" md5="23b7b51ce46759f38d1d2ba242e124f2" size="60" mtime="1684410581"/>
         </directory>
-  recorded_at: Fri, 24 Feb 2023 13:03:34 GMT
+  recorded_at: Thu, 18 May 2023 11:49:51 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:tom:branches:my_project/custom_name?expand=1&rev=5
+    uri: http://backend:5352/source/home:tom:branches:my_project/custom_name?expand=1&rev=6
     body:
       encoding: US-ASCII
       string: ''
@@ -1282,21 +2070,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="custom_name" rev="c7a21355aaa4b47f244f7156ac8c88f3" vrev="5" srcmd5="c7a21355aaa4b47f244f7156ac8c88f3">
-          <linkinfo project="my_project" package="second_package" rev="055f157b268ebdbaff27e03a1d2060ee" srcmd5="055f157b268ebdbaff27e03a1d2060ee" baserev="055f157b268ebdbaff27e03a1d2060ee" lsrcmd5="5ac8d6cfb41d4d42c0d7e7ef6fcaa273"/>
-          <entry name="_config" md5="5601a0d621508ca7f3e41db9cdfcb91d" size="56" mtime="1677088677"/>
-          <entry name="somefile.txt" md5="a2af3efd0634fb08044de0b592af6250" size="59" mtime="1677088677"/>
+        <directory name="custom_name" rev="50b049d063dda2f82b87fac70f47c8f8" vrev="6" srcmd5="50b049d063dda2f82b87fac70f47c8f8">
+          <linkinfo project="my_project" package="second_package" rev="7d091fa836670ad9e58065521548e09c" srcmd5="7d091fa836670ad9e58065521548e09c" baserev="7d091fa836670ad9e58065521548e09c" lsrcmd5="e196019a6d32d2024c34dd71ca9ddfcd"/>
+          <entry name="_config" md5="09d6e680a08aea1aa39804599c811a6c" size="68" mtime="1684410580"/>
+          <entry name="somefile.txt" md5="23b7b51ce46759f38d1d2ba242e124f2" size="60" mtime="1684410581"/>
         </directory>
-  recorded_at: Fri, 24 Feb 2023 13:03:34 GMT
+  recorded_at: Thu, 18 May 2023 11:49:51 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:tom:branches:my_project/custom_name/_history?deleted=0&meta=0&rev=5
+    uri: http://backend:5352/source/home:tom:branches:my_project/custom_name/_history?deleted=0&meta=0&rev=6
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - 3cc3e491-8848-4e3e-9f96-be68527dec1b
+      - dff25c3b-48b0-4638-83dc-be448ab4cf1e
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1320,14 +2108,14 @@ http_interactions:
       encoding: UTF-8
       string: |
         <revisionlist>
-          <revision rev="5" vrev="5">
-            <srcmd5>5ac8d6cfb41d4d42c0d7e7ef6fcaa273</srcmd5>
+          <revision rev="6" vrev="6">
+            <srcmd5>e196019a6d32d2024c34dd71ca9ddfcd</srcmd5>
             <version>unknown</version>
-            <time>1677243814</time>
+            <time>1684410590</time>
             <user>tom</user>
           </revision>
         </revisionlist>
-  recorded_at: Fri, 24 Feb 2023 13:03:34 GMT
+  recorded_at: Thu, 18 May 2023 11:49:51 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/custom_name
@@ -1336,7 +2124,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 3cc3e491-8848-4e3e-9f96-be68527dec1b
+      - dff25c3b-48b0-4638-83dc-be448ab4cf1e
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1359,13 +2147,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="custom_name" rev="5" vrev="5" srcmd5="5ac8d6cfb41d4d42c0d7e7ef6fcaa273">
-          <linkinfo project="my_project" package="second_package" rev="055f157b268ebdbaff27e03a1d2060ee" srcmd5="055f157b268ebdbaff27e03a1d2060ee" baserev="055f157b268ebdbaff27e03a1d2060ee" xsrcmd5="c7a21355aaa4b47f244f7156ac8c88f3" lsrcmd5="5ac8d6cfb41d4d42c0d7e7ef6fcaa273"/>
-          <entry name="_config" md5="5601a0d621508ca7f3e41db9cdfcb91d" size="56" mtime="1677088677"/>
-          <entry name="_link" md5="4cf56ebd40df356acef06107b749a37d" size="182" mtime="1677088687"/>
-          <entry name="somefile.txt" md5="a2af3efd0634fb08044de0b592af6250" size="59" mtime="1677088677"/>
+        <directory name="custom_name" rev="6" vrev="6" srcmd5="e196019a6d32d2024c34dd71ca9ddfcd">
+          <linkinfo project="my_project" package="second_package" rev="7d091fa836670ad9e58065521548e09c" srcmd5="7d091fa836670ad9e58065521548e09c" baserev="7d091fa836670ad9e58065521548e09c" xsrcmd5="50b049d063dda2f82b87fac70f47c8f8" lsrcmd5="e196019a6d32d2024c34dd71ca9ddfcd"/>
+          <entry name="_config" md5="09d6e680a08aea1aa39804599c811a6c" size="68" mtime="1684410580"/>
+          <entry name="_link" md5="a5bffb62f7c05e1f683137f1bcea5780" size="182" mtime="1684410590"/>
+          <entry name="somefile.txt" md5="23b7b51ce46759f38d1d2ba242e124f2" size="60" mtime="1684410581"/>
         </directory>
-  recorded_at: Fri, 24 Feb 2023 13:03:35 GMT
+  recorded_at: Thu, 18 May 2023 11:49:51 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:tom:branches:my_project/custom_name
@@ -1374,7 +2162,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 3cc3e491-8848-4e3e-9f96-be68527dec1b
+      - dff25c3b-48b0-4638-83dc-be448ab4cf1e
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1397,13 +2185,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="custom_name" rev="5" vrev="5" srcmd5="5ac8d6cfb41d4d42c0d7e7ef6fcaa273">
-          <linkinfo project="my_project" package="second_package" rev="055f157b268ebdbaff27e03a1d2060ee" srcmd5="055f157b268ebdbaff27e03a1d2060ee" baserev="055f157b268ebdbaff27e03a1d2060ee" xsrcmd5="c7a21355aaa4b47f244f7156ac8c88f3" lsrcmd5="5ac8d6cfb41d4d42c0d7e7ef6fcaa273"/>
-          <entry name="_config" md5="5601a0d621508ca7f3e41db9cdfcb91d" size="56" mtime="1677088677"/>
-          <entry name="_link" md5="4cf56ebd40df356acef06107b749a37d" size="182" mtime="1677088687"/>
-          <entry name="somefile.txt" md5="a2af3efd0634fb08044de0b592af6250" size="59" mtime="1677088677"/>
+        <directory name="custom_name" rev="6" vrev="6" srcmd5="e196019a6d32d2024c34dd71ca9ddfcd">
+          <linkinfo project="my_project" package="second_package" rev="7d091fa836670ad9e58065521548e09c" srcmd5="7d091fa836670ad9e58065521548e09c" baserev="7d091fa836670ad9e58065521548e09c" xsrcmd5="50b049d063dda2f82b87fac70f47c8f8" lsrcmd5="e196019a6d32d2024c34dd71ca9ddfcd"/>
+          <entry name="_config" md5="09d6e680a08aea1aa39804599c811a6c" size="68" mtime="1684410580"/>
+          <entry name="_link" md5="a5bffb62f7c05e1f683137f1bcea5780" size="182" mtime="1684410590"/>
+          <entry name="somefile.txt" md5="23b7b51ce46759f38d1d2ba242e124f2" size="60" mtime="1684410581"/>
         </directory>
-  recorded_at: Fri, 24 Feb 2023 13:03:35 GMT
+  recorded_at: Thu, 18 May 2023 11:49:51 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:my_project/_result?lastbuild=1&locallink=1&multibuild=1&package=custom_name&view=status
@@ -1412,7 +2200,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 47e12c71-ab83-486a-b717-85545f4c3cb7
+      - a1d0e453-4fc8-4b0d-945d-4630b35e57c3
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1437,7 +2225,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Fri, 24 Feb 2023 13:03:35 GMT
+  recorded_at: Thu, 18 May 2023 11:49:51 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:my_project/_result?lastbuild=1&locallink=1&multibuild=1&package=custom_name&view=status
@@ -1446,7 +2234,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 15f4032d-4477-412d-ac57-7cf5e8b10b17
+      - b4cfbe02-b008-479e-bec5-35095d88a30f
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1471,7 +2259,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Fri, 24 Feb 2023 13:03:35 GMT
+  recorded_at: Thu, 18 May 2023 11:49:51 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:tom:branches:my_project/_result?package=custom_name&view=status
@@ -1480,7 +2268,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - afe8b782-0cc9-44f1-b31f-f3ef73309a65
+      - fb814314-d85c-4359-a340-867dff5b4321
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1505,5 +2293,5 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Fri, 24 Feb 2023 13:03:35 GMT
+  recorded_at: Thu, 18 May 2023 11:49:51 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Package/_file_exists_/_multibuild_file_should_exist/1_4_1_1.yml
+++ b/src/api/spec/cassettes/Package/_file_exists_/_multibuild_file_should_exist/1_4_1_1.yml
@@ -1,6 +1,160 @@
 ---
 http_interactions:
 - request:
+    method: put
+    uri: http://backend:5352/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '128'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer"/>
+        </project>
+  recorded_at: Thu, 18 May 2023 11:49:38 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom/test/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test" project="home:tom">
+          <title>Everything is Illuminated</title>
+          <description>Consectetur aut fuga nobis.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '152'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test" project="home:tom">
+          <title>Everything is Illuminated</title>
+          <description>Consectetur aut fuga nobis.</description>
+        </package>
+  recorded_at: Thu, 18 May 2023 11:49:38 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom/test/_config
+    body:
+      encoding: UTF-8
+      string: Dicta repudiandae magnam. Qui qui quis. Iste in ducimus.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="1" vrev="1">
+          <srcmd5>99b43fd678d35d068155127957181f56</srcmd5>
+          <version>unknown</version>
+          <time>1684410578</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Thu, 18 May 2023 11:49:38 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom/test/_multibuild
+    body:
+      encoding: UTF-8
+      string: "<multibuild><flavor>flavor_a</flavor><flavor>flavor_b</flavor></multibuild>"
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="2" vrev="2">
+          <srcmd5>4fcee8b41ee460d94b272f2774061d43</srcmd5>
+          <version>unknown</version>
+          <time>1684410578</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Thu, 18 May 2023 11:49:38 GMT
+- request:
     method: get
     uri: http://backend:5352/source/home:tom/test
     body:
@@ -29,14 +183,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="test" rev="2" vrev="2" srcmd5="8f29383071d15921b8ec13495e66451d">
-          <entry name="_config" md5="9087f0019f87e12aaf2b999853e4f008" size="63" mtime="1643724206"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643724206"/>
+        <directory name="test" rev="2" vrev="2" srcmd5="4fcee8b41ee460d94b272f2774061d43">
+          <entry name="_config" md5="dfdee503a2a3d1a53115301a8912a5f5" size="56" mtime="1684410578"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1684410578"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:14:57 GMT
+  recorded_at: Thu, 18 May 2023 11:49:38 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:tom/test?expand=0
+    uri: http://backend:5352/source/home:tom/test
     body:
       encoding: US-ASCII
       string: ''
@@ -63,9 +217,9 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="test" rev="2" vrev="2" srcmd5="8f29383071d15921b8ec13495e66451d">
-          <entry name="_config" md5="9087f0019f87e12aaf2b999853e4f008" size="63" mtime="1643724206"/>
-          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1643724206"/>
+        <directory name="test" rev="2" vrev="2" srcmd5="4fcee8b41ee460d94b272f2774061d43">
+          <entry name="_config" md5="dfdee503a2a3d1a53115301a8912a5f5" size="56" mtime="1684410578"/>
+          <entry name="_multibuild" md5="eefca4c8b5fea7ee8342cc1dbf371e95" size="75" mtime="1684410578"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:14:57 GMT
-recorded_with: VCR 6.0.0
+  recorded_at: Thu, 18 May 2023 11:49:39 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Package/_file_exists_/with_more_than_one_file/returns_false_if_the_file_does_not_exist.yml
+++ b/src/api/spec/cassettes/Package/_file_exists_/with_more_than_one_file/returns_false_if_the_file_does_not_exist.yml
@@ -1,6 +1,160 @@
 ---
 http_interactions:
 - request:
+    method: put
+    uri: http://backend:5352/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '128'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer"/>
+        </project>
+  recorded_at: Thu, 18 May 2023 11:49:37 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom/package_with_files/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_files" project="home:tom">
+          <title>The Moon by Night</title>
+          <description>Ab officia ratione voluptate.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '160'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_files" project="home:tom">
+          <title>The Moon by Night</title>
+          <description>Ab officia ratione voluptate.</description>
+        </package>
+  recorded_at: Thu, 18 May 2023 11:49:38 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom/package_with_files/_config
+    body:
+      encoding: UTF-8
+      string: Id deleniti qui. Autem maxime quas. Quasi facere hic.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="1" vrev="1">
+          <srcmd5>24b04524ccfffffa61f38f9dce37aae3</srcmd5>
+          <version>unknown</version>
+          <time>1684410578</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Thu, 18 May 2023 11:49:38 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom/package_with_files/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Et eligendi quisquam. Rerum eum nulla. Omnis dolores officia.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="2" vrev="2">
+          <srcmd5>f431a2d968dd9919d6863302ac3cef8d</srcmd5>
+          <version>unknown</version>
+          <time>1684410578</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Thu, 18 May 2023 11:49:38 GMT
+- request:
     method: get
     uri: http://backend:5352/source/home:tom/package_with_files
     body:
@@ -25,19 +179,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '397'
+      - '303'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_files" rev="34" vrev="34" srcmd5="5533c6e87a7ed3278edbb2fda81355cf">
-          <entry name="_config" md5="b6fab2c2b7ef43fed208d5ca398d9f5f" size="68" mtime="1643724250"/>
-          <entry name="_icon" md5="95ec7ff9a4af00190b5bbdeb9d2215cb" size="70" mtime="1643724251"/>
-          <entry name="somefile.txt" md5="d04d1e7583a8e01c5c1dda514ca86c8f" size="61" mtime="1643724251"/>
+        <directory name="package_with_files" rev="2" vrev="2" srcmd5="f431a2d968dd9919d6863302ac3cef8d">
+          <entry name="_config" md5="8bc94fe881ff70a8ac7fa60e72e5d95f" size="53" mtime="1684410578"/>
+          <entry name="somefile.txt" md5="0fabd7792398a12f54029540d3ba100a" size="61" mtime="1684410578"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:14:58 GMT
+  recorded_at: Thu, 18 May 2023 11:49:38 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:tom/package_with_files?expand=0
+    uri: http://backend:5352/source/home:tom/package_with_files
     body:
       encoding: US-ASCII
       string: ''
@@ -60,14 +213,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '397'
+      - '303'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_files" rev="34" vrev="34" srcmd5="5533c6e87a7ed3278edbb2fda81355cf">
-          <entry name="_config" md5="b6fab2c2b7ef43fed208d5ca398d9f5f" size="68" mtime="1643724250"/>
-          <entry name="_icon" md5="95ec7ff9a4af00190b5bbdeb9d2215cb" size="70" mtime="1643724251"/>
-          <entry name="somefile.txt" md5="d04d1e7583a8e01c5c1dda514ca86c8f" size="61" mtime="1643724251"/>
+        <directory name="package_with_files" rev="2" vrev="2" srcmd5="f431a2d968dd9919d6863302ac3cef8d">
+          <entry name="_config" md5="8bc94fe881ff70a8ac7fa60e72e5d95f" size="53" mtime="1684410578"/>
+          <entry name="somefile.txt" md5="0fabd7792398a12f54029540d3ba100a" size="61" mtime="1684410578"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:14:58 GMT
-recorded_with: VCR 6.0.0
+  recorded_at: Thu, 18 May 2023 11:49:38 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Package/_file_exists_/with_more_than_one_file/returns_true_if_the_file_exist.yml
+++ b/src/api/spec/cassettes/Package/_file_exists_/with_more_than_one_file/returns_true_if_the_file_exist.yml
@@ -1,6 +1,160 @@
 ---
 http_interactions:
 - request:
+    method: put
+    uri: http://backend:5352/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '128'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer"/>
+        </project>
+  recorded_at: Thu, 18 May 2023 11:49:38 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom/package_with_files/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_files" project="home:tom">
+          <title>What's Become of Waring</title>
+          <description>Et odit officiis voluptatem.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '165'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_files" project="home:tom">
+          <title>What's Become of Waring</title>
+          <description>Et odit officiis voluptatem.</description>
+        </package>
+  recorded_at: Thu, 18 May 2023 11:49:38 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom/package_with_files/_config
+    body:
+      encoding: UTF-8
+      string: Voluptates quae distinctio. Aut ducimus minus. Dignissimos at soluta.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="3" vrev="3">
+          <srcmd5>da76f3f190c2265274038bddfc44e1ce</srcmd5>
+          <version>unknown</version>
+          <time>1684410578</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Thu, 18 May 2023 11:49:38 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom/package_with_files/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Minima quis sit. Rem atque soluta. Ut voluptatem ducimus.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="4" vrev="4">
+          <srcmd5>2f30b1204f67c072b33a92ee7d6f7110</srcmd5>
+          <version>unknown</version>
+          <time>1684410578</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Thu, 18 May 2023 11:49:38 GMT
+- request:
     method: get
     uri: http://backend:5352/source/home:tom/package_with_files
     body:
@@ -25,19 +179,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '397'
+      - '303'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_files" rev="34" vrev="34" srcmd5="5533c6e87a7ed3278edbb2fda81355cf">
-          <entry name="_config" md5="b6fab2c2b7ef43fed208d5ca398d9f5f" size="68" mtime="1643724250"/>
-          <entry name="_icon" md5="95ec7ff9a4af00190b5bbdeb9d2215cb" size="70" mtime="1643724251"/>
-          <entry name="somefile.txt" md5="d04d1e7583a8e01c5c1dda514ca86c8f" size="61" mtime="1643724251"/>
+        <directory name="package_with_files" rev="4" vrev="4" srcmd5="2f30b1204f67c072b33a92ee7d6f7110">
+          <entry name="_config" md5="38fd8d7c28fa49f523af6c9c58194f40" size="69" mtime="1684410578"/>
+          <entry name="somefile.txt" md5="9b44c1ac4f6f1ee78db8ca7297ff0f3a" size="57" mtime="1684410578"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:14:58 GMT
+  recorded_at: Thu, 18 May 2023 11:49:38 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:tom/package_with_files?expand=0
+    uri: http://backend:5352/source/home:tom/package_with_files
     body:
       encoding: US-ASCII
       string: ''
@@ -60,14 +213,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '397'
+      - '303'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_files" rev="34" vrev="34" srcmd5="5533c6e87a7ed3278edbb2fda81355cf">
-          <entry name="_config" md5="b6fab2c2b7ef43fed208d5ca398d9f5f" size="68" mtime="1643724250"/>
-          <entry name="_icon" md5="95ec7ff9a4af00190b5bbdeb9d2215cb" size="70" mtime="1643724251"/>
-          <entry name="somefile.txt" md5="d04d1e7583a8e01c5c1dda514ca86c8f" size="61" mtime="1643724251"/>
+        <directory name="package_with_files" rev="4" vrev="4" srcmd5="2f30b1204f67c072b33a92ee7d6f7110">
+          <entry name="_config" md5="38fd8d7c28fa49f523af6c9c58194f40" size="69" mtime="1684410578"/>
+          <entry name="somefile.txt" md5="9b44c1ac4f6f1ee78db8ca7297ff0f3a" size="57" mtime="1684410578"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:14:58 GMT
-recorded_with: VCR 6.0.0
+  recorded_at: Thu, 18 May 2023 11:49:38 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Package/_file_exists_/with_one_file/returns_false_if_the_file_does_not_exist.yml
+++ b/src/api/spec/cassettes/Package/_file_exists_/with_one_file/returns_false_if_the_file_does_not_exist.yml
@@ -1,6 +1,122 @@
 ---
 http_interactions:
 - request:
+    method: put
+    uri: http://backend:5352/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '128'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer"/>
+        </project>
+  recorded_at: Thu, 18 May 2023 11:49:39 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom/package_with_one_file/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_one_file" project="home:tom">
+          <title>Dulce et Decorum Est</title>
+          <description>Cupiditate ad quis velit.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '162'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_one_file" project="home:tom">
+          <title>Dulce et Decorum Est</title>
+          <description>Cupiditate ad quis velit.</description>
+        </package>
+  recorded_at: Thu, 18 May 2023 11:49:39 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom/package_with_one_file/_service
+    body:
+      encoding: UTF-8
+      string: "<services/>"
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="2" vrev="2">
+          <srcmd5>3ac4b29d09369cc0bd4c17dd6a5c7d4c</srcmd5>
+          <version>unknown</version>
+          <time>1684410579</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Thu, 18 May 2023 11:49:39 GMT
+- request:
     method: get
     uri: http://backend:5352/source/home:tom/package_with_one_file
     body:
@@ -25,18 +141,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '285'
+      - '208'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_one_file" rev="2" vrev="2" srcmd5="4c351807b74cb6a07071ce2dec305095">
-          <serviceinfo code="succeeded" xsrcmd5="18a86687dce43cb25a060f8d7d8628cd"/>
-          <entry name="_service" md5="53b4f5c97c7a2122b964e5182c8325a2" size="11" mtime="1643724203"/>
+        <directory name="package_with_one_file" rev="2" vrev="2" srcmd5="3ac4b29d09369cc0bd4c17dd6a5c7d4c">
+          <entry name="_service" md5="53b4f5c97c7a2122b964e5182c8325a2" size="11" mtime="1684410579"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:14:58 GMT
+  recorded_at: Thu, 18 May 2023 11:49:39 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:tom/package_with_one_file?expand=0
+    uri: http://backend:5352/source/home:tom/package_with_one_file
     body:
       encoding: US-ASCII
       string: ''
@@ -59,13 +174,12 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '285'
+      - '208'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_one_file" rev="2" vrev="2" srcmd5="4c351807b74cb6a07071ce2dec305095">
-          <serviceinfo code="succeeded" xsrcmd5="18a86687dce43cb25a060f8d7d8628cd"/>
-          <entry name="_service" md5="53b4f5c97c7a2122b964e5182c8325a2" size="11" mtime="1643724203"/>
+        <directory name="package_with_one_file" rev="2" vrev="2" srcmd5="3ac4b29d09369cc0bd4c17dd6a5c7d4c">
+          <entry name="_service" md5="53b4f5c97c7a2122b964e5182c8325a2" size="11" mtime="1684410579"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:14:58 GMT
-recorded_with: VCR 6.0.0
+  recorded_at: Thu, 18 May 2023 11:49:39 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Package/_file_exists_/with_one_file/returns_true_if_the_file_exist.yml
+++ b/src/api/spec/cassettes/Package/_file_exists_/with_one_file/returns_true_if_the_file_exist.yml
@@ -1,6 +1,122 @@
 ---
 http_interactions:
 - request:
+    method: put
+    uri: http://backend:5352/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '128'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer"/>
+        </project>
+  recorded_at: Thu, 18 May 2023 11:49:39 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom/package_with_one_file/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_one_file" project="home:tom">
+          <title>Infinite Jest</title>
+          <description>Voluptatum id exercitationem ipsa.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '164'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_one_file" project="home:tom">
+          <title>Infinite Jest</title>
+          <description>Voluptatum id exercitationem ipsa.</description>
+        </package>
+  recorded_at: Thu, 18 May 2023 11:49:39 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom/package_with_one_file/_service
+    body:
+      encoding: UTF-8
+      string: "<services/>"
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="1" vrev="1">
+          <srcmd5>3ac4b29d09369cc0bd4c17dd6a5c7d4c</srcmd5>
+          <version>unknown</version>
+          <time>1684410579</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Thu, 18 May 2023 11:49:39 GMT
+- request:
     method: get
     uri: http://backend:5352/source/home:tom/package_with_one_file
     body:
@@ -25,18 +141,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '285'
+      - '208'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_one_file" rev="2" vrev="2" srcmd5="4c351807b74cb6a07071ce2dec305095">
-          <serviceinfo code="succeeded" xsrcmd5="18a86687dce43cb25a060f8d7d8628cd"/>
-          <entry name="_service" md5="53b4f5c97c7a2122b964e5182c8325a2" size="11" mtime="1643724203"/>
+        <directory name="package_with_one_file" rev="1" vrev="1" srcmd5="3ac4b29d09369cc0bd4c17dd6a5c7d4c">
+          <entry name="_service" md5="53b4f5c97c7a2122b964e5182c8325a2" size="11" mtime="1684410579"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:14:58 GMT
+  recorded_at: Thu, 18 May 2023 11:49:39 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:tom/package_with_one_file?expand=0
+    uri: http://backend:5352/source/home:tom/package_with_one_file
     body:
       encoding: US-ASCII
       string: ''
@@ -59,13 +174,12 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '285'
+      - '208'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_one_file" rev="2" vrev="2" srcmd5="4c351807b74cb6a07071ce2dec305095">
-          <serviceinfo code="succeeded" xsrcmd5="18a86687dce43cb25a060f8d7d8628cd"/>
-          <entry name="_service" md5="53b4f5c97c7a2122b964e5182c8325a2" size="11" mtime="1643724203"/>
+        <directory name="package_with_one_file" rev="1" vrev="1" srcmd5="3ac4b29d09369cc0bd4c17dd6a5c7d4c">
+          <entry name="_service" md5="53b4f5c97c7a2122b964e5182c8325a2" size="11" mtime="1684410579"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:14:58 GMT
-recorded_with: VCR 6.0.0
+  recorded_at: Thu, 18 May 2023 11:49:39 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Package/_has_icon_/returns_false_if_the_icon_does_not_exist.yml
+++ b/src/api/spec/cassettes/Package/_has_icon_/returns_false_if_the_icon_does_not_exist.yml
@@ -1,6 +1,84 @@
 ---
 http_interactions:
 - request:
+    method: put
+    uri: http://backend:5352/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '128'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer"/>
+        </project>
+  recorded_at: Thu, 18 May 2023 11:49:39 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom/test_package/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>The Last Temptation</title>
+          <description>Distinctio aliquam voluptatem et.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '160'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:tom">
+          <title>The Last Temptation</title>
+          <description>Distinctio aliquam voluptatem et.</description>
+        </package>
+  recorded_at: Thu, 18 May 2023 11:49:39 GMT
+- request:
     method: get
     uri: http://backend:5352/source/home:tom/test_package
     body:
@@ -25,47 +103,11 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '296'
+      - '87'
     body:
       encoding: UTF-8
       string: |
-        <directory name="test_package" rev="2" vrev="2" srcmd5="9b1c1ddcaab8327d31b5f9d882782630">
-          <entry name="foo.kiwi.txz" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1643724197"/>
-          <entry name="foo.spec" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1643724198"/>
+        <directory name="test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:15:45 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/home:tom/test_package?expand=0
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '296'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="test_package" rev="2" vrev="2" srcmd5="9b1c1ddcaab8327d31b5f9d882782630">
-          <entry name="foo.kiwi.txz" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1643724197"/>
-          <entry name="foo.spec" md5="d41d8cd98f00b204e9800998ecf8427e" size="0" mtime="1643724198"/>
-        </directory>
-  recorded_at: Tue, 01 Feb 2022 14:15:45 GMT
-recorded_with: VCR 6.0.0
+  recorded_at: Thu, 18 May 2023 11:49:39 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Package/_has_icon_/returns_true_if_the_icon_exist.yml
+++ b/src/api/spec/cassettes/Package/_has_icon_/returns_true_if_the_icon_exist.yml
@@ -1,6 +1,198 @@
 ---
 http_interactions:
 - request:
+    method: put
+    uri: http://backend:5352/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '128'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer"/>
+        </project>
+  recorded_at: Thu, 18 May 2023 11:49:40 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom/package_with_files/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_files" project="home:tom">
+          <title>Fear and Trembling</title>
+          <description>Nam excepturi minima dolores.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '161'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_with_files" project="home:tom">
+          <title>Fear and Trembling</title>
+          <description>Nam excepturi minima dolores.</description>
+        </package>
+  recorded_at: Thu, 18 May 2023 11:49:40 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom/package_with_files/_config
+    body:
+      encoding: UTF-8
+      string: Iusto beatae consectetur. Sint provident quam. Voluptas eius velit.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="5" vrev="5">
+          <srcmd5>af3d1166f1682d552a4f1d76790ccca9</srcmd5>
+          <version>unknown</version>
+          <time>1684410580</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Thu, 18 May 2023 11:49:40 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom/package_with_files/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Maxime vitae mollitia. Sequi sed beatae. Minus qui aliquid.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="6" vrev="6">
+          <srcmd5>76862b50d5d97cfdc22ba184a9237193</srcmd5>
+          <version>unknown</version>
+          <time>1684410580</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Thu, 18 May 2023 11:49:40 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom/package_with_files/_icon
+    body:
+      encoding: UTF-8
+      string: Excepturi atque magni. Ea distinctio consectetur. Illum explicabo eveniet.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="7" vrev="7">
+          <srcmd5>2d506ba364a1b03927fe1c6175930b95</srcmd5>
+          <version>unknown</version>
+          <time>1684410580</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Thu, 18 May 2023 11:49:40 GMT
+- request:
     method: get
     uri: http://backend:5352/source/home:tom/package_with_files
     body:
@@ -25,19 +217,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '397'
+      - '395'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_files" rev="34" vrev="34" srcmd5="5533c6e87a7ed3278edbb2fda81355cf">
-          <entry name="_config" md5="b6fab2c2b7ef43fed208d5ca398d9f5f" size="68" mtime="1643724250"/>
-          <entry name="_icon" md5="95ec7ff9a4af00190b5bbdeb9d2215cb" size="70" mtime="1643724251"/>
-          <entry name="somefile.txt" md5="d04d1e7583a8e01c5c1dda514ca86c8f" size="61" mtime="1643724251"/>
+        <directory name="package_with_files" rev="7" vrev="7" srcmd5="2d506ba364a1b03927fe1c6175930b95">
+          <entry name="_config" md5="99609894a7b1834c1b25d37cfb5cfc6e" size="67" mtime="1684410580"/>
+          <entry name="_icon" md5="3153701fdf2adb4682007ec59f54e5ca" size="74" mtime="1684410580"/>
+          <entry name="somefile.txt" md5="7072dbbf1f61021d5ebc9ca4e37bb6f0" size="59" mtime="1684410580"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:15:28 GMT
+  recorded_at: Thu, 18 May 2023 11:49:40 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/home:tom/package_with_files?expand=0
+    uri: http://backend:5352/source/home:tom/package_with_files
     body:
       encoding: US-ASCII
       string: ''
@@ -60,14 +252,14 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '397'
+      - '395'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_with_files" rev="34" vrev="34" srcmd5="5533c6e87a7ed3278edbb2fda81355cf">
-          <entry name="_config" md5="b6fab2c2b7ef43fed208d5ca398d9f5f" size="68" mtime="1643724250"/>
-          <entry name="_icon" md5="95ec7ff9a4af00190b5bbdeb9d2215cb" size="70" mtime="1643724251"/>
-          <entry name="somefile.txt" md5="d04d1e7583a8e01c5c1dda514ca86c8f" size="61" mtime="1643724251"/>
+        <directory name="package_with_files" rev="7" vrev="7" srcmd5="2d506ba364a1b03927fe1c6175930b95">
+          <entry name="_config" md5="99609894a7b1834c1b25d37cfb5cfc6e" size="67" mtime="1684410580"/>
+          <entry name="_icon" md5="3153701fdf2adb4682007ec59f54e5ca" size="74" mtime="1684410580"/>
+          <entry name="somefile.txt" md5="7072dbbf1f61021d5ebc9ca4e37bb6f0" size="59" mtime="1684410580"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:15:28 GMT
-recorded_with: VCR 6.0.0
+  recorded_at: Thu, 18 May 2023 11:49:40 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/Package/_ignored_requests/when_the_package_has_an_ignored_requests_file/parses_the_content_as_YAML_and_returns_a_hash.yml
+++ b/src/api/spec/cassettes/Package/_ignored_requests/when_the_package_has_an_ignored_requests_file/parses_the_content_as_YAML_and_returns_a_hash.yml
@@ -1,6 +1,198 @@
 ---
 http_interactions:
 - request:
+    method: put
+    uri: http://backend:5352/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '128'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer"/>
+        </project>
+  recorded_at: Thu, 18 May 2023 11:49:37 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/my_project/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="my_project">
+          <title>For Whom the Bell Tolls</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '110'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="my_project">
+          <title>For Whom the Bell Tolls</title>
+          <description></description>
+        </project>
+  recorded_at: Thu, 18 May 2023 11:49:37 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/my_project/dashboard_1/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="dashboard_1" project="my_project">
+          <title>The World, the Flesh and the Devil</title>
+          <description>Alias ab illum soluta.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '165'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="dashboard_1" project="my_project">
+          <title>The World, the Flesh and the Devil</title>
+          <description>Alias ab illum soluta.</description>
+        </package>
+  recorded_at: Thu, 18 May 2023 11:49:37 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/my_project/dashboard_1/_config
+    body:
+      encoding: UTF-8
+      string: Est magnam animi. Est et eligendi. Sint ad qui.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="1" vrev="1">
+          <srcmd5>f7cdcc52b4ed585c55351f709beffc1d</srcmd5>
+          <version>unknown</version>
+          <time>1684410577</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Thu, 18 May 2023 11:49:37 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/my_project/dashboard_1/ignored_requests
+    body:
+      encoding: UTF-8
+      string: 'foo: bar'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="2" vrev="2">
+          <srcmd5>56cf12a97e35d66bf013421d9f7c90be</srcmd5>
+          <version>unknown</version>
+          <time>1684410577</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Thu, 18 May 2023 11:49:37 GMT
+- request:
     method: get
     uri: http://backend:5352/source/my_project/dashboard_1
     body:
@@ -29,14 +221,14 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="dashboard_1" rev="4" vrev="4" srcmd5="690e63d1945160c2bda5e918a28f1f09">
-          <entry name="_config" md5="b302fd17beba50cb6b52555c165b94c9" size="70" mtime="1643724273"/>
-          <entry name="ignored_requests" md5="e1dcf98b4c823827be0a0524052ae95a" size="8" mtime="1643724116"/>
+        <directory name="dashboard_1" rev="2" vrev="2" srcmd5="56cf12a97e35d66bf013421d9f7c90be">
+          <entry name="_config" md5="dd4fe00fb52c33abe92fe68c51085311" size="47" mtime="1684410577"/>
+          <entry name="ignored_requests" md5="e1dcf98b4c823827be0a0524052ae95a" size="8" mtime="1684410577"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:14:17 GMT
+  recorded_at: Thu, 18 May 2023 11:49:37 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/my_project/dashboard_1?expand=0
+    uri: http://backend:5352/source/my_project/dashboard_1
     body:
       encoding: US-ASCII
       string: ''
@@ -63,11 +255,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="dashboard_1" rev="4" vrev="4" srcmd5="690e63d1945160c2bda5e918a28f1f09">
-          <entry name="_config" md5="b302fd17beba50cb6b52555c165b94c9" size="70" mtime="1643724273"/>
-          <entry name="ignored_requests" md5="e1dcf98b4c823827be0a0524052ae95a" size="8" mtime="1643724116"/>
+        <directory name="dashboard_1" rev="2" vrev="2" srcmd5="56cf12a97e35d66bf013421d9f7c90be">
+          <entry name="_config" md5="dd4fe00fb52c33abe92fe68c51085311" size="47" mtime="1684410577"/>
+          <entry name="ignored_requests" md5="e1dcf98b4c823827be0a0524052ae95a" size="8" mtime="1684410577"/>
         </directory>
-  recorded_at: Tue, 01 Feb 2022 14:14:17 GMT
+  recorded_at: Thu, 18 May 2023 11:49:37 GMT
 - request:
     method: get
     uri: http://backend:5352/source/my_project/dashboard_1/ignored_requests
@@ -97,5 +289,5 @@ http_interactions:
     body:
       encoding: UTF-8
       string: 'foo: bar'
-  recorded_at: Tue, 01 Feb 2022 14:14:17 GMT
-recorded_with: VCR 6.0.0
+  recorded_at: Thu, 18 May 2023 11:49:37 GMT
+recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/SourcediffComponent/with_a_request_with_a_submit_action/renders_the_diff.yml
+++ b/src/api/spec/cassettes/SourcediffComponent/with_a_request_with_a_submit_action/renders_the_diff.yml
@@ -2,12 +2,12 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/target_project/_meta?user=user_1
+    uri: http://backend:5352/source/target_project/_meta?user=user_11
     body:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>Where Angels Fear to Tread</title>
+          <title>Tender Is the Night</title>
           <description/>
         </project>
     headers:
@@ -29,24 +29,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '117'
+      - '110'
     body:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>Where Angels Fear to Tread</title>
+          <title>Tender Is the Night</title>
           <description></description>
         </project>
-  recorded_at: Tue, 26 Jul 2022 11:49:44 GMT
+  recorded_at: Thu, 18 May 2023 11:50:00 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/target_project/target_package/_meta?user=user_2
+    uri: http://backend:5352/source/target_project/target_package/_meta?user=user_12
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>Specimen Days</title>
-          <description>Cum natus qui provident.</description>
+          <title>A Monstrous Regiment of Women</title>
+          <description>Et illum temporibus culpa.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -67,21 +67,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '153'
+      - '171'
     body:
       encoding: UTF-8
       string: |
         <package name="target_package" project="target_project">
-          <title>Specimen Days</title>
-          <description>Cum natus qui provident.</description>
+          <title>A Monstrous Regiment of Women</title>
+          <description>Et illum temporibus culpa.</description>
         </package>
-  recorded_at: Tue, 26 Jul 2022 11:49:44 GMT
+  recorded_at: Thu, 18 May 2023 11:50:00 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/target_package/_config
     body:
       encoding: UTF-8
-      string: Omnis qui minus. Mollitia corrupti dolorem. Quo soluta libero.
+      string: Eos ducimus ea. Nam itaque consequatur. Culpa omnis rerum.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -101,19 +101,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '209'
+      - '207'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="11" vrev="11">
-          <srcmd5>9df555568356a4ba4517e1705564d17b</srcmd5>
+        <revision rev="7" vrev="7">
+          <srcmd5>06416a9df56262746245459a2a2dda79</srcmd5>
           <version>unknown</version>
-          <time>1658836184</time>
+          <time>1684410600</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Tue, 26 Jul 2022 11:49:44 GMT
+  recorded_at: Thu, 18 May 2023 11:50:00 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/target_package/somefile.txt
@@ -139,27 +139,27 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '209'
+      - '207'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="12" vrev="12">
-          <srcmd5>9df555568356a4ba4517e1705564d17b</srcmd5>
+        <revision rev="8" vrev="8">
+          <srcmd5>06416a9df56262746245459a2a2dda79</srcmd5>
           <version>unknown</version>
-          <time>1658836184</time>
+          <time>1684410600</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Tue, 26 Jul 2022 11:49:44 GMT
+  recorded_at: Thu, 18 May 2023 11:50:00 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/source_project/_meta?user=user_3
+    uri: http://backend:5352/source/source_project/_meta?user=user_13
     body:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>Jesting Pilate</title>
+          <title>Number the Stars</title>
           <description/>
         </project>
     headers:
@@ -181,18 +181,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '105'
+      - '107'
     body:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>Jesting Pilate</title>
+          <title>Number the Stars</title>
           <description></description>
         </project>
-  recorded_at: Tue, 26 Jul 2022 11:49:44 GMT
+  recorded_at: Thu, 18 May 2023 11:50:00 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/source_project/_project/_attribute?meta=1&user=user_3
+    uri: http://backend:5352/source/source_project/_project/_attribute?meta=1&user=user_13
     body:
       encoding: UTF-8
       string: |
@@ -218,27 +218,27 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '169'
+      - '170'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="16">
-          <srcmd5>1f3a95bdcd545248eba9eb2732cce683</srcmd5>
-          <time>1658836184</time>
-          <user>user_3</user>
+        <revision rev="55">
+          <srcmd5>1e9907d0c1a0101ea58f91d52132c5fb</srcmd5>
+          <time>1684410600</time>
+          <user>user_13</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Tue, 26 Jul 2022 11:49:44 GMT
+  recorded_at: Thu, 18 May 2023 11:50:00 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/source_project/source_package/_meta?user=user_4
+    uri: http://backend:5352/source/source_project/source_package/_meta?user=user_14
     body:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>The Lathe of Heaven</title>
-          <description>Ut sequi dolores velit.</description>
+          <title>Many Waters</title>
+          <description>Tempore reprehenderit voluptatum laborum.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -259,21 +259,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '158'
+      - '168'
     body:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>The Lathe of Heaven</title>
-          <description>Ut sequi dolores velit.</description>
+          <title>Many Waters</title>
+          <description>Tempore reprehenderit voluptatum laborum.</description>
         </package>
-  recorded_at: Tue, 26 Jul 2022 11:49:44 GMT
+  recorded_at: Thu, 18 May 2023 11:50:00 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/source_package/_config
     body:
       encoding: UTF-8
-      string: Soluta voluptatem est. Velit odio aut. Soluta fugiat nostrum.
+      string: Officia repellendus consequatur. Eos aspernatur omnis. Est et voluptatibus.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -293,19 +293,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '209'
+      - '207'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="11" vrev="11">
-          <srcmd5>2f8cba61bcfa7eaae11ab65302d2a516</srcmd5>
+        <revision rev="7" vrev="7">
+          <srcmd5>cd0a14a7bdf4cc8b3e27710436550358</srcmd5>
           <version>unknown</version>
-          <time>1658836184</time>
+          <time>1684410600</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Tue, 26 Jul 2022 11:49:44 GMT
+  recorded_at: Thu, 18 May 2023 11:50:00 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/source_package/somefile.txt
@@ -331,19 +331,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '209'
+      - '207'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="12" vrev="12">
-          <srcmd5>2f8cba61bcfa7eaae11ab65302d2a516</srcmd5>
+        <revision rev="8" vrev="8">
+          <srcmd5>cd0a14a7bdf4cc8b3e27710436550358</srcmd5>
           <version>unknown</version>
-          <time>1658836184</time>
+          <time>1684410600</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Tue, 26 Jul 2022 11:49:44 GMT
+  recorded_at: Thu, 18 May 2023 11:50:00 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package
@@ -369,15 +369,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '301'
+      - '299'
     body:
       encoding: UTF-8
       string: |
-        <directory name="source_package" rev="12" vrev="12" srcmd5="2f8cba61bcfa7eaae11ab65302d2a516">
-          <entry name="_config" md5="cf9b23c1e23c044aa48fd2af9cac0ce0" size="61" mtime="1658836184"/>
-          <entry name="somefile.txt" md5="8bc8b279be5b9899070591b779e593e4" size="22" mtime="1658835780"/>
+        <directory name="source_package" rev="8" vrev="8" srcmd5="cd0a14a7bdf4cc8b3e27710436550358">
+          <entry name="_config" md5="4475d9e26e24695f59701b614dd622f9" size="75" mtime="1684410600"/>
+          <entry name="somefile.txt" md5="8bc8b279be5b9899070591b779e593e4" size="22" mtime="1677507608"/>
         </directory>
-  recorded_at: Tue, 26 Jul 2022 11:49:44 GMT
+  recorded_at: Thu, 18 May 2023 11:50:00 GMT
 - request:
     method: post
     uri: http://backend:5352/source/source_project/source_package?cmd=diff&expand=1&filelimit=10000&opackage=target_package&oproject=target_project&tarlimit=10000&view=xml&withissues=1
@@ -405,21 +405,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '1106'
+      - '1114'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="c9d051727e611167e8d753be829a669b">
-          <old project="target_project" package="target_package" rev="12" srcmd5="9df555568356a4ba4517e1705564d17b"/>
-          <new project="source_project" package="source_package" rev="12" srcmd5="2f8cba61bcfa7eaae11ab65302d2a516"/>
+        <sourcediff key="bfd2d45ebcce3d7c6606f024ecf1f9fe">
+          <old project="target_project" package="target_package" rev="8" srcmd5="06416a9df56262746245459a2a2dda79"/>
+          <new project="source_project" package="source_package" rev="8" srcmd5="cd0a14a7bdf4cc8b3e27710436550358"/>
           <files>
             <file state="changed">
-              <old name="_config" md5="d424b88c51098bbbde14185e47ad2710" size="62"/>
-              <new name="_config" md5="cf9b23c1e23c044aa48fd2af9cac0ce0" size="61"/>
+              <old name="_config" md5="c5e56d3469b4098fe11366062f8c523d" size="58"/>
+              <new name="_config" md5="4475d9e26e24695f59701b614dd622f9" size="75"/>
               <diff lines="5">@@ -1,1 +1,1 @@
-        -Omnis qui minus. Mollitia corrupti dolorem. Quo soluta libero.
+        -Eos ducimus ea. Nam itaque consequatur. Culpa omnis rerum.
         \ No newline at end of file
-        +Soluta voluptatem est. Velit odio aut. Soluta fugiat nostrum.
+        +Officia repellendus consequatur. Eos aspernatur omnis. Est et voluptatibus.
         \ No newline at end of file
         </diff>
             </file>
@@ -437,7 +437,7 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Tue, 26 Jul 2022 11:49:44 GMT
+  recorded_at: Thu, 18 May 2023 11:50:00 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package
@@ -463,15 +463,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '301'
+      - '299'
     body:
       encoding: UTF-8
       string: |
-        <directory name="source_package" rev="12" vrev="12" srcmd5="2f8cba61bcfa7eaae11ab65302d2a516">
-          <entry name="_config" md5="cf9b23c1e23c044aa48fd2af9cac0ce0" size="61" mtime="1658836184"/>
-          <entry name="somefile.txt" md5="8bc8b279be5b9899070591b779e593e4" size="22" mtime="1658835780"/>
+        <directory name="source_package" rev="8" vrev="8" srcmd5="cd0a14a7bdf4cc8b3e27710436550358">
+          <entry name="_config" md5="4475d9e26e24695f59701b614dd622f9" size="75" mtime="1684410600"/>
+          <entry name="somefile.txt" md5="8bc8b279be5b9899070591b779e593e4" size="22" mtime="1677507608"/>
         </directory>
-  recorded_at: Tue, 26 Jul 2022 11:49:44 GMT
+  recorded_at: Thu, 18 May 2023 11:50:00 GMT
 - request:
     method: post
     uri: http://backend:5352/source/source_project/source_package?cacheonly=1&cmd=diff&expand=1&filelimit=10000&opackage=target_package&oproject=target_project&tarlimit=10000&view=xml&withissues=1
@@ -495,7 +495,7 @@ http_interactions:
       Content-Type:
       - text/xml
       Content-Length:
-      - '1106'
+      - '1114'
       Cache-Control:
       - no-cache
       Connection:
@@ -503,17 +503,17 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="c9d051727e611167e8d753be829a669b">
-          <old project="target_project" package="target_package" rev="12" srcmd5="9df555568356a4ba4517e1705564d17b"/>
-          <new project="source_project" package="source_package" rev="12" srcmd5="2f8cba61bcfa7eaae11ab65302d2a516"/>
+        <sourcediff key="bfd2d45ebcce3d7c6606f024ecf1f9fe">
+          <old project="target_project" package="target_package" rev="8" srcmd5="06416a9df56262746245459a2a2dda79"/>
+          <new project="source_project" package="source_package" rev="8" srcmd5="cd0a14a7bdf4cc8b3e27710436550358"/>
           <files>
             <file state="changed">
-              <old name="_config" md5="d424b88c51098bbbde14185e47ad2710" size="62"/>
-              <new name="_config" md5="cf9b23c1e23c044aa48fd2af9cac0ce0" size="61"/>
+              <old name="_config" md5="c5e56d3469b4098fe11366062f8c523d" size="58"/>
+              <new name="_config" md5="4475d9e26e24695f59701b614dd622f9" size="75"/>
               <diff lines="5">@@ -1,1 +1,1 @@
-        -Omnis qui minus. Mollitia corrupti dolorem. Quo soluta libero.
+        -Eos ducimus ea. Nam itaque consequatur. Culpa omnis rerum.
         \ No newline at end of file
-        +Soluta voluptatem est. Velit odio aut. Soluta fugiat nostrum.
+        +Officia repellendus consequatur. Eos aspernatur omnis. Est et voluptatibus.
         \ No newline at end of file
         </diff>
             </file>
@@ -531,7 +531,7 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Tue, 26 Jul 2022 11:49:45 GMT
+  recorded_at: Thu, 18 May 2023 11:50:00 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/target_package
@@ -557,13 +557,285 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '301'
+      - '299'
     body:
       encoding: UTF-8
       string: |
-        <directory name="target_package" rev="12" vrev="12" srcmd5="9df555568356a4ba4517e1705564d17b">
-          <entry name="_config" md5="d424b88c51098bbbde14185e47ad2710" size="62" mtime="1658836184"/>
-          <entry name="somefile.txt" md5="11a31b90d280a13710401556a3256e44" size="23" mtime="1658835780"/>
+        <directory name="target_package" rev="8" vrev="8" srcmd5="06416a9df56262746245459a2a2dda79">
+          <entry name="_config" md5="c5e56d3469b4098fe11366062f8c523d" size="58" mtime="1684410600"/>
+          <entry name="somefile.txt" md5="11a31b90d280a13710401556a3256e44" size="23" mtime="1677507608"/>
         </directory>
-  recorded_at: Tue, 26 Jul 2022 11:49:45 GMT
+  recorded_at: Thu, 18 May 2023 11:50:00 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/source_project/source_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '299'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="source_package" rev="8" vrev="8" srcmd5="cd0a14a7bdf4cc8b3e27710436550358">
+          <entry name="_config" md5="4475d9e26e24695f59701b614dd622f9" size="75" mtime="1684410600"/>
+          <entry name="somefile.txt" md5="8bc8b279be5b9899070591b779e593e4" size="22" mtime="1677507608"/>
+        </directory>
+  recorded_at: Thu, 18 May 2023 11:50:01 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/source_project/source_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '299'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="source_package" rev="8" vrev="8" srcmd5="cd0a14a7bdf4cc8b3e27710436550358">
+          <entry name="_config" md5="4475d9e26e24695f59701b614dd622f9" size="75" mtime="1684410600"/>
+          <entry name="somefile.txt" md5="8bc8b279be5b9899070591b779e593e4" size="22" mtime="1677507608"/>
+        </directory>
+  recorded_at: Thu, 18 May 2023 11:50:01 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/target_project/target_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '299'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="target_package" rev="8" vrev="8" srcmd5="06416a9df56262746245459a2a2dda79">
+          <entry name="_config" md5="c5e56d3469b4098fe11366062f8c523d" size="58" mtime="1684410600"/>
+          <entry name="somefile.txt" md5="11a31b90d280a13710401556a3256e44" size="23" mtime="1677507608"/>
+        </directory>
+  recorded_at: Thu, 18 May 2023 11:50:01 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/target_project/target_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '299'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="target_package" rev="8" vrev="8" srcmd5="06416a9df56262746245459a2a2dda79">
+          <entry name="_config" md5="c5e56d3469b4098fe11366062f8c523d" size="58" mtime="1684410600"/>
+          <entry name="somefile.txt" md5="11a31b90d280a13710401556a3256e44" size="23" mtime="1677507608"/>
+        </directory>
+  recorded_at: Thu, 18 May 2023 11:50:01 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/source_project/source_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '299'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="source_package" rev="8" vrev="8" srcmd5="cd0a14a7bdf4cc8b3e27710436550358">
+          <entry name="_config" md5="4475d9e26e24695f59701b614dd622f9" size="75" mtime="1684410600"/>
+          <entry name="somefile.txt" md5="8bc8b279be5b9899070591b779e593e4" size="22" mtime="1677507608"/>
+        </directory>
+  recorded_at: Thu, 18 May 2023 11:50:01 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/source_project/source_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '299'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="source_package" rev="8" vrev="8" srcmd5="cd0a14a7bdf4cc8b3e27710436550358">
+          <entry name="_config" md5="4475d9e26e24695f59701b614dd622f9" size="75" mtime="1684410600"/>
+          <entry name="somefile.txt" md5="8bc8b279be5b9899070591b779e593e4" size="22" mtime="1677507608"/>
+        </directory>
+  recorded_at: Thu, 18 May 2023 11:50:01 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/target_project/target_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '299'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="target_package" rev="8" vrev="8" srcmd5="06416a9df56262746245459a2a2dda79">
+          <entry name="_config" md5="c5e56d3469b4098fe11366062f8c523d" size="58" mtime="1684410600"/>
+          <entry name="somefile.txt" md5="11a31b90d280a13710401556a3256e44" size="23" mtime="1677507608"/>
+        </directory>
+  recorded_at: Thu, 18 May 2023 11:50:01 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/target_project/target_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '299'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="target_package" rev="8" vrev="8" srcmd5="06416a9df56262746245459a2a2dda79">
+          <entry name="_config" md5="c5e56d3469b4098fe11366062f8c523d" size="58" mtime="1684410600"/>
+          <entry name="somefile.txt" md5="11a31b90d280a13710401556a3256e44" size="23" mtime="1677507608"/>
+        </directory>
+  recorded_at: Thu, 18 May 2023 11:50:01 GMT
 recorded_with: VCR 6.1.0

--- a/src/api/spec/cassettes/SourcediffComponent/with_a_request_with_a_submit_action/renders_the_diff.yml
+++ b/src/api/spec/cassettes/SourcediffComponent/with_a_request_with_a_submit_action/renders_the_diff.yml
@@ -2,164 +2,12 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/target_project/_meta?user=user_11
+    uri: http://backend:5352/source/target_project/_meta?user=user_1
     body:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>Tender Is the Night</title>
-          <description/>
-        </project>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '110'
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="target_project">
-          <title>Tender Is the Night</title>
-          <description></description>
-        </project>
-  recorded_at: Thu, 18 May 2023 11:50:00 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/target_project/target_package/_meta?user=user_12
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="target_package" project="target_project">
-          <title>A Monstrous Regiment of Women</title>
-          <description>Et illum temporibus culpa.</description>
-        </package>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '171'
-    body:
-      encoding: UTF-8
-      string: |
-        <package name="target_package" project="target_project">
-          <title>A Monstrous Regiment of Women</title>
-          <description>Et illum temporibus culpa.</description>
-        </package>
-  recorded_at: Thu, 18 May 2023 11:50:00 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/target_project/target_package/_config
-    body:
-      encoding: UTF-8
-      string: Eos ducimus ea. Nam itaque consequatur. Culpa omnis rerum.
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '207'
-    body:
-      encoding: UTF-8
-      string: |
-        <revision rev="7" vrev="7">
-          <srcmd5>06416a9df56262746245459a2a2dda79</srcmd5>
-          <version>unknown</version>
-          <time>1684410600</time>
-          <user>unknown</user>
-          <comment></comment>
-          <requestid/>
-        </revision>
-  recorded_at: Thu, 18 May 2023 11:50:00 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/target_project/target_package/somefile.txt
-    body:
-      encoding: UTF-8
-      string: "# This will be replaced"
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '207'
-    body:
-      encoding: UTF-8
-      string: |
-        <revision rev="8" vrev="8">
-          <srcmd5>06416a9df56262746245459a2a2dda79</srcmd5>
-          <version>unknown</version>
-          <time>1684410600</time>
-          <user>unknown</user>
-          <comment></comment>
-          <requestid/>
-        </revision>
-  recorded_at: Thu, 18 May 2023 11:50:00 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/source_project/_meta?user=user_13
-    body:
-      encoding: UTF-8
-      string: |
-        <project name="source_project">
-          <title>Number the Stars</title>
+          <title>The Proper Study</title>
           <description/>
         </project>
     headers:
@@ -185,14 +33,167 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <project name="source_project">
-          <title>Number the Stars</title>
+        <project name="target_project">
+          <title>The Proper Study</title>
           <description></description>
         </project>
-  recorded_at: Thu, 18 May 2023 11:50:00 GMT
+  recorded_at: Fri, 19 May 2023 11:55:36 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/source_project/_project/_attribute?meta=1&user=user_13
+    uri: http://backend:5352/source/target_project/target_package/_meta?user=user_2
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="target_project">
+          <title>An Instant In The Wind</title>
+          <description>Nobis soluta sed ipsum.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '161'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="target_package" project="target_project">
+          <title>An Instant In The Wind</title>
+          <description>Nobis soluta sed ipsum.</description>
+        </package>
+  recorded_at: Fri, 19 May 2023 11:55:36 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/target_project/target_package/_config
+    body:
+      encoding: UTF-8
+      string: Tenetur voluptatem unde. Voluptas corporis consectetur. Enim debitis
+        dolorem.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="9" vrev="9">
+          <srcmd5>7251f5d682a3fe94ce35c4d19c108a77</srcmd5>
+          <version>unknown</version>
+          <time>1684497336</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Fri, 19 May 2023 11:55:36 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/target_project/target_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: "# This will be replaced"
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="10" vrev="10">
+          <srcmd5>7251f5d682a3fe94ce35c4d19c108a77</srcmd5>
+          <version>unknown</version>
+          <time>1684497336</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Fri, 19 May 2023 11:55:36 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/source_project/_meta?user=user_3
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="source_project">
+          <title>Endless Night</title>
+          <description/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '104'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="source_project">
+          <title>Endless Night</title>
+          <description></description>
+        </project>
+  recorded_at: Fri, 19 May 2023 11:55:36 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/source_project/_project/_attribute?meta=1&user=user_3
     body:
       encoding: UTF-8
       string: |
@@ -218,27 +219,27 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '170'
+      - '169'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="55">
-          <srcmd5>1e9907d0c1a0101ea58f91d52132c5fb</srcmd5>
-          <time>1684410600</time>
-          <user>user_13</user>
+        <revision rev="57">
+          <srcmd5>88f9eb2ec37d6e6bec49f42a36e4d53d</srcmd5>
+          <time>1684497337</time>
+          <user>user_3</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 18 May 2023 11:50:00 GMT
+  recorded_at: Fri, 19 May 2023 11:55:37 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/source_project/source_package/_meta?user=user_14
+    uri: http://backend:5352/source/source_project/source_package/_meta?user=user_4
     body:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>Many Waters</title>
-          <description>Tempore reprehenderit voluptatum laborum.</description>
+          <title>That Hideous Strength</title>
+          <description>Laudantium id quod iure.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -259,21 +260,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '168'
+      - '161'
     body:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>Many Waters</title>
-          <description>Tempore reprehenderit voluptatum laborum.</description>
+          <title>That Hideous Strength</title>
+          <description>Laudantium id quod iure.</description>
         </package>
-  recorded_at: Thu, 18 May 2023 11:50:00 GMT
+  recorded_at: Fri, 19 May 2023 11:55:37 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/source_package/_config
     body:
       encoding: UTF-8
-      string: Officia repellendus consequatur. Eos aspernatur omnis. Est et voluptatibus.
+      string: Ea earum perferendis. Et et quas. Inventore consectetur facere.
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -297,15 +298,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="7" vrev="7">
-          <srcmd5>cd0a14a7bdf4cc8b3e27710436550358</srcmd5>
+        <revision rev="9" vrev="9">
+          <srcmd5>8fd61c1124aa43f064e28fedf8467d05</srcmd5>
           <version>unknown</version>
-          <time>1684410600</time>
+          <time>1684497337</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 18 May 2023 11:50:00 GMT
+  recorded_at: Fri, 19 May 2023 11:55:37 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/source_package/somefile.txt
@@ -331,19 +332,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '209'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="8" vrev="8">
-          <srcmd5>cd0a14a7bdf4cc8b3e27710436550358</srcmd5>
+        <revision rev="10" vrev="10">
+          <srcmd5>8fd61c1124aa43f064e28fedf8467d05</srcmd5>
           <version>unknown</version>
-          <time>1684410600</time>
+          <time>1684497337</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 18 May 2023 11:50:00 GMT
+  recorded_at: Fri, 19 May 2023 11:55:37 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package
@@ -369,15 +370,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '299'
+      - '301'
     body:
       encoding: UTF-8
       string: |
-        <directory name="source_package" rev="8" vrev="8" srcmd5="cd0a14a7bdf4cc8b3e27710436550358">
-          <entry name="_config" md5="4475d9e26e24695f59701b614dd622f9" size="75" mtime="1684410600"/>
+        <directory name="source_package" rev="10" vrev="10" srcmd5="8fd61c1124aa43f064e28fedf8467d05">
+          <entry name="_config" md5="61b7917d2e2343f2ca5961eb2b62f65d" size="63" mtime="1684497337"/>
           <entry name="somefile.txt" md5="8bc8b279be5b9899070591b779e593e4" size="22" mtime="1677507608"/>
         </directory>
-  recorded_at: Thu, 18 May 2023 11:50:00 GMT
+  recorded_at: Fri, 19 May 2023 11:55:37 GMT
 - request:
     method: post
     uri: http://backend:5352/source/source_project/source_package?cmd=diff&expand=1&filelimit=10000&opackage=target_package&oproject=target_project&tarlimit=10000&view=xml&withissues=1
@@ -405,21 +406,21 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '1114'
+      - '1123'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="bfd2d45ebcce3d7c6606f024ecf1f9fe">
-          <old project="target_project" package="target_package" rev="8" srcmd5="06416a9df56262746245459a2a2dda79"/>
-          <new project="source_project" package="source_package" rev="8" srcmd5="cd0a14a7bdf4cc8b3e27710436550358"/>
+        <sourcediff key="6568ef1cdbfc5ec799a3806f1b74cd9b">
+          <old project="target_project" package="target_package" rev="10" srcmd5="7251f5d682a3fe94ce35c4d19c108a77"/>
+          <new project="source_project" package="source_package" rev="10" srcmd5="8fd61c1124aa43f064e28fedf8467d05"/>
           <files>
             <file state="changed">
-              <old name="_config" md5="c5e56d3469b4098fe11366062f8c523d" size="58"/>
-              <new name="_config" md5="4475d9e26e24695f59701b614dd622f9" size="75"/>
+              <old name="_config" md5="ecbb6430dad2ff975c25d01f137456f2" size="77"/>
+              <new name="_config" md5="61b7917d2e2343f2ca5961eb2b62f65d" size="63"/>
               <diff lines="5">@@ -1,1 +1,1 @@
-        -Eos ducimus ea. Nam itaque consequatur. Culpa omnis rerum.
+        -Tenetur voluptatem unde. Voluptas corporis consectetur. Enim debitis dolorem.
         \ No newline at end of file
-        +Officia repellendus consequatur. Eos aspernatur omnis. Est et voluptatibus.
+        +Ea earum perferendis. Et et quas. Inventore consectetur facere.
         \ No newline at end of file
         </diff>
             </file>
@@ -437,7 +438,7 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 18 May 2023 11:50:00 GMT
+  recorded_at: Fri, 19 May 2023 11:55:37 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/source_package
@@ -463,15 +464,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '299'
+      - '301'
     body:
       encoding: UTF-8
       string: |
-        <directory name="source_package" rev="8" vrev="8" srcmd5="cd0a14a7bdf4cc8b3e27710436550358">
-          <entry name="_config" md5="4475d9e26e24695f59701b614dd622f9" size="75" mtime="1684410600"/>
+        <directory name="source_package" rev="10" vrev="10" srcmd5="8fd61c1124aa43f064e28fedf8467d05">
+          <entry name="_config" md5="61b7917d2e2343f2ca5961eb2b62f65d" size="63" mtime="1684497337"/>
           <entry name="somefile.txt" md5="8bc8b279be5b9899070591b779e593e4" size="22" mtime="1677507608"/>
         </directory>
-  recorded_at: Thu, 18 May 2023 11:50:00 GMT
+  recorded_at: Fri, 19 May 2023 11:55:37 GMT
 - request:
     method: post
     uri: http://backend:5352/source/source_project/source_package?cacheonly=1&cmd=diff&expand=1&filelimit=10000&opackage=target_package&oproject=target_project&tarlimit=10000&view=xml&withissues=1
@@ -495,7 +496,7 @@ http_interactions:
       Content-Type:
       - text/xml
       Content-Length:
-      - '1114'
+      - '1123'
       Cache-Control:
       - no-cache
       Connection:
@@ -503,17 +504,17 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="bfd2d45ebcce3d7c6606f024ecf1f9fe">
-          <old project="target_project" package="target_package" rev="8" srcmd5="06416a9df56262746245459a2a2dda79"/>
-          <new project="source_project" package="source_package" rev="8" srcmd5="cd0a14a7bdf4cc8b3e27710436550358"/>
+        <sourcediff key="6568ef1cdbfc5ec799a3806f1b74cd9b">
+          <old project="target_project" package="target_package" rev="10" srcmd5="7251f5d682a3fe94ce35c4d19c108a77"/>
+          <new project="source_project" package="source_package" rev="10" srcmd5="8fd61c1124aa43f064e28fedf8467d05"/>
           <files>
             <file state="changed">
-              <old name="_config" md5="c5e56d3469b4098fe11366062f8c523d" size="58"/>
-              <new name="_config" md5="4475d9e26e24695f59701b614dd622f9" size="75"/>
+              <old name="_config" md5="ecbb6430dad2ff975c25d01f137456f2" size="77"/>
+              <new name="_config" md5="61b7917d2e2343f2ca5961eb2b62f65d" size="63"/>
               <diff lines="5">@@ -1,1 +1,1 @@
-        -Eos ducimus ea. Nam itaque consequatur. Culpa omnis rerum.
+        -Tenetur voluptatem unde. Voluptas corporis consectetur. Enim debitis dolorem.
         \ No newline at end of file
-        +Officia repellendus consequatur. Eos aspernatur omnis. Est et voluptatibus.
+        +Ea earum perferendis. Et et quas. Inventore consectetur facere.
         \ No newline at end of file
         </diff>
             </file>
@@ -531,7 +532,7 @@ http_interactions:
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 18 May 2023 11:50:00 GMT
+  recorded_at: Fri, 19 May 2023 11:55:37 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/target_package
@@ -557,18 +558,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '299'
+      - '301'
     body:
       encoding: UTF-8
       string: |
-        <directory name="target_package" rev="8" vrev="8" srcmd5="06416a9df56262746245459a2a2dda79">
-          <entry name="_config" md5="c5e56d3469b4098fe11366062f8c523d" size="58" mtime="1684410600"/>
+        <directory name="target_package" rev="10" vrev="10" srcmd5="7251f5d682a3fe94ce35c4d19c108a77">
+          <entry name="_config" md5="ecbb6430dad2ff975c25d01f137456f2" size="77" mtime="1684497336"/>
           <entry name="somefile.txt" md5="11a31b90d280a13710401556a3256e44" size="23" mtime="1677507608"/>
         </directory>
-  recorded_at: Thu, 18 May 2023 11:50:00 GMT
+  recorded_at: Fri, 19 May 2023 11:55:37 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/source_project/source_package
+    uri: http://backend:5352/source/source_project/source_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -591,18 +592,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '299'
+      - '301'
     body:
       encoding: UTF-8
       string: |
-        <directory name="source_package" rev="8" vrev="8" srcmd5="cd0a14a7bdf4cc8b3e27710436550358">
-          <entry name="_config" md5="4475d9e26e24695f59701b614dd622f9" size="75" mtime="1684410600"/>
+        <directory name="source_package" rev="10" vrev="10" srcmd5="8fd61c1124aa43f064e28fedf8467d05">
+          <entry name="_config" md5="61b7917d2e2343f2ca5961eb2b62f65d" size="63" mtime="1684497337"/>
           <entry name="somefile.txt" md5="8bc8b279be5b9899070591b779e593e4" size="22" mtime="1677507608"/>
         </directory>
-  recorded_at: Thu, 18 May 2023 11:50:01 GMT
+  recorded_at: Fri, 19 May 2023 11:55:37 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/source_project/source_package
+    uri: http://backend:5352/source/source_project/source_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -625,18 +626,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '299'
+      - '301'
     body:
       encoding: UTF-8
       string: |
-        <directory name="source_package" rev="8" vrev="8" srcmd5="cd0a14a7bdf4cc8b3e27710436550358">
-          <entry name="_config" md5="4475d9e26e24695f59701b614dd622f9" size="75" mtime="1684410600"/>
+        <directory name="source_package" rev="10" vrev="10" srcmd5="8fd61c1124aa43f064e28fedf8467d05">
+          <entry name="_config" md5="61b7917d2e2343f2ca5961eb2b62f65d" size="63" mtime="1684497337"/>
           <entry name="somefile.txt" md5="8bc8b279be5b9899070591b779e593e4" size="22" mtime="1677507608"/>
         </directory>
-  recorded_at: Thu, 18 May 2023 11:50:01 GMT
+  recorded_at: Fri, 19 May 2023 11:55:37 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/target_project/target_package
+    uri: http://backend:5352/source/target_project/target_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -659,18 +660,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '299'
+      - '301'
     body:
       encoding: UTF-8
       string: |
-        <directory name="target_package" rev="8" vrev="8" srcmd5="06416a9df56262746245459a2a2dda79">
-          <entry name="_config" md5="c5e56d3469b4098fe11366062f8c523d" size="58" mtime="1684410600"/>
+        <directory name="target_package" rev="10" vrev="10" srcmd5="7251f5d682a3fe94ce35c4d19c108a77">
+          <entry name="_config" md5="ecbb6430dad2ff975c25d01f137456f2" size="77" mtime="1684497336"/>
           <entry name="somefile.txt" md5="11a31b90d280a13710401556a3256e44" size="23" mtime="1677507608"/>
         </directory>
-  recorded_at: Thu, 18 May 2023 11:50:01 GMT
+  recorded_at: Fri, 19 May 2023 11:55:37 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/target_project/target_package
+    uri: http://backend:5352/source/target_project/target_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -693,18 +694,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '299'
+      - '301'
     body:
       encoding: UTF-8
       string: |
-        <directory name="target_package" rev="8" vrev="8" srcmd5="06416a9df56262746245459a2a2dda79">
-          <entry name="_config" md5="c5e56d3469b4098fe11366062f8c523d" size="58" mtime="1684410600"/>
+        <directory name="target_package" rev="10" vrev="10" srcmd5="7251f5d682a3fe94ce35c4d19c108a77">
+          <entry name="_config" md5="ecbb6430dad2ff975c25d01f137456f2" size="77" mtime="1684497336"/>
           <entry name="somefile.txt" md5="11a31b90d280a13710401556a3256e44" size="23" mtime="1677507608"/>
         </directory>
-  recorded_at: Thu, 18 May 2023 11:50:01 GMT
+  recorded_at: Fri, 19 May 2023 11:55:37 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/source_project/source_package
+    uri: http://backend:5352/source/source_project/source_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -727,18 +728,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '299'
+      - '301'
     body:
       encoding: UTF-8
       string: |
-        <directory name="source_package" rev="8" vrev="8" srcmd5="cd0a14a7bdf4cc8b3e27710436550358">
-          <entry name="_config" md5="4475d9e26e24695f59701b614dd622f9" size="75" mtime="1684410600"/>
+        <directory name="source_package" rev="10" vrev="10" srcmd5="8fd61c1124aa43f064e28fedf8467d05">
+          <entry name="_config" md5="61b7917d2e2343f2ca5961eb2b62f65d" size="63" mtime="1684497337"/>
           <entry name="somefile.txt" md5="8bc8b279be5b9899070591b779e593e4" size="22" mtime="1677507608"/>
         </directory>
-  recorded_at: Thu, 18 May 2023 11:50:01 GMT
+  recorded_at: Fri, 19 May 2023 11:55:37 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/source_project/source_package
+    uri: http://backend:5352/source/source_project/source_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -761,18 +762,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '299'
+      - '301'
     body:
       encoding: UTF-8
       string: |
-        <directory name="source_package" rev="8" vrev="8" srcmd5="cd0a14a7bdf4cc8b3e27710436550358">
-          <entry name="_config" md5="4475d9e26e24695f59701b614dd622f9" size="75" mtime="1684410600"/>
+        <directory name="source_package" rev="10" vrev="10" srcmd5="8fd61c1124aa43f064e28fedf8467d05">
+          <entry name="_config" md5="61b7917d2e2343f2ca5961eb2b62f65d" size="63" mtime="1684497337"/>
           <entry name="somefile.txt" md5="8bc8b279be5b9899070591b779e593e4" size="22" mtime="1677507608"/>
         </directory>
-  recorded_at: Thu, 18 May 2023 11:50:01 GMT
+  recorded_at: Fri, 19 May 2023 11:55:37 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/target_project/target_package
+    uri: http://backend:5352/source/target_project/target_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -795,18 +796,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '299'
+      - '301'
     body:
       encoding: UTF-8
       string: |
-        <directory name="target_package" rev="8" vrev="8" srcmd5="06416a9df56262746245459a2a2dda79">
-          <entry name="_config" md5="c5e56d3469b4098fe11366062f8c523d" size="58" mtime="1684410600"/>
+        <directory name="target_package" rev="10" vrev="10" srcmd5="7251f5d682a3fe94ce35c4d19c108a77">
+          <entry name="_config" md5="ecbb6430dad2ff975c25d01f137456f2" size="77" mtime="1684497336"/>
           <entry name="somefile.txt" md5="11a31b90d280a13710401556a3256e44" size="23" mtime="1677507608"/>
         </directory>
-  recorded_at: Thu, 18 May 2023 11:50:01 GMT
+  recorded_at: Fri, 19 May 2023 11:55:37 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/target_project/target_package
+    uri: http://backend:5352/source/target_project/target_package?expand=1
     body:
       encoding: US-ASCII
       string: ''
@@ -829,13 +830,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '299'
+      - '301'
     body:
       encoding: UTF-8
       string: |
-        <directory name="target_package" rev="8" vrev="8" srcmd5="06416a9df56262746245459a2a2dda79">
-          <entry name="_config" md5="c5e56d3469b4098fe11366062f8c523d" size="58" mtime="1684410600"/>
+        <directory name="target_package" rev="10" vrev="10" srcmd5="7251f5d682a3fe94ce35c4d19c108a77">
+          <entry name="_config" md5="ecbb6430dad2ff975c25d01f137456f2" size="77" mtime="1684497336"/>
           <entry name="somefile.txt" md5="11a31b90d280a13710401556a3256e44" size="23" mtime="1677507608"/>
         </directory>
-  recorded_at: Thu, 18 May 2023 11:50:01 GMT
+  recorded_at: Fri, 19 May 2023 11:55:37 GMT
 recorded_with: VCR 6.1.0


### PR DESCRIPTION

![Screenshot from 2023-05-18 11-29-31](https://github.com/openSUSE/open-build-service/assets/114928900/7bb814c0-091a-429e-9856-5e3d3bc011fa)


Displays links to the source and target files inline with the git range information. I wanted to include anchors for the lines that the range is referring to, but as far as I can tell codemirror doesn't have a simple way of having line ids in html.

To verify this feature:
- Create a request with a diff
- Open changes tab in the beta view
- Click the new icons in the range lines