### PR TITLE
Request tab visibility helper

### DIFF
--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -1,4 +1,5 @@
 class Webui::RequestController < Webui::WebuiController
+  helper 'webui/request'
   helper 'webui/package'
 
   before_action :require_login,
@@ -306,13 +307,13 @@ class Webui::RequestController < Webui::WebuiController
   end
 
   def changes
-    redirect_to request_show_path(params[:number], params[:request_action_id]) unless @action[:type].in?(@actions_for_diff)
+    redirect_to request_show_path(params[:number], params[:request_action_id]) unless ApplicationController.helpers.request_action_tab_visibility(@action, 'changes')
 
     @active_tab = 'changes'
   end
 
   def mentioned_issues
-    redirect_to request_show_path(params[:number], params[:request_action_id]) unless @action[:type].in?(@actions_for_diff)
+    redirect_to request_show_path(params[:number], params[:request_action_id]) unless ApplicationController.helpers.request_action_tab_visibility(@action, 'mentioned_issues')
 
     @active_tab = 'mentioned_issues'
   end
@@ -561,7 +562,6 @@ class Webui::RequestController < Webui::WebuiController
 
     # Handling build results
     @staging_project = @bs_request.staging_project.name unless @bs_request.staging_project_id.nil?
-    @actions_for_diff = [:submit, :delete, :maintenance_incident, :maintenance_release]
 
     handle_notification
   end

--- a/src/api/app/helpers/webui/request_helper.rb
+++ b/src/api/app/helpers/webui/request_helper.rb
@@ -203,6 +203,8 @@ module Webui::RequestHelper
   # Handle tabs visibility
   def request_action_tab_visibility(action, tab_name)
     case tab_name
+    when 'build_results', 'rpm_lint'
+      return action[:sprj] || action[:spkg]
     when 'changes', 'mentioned_issues'
       return action[:type].in?([:submit, :delete, :maintenance_incident, :maintenance_release])
     end

--- a/src/api/app/helpers/webui/request_helper.rb
+++ b/src/api/app/helpers/webui/request_helper.rb
@@ -199,4 +199,12 @@ module Webui::RequestHelper
       request_show_path(parameters)
     end
   end
+
+  # Handle tabs visibility
+  def request_action_tab_visibility(action, tab_name)
+    case tab_name
+    when 'changes', 'mentioned_issues'
+      return action[:type].in?([:submit, :delete, :maintenance_incident, :maintenance_release])
+    end
+  end
 end

--- a/src/api/app/helpers/webui/request_helper.rb
+++ b/src/api/app/helpers/webui/request_helper.rb
@@ -204,9 +204,9 @@ module Webui::RequestHelper
   def request_action_tab_visibility(action, tab_name)
     case tab_name
     when 'build_results', 'rpm_lint'
-      return action[:sprj] || action[:spkg]
+      action[:sprj] || action[:spkg]
     when 'changes', 'mentioned_issues'
-      return action[:type].in?([:submit, :delete, :maintenance_incident, :maintenance_release])
+      action[:type].in?([:submit, :delete, :maintenance_incident, :maintenance_release])
     end
   end
 end

--- a/src/api/app/views/webui/request/_request_tabs.html.haml
+++ b/src/api/app/views/webui/request/_request_tabs.html.haml
@@ -10,11 +10,11 @@
       %li.nav-item.scrollable-tab-link
         = link_to('RPM Lint', request_rpm_lint_path(bs_request.number, actions_count > 1 ? active_action : nil),
                   class: "nav-link text-nowrap #{active_tab == 'rpm_lint' ? 'active' : ''}")
-    - if action[:type].in?(actions_for_diff)
+    - if request_action_tab_visibility(action, 'changes')
       %li.nav-item.scrollable-tab-link
         = link_to('Changes', request_changes_path(bs_request.number, actions_count > 1 ? active_action : nil),
                   class: "nav-link text-nowrap #{active_tab == 'changes' ? 'active' : ''}")
-    - if action[:type].in?(actions_for_diff)
+    - if request_action_tab_visibility(action, 'mentioned_issues')
       %li.nav-item.scrollable-tab-link
         = link_to(request_mentioned_issues_path(bs_request.number, actions_count > 1 ? active_action : nil),
                   class: "nav-link text-nowrap #{active_tab == 'mentioned_issues' ? 'active' : ''}") do

--- a/src/api/app/views/webui/request/_request_tabs.html.haml
+++ b/src/api/app/views/webui/request/_request_tabs.html.haml
@@ -3,10 +3,11 @@
     %li.nav-item.scrollable-tab-link
       = link_to('Conversation', request_show_path(bs_request.number, actions_count > 1 ? active_action : nil),
                 class: "nav-link text-nowrap #{active_tab == 'conversation' ? 'active' : ''}")
-    - if action[:sprj] || action[:spkg]
+    - if request_action_tab_visibility(action, 'build_results')
       %li.nav-item.scrollable-tab-link.active
         = link_to('Build Results', request_build_results_path(bs_request.number, actions_count > 1 ? active_action : nil),
                   class: "nav-link text-nowrap #{active_tab == 'build_results' ? 'active' : ''}")
+    - if request_action_tab_visibility(action, 'rpm_lint')
       %li.nav-item.scrollable-tab-link
         = link_to('RPM Lint', request_rpm_lint_path(bs_request.number, actions_count > 1 ? active_action : nil),
                   class: "nav-link text-nowrap #{active_tab == 'rpm_lint' ? 'active' : ''}")

--- a/src/api/app/views/webui/request/beta_show.html.haml
+++ b/src/api/app/views/webui/request/beta_show.html.haml
@@ -12,8 +12,8 @@
                   prev_action: @prev_action, next_action: @next_action, supported_actions: @supported_actions,
                   diff_to_superseded_id: @diff_to_superseded_id, diff_limit: @diff_limit, page_name: '' }
     = render partial: 'request_tabs',
-        locals: { actions_for_diff: @actions_for_diff, bs_request: @bs_request, action: @action, issues: @issues,
-                  active_action: @active_action, actions_count: @supported_actions.count, active_tab: @active_tab }
+        locals: { bs_request: @bs_request, action: @action, issues: @issues, active_action: @active_action,
+                  actions_count: @supported_actions.count, active_tab: @active_tab }
     .container.p-4
       .row
         .col-md-12

--- a/src/api/app/views/webui/request/build_results.html.haml
+++ b/src/api/app/views/webui/request/build_results.html.haml
@@ -10,8 +10,8 @@
                   prev_action: @prev_action, next_action: @next_action, supported_actions: @supported_actions,
                   diff_to_superseded_id: @diff_to_superseded_id, diff_limit: @diff_limit, page_name: 'request_build_results' }
     = render partial: 'request_tabs',
-        locals: { actions_for_diff: @actions_for_diff, bs_request: @bs_request, action: @action, issues: @issues,
-                  active_action: @active_action, actions_count: @supported_actions.count, active_tab: @active_tab }
+        locals: { bs_request: @bs_request, action: @action, issues: @issues, active_action: @active_action,
+                  actions_count: @supported_actions.count, active_tab: @active_tab }
     .container.p-4
       - if @buildable
         .build-results-content{ data: @ajax_data }

--- a/src/api/app/views/webui/request/changes.html.haml
+++ b/src/api/app/views/webui/request/changes.html.haml
@@ -10,8 +10,8 @@
                   prev_action: @prev_action, next_action: @next_action, supported_actions: @supported_actions,
                   diff_to_superseded_id: @diff_to_superseded_id, diff_limit: @diff_limit, page_name: 'request_changes' }
     = render partial: 'request_tabs',
-        locals: { actions_for_diff: @actions_for_diff, bs_request: @bs_request, action: @action, issues: @issues,
-                  active_action: @active_action, actions_count: @supported_actions.count, active_tab: @active_tab }
+        locals: { bs_request: @bs_request, action: @action, issues: @issues, active_action: @active_action,
+                  actions_count: @supported_actions.count, active_tab: @active_tab }
     .container.p-4
       .tab-content.sourcediff
         = render SourcediffComponent.new(bs_request: @bs_request, action: @action, index: 0)

--- a/src/api/app/views/webui/request/mentioned_issues.html.haml
+++ b/src/api/app/views/webui/request/mentioned_issues.html.haml
@@ -10,8 +10,8 @@
                   prev_action: @prev_action, next_action: @next_action, supported_actions: @supported_actions,
                   diff_to_superseded_id: @diff_to_superseded_id, diff_limit: @diff_limit, page_name: 'request_mentioned_issues' }
     = render partial: 'request_tabs',
-        locals: { actions_for_diff: @actions_for_diff, bs_request: @bs_request, action: @action, issues: @issues,
-                  active_action: @active_action, actions_count: @supported_actions.count, active_tab: @active_tab }
+        locals: { bs_request: @bs_request, action: @action, issues: @issues, active_action: @active_action,
+                  actions_count: @supported_actions.count, active_tab: @active_tab }
     .container.p-4
       - if @issues.empty?
         %p No issues are mentioned for this request action.

--- a/src/api/app/views/webui/request/rpm_lint.html.haml
+++ b/src/api/app/views/webui/request/rpm_lint.html.haml
@@ -10,8 +10,8 @@
                   prev_action: @prev_action, next_action: @next_action, supported_actions: @supported_actions,
                   diff_to_superseded_id: @diff_to_superseded_id, diff_limit: @diff_limit, page_name: 'request_rpm_lint' }
     = render partial: 'request_tabs',
-        locals: { actions_for_diff: @actions_for_diff, bs_request: @bs_request, action: @action, issues: @issues,
-                  active_action: @active_action, actions_count: @supported_actions.count, active_tab: @active_tab }
+        locals: { bs_request: @bs_request, action: @action, issues: @issues, active_action: @active_action,
+                  actions_count: @supported_actions.count, active_tab: @active_tab }
     .container.p-4
       - if @action[:spkg]
         .rpm-lint-content{ data: @ajax_data }


### PR DESCRIPTION
Instead of passing around an array of `action[:type]`s only to decide whether or not to show a request action tab, let an helper compute the tab visibility instead.
This PR is a refactoring in order to centralize visibility checks, then adding more complexity to the conditions as per https://github.com/openSUSE/open-build-service/pull/14347