### PR TITLE
Allow versioning for SCM/CI workflow features and add support for event aliases (v.1.1)

### DIFF
--- a/src/api/app/instrumentations/workflow_instrumentation.rb
+++ b/src/api/app/instrumentations/workflow_instrumentation.rb
@@ -18,7 +18,7 @@ module WorkflowInstrumentation
 
   def track_execution
     RabbitmqBus.send_to_bus('metrics', "workflow,action=execution,default_configuration_path=#{token.workflow_configuration_path_default?}," \
-                                       "using_configuration_url=#{token.workflow_configuration_url.present?} count=1")
+                                       "using_configuration_url=#{token.workflow_configuration_url.present?}, using_workflow_version_number=#{workflow_version_number.present?} count=1")
   end
 
   def track_workflow_filters

--- a/src/api/app/models/concerns/workflow_version_matcher.rb
+++ b/src/api/app/models/concerns/workflow_version_matcher.rb
@@ -1,0 +1,16 @@
+module WorkflowVersionMatcher
+  # In case no version is specified in the workflow yaml, we fallback
+  # to the current highest minor version, since we don't introduce
+  # breaking changes with those
+  FALLBACK_VERSION = '1.1'.freeze
+  FEATURES_FOR_VERSION = { '1.1': ['event_aliases'] }.freeze
+
+  def feature_available_for_workflow_version?(workflow_version:, feature_name:)
+    workflow_version = FALLBACK_VERSION if workflow_version.blank?
+
+    FEATURES_FOR_VERSION.each do |feature_version, features|
+      return true if Gem::Version.new(workflow_version) >= Gem::Version.new(feature_version) && features.include?(feature_name)
+    end
+    false
+  end
+end

--- a/src/api/app/models/workflow.rb
+++ b/src/api/app/models/workflow.rb
@@ -1,6 +1,7 @@
 class Workflow
   include ActiveModel::Model
   include WorkflowInstrumentation # for run_callbacks
+  include WorkflowVersionMatcher
 
   SCM_CI_DOCUMENTATION_URL = 'https://openbuildservice.org/help/manuals/obs-user-guide/cha.obs.scm_ci_workflow_integration.html'.freeze
 
@@ -14,7 +15,7 @@ class Workflow
   STEPS_WITH_NO_TARGET_PROJECT_TO_RESTORE_OR_DESTROY = [Workflow::Step::ConfigureRepositories, Workflow::Step::RebuildPackage,
                                                         Workflow::Step::SetFlags, Workflow::Step::TriggerServices].freeze
 
-  attr_accessor :workflow_instructions, :scm_webhook, :token, :workflow_run
+  attr_accessor :workflow_instructions, :scm_webhook, :token, :workflow_run, :workflow_version_number
 
   def initialize(attributes = {})
     run_callbacks(:initialize) do

--- a/src/api/app/models/workflow.rb
+++ b/src/api/app/models/workflow.rb
@@ -20,6 +20,7 @@ class Workflow
     run_callbacks(:initialize) do
       super
       @workflow_instructions = attributes[:workflow_instructions].deep_symbolize_keys
+      @workflow_version_number = attributes[:workflow_version_number]
     end
   end
 

--- a/src/api/app/models/workflow.rb
+++ b/src/api/app/models/workflow.rb
@@ -27,6 +27,7 @@ class Workflow
 
   validates_with WorkflowStepsValidator
   validates_with WorkflowFiltersValidator
+  validates_with WorkflowVersionValidator
   validate :event_supports_branches_filter?, on: :call, if: :event_matches_event_filter?
 
   def call

--- a/src/api/app/models/workflow.rb
+++ b/src/api/app/models/workflow.rb
@@ -108,6 +108,8 @@ class Workflow
       scm_webhook.tag_push_event?
     when 'pull_request'
       scm_webhook.pull_request_event?
+    when 'merge_request'
+      scm_webhook.pull_request_event? && feature_available_for_workflow_version?(workflow_version: workflow_version_number, feature_name: 'event_aliases')
     else
       false
     end

--- a/src/api/app/services/workflows/yaml_to_workflows_service.rb
+++ b/src/api/app/services/workflows/yaml_to_workflows_service.rb
@@ -24,11 +24,13 @@ module Workflows
       rescue Psych::SyntaxError, Token::Errors::WorkflowsYamlFormatError => e
         raise Token::Errors::WorkflowsYamlNotParsable, "Unable to parse #{@token.workflow_configuration_path}: #{e.message}"
       end
-
+      # Receive and delete the version key from the parsed yaml, so it is not
+      # confused with a workflow name in the next step
+      workflow_version_number = parsed_workflows_yaml.delete('version')
       parsed_workflows_yaml
         .map do |_workflow_name, workflow_instructions|
         Workflow.new(workflow_instructions: workflow_instructions, scm_webhook: @scm_webhook, token: @token,
-                     workflow_run: @workflow_run)
+                     workflow_run: @workflow_run, workflow_version_number: workflow_version_number)
       end
     end
 

--- a/src/api/app/services/workflows/yaml_to_workflows_service.rb
+++ b/src/api/app/services/workflows/yaml_to_workflows_service.rb
@@ -24,13 +24,12 @@ module Workflows
       rescue Psych::SyntaxError, Token::Errors::WorkflowsYamlFormatError => e
         raise Token::Errors::WorkflowsYamlNotParsable, "Unable to parse #{@token.workflow_configuration_path}: #{e.message}"
       end
-      # Receive and delete the version key from the parsed yaml, so it is not
-      # confused with a workflow name in the next step
-      workflow_version_number = parsed_workflows_yaml.delete('version')
+
+      parsed_workflows_yaml = extract_and_set_workflow_version(parsed_workflows_yaml: parsed_workflows_yaml)
       parsed_workflows_yaml
         .map do |_workflow_name, workflow_instructions|
         Workflow.new(workflow_instructions: workflow_instructions, scm_webhook: @scm_webhook, token: @token,
-                     workflow_run: @workflow_run, workflow_version_number: workflow_version_number)
+                     workflow_run: @workflow_run, workflow_version_number: @workflow_version_number)
       end
     end
 
@@ -54,6 +53,14 @@ module Workflows
       rescue ArgumentError => e
         raise Token::Errors::WorkflowsYamlFormatError, e.message
       end
+    end
+
+    def extract_and_set_workflow_version(parsed_workflows_yaml:)
+      # Receive and delete the version key from the parsed yaml, so it is not
+      # confused with a workflow name. Check if the version key points to a hash
+      # incase 'version' is the name of a workflow e.g. {"version"=>1.1, "version"=>{"steps"=>[{"trigger_services"...
+      @workflow_version_number ||= parsed_workflows_yaml.delete('version') unless parsed_workflows_yaml['version'].is_a?(Hash)
+      parsed_workflows_yaml
     end
   end
 end

--- a/src/api/app/validators/workflow_version_validator.rb
+++ b/src/api/app/validators/workflow_version_validator.rb
@@ -1,0 +1,12 @@
+class WorkflowVersionValidator < ActiveModel::Validator
+  def validate(record)
+    # For now we don't enforce a version number in the workflow yaml
+    return if record.workflow_version_number.blank?
+
+    begin
+      Gem::Version.new(record.workflow_version_number)
+    rescue ArgumentError
+      record.errors.add(:base, "Malformed workflow version string, please provide the version number in the format: 'major.minor' e.g. '1.1'")
+    end
+  end
+end

--- a/src/api/spec/models/concerns/workflow_version_matcher_spec.rb
+++ b/src/api/spec/models/concerns/workflow_version_matcher_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe WorkflowVersionMatcher do
+  let(:dummy_instance) do
+    dummy_obj = Object.new
+    dummy_obj.extend(WorkflowVersionMatcher)
+    dummy_obj
+  end
+
+  describe '#feature_available_for_workflow_version?' do
+    context 'when no workflow version is provided' do
+      it 'uses the fallback version number' do
+        expect(dummy_instance.feature_available_for_workflow_version?(workflow_version: nil, feature_name: 'event_aliases')).to be(true)
+      end
+    end
+
+    context 'when a workflow version is provided which includes the given feature' do
+      it { expect(dummy_instance.feature_available_for_workflow_version?(workflow_version: '1.1', feature_name: 'event_aliases')).to be(true) }
+    end
+
+    context 'when a workflow version is provided that is higher then the version with the given feature' do
+      it { expect(dummy_instance.feature_available_for_workflow_version?(workflow_version: '2.1', feature_name: 'event_aliases')).to be(true) }
+    end
+
+    context 'when a feature name is provided that is not part of any workflow version' do
+      it { expect(dummy_instance.feature_available_for_workflow_version?(workflow_version: '1.1', feature_name: 'not_available_feature_name')).to be(false) }
+    end
+
+    context 'when a workflow version is provided that is lower then the version with the given feature' do
+      it { expect(dummy_instance.feature_available_for_workflow_version?(workflow_version: '1.0', feature_name: 'event_aliases')).to be(false) }
+    end
+  end
+end

--- a/src/api/spec/validators/workflow_version_validator_spec.rb
+++ b/src/api/spec/validators/workflow_version_validator_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe WorkflowVersionValidator do
+  let(:fake_model) do
+    Struct.new(:workflow_version_number) do
+      include ActiveModel::Validations
+
+      validates_with WorkflowVersionValidator
+    end
+  end
+
+  describe '#validate' do
+    subject { fake_model.new(workflow_version_number) }
+
+    context 'with a version number provided in the correct format' do
+      let(:workflow_version_number) { '1.1' }
+
+      it { expect(subject).to be_valid }
+    end
+
+    context 'with a version number provided in the wrong format' do
+      let(:workflow_version_number) { 'wrong_version_scheme' }
+
+      it 'is not valid and has an error message' do
+        subject.valid?
+        expect(subject.errors.full_messages.to_sentence).to eq("Malformed workflow version string, please provide the version number in the format: 'major.minor' e.g. '1.1'")
+      end
+    end
+
+    context 'when no version number is provided' do
+      let(:workflow_version_number) { nil }
+
+      it { expect(subject).to be_valid }
+    end
+  end
+end


### PR DESCRIPTION
This PR introduces a small implementation to allow versioning for SCM/CI workflow features and changes. The version scheme I would suggest would be `major.minor`. Major versions for non-backwards compatible features and changes. Minor versions for backwards compatible features and changes (non breaking features). For now I would not enforce to specify a version and would fallback to the latest minor version.

The version is specified on the top level and matches the whole `workflow.yml` file against a specific version:
```
version: '1.1'
workflow:
  steps:                                                                                                                                                                                                                                           
    - trigger_services:                                                                                                                                                                                                                            
        project: home:krauselukas
        package: hello_world
  filters:
    event: merge_request
```


**Documentation will happen as follow up PR**