### PR TITLE
Apidocs swagger initially collapsed

### DIFF
--- a/src/api/public/apidocs/swagger-initializer.js
+++ b/src/api/public/apidocs/swagger-initializer.js
@@ -15,6 +15,7 @@ window.onload = function() {
       SwaggerUIBundle.plugins.DownloadUrl
     ],
     showExplorer: false,
+    docExpansion : "none",
   });
 
   //</editor-fold>


### PR DESCRIPTION
According to official documentation, https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/, this PR sets the parameter to initially loads the index page of the apidocs endpoints all collapsed.

The reason behind it: the index list is already long, and it separates concepts and topics by "chapters". Having them exploded generates instead a bit of fuss that is somehow useless. The user comes to the apidocs index to look for a topic and its endpoints, not to browse them all.

Note: it is important to notice that the topic name is also exactly the first slice of the endpoint name (i.e.: **Staging** --> "/**staging**/{project_name}/excluded_requests"). The user can always reach the topic by using the browser search function with that text slice and then expand it.

Additionally: now that the loading time is fast with the latest changes (this will be noticed in production only btw), the page can load the index and once the user expand a topic, it will display immediately the content of that topic only, without taking the focus away with all the other topics content.

You can check it at https://obs-reviewlab.opensuse.org/ncounter-apidocs-collapsed/apidocs/index.html