### PR TITLE
Make package_controller_spec test more reliable

### DIFF
--- a/src/api/spec/controllers/webui/package_controller_spec.rb
+++ b/src/api/spec/controllers/webui/package_controller_spec.rb
@@ -784,7 +784,7 @@ RSpec.describe Webui::PackageController, vcr: true do
         it { expect(assigns(:what_depends_on)).to eq(['apache2']) }
         it { expect(assigns(:status)).to eq('succeeded') }
         it { expect(assigns(:workerid)).to eq('42') }
-        it { expect(assigns(:buildtime)).to eq(1.hour.to_i) }
+        it { expect(assigns(:buildtime)).to be_within(1).of(1.hour.to_i) }
         it { expect(assigns(:package)).to eq(source_package) }
         it { expect(assigns(:package_name)).to eq("#{source_package}:multibuild-package") }
       end


### PR DESCRIPTION
https://app.circleci.com/pipelines/github/openSUSE/open-build-service/12481/workflows/8f0de2b1-88b2-4bc2-905a-e2ddf0c7f9b4/jobs/132665

failed with

    1) Webui::PackageController build logs GET #package_live_build_log with a multibuild package is expected to eq 3600
       Failure/Error: it { expect(assigns(:buildtime)).to eq(1.hour.to_i) }

       expected: 3600
            got: 3601

       (compared using ==)
     # ./spec/controllers/webui/package_controller_spec.rb:787:in `block (5 levels) in <top (required)>'