### PR TITLE
[api] add architecture filter on release

### DIFF
--- a/src/api/app/controllers/source_controller.rb
+++ b/src/api/app/controllers/source_controller.rb
@@ -1087,6 +1087,7 @@ class SourceController < ApplicationController
                     pkg.release_target_name(targetrepo, time_now),
                     { filter_source_repository: repo,
                       multibuild_container: multibuild_container,
+                      filter_architecture: params[:arch],
                       setrelease: params[:setrelease],
                       manual: true,
                       comment: "Releasing package #{pkg.name}" })


### PR DESCRIPTION
Somewhere lost in refactoring. Was ignored when target was manually specified