### PR TITLE
Handle config file URL or path easily from workflow run

### DIFF
--- a/src/api/app/components/workflow_run_detail_component.html.haml
+++ b/src/api/app/components/workflow_run_detail_component.html.haml
@@ -4,6 +4,10 @@
                  role: 'tab', aria: { controls: "incoming-webhook-tab-content#{id}", selected: 'false' } }
       Webhook from #{scm_vendor}
   %li.nav-item{ role: 'presentation' }
+    %a.nav-link{ id: "workflow-configuration-tab#{id}", data: { 'bs-toggle': 'tab' }, href: "#workflow-configuration-tab-content#{id}",
+                 role: 'tab', aria: { controls: "workflow-configuration-tab-content#{id}", selected: 'false' } }
+      Workflow Configuration
+  %li.nav-item{ role: 'presentation' }
     %a.nav-link{ id: "scm-reports-tab#{id}", data: { 'bs-toggle': 'tab' }, href: "#scm-reports-tab-content#{id}",
                  role: 'tab', aria: { controls: "scm-reports-tab-content#{id}", selected: 'false' } }
       Reports to the SCM
@@ -29,6 +33,9 @@
       %h5 Webhook Request Payload
       %pre.border.p-2#request-payload
         = pretty_request_payload
+  .tab-pane.fade{ id: "workflow-configuration-tab-content#{id}", role: 'tabpanel',
+                  aria: { labelledby: "workflow-configuration-tab#{id}" } }
+    = workflow_configuration_data
   .tab-pane.fade{ id: "scm-reports-tab-content#{id}", role: 'tabpanel',
                   aria: { labelledby: "scm-reports-tab#{id}" } }
     - if status_reports.any?

--- a/src/api/app/components/workflow_run_detail_component.rb
+++ b/src/api/app/components/workflow_run_detail_component.rb
@@ -26,14 +26,11 @@ class WorkflowRunDetailComponent < ApplicationComponent
 
   # Old workflow run entries didn't store the configuration-related information
   def workflow_configuration_data
-    configuration_source = [workflow_run.workflow_configuration_url,
-                            workflow_run.workflow_configuration_path].filter_map(&:presence).first
-
-    return content_tag(:p, 'This information is not available.') unless configuration_source
+    return content_tag(:p, 'This information is not available.') unless workflow_run.configuration_source
 
     content_tag(:h5, "Workflow Configuration File #{workflow_run.workflow_configuration_url.present? ? 'URL' : 'Path'}").concat(
       content_tag(:pre,
-                  configuration_source,
+                  workflow_run.configuration_source,
                   class: 'border p-2')
     )
   end

--- a/src/api/app/components/workflow_run_detail_component.rb
+++ b/src/api/app/components/workflow_run_detail_component.rb
@@ -1,11 +1,12 @@
 class WorkflowRunDetailComponent < ApplicationComponent
-  attr_reader :id, :request_headers, :pretty_request_payload,
+  attr_reader :id, :workflow_run, :request_headers, :pretty_request_payload,
               :response_url, :response_body, :artifacts,
               :scm_vendor, :status_reports
 
   def initialize(workflow_run:)
     super
     @id = workflow_run.id
+    @workflow_run = workflow_run
     @request_headers = workflow_run.request_headers
     @pretty_request_payload = parse_payload(workflow_run)
     @response_url = workflow_run.response_url
@@ -21,5 +22,19 @@ class WorkflowRunDetailComponent < ApplicationComponent
     JSON.pretty_generate(JSON.parse(workflow_run.request_payload))
   rescue JSON::ParserError
     workflow_run.request_payload
+  end
+
+  # Old workflow run entries didn't store the configuration-related information
+  def workflow_configuration_data
+    configuration_source = [workflow_run.workflow_configuration_url,
+                            workflow_run.workflow_configuration_path].filter_map(&:presence).first
+
+    return content_tag(:p, 'This information is not available.') unless configuration_source
+
+    content_tag(:h5, "Workflow Configuration File #{workflow_run.workflow_configuration_url.present? ? 'URL' : 'Path'}").concat(
+      content_tag(:pre,
+                  configuration_source,
+                  class: 'border p-2')
+    )
   end
 end

--- a/src/api/app/controllers/trigger_workflow_controller.rb
+++ b/src/api/app/controllers/trigger_workflow_controller.rb
@@ -75,7 +75,10 @@ class TriggerWorkflowController < TriggerController
     raise Trigger::Errors::InvalidToken, 'Wrong token type. Please use workflow tokens only.' unless @token.is_a?(Token::Workflow)
 
     request_headers = request.headers.to_h.keys.map { |k| "#{k}: #{request.headers[k]}" if k.match?(/^HTTP_/) }.compact.join("\n")
-    @workflow_run = @token.workflow_runs.create(request_headers: request_headers, request_payload: request.body.read)
+    @workflow_run = @token.workflow_runs.create(request_headers: request_headers,
+                                                request_payload: request.body.read,
+                                                workflow_configuration_path: @token.workflow_configuration_path,
+                                                workflow_configuration_url: @token.workflow_configuration_url)
   end
 
   def extract_scm_webhook

--- a/src/api/app/models/workflow_run.rb
+++ b/src/api/app/models/workflow_run.rb
@@ -125,6 +125,10 @@ class WorkflowRun < ApplicationRecord
     scm_status_reports.last&.response_body
   end
 
+  def configuration_source
+    [workflow_configuration_url, workflow_configuration_path].filter_map(&:presence).first
+  end
+
   private
 
   def parsed_request_headers

--- a/src/api/app/models/workflow_run.rb
+++ b/src/api/app/models/workflow_run.rb
@@ -23,7 +23,7 @@ class WorkflowRun < ApplicationRecord
     :state, :status_options
   ].freeze
 
-  validates :response_url, length: { maximum: 255 }
+  validates :response_url, :workflow_configuration_path, :workflow_configuration_url, length: { maximum: 255 }
   validates :request_headers, :status, presence: true
 
   belongs_to :token, class_name: 'Token::Workflow', optional: true
@@ -150,15 +150,17 @@ end
 #
 # Table name: workflow_runs
 #
-#  id              :integer          not null, primary key
-#  request_headers :text(65535)      not null
-#  request_payload :text(4294967295) not null
-#  response_body   :text(65535)
-#  response_url    :string(255)
-#  status          :integer          default("running"), not null
-#  created_at      :datetime         not null
-#  updated_at      :datetime         not null
-#  token_id        :integer          not null, indexed
+#  id                          :integer          not null, primary key
+#  request_headers             :text(65535)      not null
+#  request_payload             :text(4294967295) not null
+#  response_body               :text(65535)
+#  response_url                :string(255)
+#  status                      :integer          default("running"), not null
+#  workflow_configuration_path :string(255)
+#  workflow_configuration_url  :string(255)
+#  created_at                  :datetime         not null
+#  updated_at                  :datetime         not null
+#  token_id                    :integer          not null, indexed
 #
 # Indexes
 #

--- a/src/api/db/migrate/20230615111252_add_configuration_url_and_path_columns_to_workflow_run.rb
+++ b/src/api/db/migrate/20230615111252_add_configuration_url_and_path_columns_to_workflow_run.rb
@@ -1,0 +1,6 @@
+class AddConfigurationUrlAndPathColumnsToWorkflowRun < ActiveRecord::Migration[7.0]
+  def change
+    add_column :workflow_runs, :workflow_configuration_path, :string
+    add_column :workflow_runs, :workflow_configuration_url, :string
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_14_085150) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_15_111252) do
   create_table "architectures", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "name", null: false, collation: "utf8mb3_general_ci"
     t.boolean "available", default: false
@@ -1115,6 +1115,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_14_085150) do
     t.datetime "updated_at", null: false
     t.integer "token_id", null: false
     t.string "response_url"
+    t.string "workflow_configuration_path"
+    t.string "workflow_configuration_url"
     t.index ["token_id"], name: "index_workflow_runs_on_token_id"
   end
 

--- a/src/api/spec/components/workflow_run_detail_component_spec.rb
+++ b/src/api/spec/components/workflow_run_detail_component_spec.rb
@@ -32,4 +32,24 @@ RSpec.describe WorkflowRunDetailComponent, type: :component do
       expect(rendered_content).to have_text('Unparseable payload')
     end
   end
+
+  context 'in Workflow Configuration tab' do
+    context 'when the configuration information was not stored' do
+      it { expect(rendered_content).to have_text('This information is not available.') }
+    end
+
+    context 'when the configuration path was stored' do
+      let(:workflow_run) { create(:workflow_run, :with_configuration_path, token: workflow_token) }
+
+      it { expect(rendered_content).to have_text('Workflow Configuration File Path') }
+      it { expect(rendered_content).to have_text('.obs/workflows.yml') }
+    end
+
+    context 'when the configuration URL was stored' do
+      let(:workflow_run) { create(:workflow_run, :with_configuration_url, token: workflow_token) }
+
+      it { expect(rendered_content).to have_text('Workflow Configuration File URL') }
+      it { expect(rendered_content).to have_text('http://example.com/workflows.yml') }
+    end
+  end
 end

--- a/src/api/spec/factories/workflow_runs.rb
+++ b/src/api/spec/factories/workflow_runs.rb
@@ -9,6 +9,14 @@ FactoryBot.define do
     request_payload do
       File.read('spec/support/files/request_payload_github_pull_request_opened.json')
     end
+
+    trait 'with_configuration_path' do
+      workflow_configuration_path { '.obs/workflows.yml' }
+    end
+
+    trait 'with_configuration_url' do
+      workflow_configuration_url { 'http://example.com/workflows.yml' }
+    end
   end
 
   # GitHub


### PR DESCRIPTION
We are extending the WorkflowRun model to make it easier to query by relevant data that helps us debug failed integrations.

Two of the relevant values are stored in  `Token#workflow_configuration_(url|path)`. As we want to know the values stored on those fields when the workflow ran, I added new columns to the `workflow_runs` table.

In the UI, I added a new tab, `Workflow configuration`, where we are going to display all the information related to the workflow configuration file: URL, path, content etc.

![Screenshot 2023-06-15 at 16-04-37 Open Build Service](https://github.com/openSUSE/open-build-service/assets/2581944/fecc62a7-5b1f-48b3-aa21-f9a41d62a6de)
