### PR TITLE
Handle non-existent project in sourcediff

### DIFF
--- a/src/api/app/components/sourcediff_component.rb
+++ b/src/api/app/components/sourcediff_component.rb
@@ -25,7 +25,7 @@ class SourcediffComponent < ApplicationComponent
 
   def source_package
     Package.get_by_project_and_name(@action[:sprj], @action[:spkg], { follow_multibuild: true })
-  rescue Package::UnknownObjectError
+  rescue Package::UnknownObjectError, Project::Errors::UnknownObjectError
   end
 
   def target_package
@@ -33,6 +33,6 @@ class SourcediffComponent < ApplicationComponent
     return nil unless @action[:tpkg]
 
     Package.get_by_project_and_name(@action[:tprj], @action[:tpkg], { follow_multibuild: true })
-  rescue Package::UnknownObjectError
+  rescue Package::UnknownObjectError, Project::Errors::UnknownObjectError
   end
 end


### PR DESCRIPTION
This crashes when for example the source project of a request gets deleted, after the request got accepted.

Fixes #14392

Similar to https://github.com/openSUSE/open-build-service/pull/14380