### PR TITLE
Cover keyinfo special cases

### DIFF
--- a/src/api/app/models/project/signing_key_gpg.rb
+++ b/src/api/app/models/project/signing_key_gpg.rb
@@ -15,10 +15,9 @@ class Project
 
     def initialize(project_name)
       keyinfo = Xmlhash.parse(key_info_for_project(project_name))
-      @origin = keyinfo['project']
-
       return if keyinfo['pubkey'].blank?
 
+      @origin = keyinfo['project'] || project_name
       @id = keyinfo['pubkey']['keyid']
       @user_id = keyinfo['pubkey']['userid']
       @algorithm = keyinfo['pubkey']['algo']

--- a/src/api/app/models/project/signing_key_ssl.rb
+++ b/src/api/app/models/project/signing_key_ssl.rb
@@ -18,10 +18,9 @@ class Project
 
     def initialize(project_name)
       keyinfo = Xmlhash.parse(key_info_for_project(project_name))
-      @origin = keyinfo['project']
-
       return if keyinfo['sslcert'].blank?
 
+      @origin = keyinfo['project'] || project_name
       @id = keyinfo['sslcert']['keyid']
       @serial = keyinfo['sslcert']['serial']
       @issuer = keyinfo['sslcert']['issuer']


### PR DESCRIPTION
Getting the project attribute from the backend may depend on the config in the signer wrapper script, better not expect it to be there always.