### PR TITLE
Ignore missing keys

### DIFF
--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -1395,6 +1395,8 @@ class Project < ApplicationRecord
   end
 
   def signing_key(type:)
+    return nil if type.nil?
+
     case type.to_sym
     when :ssl
       key = SigningKeySSL.new(name)


### PR DESCRIPTION
**Ignore missing keys**
instead of throwing an exception that produces an ugly 500 internal server error for the user, we get a nice red box `'Key not found for project PRJ'`

Fixes #14445