### PR TITLE
Deprecate `/build/.../_builddepinfo` POST API endpoint

### DIFF
--- a/src/api/public/apidocs-new/paths/build_project_name_repository_name_architecture_name_builddepinfo.yaml
+++ b/src/api/public/apidocs-new/paths/build_project_name_repository_name_architecture_name_builddepinfo.yaml
@@ -41,3 +41,12 @@ get:
       $ref: '../components/responses/unknown_project.yaml'
   tags:
     - Build
+
+post:
+  deprecated: true
+  summary: Show the build dependencies of packages that are part of the project.
+  description: |
+    This endpoint is exactly the same as
+    `GET /build/{project_name}/{repository_name}/{architecture_name}/{package_name}/_builddepinfo`, please use that one.
+  tags:
+    - Build


### PR DESCRIPTION
Even if this endpoint is somehow implemented in the backend, it is not tested nor used by `osc`.

### For reviewers

Access the [link](https://obs-reviewlab.opensuse.org/eduardoj-apidocs_newbuild_builddepinfo/apidocs-new/index.html#/Build/post_build__project_name___repository_name___architecture_name___builddepinfo) to the direct deprecated endpoint in the review app.