### PR TITLE
Disallow deleting and replying to deleted comments

### DIFF
--- a/src/api/app/components/bs_request_comment_component.html.haml
+++ b/src/api/app/components/bs_request_comment_component.html.haml
@@ -42,7 +42,7 @@
          comment: comment, commentable: commentable, element_suffix: "edit_#{comment.id}", has_cancel: true })
 
   -# This should be refactored to avoid relying on global state
-  - if User.session && !comment.user.is_nobody? # rubocop:disable ViewComponent/AvoidGlobalState
+  - if policy(comment).reply?
     .mb-2
       = link_to("#reply_form_of_#{comment.id}", id: "reply_button_of_#{comment.id}", 'data-bs-toggle': 'collapse',
                 class: 'font-italic small collapsed') do

--- a/src/api/app/components/bs_request_comment_component.html.haml
+++ b/src/api/app/components/bs_request_comment_component.html.haml
@@ -42,7 +42,7 @@
          comment: comment, commentable: commentable, element_suffix: "edit_#{comment.id}", has_cancel: true })
 
   -# This should be refactored to avoid relying on global state
-  - if User.session # rubocop:disable ViewComponent/AvoidGlobalState
+  - if User.session && !comment.user.is_nobody? # rubocop:disable ViewComponent/AvoidGlobalState
     .mb-2
       = link_to("#reply_form_of_#{comment.id}", id: "reply_button_of_#{comment.id}", 'data-bs-toggle': 'collapse',
                 class: 'font-italic small collapsed') do

--- a/src/api/app/policies/comment_policy.rb
+++ b/src/api/app/policies/comment_policy.rb
@@ -4,12 +4,13 @@ class CommentPolicy < ApplicationPolicy
   end
 
   def destroy?
-    return false if user.blank?
+    # Can't destroy comments without being logged in or a comment that was already deleted (ie. Comment#user is nobody)
+    return false if user.blank? || record.user.is_nobody?
     # Admins can always delete all comments
     return true if user.is_admin?
 
-    # Users can always delete their own comments - or if the user of the comment is deleted
-    return true if user == record.user || record.user.is_nobody?
+    # Users can always delete their own comments
+    return true if user == record.user
 
     case record.commentable_type
     when 'Package'

--- a/src/api/app/policies/comment_policy.rb
+++ b/src/api/app/policies/comment_policy.rb
@@ -29,8 +29,6 @@ class CommentPolicy < ApplicationPolicy
   end
 
   def reply?
-    return false if user.blank? || user.is_nobody? || record.user.is_nobody?
-
-    true
+    !(user.blank? || user.is_nobody? || record.user.is_nobody?)
   end
 end

--- a/src/api/app/policies/comment_policy.rb
+++ b/src/api/app/policies/comment_policy.rb
@@ -27,4 +27,10 @@ class CommentPolicy < ApplicationPolicy
 
     user == record.user
   end
+
+  def reply?
+    return false if user.blank? || user.is_nobody? || record.user.is_nobody?
+
+    true
+  end
 end

--- a/src/api/app/views/webui/comment/_reply.html.haml
+++ b/src/api/app/views/webui/comment/_reply.html.haml
@@ -1,5 +1,5 @@
 %ul.list-inline
-  - if User.session && !comment.user.is_nobody?
+  - if policy(comment).reply?
     %li.list-inline-item
       %button.btn.btn-outline-success.collapsed{ id: "reply_button_of_#{comment.id}",
       data: { 'bs-toggle': 'collapse', 'bs-target': "#reply_form_of_#{comment.id}" } }
@@ -15,11 +15,11 @@
       = link_to('#', data: { 'bs-toggle': 'modal', 'bs-target': "#delete-comment-modal-#{comment.id}" },
                 class: 'delete_link btn btn-outline-danger', title: 'Delete comment') do
         Delete
-- if User.session && !comment.user.is_nobody?
+- if policy(comment).reply?
   .collapse{ id: "reply_form_of_#{comment.id}" }
     = render(partial: 'webui/comment/comment_field', locals: { form_method: :post,
      comment: comment.children.new, commentable: commentable, element_suffix: "reply_for_#{comment.id}", has_cancel: true })
-  - if policy(comment).update?
-    .collapse{ id: "edit_form_of_#{comment.id}" }
-      = render(partial: 'webui/comment/comment_field', locals: { form_method: :put,
-       comment: comment, commentable: commentable, element_suffix: "edit_#{comment.id}", has_cancel: true })
+- if policy(comment).update?
+  .collapse{ id: "edit_form_of_#{comment.id}" }
+    = render(partial: 'webui/comment/comment_field', locals: { form_method: :put,
+     comment: comment, commentable: commentable, element_suffix: "edit_#{comment.id}", has_cancel: true })

--- a/src/api/app/views/webui/comment/_reply.html.haml
+++ b/src/api/app/views/webui/comment/_reply.html.haml
@@ -1,5 +1,5 @@
 %ul.list-inline
-  - if User.session
+  - if User.session && !comment.user.is_nobody?
     %li.list-inline-item
       %button.btn.btn-outline-success.collapsed{ id: "reply_button_of_#{comment.id}",
       data: { 'bs-toggle': 'collapse', 'bs-target': "#reply_form_of_#{comment.id}" } }
@@ -15,7 +15,7 @@
       = link_to('#', data: { 'bs-toggle': 'modal', 'bs-target': "#delete-comment-modal-#{comment.id}" },
                 class: 'delete_link btn btn-outline-danger', title: 'Delete comment') do
         Delete
-- if User.session
+- if User.session && !comment.user.is_nobody?
   .collapse{ id: "reply_form_of_#{comment.id}" }
     = render(partial: 'webui/comment/comment_field', locals: { form_method: :post,
      comment: comment.children.new, commentable: commentable, element_suffix: "reply_for_#{comment.id}", has_cancel: true })

--- a/src/api/spec/policies/comment_policy_spec.rb
+++ b/src/api/spec/policies/comment_policy_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe CommentPolicy do
   let(:request) { create(:bs_request_with_submit_action, target_package: package) }
   let(:comment_on_package) { create(:comment_package, commentable: package, user: comment_author) }
   let(:comment_on_request) { create(:comment_request, commentable: request, user: comment_author) }
-  let(:comment_deleted_user) { create(:comment_project, commentable: project, user: anonymous_user) }
+  let(:comment_deleted) { create(:comment_project, commentable: project, user: anonymous_user) }
 
   subject { CommentPolicy }
 
@@ -31,8 +31,16 @@ RSpec.describe CommentPolicy do
       expect(subject).to permit(comment_author, comment)
     end
 
-    it 'Logged users can destroy comments by deleted users' do
-      expect(subject).to permit(comment_author, comment_deleted_user)
+    it 'Anonymous users cannot destroy already deleted comments' do
+      expect(subject).not_to permit(nil, comment_deleted)
+    end
+
+    it 'Logged users cannot destroy already deleted comments' do
+      expect(subject).not_to permit(comment_author, comment_deleted)
+    end
+
+    it 'Admin cannot destroy already deleted comments' do
+      expect(subject).not_to permit(admin_user, comment_deleted)
     end
 
     it 'User cannot destroy comments of other user' do
@@ -90,17 +98,48 @@ RSpec.describe CommentPolicy do
       expect(subject).not_to permit(other_user, comment)
     end
 
-    context 'with an anonymous user comment' do
-      it 'a normal user is unable to update an anonymous user comment' do
-        expect(subject).not_to permit(other_user, comment_deleted_user)
+    context 'with a deleted comment' do
+      it 'a normal user is unable to update a deleted comment' do
+        expect(subject).not_to permit(other_user, comment_deleted)
       end
 
-      it 'an admin user is unable to update an anonymous user comment' do
-        expect(subject).not_to permit(admin_user, comment_deleted_user)
+      it 'an admin user is unable to update a deleted comment' do
+        expect(subject).not_to permit(admin_user, comment_deleted)
       end
 
-      it 'an anonymous user is unable to update an anonymous user comment' do
-        expect(subject).not_to permit(anonymous_user, comment_deleted_user)
+      it 'an anonymous user is unable to update a deleted comment' do
+        expect(subject).not_to permit(anonymous_user, comment_deleted)
+      end
+    end
+  end
+  # rubocop:enable RSpec/RepeatedExample
+
+  # rubocop:disable RSpec/RepeatedExample
+  # This cop is currently not recognizing the permissions block as separate test
+  permissions :reply? do
+    it 'an anonymous user cannot reply to comments' do
+      expect(subject).not_to permit(nil, comment)
+    end
+
+    it 'an admin user can reply to other comments' do
+      expect(subject).to permit(admin_user, comment)
+    end
+
+    it 'a user can reply to comments' do
+      expect(subject).to permit(comment_author, comment)
+    end
+
+    context 'with a deleted comment' do
+      it 'a normal user is unable to reply to a deleted comment' do
+        expect(subject).not_to permit(other_user, comment_deleted)
+      end
+
+      it 'an admin user is unable to reply to a deleted comment' do
+        expect(subject).not_to permit(admin_user, comment_deleted)
+      end
+
+      it 'an anonymous user is unable to reply to a deleted comment' do
+        expect(subject).not_to permit(anonymous_user, comment_deleted)
       end
     end
   end


### PR DESCRIPTION
To verify:
- Create a comment
- Reply to the comment
- Delete the root comment
- You will no longer be able to reply to or delete the root comment even as admin