### PR TITLE
API documentation: sort sections alphabetically

### DIFF
--- a/src/api/public/apidocs/OBS-v2.10.50.yaml
+++ b/src/api/public/apidocs/OBS-v2.10.50.yaml
@@ -50,6 +50,7 @@ tags:
   - name: Staging Workflow
   - name: Statistics
   - name: Status Messages
+  - name: Status Project
   - name: Status Reports
   - name: Status Reports - Required Checks
   - name: Trigger


### PR DESCRIPTION
The "Status Project" section was not added to the `tags` section. It was shown at the end of the page.

Include the "Status Project" section into the `tags` section, alphabetically sorted. This solves the sort issue.

Related to #14450.