### PR TITLE
Revert "Use fuubar for rubocop progress report"

### DIFF
--- a/src/api/Rakefile
+++ b/src/api/Rakefile
@@ -14,7 +14,7 @@ unless Rails.env.production?
   require 'haml_lint/rake_task'
 
   RuboCop::RakeTask.new(:rubocop) do |task|
-    task.options = ['-D', '-F', '--fail-level', 'convention', '--format', 'fuubar']
+    task.options = ['-D', '-F', '--fail-level', 'convention']
   end
 
   HamlLint::RakeTask.new

--- a/src/api/lib/tasks/dev/lint.rake
+++ b/src/api/lib/tasks/dev/lint.rake
@@ -29,13 +29,13 @@ namespace :dev do
 
       desc 'Run the ruby linter in rails'
       task :rails do
-        sh 'rubocop', '--fail-fast', '--display-style-guide', '--fail-level', 'convention', '--ignore_parent_exclusion', '--format', 'fuubar'
+        sh 'rubocop', '--fail-fast', '--display-style-guide', '--fail-level', 'convention', '--ignore_parent_exclusion'
       end
 
       desc 'Run the ruby linter in root'
       task :root do
         Dir.chdir('../..') do
-          sh 'rubocop', '--fail-fast', '--display-style-guide', '--fail-level', 'convention', '--format', 'fuubar'
+          sh 'rubocop', '--fail-fast', '--display-style-guide', '--fail-level', 'convention'
         end
       end
 


### PR DESCRIPTION
Reverts openSUSE/open-build-service#14334

On CircleCI there are some scrolling issues that makes harder to get to the point of the issues. We'll fix the issues with fuubar later