### PR TITLE
Remove operationId param from all endpoints

### DIFF
--- a/src/api/public/apidocs-new/paths/build_project_name_repository_name_architecture_name_package_name_buildinfo.yaml
+++ b/src/api/public/apidocs-new/paths/build_project_name_repository_name_architecture_name_package_name_buildinfo.yaml
@@ -1,6 +1,5 @@
 get:
   description: This endpoint returns information about some specific artifact
-  operationId: getBuildProjectRepositoryArchPackageBuildinfo
   security:
     - basic_authentication: []
   parameters:

--- a/src/api/public/apidocs-new/paths/build_project_name_repository_name_architecture_name_package_name_file_name.yaml
+++ b/src/api/public/apidocs-new/paths/build_project_name_repository_name_architecture_name_package_name_file_name.yaml
@@ -2,7 +2,6 @@ get:
   summary: Return a specific artifact file contents
   description: |
     Given a project, repository, architecture and package, retrieve the given file's content.
-  operationId: getBuildProjectRepositoryArchitecturePackageFile
   security:
     - basic_authentication: []
   parameters:
@@ -44,7 +43,6 @@ put:
     Given a project, repository, architecture and package, update the given file's content.
 
     This is for Admins only.
-  operationId: putBuildProjectRepositoryArchitecturePackageFile
   security:
     - basic_authentication: []
   parameters:

--- a/src/api/public/apidocs-new/paths/build_project_name_repository_name_architecture_name_package_name_file_name_view_fileinfo.yaml
+++ b/src/api/public/apidocs-new/paths/build_project_name_repository_name_architecture_name_package_name_file_name_view_fileinfo.yaml
@@ -2,7 +2,6 @@ get:
   summary: This endpoint returns details about an specific artifact
   description: |
     Given a project, repository, architecture and package, retrieve the given artifact's details.
-  operationId: getBuildProjectRepositoryArchitecturePackageFileViewFileinfo
   security:
     - basic_authentication: []
   parameters:

--- a/src/api/public/apidocs-new/paths/build_project_name_repository_name_architecture_name_package_name_history.yaml
+++ b/src/api/public/apidocs-new/paths/build_project_name_repository_name_architecture_name_package_name_history.yaml
@@ -1,6 +1,5 @@
 get:
   description: This endpoint returns the build history for a specific artifact
-  operationId: getBuildProjectRepositoryArchPackageHistory
   security:
     - basic_authentication: []
   parameters:

--- a/src/api/public/apidocs-new/paths/build_project_name_repository_name_architecture_name_package_name_log.yaml
+++ b/src/api/public/apidocs-new/paths/build_project_name_repository_name_architecture_name_package_name_log.yaml
@@ -1,6 +1,5 @@
 get:
   description: This endpoint returns the last log file for a specific build artifact
-  operationId: getBuildProjectRepositoryArchPackageLog
   security:
     - basic_authentication: []
   parameters:

--- a/src/api/public/apidocs-new/paths/build_project_name_repository_name_architecture_name_package_name_status.yaml
+++ b/src/api/public/apidocs-new/paths/build_project_name_repository_name_architecture_name_package_name_status.yaml
@@ -1,6 +1,5 @@
 get:
   description: This endpoint returns the building status for a specific artifact
-  operationId: getBuildProjectRepositoryArchPackageStatus
   security:
     - basic_authentication: []
   parameters:


### PR DESCRIPTION
It is not required to have an operationId for an endpoint, and if not provided, Swagger will create one from the path.