### PR TITLE
Cover another case of incident request

### DIFF
--- a/src/api/lib/tasks/dev/requests.rake
+++ b/src/api/lib/tasks/dev/requests.rake
@@ -82,7 +82,7 @@ namespace :dev do
 
       # Current devel package
       servers_project = Project.find_by(name: 'servers') || create(:project, name: 'servers')
-      apache2_servers = Package.find_by_project_and_name(servers_project.name, 'apache2') || create(:package, project: servers_project, name: 'apache2')
+      apache2_servers = Package.find_by_project_and_name(servers_project.name, 'apache2') || create(:package_with_file, project: servers_project, name: 'apache2')
 
       # Future devel package (source)
       # source_project -> home:Admin:branches:openSUSE:Factory

--- a/src/api/lib/tasks/dev/test_data/maintenance.rb
+++ b/src/api/lib/tasks/dev/test_data/maintenance.rb
@@ -49,26 +49,31 @@ module TestData
              commit_user: admin)
     end
 
-    def create_request_with_incident_actions(update_project_branch_name:, maintenance_project:, package_names:, update_project_names:, patchinfo: false)
+    def create_request_with_incident_actions(source_project_name:, source_package_names:, target_project_name:, target_releaseproject_names:, patchinfo: false)
       iggy = User.find_by(login: 'Iggy')
       bs_request_actions = []
 
       iggy.run_as do
-        package_names.each do |package_name|
-          update_project_names.each do |update_project_name|
+        source_package_names.each do |source_package_name|
+          target_releaseproject_names.each do |target_releaseproject_name|
+            # TODO: find a better way to find out if the request comes from a branched project or and official project
+            # i.e. 'cacti.openSUSE_Leap_15.4_Update'
+            package_name = source_package_name
+            package_name += ".#{target_releaseproject_name.tr(':', '_')}" if source_project_name.starts_with?('home:')
+
             bs_request_actions << create(:bs_request_action_maintenance_incident,
-                                         source_project: update_project_branch_name,
-                                         source_package: "#{package_name}.#{update_project_name.tr(':', '_')}", # i.e. 'cacti.openSUSE_Leap_15.4_Update'
-                                         target_project: maintenance_project,
-                                         target_releaseproject: update_project_name)
+                                         source_project: source_project_name,
+                                         source_package: package_name,
+                                         target_project: target_project_name,
+                                         target_releaseproject: target_releaseproject_name)
           end
         end
 
         if patchinfo
           bs_request_actions << create(:bs_request_action_maintenance_incident,
-                                       source_project: update_project_branch_name,
+                                       source_project: source_project_name,
                                        source_package: 'patchinfo',
-                                       target_project: maintenance_project)
+                                       target_project: target_project_name)
         end
       end
 
@@ -143,10 +148,10 @@ module TestData
       # Create the first incident request (one action; not accepted; no patchinfo)
       update_project_branch = mimic_mbranch('bash')
       add_changes_to_update_project_branch(update_project_branch)
-      create_request_with_incident_actions(update_project_branch_name: update_project_branch.name,
-                                           maintenance_project: maintenance_project,
-                                           package_names: ['bash'],
-                                           update_project_names: [update_project1.name],
+      create_request_with_incident_actions(source_project_name: update_project_branch.name,
+                                           target_project_name: maintenance_project,
+                                           source_package_names: ['bash'],
+                                           target_releaseproject_names: [update_project1.name],
                                            patchinfo: false)
 
       update_project_branch = mimic_mbranch('cacti')
@@ -156,17 +161,17 @@ module TestData
       mimic_patchinfo(update_project_branch.name)
 
       # Create the second incident request (many actions; not accepted; with patchinfo)
-      create_request_with_incident_actions(update_project_branch_name: update_project_branch.name,
-                                           maintenance_project: maintenance_project,
-                                           package_names: ['cacti', 'cacti-spine'],
-                                           update_project_names: [update_project1.name, update_project2.name],
+      create_request_with_incident_actions(source_project_name: update_project_branch.name,
+                                           target_project_name: maintenance_project,
+                                           source_package_names: ['cacti', 'cacti-spine'],
+                                           target_releaseproject_names: [update_project1.name, update_project2.name],
                                            patchinfo: true)
 
       # Create the third incident request (many actions; with patchinfo)
-      bs_request = create_request_with_incident_actions(update_project_branch_name: update_project_branch.name,
-                                                        maintenance_project: maintenance_project,
-                                                        package_names: ['cacti', 'cacti-spine'],
-                                                        update_project_names: [update_project1.name, update_project2.name],
+      bs_request = create_request_with_incident_actions(source_project_name: update_project_branch.name,
+                                                        target_project_name: maintenance_project,
+                                                        source_package_names: ['cacti', 'cacti-spine'],
+                                                        target_releaseproject_names: [update_project1.name, update_project2.name],
                                                         patchinfo: true)
       # Accept the last incident request
       admin = User.get_default_admin

--- a/src/api/lib/tasks/dev/test_data/maintenance.rb
+++ b/src/api/lib/tasks/dev/test_data/maintenance.rb
@@ -177,6 +177,14 @@ module TestData
       admin = User.get_default_admin
       User.session = admin
       bs_request.change_state(newstate: 'accepted', force: true, user: admin.login, comment: 'Accepted by admin')
+
+      # Open a request from a package that is not branched, but developed on an "official" project.
+      # Simulate `osc maintenancerequest servers apache2 openSUSE:Leap:15.4:Update`
+      create_request_with_incident_actions(source_project_name: 'servers',
+                                           target_project_name: maintenance_project.name,
+                                           source_package_names: ['apache2'],
+                                           target_releaseproject_names: [update_project1.name],
+                                           patchinfo: false)
     end
   end
 end


### PR DESCRIPTION
The request doesn't come from a user's branched package but from a package which is "officially" developed on a specific project.

**Reviewing Tips**

Run `bundle exec rake dev:test_data:create` locally. You should see an incident request with number 14: many actions, with patchinfo, accepted