### PR TITLE
Ignore trigger services step for destroy and restore on pull request event

### DIFF
--- a/src/api/app/models/workflow.rb
+++ b/src/api/app/models/workflow.rb
@@ -12,7 +12,7 @@ class Workflow
 
   SUPPORTED_FILTERS = [:branches, :event].freeze
   STEPS_WITH_NO_TARGET_PROJECT_TO_RESTORE_OR_DESTROY = [Workflow::Step::ConfigureRepositories, Workflow::Step::RebuildPackage,
-                                                        Workflow::Step::SetFlags].freeze
+                                                        Workflow::Step::SetFlags, Workflow::Step::TriggerServices].freeze
 
   attr_accessor :workflow_instructions, :scm_webhook, :token, :workflow_run
 


### PR DESCRIPTION
For this step there is also no target project to restore or destroy when a pull request is closed or reopened. We should ignore it as well. Otherwise it throws an error and creates a workflow run with a failed status.