### PR TITLE
Filter nil entries from directory list

### DIFF
--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -1273,7 +1273,7 @@ class Package < ApplicationRecord
   end
 
   def file_exists?(filename, opts = {})
-    dir_hash(opts).key?('entry') && [dir_hash(opts)['entry']].flatten.any? { |item| item['name'] == filename }
+    dir_hash(opts).key?('entry') && [dir_hash(opts)['entry']].flatten.compact.any? { |item| item['name'] == filename }
   end
 
   def has_icon?


### PR DESCRIPTION
closes #14503 

The only possibility of this exception is because of nil values in the directory list. 