### PR TITLE
Start rolling out the new API documentation

### DIFF
--- a/src/api/config/routes/api_routes.rb
+++ b/src/api/config/routes/api_routes.rb
@@ -340,8 +340,9 @@ OBSApi::Application.routes.draw do
   end
 
   # this can be requested by non browsers (like HA proxies :)
-  get 'apidocs/:filename' => 'webui/apidocs#file', constraints: cons
   get 'apidocs-old/:filename' => 'webui/apidocs#file', constraints: cons
+  # Redirection to be removed, just to keep the legacy route reachable
+  get 'apidocs/:filename', to: redirect('/apidocs-old/%{filename}'), constraints: cons
 
   # spiders request this, not browsers
   controller 'webui/sitemaps' do

--- a/src/api/config/routes/api_routes.rb
+++ b/src/api/config/routes/api_routes.rb
@@ -340,7 +340,8 @@ OBSApi::Application.routes.draw do
   end
 
   # this can be requested by non browsers (like HA proxies :)
-  get 'apidocs/:filename' => 'webui/apidocs#file', constraints: cons, as: 'apidocs_file'
+  get 'apidocs/:filename' => 'webui/apidocs#file', constraints: cons
+  get 'apidocs-old/:filename' => 'webui/apidocs#file', constraints: cons
 
   # spiders request this, not browsers
   controller 'webui/sitemaps' do

--- a/src/api/config/routes/webui_routes.rb
+++ b/src/api/config/routes/webui_routes.rb
@@ -403,7 +403,10 @@ OBSApi::Application.routes.draw do
 
     ### /apidocs
     get 'apidocs', to: redirect('/apidocs/index')
-    get 'apidocs/(index)' => 'webui/apidocs#index', as: 'apidocs_index'
+    get 'apidocs/(index)' => 'webui/apidocs#index'
+    ### /apidocs-old
+    get 'apidocs-old', to: redirect('/apidocs-old/index')
+    get 'apidocs-old/(index)' => 'webui/apidocs#index', as: 'apidocs_index'
   end
 
   resources :staging_workflows, except: :index, controller: 'webui/staging/workflows', param: :workflow_project, constraints: cons do

--- a/src/api/config/routes/webui_routes.rb
+++ b/src/api/config/routes/webui_routes.rb
@@ -401,12 +401,14 @@ OBSApi::Application.routes.draw do
       end
     end
 
-    ### /apidocs
-    get 'apidocs', to: redirect('/apidocs/index')
-    get 'apidocs/(index)' => 'webui/apidocs#index'
     ### /apidocs-old
     get 'apidocs-old', to: redirect('/apidocs-old/index')
     get 'apidocs-old/(index)' => 'webui/apidocs#index', as: 'apidocs_index'
+
+    # Redirections to be removed, just to keep the legacy routes reachable
+    ### /apidocs
+    get 'apidocs', to: redirect('/apidocs-old/index')
+    get 'apidocs/(index)', to: redirect('apidocs-old/index')
   end
 
   resources :staging_workflows, except: :index, controller: 'webui/staging/workflows', param: :workflow_project, constraints: cons do

--- a/src/api/test/functional/webui/spider_test.rb
+++ b/src/api/test/functional/webui/spider_test.rb
@@ -27,8 +27,8 @@ class Webui::SpiderTest < Webui::IntegrationTest
     return true if link =~ %r{/live_build_log}
     # we do not really serve binary packages in the test environment
     return true if link =~ %r{/package/binary/}
-    # apidocs is not configured in test environment
-    return true if link.end_with?('/apidocs/index')
+    # old apidocs are not configured in test environment
+    return true if link.end_with?('/apidocs-old/index')
     # no need to visit flipper
     return true if link.end_with?('/flipper')
   end


### PR DESCRIPTION
This is the first step on rolling out the new API documentation.

In this PR:
- create `apidocs-old` routes
- create redirections from `/apidocs` to `/apidocs-old`

## For reviewers

1. On a running development environment set up the apidocs:
   - `docker-compose exec frontend bash`
   - `cd /obs/`
   -  `make -C docs/api/api apidocs`
   - `cd /obs/src/`
   - `ln -s ../doc`
1. Access the new path: http://localhost:3000/apidocs-old/
1. Access the old path. It should redirect to the new path: http://localhost:3000/apidocs/