### PR TITLE
[dist] removed 'data:schema:load' from obsapisetup

### DIFF
--- a/dist/functions.setup-appliance.sh
+++ b/dist/functions.setup-appliance.sh
@@ -274,7 +274,7 @@ function prepare_database_setup {
   if [ -n "$RUN_INITIAL_SETUP" ]; then
     logline "Initialize OBS api database (first time only)"
     cd $apidir
-    RAKE_COMMANDS="db:setup writeconfiguration data:schema:load"
+    RAKE_COMMANDS="db:setup writeconfiguration"
   else
     logline "Migrate OBS api database"
     cd $apidir


### PR DESCRIPTION
Fixes: #14518

'data:schema:load' seems not needed to be called separatly any longer.