### PR TITLE
Revert "Add continuation orb"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,6 @@ setup: true
 # the path-filtering orb is required to continue a pipeline based on
 # the path of an updated fileset
 orbs:
-  continuation: circleci/continuation@0
   path-filtering: circleci/path-filtering@0
 
 workflows:


### PR DESCRIPTION
Reverts openSUSE/open-build-service#14466

This is not needed according to https://circleci.com/docs/using-dynamic-configuration/#execute-specific-workflows-or-steps-based-on-which-files-are-modified