### PR TITLE
Add `arch` parameter to `POST /source/<project>/<package>?cmd=release` OpenAPI docs

### DIFF
--- a/src/api/public/apidocs/paths/source_project_name_package_name_cmd_release.yaml
+++ b/src/api/public/apidocs/paths/source_project_name_package_name_cmd_release.yaml
@@ -41,6 +41,12 @@ post:
       description: |
         If this parameter is present, the release will be tagged with this parameter's value.
       example: Build8.18
+    - in: query
+      name: arch
+      schema:
+        type: string
+      description:
+        The name of the architecture. Limit the release to a certain architecture.
   responses:
     '200':
       $ref: '../components/responses/succeeded.yaml'


### PR DESCRIPTION
The endpoint accepts the the arch parameter now as well.

Introduced in https://github.com/openSUSE/open-build-service/pull/14432