### PR TITLE
Document `POST /build/.../_buildinfo` endpoint with OpenAPI

### DIFF
--- a/src/api/public/apidocs-new/components/schemas/buildinfo.yaml
+++ b/src/api/public/apidocs-new/components/schemas/buildinfo.yaml
@@ -109,6 +109,16 @@ properties:
         example: 'https://download.opensuse.org/repositories/home:/enavarro_suse/openSUSE_Tumbleweed/'
         xml:
           attribute: true
+  expanddebug:
+    type: string
+    example: |
+      === meta deps expansion
+      expand args: rpm-build gcc-PIE
+      added rpm-build@openSUSE:Tumbleweed/dod because of (direct):rpm-build
+      added gcc-PIE@openSUSE:Tumbleweed/dod because of (direct):gcc-PIE
+      --- now doing normal dependencies
+      added glibc@openSUSE:Tumbleweed/dod because of rpm-build:libc.so.6(GLIBC_2.34)(64bit)
+      added glibc@openSUSE:Tumbleweed/dod because of rpm-build:libc.so.6(GLIBC_2.4)(64bit)
 
 xml:
   name: 'buildinfo'

--- a/src/api/public/apidocs-new/components/schemas/buildinfo.yaml
+++ b/src/api/public/apidocs-new/components/schemas/buildinfo.yaml
@@ -92,16 +92,23 @@ properties:
         xml:
           attribute: true
   path:
-    project:
-      type: string
-      example: 'home:Admin'
-      xml:
-        attribute: true
-    repository:
-      type: string
-      example: 'openSUSE_Tumbleweed'
-      xml:
-        attribute: true
+    type: object
+    properties:
+      project:
+        type: string
+        example: 'home:Admin'
+        xml:
+          attribute: true
+      repository:
+        type: string
+        example: 'openSUSE_Tumbleweed'
+        xml:
+          attribute: true
+      url:
+        type: string
+        example: 'https://download.opensuse.org/repositories/home:/enavarro_suse/openSUSE_Tumbleweed/'
+        xml:
+          attribute: true
 
 xml:
   name: 'buildinfo'

--- a/src/api/public/apidocs-new/paths/build_project_name_repository_name_architecture_name_package_name_buildinfo.yaml
+++ b/src/api/public/apidocs-new/paths/build_project_name_repository_name_architecture_name_package_name_buildinfo.yaml
@@ -1,5 +1,9 @@
 get:
-  description: This endpoint returns information about some specific artifact
+  summary: Return build information about a build description would produce.
+  description: |
+    Get build information using the default spec file.
+
+    To use other file than the default spec file, use this same endpoint path with the `POST` action.
   security:
     - basic_authentication: []
   parameters:
@@ -7,6 +11,22 @@ get:
     - $ref: '../components/parameters/repository_name.yaml'
     - $ref: '../components/parameters/architecture_name.yaml'
     - $ref: '../components/parameters/package_name.yaml'
+    - name: add
+      in: query
+      schema:
+        type: array
+        items:
+          type: string
+      description: Add a list of build dependencies (`BuildRequires`) to the build.
+      example:
+        - less
+        - vim
+    - name: debug
+      in: query
+      schema:
+        type: string
+      description: Set to `1` to add debug information about dependencies. This information is added inside an `expandeddebug` xml element.
+      example: 0
   responses:
     '200':
       description:

--- a/src/api/public/apidocs-new/paths/build_project_name_repository_name_architecture_name_package_name_buildinfo.yaml
+++ b/src/api/public/apidocs-new/paths/build_project_name_repository_name_architecture_name_package_name_buildinfo.yaml
@@ -52,3 +52,112 @@ get:
 
   tags:
     - Build
+
+post:
+  summary: Return build information about a build description would produce.
+  description: |
+    Get build information using the file passed in the request body.
+
+    Despite using the method `POST`, this endpoint doesn't alter any data.
+  security:
+    - basic_authentication: []
+  parameters:
+    - $ref: '../components/parameters/project_name.yaml'
+    - $ref: '../components/parameters/repository_name.yaml'
+    - $ref: '../components/parameters/architecture_name.yaml'
+    - in: path
+      name: package_name
+      schema:
+        type: string
+      required: true
+      description: |
+        Package name.
+
+        It can take the value `_repository`, if the designated package does not exist yet in the server.
+        This is useful for testing a build locally before committing a package.
+      examples:
+        Normal Package Name:
+          value: ctris
+        No Package Yet:
+          value: _repository
+    - name: add
+      in: query
+      schema:
+        type: array
+        items:
+          type: string
+      description: Add a list of build dependencies (`BuildRequires`) to the build.
+      example:
+        - less
+        - vim
+    - name: debug
+      in: query
+      schema:
+        type: string
+      description: Set to `1` to add debug information about dependencies. This information is added inside an `expandeddebug` xml element.
+      example: 0
+  requestBody:
+    description: A RPM specfile or a Debian "dsc" file.
+    required: true
+    content:
+      text/plain:
+        schema:
+          type: string
+        example: |
+          Name:       hello_world
+          Version:    1
+          Release:    1
+          Summary:    Most simple RPM package
+          License:    CC0-1.0
+
+          %build
+          cat > hello_world.sh <<EOF
+          #!/usr/bin/bash
+          echo Hello world
+          EOF
+
+          %install
+          mkdir -p %{buildroot}/usr/bin/
+          install -m 755 hello_world.sh %{buildroot}/usr/bin/hello_world.sh
+
+          %files
+          /usr/bin/hello_world.sh
+  responses:
+    '200':
+      description:
+        Returns the artifact building information.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/buildinfo.yaml'
+    '400':
+      description: |
+        Bad Request.
+
+        XML Schema used for body validation: [status.xsd](../schema/status.xsd)
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          example:
+            code: 400
+            origin: backend
+            details: '400 remote error: could not parse name in build description (spec) (http://backend:5252/build/home:Admin/openSUSE_Tumbleweed/x86_64/hello_world/_buildinfo)'
+            summary: 'remote error: could not parse name in build description (spec) (http://backend:5252/build/home:Admin/openSUSE_Tumbleweed/x86_64/hello_world/_buildinfo)'
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '404':
+      description: |
+        Error: Not Found
+
+        XML Schema used for body validation: [status.xsd](../schema/status.xsd)
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          example:
+            code: 'unknown_project'
+            summary: 'Project not found: 1'
+
+  tags:
+    - Build


### PR DESCRIPTION
### For reviewers

Access with this [link](https://obs-reviewlab.opensuse.org/eduardoj-apidocs_newpost_build_buildinfo/apidocs-new/index.html#/Build/post_build__project_name___repository_name___architecture_name___package_name___buildinfo) the documented endpoint in the review app.

