### PR TITLE
Validate workflow_configuration_url before saving it

### DIFF
--- a/src/api/app/models/token.rb
+++ b/src/api/app/models/token.rb
@@ -15,6 +15,8 @@ class Token < ApplicationRecord
   validates :string, uniqueness: { case_sensitive: false }
   validates :scm_token, absence: true, if: -> { type != 'Token::Workflow' }
 
+  validate :workflow_configuration_url_valid_and_accessible
+
   include Token::Errors
 
   # TODO: move to Token::Workflow model
@@ -64,6 +66,22 @@ class Token < ApplicationRecord
 
   def owned_by?(some_user)
     executor == some_user
+  end
+
+  private
+
+  def workflow_configuration_url_valid_and_accessible
+    return true if workflow_configuration_url.blank?
+
+    # Check if the URI is valid
+    URI.parse(workflow_configuration_url)
+
+    # Check if we get a successful response
+    Workflows::YAMLDownloader.new({}, token: self).call
+  rescue URI::InvalidURIError => e
+    errors.add(:workflow_configuration_url, "must be a valid url: #{e}")
+  rescue Token::Errors::NonExistentWorkflowsFile => e
+    errors.add(:workflow_configuration_url, "failed to get: #{e}")
   end
 end
 


### PR DESCRIPTION
A simple validation of validity and accessibility of a workflow token url.

To verify:
- Create or edit a workflow token
- Set the workflow configuration url

Look at the tests for ideas on how to break this nicely