### PR TITLE
Document DELETE required checks api endpoints 

### DIFF
--- a/src/api/public/apidocs/OBS-v2.10.50.yaml
+++ b/src/api/public/apidocs/OBS-v2.10.50.yaml
@@ -460,6 +460,8 @@ paths:
   /status_reports/built_repositories/{project_name}/{repository_name}/{architecture_name}/required_checks/{check_name}:
     $ref: 'paths/status_reports_built_repositories_project_name_repository_name_architecture_name_required_checks_check_name.yaml'
   /status_reports/projects/{project_name}/required_checks:
+    $ref: 'paths/status_reports_projects_project_name_required_checks.yaml'
+  /status_reports/projects/{project_name}/required_checks/{check_name}:
     $ref: 'paths/status_reports_projects_project_name_required_checks_check_name.yaml'
   /status_reports/repositories/{project_name}/{repository_name}/required_checks:
     $ref: 'paths/status_reports_repositories_project_name_repository_name_required_checks.yaml'

--- a/src/api/public/apidocs/OBS-v2.10.50.yaml
+++ b/src/api/public/apidocs/OBS-v2.10.50.yaml
@@ -457,8 +457,10 @@ paths:
   # Status reports - Required Checks
   /status_reports/built_repositories/{project_name}/{repository_name}/{architecture_name}/required_checks:
     $ref: 'paths/status_reports_built_repositories_project_name_repository_name_architecture_name_required_checks.yaml'
+  /status_reports/built_repositories/{project_name}/{repository_name}/{architecture_name}/required_checks/{check_name}:
+    $ref: 'paths/status_reports_built_repositories_project_name_repository_name_architecture_name_required_checks_check_name.yaml'
   /status_reports/projects/{project_name}/required_checks:
-    $ref: 'paths/status_reports_projects_project_name_required_checks.yaml'
+    $ref: 'paths/status_reports_projects_project_name_required_checks_check_name.yaml'
   /status_reports/repositories/{project_name}/{repository_name}/required_checks:
     $ref: 'paths/status_reports_repositories_project_name_repository_name_required_checks.yaml'
 

--- a/src/api/public/apidocs/OBS-v2.10.50.yaml
+++ b/src/api/public/apidocs/OBS-v2.10.50.yaml
@@ -465,6 +465,8 @@ paths:
     $ref: 'paths/status_reports_projects_project_name_required_checks_check_name.yaml'
   /status_reports/repositories/{project_name}/{repository_name}/required_checks:
     $ref: 'paths/status_reports_repositories_project_name_repository_name_required_checks.yaml'
+  /status_reports/repositories/{project_name}/{repository_name}/required_checks/{check_name}:
+    $ref: 'paths/status_reports_repositories_project_name_repository_name_required_checks_check_name.yaml'
 
   /trigger/{operation}:
     $ref: 'paths/trigger_operation.yaml'

--- a/src/api/public/apidocs/components/parameters/check_name.yaml
+++ b/src/api/public/apidocs/components/parameters/check_name.yaml
@@ -1,0 +1,7 @@
+in: path
+name: check_name
+schema:
+  type: string
+required: true
+description: Check name.
+example: first

--- a/src/api/public/apidocs/components/responses/status_report/delete_project_forbidden.yaml
+++ b/src/api/public/apidocs/components/responses/status_report/delete_project_forbidden.yaml
@@ -1,0 +1,10 @@
+description: |
+  Forbidden.
+  XML Schema used for body validation: [status.xsd](../schema/status.xsd)
+content:
+  application/xml; charset=utf-8:
+    schema:
+      $ref: '../../schemas/api_response.yaml'
+    example:
+      code: delete_project_not_authorized
+      summary: Sorry, you are not authorized to delete this project.

--- a/src/api/public/apidocs/components/responses/status_report/delete_repository_architecture_forbidden.yaml
+++ b/src/api/public/apidocs/components/responses/status_report/delete_repository_architecture_forbidden.yaml
@@ -1,0 +1,10 @@
+description: |
+  Forbidden.
+  XML Schema used for body validation: [status.xsd](../schema/status.xsd)
+content:
+  application/xml; charset=utf-8:
+    schema:
+      $ref: '../../schemas/api_response.yaml'
+    example:
+      code: delete_repository_architecture_not_authorized
+      summary: Sorry, you are not authorized to delete this repository architecture.

--- a/src/api/public/apidocs/components/responses/status_report/delete_repository_forbidden.yaml
+++ b/src/api/public/apidocs/components/responses/status_report/delete_repository_forbidden.yaml
@@ -1,0 +1,10 @@
+description: |
+  Forbidden.
+  XML Schema used for body validation: [status.xsd](../schema/status.xsd)
+content:
+  application/xml; charset=utf-8:
+    schema:
+      $ref: '../../schemas/api_response.yaml'
+    example:
+      code: delete_repository_not_authorized
+      summary: Sorry, you are not authorized to delete this repository.

--- a/src/api/public/apidocs/paths/status_reports_built_repositories_project_name_repository_name_architecture_name_required_checks_check_name.yaml
+++ b/src/api/public/apidocs/paths/status_reports_built_repositories_project_name_repository_name_architecture_name_required_checks_check_name.yaml
@@ -1,0 +1,23 @@
+delete:
+  summary: Delete a required check from the built repository
+  description: Delete a required check from the built repository
+  security:
+    - basic_authentication: []
+  parameters:
+    - $ref: '../components/parameters/project_name.yaml'
+    - $ref: '../components/parameters/repository_name.yaml'
+    - $ref: '../components/parameters/architecture_name.yaml'
+    - $ref: '../components/parameters/check_name.yaml'
+  responses:
+    '200':
+      $ref: '../components/responses/succeeded.yaml'
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '403':
+      $ref: '../components/responses/status_report/delete_repository_architecture_forbidden.yaml'
+    '404':
+      $ref: '../components/responses/unknown_project_or_repository_or_architecture.yaml'
+    '422':
+      $ref: '../components/responses/invalid_required_check.yaml'
+  tags:
+    - Status Reports - Required Checks

--- a/src/api/public/apidocs/paths/status_reports_projects_project_name_required_checks_check_name.yaml
+++ b/src/api/public/apidocs/paths/status_reports_projects_project_name_required_checks_check_name.yaml
@@ -1,0 +1,21 @@
+delete:
+  summary: Delete a required checks from the project
+  description: Delete a required check from the project
+  security:
+    - basic_authentication: []
+  parameters:
+    - $ref: '../components/parameters/project_name.yaml'
+    - $ref: '../components/parameters/check_name.yaml'
+  responses:
+    '200':
+      $ref: '../components/responses/succeeded.yaml'
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '403':
+      $ref: '../components/responses/status_report/delete_project_forbidden.yaml'
+    '404':
+      $ref: '../components/responses/unknown_project.yaml'
+    '422':
+      $ref: '../components/responses/invalid_required_check.yaml'
+  tags:
+    - Status Reports - Required Checks

--- a/src/api/public/apidocs/paths/status_reports_repositories_project_name_repository_name_required_checks_check_name.yaml
+++ b/src/api/public/apidocs/paths/status_reports_repositories_project_name_repository_name_required_checks_check_name.yaml
@@ -1,0 +1,22 @@
+delete:
+  summary: Delete a required check from the project repository
+  description: Delete a required checks from the project repository
+  security:
+    - basic_authentication: []
+  parameters:
+    - $ref: '../components/parameters/project_name.yaml'
+    - $ref: '../components/parameters/repository_name.yaml'
+    - $ref: '../components/parameters/check_name.yaml'
+  responses:
+    '200':
+      $ref: '../components/responses/succeeded.yaml'
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '403':
+      $ref: '../components/responses/status_report/delete_repository_forbidden.yaml'
+    '404':
+      $ref: '../components/responses/unknown_project_or_repository.yaml'
+    '422':
+      $ref: '../components/responses/invalid_required_check.yaml'
+  tags:
+    - Status Reports - Required Checks


### PR DESCRIPTION
This is a continuation of #14470 and so it depends on it. The first commit (which is the 4th after the previous PR's commits) has most of the content, the remaining commits are copies with most of the same content.

To verify:
- Use POST endpoint to create checks
- Use DELETE endpoint to delete checks
- Use GET endpoint to verify they aren't there