### PR TITLE
Validate supported filter for event on workflow execution

### DIFF
--- a/src/api/app/validators/workflow_filters_validator.rb
+++ b/src/api/app/validators/workflow_filters_validator.rb
@@ -27,8 +27,6 @@ class WorkflowFiltersValidator < ActiveModel::Validator
                            "#{unsupported_filters.keys.to_sentence} are unsupported")
     end
 
-    @workflow.errors.add(:filters, 'for branches are not supported for the tag push event') if unsupported_filters_for_event?
-
     return if unsupported_filter_values.blank?
 
     @workflow.errors.add(:filters, "#{unsupported_filter_values.to_sentence} have unsupported values, " \
@@ -57,10 +55,5 @@ class WorkflowFiltersValidator < ActiveModel::Validator
       end
       unsupported_filter_values
     end
-  end
-
-  def unsupported_filters_for_event?
-    # Tags do not have a reference to a branch, they are referring to a commit
-    @workflow_instructions[:filters][:branches].present? && @workflow.scm_webhook.tag_push_event?
   end
 end

--- a/src/api/spec/models/workflow_spec.rb
+++ b/src/api/spec/models/workflow_spec.rb
@@ -328,6 +328,28 @@ RSpec.describe Workflow, vcr: true do
         expect(subject.steps.first).to have_received(:call)
       end
     end
+
+    context 'when the webhook event is not supported by the branches filter' do
+      let(:yaml) do
+        { 'steps' => [{ 'trigger_services' => { 'project' => 'test-project', 'package' => 'test-package' } }],
+          'filters' => { 'branches' => { 'only' => ['develop'] } } }
+      end
+
+      let(:extractor_payload) do
+        {
+          scm: 'gitlab',
+          event: 'Tag Push Hook',
+          ref: 'refs/tags/release_abc',
+          target_branch: '9e0ea1fd99c9000cbb8b8c9d28763d0ddace0b65'
+        }
+      end
+
+      it 'is not valid and has an error message' do
+        subject.valid?(:call)
+        expect(subject.errors.full_messages.to_sentence).to eq('Filters for branches are not supported for the tag push event. ' \
+                                                               "Documentation for filters: #{WorkflowFiltersValidator::DOCUMENTATION_LINK}")
+      end
+    end
   end
 
   describe '#steps' do

--- a/src/api/spec/validators/workflow_filters_validator_spec.rb
+++ b/src/api/spec/validators/workflow_filters_validator_spec.rb
@@ -67,16 +67,5 @@ RSpec.describe WorkflowFiltersValidator do
 
       it { is_expected.to be_valid }
     end
-
-    context 'with a branches filter for a tag push event' do
-      let(:workflow_instructions) { { filters: { event: 'tag_push', branches: { only: [] } } } }
-      let(:scm_webhook) { SCMWebhook.new(payload: { scm: 'github', event: 'push', ref: 'refs/tags/1.0.0' }) }
-
-      it 'is not valid and has an error message' do
-        subject.valid?
-        expect(subject.errors.full_messages.to_sentence).to eq('Filters for branches are not supported for the tag push event and ' \
-                                                               "Documentation for filters: #{described_class::DOCUMENTATION_LINK}")
-      end
-    end
   end
 end


### PR DESCRIPTION
Right now we have an intermix we the validations for a SCM
workflow. When we intialize the `Workflow` class we run
the `WorkflowFiltersValidator`. This validator makes sure that
all filters in the `Workflow` are valid (so basically that every
filter definition in the `workflow.yml` file is correct).

The problem right now is, we cannot check in this validator that
the current webhook event is supported by the filters (in this
case the branches filter for the `tag_push`) since the class is
always intialized no matter if it is meant for the currently incoming
webhook.

If a certain webhook event is meant for the workflow is checked
when we execute the workflow (`Workflow.call`). Here we check
if the event matches the event filter etc.
Therefore we also have to check here if the current event supports
the filters or not.

An issue occurs currently when there a multiple workflow definitions
in the same `workflow.yml` file. For example:

```
branch:
  steps:
    - branch_package:
        source_project: home:krauselukas
        source_package: hello_world
        target_project: home:krauselukas:test
  filters:
    event: push
    branches:
      only:
        - main
release:
  steps:
    - trigger_services:
        project: home:krauselukas
        package: hello_world
  filters:
    event: tag_push
```

The first workflow is for the `push` event, which supports
the `branches` filter. The second for `tag_push` doesn't.
This will fail, when the event is a `tag_push` since the
`WorkflowFiltersValidator` is called when intializing the workflow
and checks the current webhook event against all filters (which in
this example also includes a branches filter).

With the current architecture we have to validate for this
when the workflow is executed.