### PR TITLE
[backend] bs_dodup: maintain a directory containing failed dod updates

### DIFF
--- a/src/backend/bs_dodup
+++ b/src/backend/bs_dodup
@@ -39,6 +39,7 @@ my $reporoot = "$bsdir/build";
 my $rundir = "$bsdir/run";
 my $eventdir = "$bsdir/events";
 my $dodsdir = "$bsdir/dods";
+my $faileddir = "$dodsdir/.failed";
 
 my $runname = 'bs_dodup';
 
@@ -169,7 +170,7 @@ sub uncompress {
       rename($nfile, $file) || die("rename $nfile, $file\n");
     }
   }
-  die("bzip2 in unimplemented\n") if $reffile =~ /\.bz2$/;
+  die("bzip2 is unimplemented\n") if $reffile =~ /\.bz2$/;
 }
 
 sub mastercheck {
@@ -741,6 +742,7 @@ sub scan_dodsdir {
     my $doddata = readxml("$dodsdir/$f", $BSXML::doddata, 1);
     next unless $doddata;
     $doddata->{'id'} = $id;
+    $doddata->{'failedfile'} = $f;
     my $prpa = "$doddata->{'project'}/$doddata->{'repository'}/$doddata->{'arch'}";
     if ($startup) {
       # get lastcheck from old cookie
@@ -765,6 +767,10 @@ sub scan_dodsdir {
       $doddata->{'lastcheck'} = 0;
     }
   }
+  if ($faileddir) {
+    my %knownf = map {$_->{'failedfile'} => 1} values %newdoddatas;
+    unlink("$faileddir/$_") for grep {!$knownf{$_}} sort(ls($faileddir));
+  }
   return %newdoddatas;
 }
 
@@ -778,12 +784,18 @@ sub check_dod {
   if ($@) {
     warn($@);
     $doddata->{'haderror'} = 1;
+    if ($faileddir && $doddata->{'failedfile'}) {
+      mkdir_p($faileddir);
+      writestr("$faileddir/.$doddata->{'failedfile'}", "$faileddir/$doddata->{'failedfile'}", $@);
+    }
     # update lastcheck time in cookie
     my $cookie = readstr("$reporoot/$prpa/:full/doddata.cookie", 1) || '';
     chomp $cookie;
     $cookie =~ s/^(\d+ )//s if $cookie;	# strip lastcheck time
     mkdir_p("$reporoot/$prpa/:full");
     writestr("$reporoot/$prpa/:full/.doddata.cookie", "$reporoot/$prpa/:full/doddata.cookie", "$now $cookie\n");
+  } else {
+    unlink("$faileddir/$doddata->{'failedfile'}") if $faileddir && $doddata->{'failedfile'};
   }
 }
 


### PR DESCRIPTION
This can be used by tools like nagios so that failed dod updates can show up in monitioring.