### PR TITLE
Fix the link pointing back to the legacy documentation in the new API documentation

### DIFF
--- a/src/api/public/apidocs-new/OBS-v2.10.50.yaml
+++ b/src/api/public/apidocs-new/OBS-v2.10.50.yaml
@@ -74,7 +74,7 @@ info:
     in the endpoint documentation. If there is no schema file mentioned, no validation of the XML is done.
     In case the XML is not valid, a validation error is reported.
 
-    The legacy API documentation is reachable [here](https://api.opensuse.org/apidocs/index).
+    The legacy API documentation is reachable [here](https://api.opensuse.org/apidocs-old/index).
   version: '2.10.50'
   title: Open Build Service API
   contact:


### PR DESCRIPTION
Depends on #14423.