### PR TITLE
Support maintenance release actions in beta

### DIFF
--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -480,7 +480,7 @@ class Webui::RequestController < Webui::WebuiController
 
   def set_supported_actions
     # Change supported_actions below into actions here when all actions are supported
-    @supported_actions = @actions.where(type: [:add_role, :change_devel, :delete, :submit, :maintenance_incident])
+    @supported_actions = @actions.where(type: [:add_role, :change_devel, :delete, :submit, :maintenance_incident, :maintenance_release])
   end
 
   def set_action_id

--- a/src/api/app/helpers/webui/request_helper.rb
+++ b/src/api/app/helpers/webui/request_helper.rb
@@ -174,6 +174,11 @@ module Webui::RequestHelper
                         source_container: project_or_package_link(source_project_hash),
                         target_container: project_or_package_link(project: action[:tprj], package: action[:tpkg], trim_to: nil)
                       }
+                    when :maintenance_release
+                      'Maintenance release %{source_container} to %{target_container}' % {
+                        source_container: project_or_package_link(source_project_hash),
+                        target_container: project_or_package_link(project: action[:tprj], package: action[:tpkg], trim_to: nil)
+                      }
                     else
                       description
                     end

--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -867,6 +867,11 @@ class BsRequest < ApplicationRecord
     bs_request_actions.where(type: 'maintenance_incident').any?
   end
 
+  # It is considered a "release request" if it has at least one maintenance_release action
+  def maintenance_release_request?
+    bs_request_actions.where(type: 'maintenance_release').any?
+  end
+
   def auto_accept
     # do not run for processed requests. Ignoring review on purpose since this
     # must also work when people do not react anymore

--- a/src/api/app/views/webui/request/_action_text.html.haml
+++ b/src/api/app/views/webui/request/_action_text.html.haml
@@ -31,6 +31,8 @@
           Set #{project_or_package_text(action.source_project, action.source_package)}
         - when 'maintenance_incident'
           Incident #{action.source_package}
+        - when 'maintenance_release'
+          Release #{action.source_package}
         - else
           = action.name
 
@@ -44,6 +46,8 @@
           as development package of #{action.target_project}/#{action.target_package}
         - when 'maintenance_incident'
           from #{action.source_project} to #{action.target_project}
+        - when 'maintenance_release'
+          from #{action.source_project} to #{action.target_project} / #{action.target_package}
         - else
           from #{project_or_package_text(action.source_project, action.source_package)}
     - if details

--- a/src/api/app/views/webui/request/_request_header.html.haml
+++ b/src/api/app/views/webui/request/_request_header.html.haml
@@ -56,6 +56,11 @@
       %li
         This is a
         %mark.text-light.bg-maintenance.text-nowrap.text Maintenance Incident
+    -# Maintenance Release Request
+    - if bs_request.maintenance_release_request?
+      %li
+        This is a
+        %mark.text-light.bg-maintenance.text-nowrap.text Maintenance Release
         request
   .mt-4
     -# action description, prev + dropdown select + next

--- a/src/api/app/views/webui/request/_request_tabs.html.haml
+++ b/src/api/app/views/webui/request/_request_tabs.html.haml
@@ -3,7 +3,7 @@
     %li.nav-item.scrollable-tab-link
       = link_to('Conversation', request_show_path(bs_request.number, actions_count > 1 ? active_action : nil),
                 class: "nav-link text-nowrap #{active_tab == 'conversation' ? 'active' : ''}")
-    - if (action[:sprj] || action[:spkg]) && !(action[:type] == :maintenance_incident && action[:spkg] == 'patchinfo')
+    - if (action[:sprj] || action[:spkg]) && !(action[:type].in?([:maintenance_incident, :maintenance_release]) && action[:spkg] == 'patchinfo')
       %li.nav-item.scrollable-tab-link.active
         = link_to('Build Results', request_build_results_path(bs_request.number, actions_count > 1 ? active_action : nil),
                   class: "nav-link text-nowrap #{active_tab == 'build_results' ? 'active' : ''}")


### PR DESCRIPTION
Adapt the beta request show view to display maintenance release requests.

**Before:**

![Screenshot 2023-05-25 at 19-22-19 Request 15 (new)](https://github.com/openSUSE/open-build-service/assets/2581944/2d8118ac-52d9-43e9-bf1a-05b1c3bba2f4)

**Now:**

- At the top of the page, it is highlighted that the request is a Maintenance Release Request.
- The names of the projects and packages are not trimmed.
- The dropdown's action text only displays the relevant information

![Screenshot 2023-05-25 at 19-21-07 Open Build Service](https://github.com/openSUSE/open-build-service/assets/2581944/a1d7dbcc-9730-4948-b549-030e8e4a4570)

![Screenshot 2023-05-25 at 19-21-20 Open Build Service](https://github.com/openSUSE/open-build-service/assets/2581944/b5375524-be9b-449b-aac4-bfeee5608ff8)


**Reviewing Tips**

Run `bundle exec rake dev:test_data:create` to set up all the data you need. Request with number 15 is a release one.

NOTE: specs will be covered in another PR.
