### PR TITLE
Expand workflow run with headers info

### DIFF
--- a/src/api/app/components/workflow_run_detail_component.rb
+++ b/src/api/app/components/workflow_run_detail_component.rb
@@ -12,7 +12,7 @@ class WorkflowRunDetailComponent < ApplicationComponent
     @response_url = workflow_run.response_url
     @response_body = workflow_run.response_body
     @artifacts = workflow_run.artifacts # collection of WorkflowArtifactsPerStep
-    @scm_vendor = workflow_run.scm_vendor.to_s.humanize
+    @scm_vendor = workflow_run.scm_vendor.humanize
     @status_reports = workflow_run.scm_status_reports
   end
 

--- a/src/api/app/components/workflow_run_row_component.rb
+++ b/src/api/app/components/workflow_run_row_component.rb
@@ -6,7 +6,7 @@ class WorkflowRunRowComponent < ApplicationComponent
 
     @workflow_run = workflow_run
     @status = workflow_run.status
-    @hook_event = workflow_run.hook_event
+    @hook_event = workflow_run.hook_event || 'unknown'
     @hook_action = workflow_run.hook_action
     @repository_name = workflow_run.repository_name
     @repository_url = workflow_run.repository_url

--- a/src/api/app/controllers/trigger_workflow_controller.rb
+++ b/src/api/app/controllers/trigger_workflow_controller.rb
@@ -36,16 +36,21 @@ class TriggerWorkflowController < TriggerController
   end
 
   def set_scm_extractor
-    scm = if @gitlab_event
-            'gitlab'
-          elsif @github_event
-            'github'
-          elsif @gitea_event
-            'gitea'
-          end
-    event = @github_event || @gitlab_event || @gitea_event
-
     @scm_extractor = TriggerControllerService::SCMExtractor.new(scm, event, payload)
+  end
+
+  def scm
+    if @gitlab_event
+      'gitlab'
+    elsif @github_event
+      'github'
+    elsif @gitea_event
+      'gitea'
+    end
+  end
+
+  def event
+    @github_event || @gitlab_event || @gitea_event
   end
 
   def validate_scm_event
@@ -78,7 +83,9 @@ class TriggerWorkflowController < TriggerController
     @workflow_run = @token.workflow_runs.create(request_headers: request_headers,
                                                 request_payload: request.body.read,
                                                 workflow_configuration_path: @token.workflow_configuration_path,
-                                                workflow_configuration_url: @token.workflow_configuration_url)
+                                                workflow_configuration_url: @token.workflow_configuration_url,
+                                                scm_vendor: scm,
+                                                hook_event: event)
   end
 
   def extract_scm_webhook

--- a/src/api/app/models/workflow_run.rb
+++ b/src/api/app/models/workflow_run.rb
@@ -23,7 +23,7 @@ class WorkflowRun < ApplicationRecord
     :state, :status_options
   ].freeze
 
-  validates :response_url, :workflow_configuration_path, :workflow_configuration_url, length: { maximum: 255 }
+  validates :response_url, :workflow_configuration_path, :workflow_configuration_url, :scm_vendor, :hook_event, length: { maximum: 255 }
   validates :request_headers, :status, presence: true
 
   belongs_to :token, class_name: 'Token::Workflow', optional: true
@@ -155,10 +155,12 @@ end
 # Table name: workflow_runs
 #
 #  id                          :integer          not null, primary key
+#  hook_event                  :string(255)
 #  request_headers             :text(65535)      not null
 #  request_payload             :text(4294967295) not null
 #  response_body               :text(65535)
 #  response_url                :string(255)
+#  scm_vendor                  :string(255)
 #  status                      :integer          default("running"), not null
 #  workflow_configuration_path :string(255)
 #  workflow_configuration_url  :string(255)

--- a/src/api/db/data/20230620110143_backfill_scm_vendor_and_hook_event_in_workflow_run.rb
+++ b/src/api/db/data/20230620110143_backfill_scm_vendor_and_hook_event_in_workflow_run.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class BackfillScmVendorAndHookEventInWorkflowRun < ActiveRecord::Migration[7.0]
+  def up
+    WorkflowRun.where(scm_vendor: nil, hook_event: nil).each do |workflow_run|
+      headers = parse_request_headers(workflow_run)
+      workflow_run.update(scm_vendor: scm_vendor(headers),
+                          hook_event: hook_event(headers))
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+  def scm_vendor(headers)
+    if headers['HTTP_X_GITEA_EVENT']
+      'gitea'
+    elsif headers['HTTP_X_GITHUB_EVENT']
+      'github'
+    elsif headers['HTTP_X_GITLAB_EVENT']
+      'gitlab'
+    end
+  end
+
+  def hook_event(headers)
+    headers['HTTP_X_GITHUB_EVENT'] ||
+      headers['HTTP_X_GITLAB_EVENT'] || nil
+  end
+
+  def parse_request_headers(workflow_run)
+    workflow_run.request_headers.split("\n").each_with_object({}) do |h, headers|
+      k, v = h.split(':')
+      headers[k] = v.strip
+    end
+  end
+end

--- a/src/api/db/data_schema.rb
+++ b/src/api/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20230523131226)
+DataMigrate::Data.define(version: 20230620110143)

--- a/src/api/db/migrate/20230616154316_add_scm_vendor_and_hook_event_columns_to_workflow_run.rb
+++ b/src/api/db/migrate/20230616154316_add_scm_vendor_and_hook_event_columns_to_workflow_run.rb
@@ -1,0 +1,6 @@
+class AddScmVendorAndHookEventColumnsToWorkflowRun < ActiveRecord::Migration[7.0]
+  def change
+    add_column :workflow_runs, :scm_vendor, :string
+    add_column :workflow_runs, :hook_event, :string
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_15_111252) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_16_154316) do
   create_table "architectures", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "name", null: false, collation: "utf8mb3_general_ci"
     t.boolean "available", default: false
@@ -1117,6 +1117,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_15_111252) do
     t.string "response_url"
     t.string "workflow_configuration_path"
     t.string "workflow_configuration_url"
+    t.string "scm_vendor"
+    t.string "hook_event"
     t.index ["token_id"], name: "index_workflow_runs_on_token_id"
   end
 

--- a/src/api/spec/components/workflow_run_header_component_spec.rb
+++ b/src/api/spec/components/workflow_run_header_component_spec.rb
@@ -2,11 +2,13 @@ require 'rails_helper'
 
 RSpec.describe WorkflowRunHeaderComponent, type: :component do
   let(:workflow_token) { create(:workflow_token) }
+  let(:hook_event) { 'fake' }
   let(:workflow_run) do
     create(:workflow_run,
            token: workflow_token,
            request_headers: request_headers,
-           request_payload: request_payload)
+           request_payload: request_payload,
+           hook_event: hook_event)
   end
 
   before do
@@ -65,6 +67,7 @@ RSpec.describe WorkflowRunHeaderComponent, type: :component do
             }
           END_OF_REQUEST
         end
+        let(:hook_event) { 'pull_request' }
 
         it 'shows the action' do
           expect(rendered_content).to have_text('Opened')
@@ -95,6 +98,7 @@ RSpec.describe WorkflowRunHeaderComponent, type: :component do
             }
           END_OF_REQUEST
         end
+        let(:hook_event) { 'pull_request' }
 
         it 'does not show the action' do
           expect(rendered_content).not_to have_text('edit')
@@ -130,6 +134,7 @@ RSpec.describe WorkflowRunHeaderComponent, type: :component do
           }
         END_OF_REQUEST
       end
+      let(:hook_event) { 'push' }
 
       it 'shows a link to the commit diff' do
         expect(rendered_content).to have_link('1234', href: 'https://example.com/commit/1234')
@@ -154,6 +159,7 @@ RSpec.describe WorkflowRunHeaderComponent, type: :component do
         }
       END_OF_PAYLOAD
     end
+    let(:hook_event) { 'Fake Hook' }
 
     it 'shows the event as a title' do
       expect(rendered_content).to have_text('Fake hook event')
@@ -187,6 +193,7 @@ RSpec.describe WorkflowRunHeaderComponent, type: :component do
           }
         END_OF_REQUEST
       end
+      let(:hook_event) { 'Merge Request Hook' }
 
       ['close', 'merge', 'open', 'reopen', 'update'].each do |action|
         context "and has an #{action}" do
@@ -204,6 +211,7 @@ RSpec.describe WorkflowRunHeaderComponent, type: :component do
               }
             END_OF_REQUEST
           end
+          let(:hook_event) { 'Merge Request Hook' }
 
           it "shows the #{action}" do
             expect(rendered_content).to have_text(action.humanize)
@@ -227,6 +235,7 @@ RSpec.describe WorkflowRunHeaderComponent, type: :component do
             }
           END_OF_REQUEST
         end
+        let(:hook_event) { 'Merge Request Hook' }
 
         it 'does not show the action' do
           expect(rendered_content).not_to have_text('unapproved')
@@ -276,6 +285,7 @@ RSpec.describe WorkflowRunHeaderComponent, type: :component do
           }
         END_OF_PAYLOAD
       end
+      let(:hook_event) { 'Push Hook' }
 
       it 'shows a link to the commit diff' do
         expect(rendered_content).to have_link('3075e06879c6c4bd2ab207b30c5a09d75f825d78',

--- a/src/api/spec/components/workflow_run_row_component_spec.rb
+++ b/src/api/spec/components/workflow_run_row_component_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe WorkflowRunRowComponent, type: :component do
   let(:workflow_token) { create(:workflow_token) }
+  let(:hook_event) { 'pull_request' }
   let(:request_headers) do
     <<~END_OF_HEADERS
       HTTP_X_GITHUB_EVENT: pull_request
@@ -18,7 +19,8 @@ RSpec.describe WorkflowRunRowComponent, type: :component do
     create(:workflow_run,
            token: workflow_token,
            request_headers: request_headers,
-           request_payload: request_payload)
+           request_payload: request_payload,
+           hook_event: hook_event)
   end
 
   before do
@@ -119,6 +121,7 @@ RSpec.describe WorkflowRunRowComponent, type: :component do
     end
 
     context 'when the workflow comes from a push event' do
+      let(:hook_event) { 'push' }
       let(:request_headers) do
         <<~END_OF_HEADERS
           HTTP_X_GITHUB_EVENT: push
@@ -152,6 +155,7 @@ RSpec.describe WorkflowRunRowComponent, type: :component do
   end
 
   context 'when the workflow is triggered via GitLab' do
+    let(:hook_event) { 'Merge Request Hook' }
     let(:request_headers) do
       <<~END_OF_HEADERS
         HTTP_X_GITLAB_EVENT: Merge Request Hook
@@ -235,6 +239,7 @@ RSpec.describe WorkflowRunRowComponent, type: :component do
     end
 
     context 'and comes from a push event' do
+      let(:hook_event) { 'Push Hook' }
       let(:request_headers) do
         <<~END_OF_HEADERS
           HTTP_X_GITLAB_EVENT: Push Hook
@@ -273,7 +278,7 @@ RSpec.describe WorkflowRunRowComponent, type: :component do
         expect(rendered_content).to have_link('vpereira/hello_world', href: 'https://gitlab.com/vpereira/hello_world')
       end
 
-      it 'is expected to have text "Push Event"' do
+      it 'is expected to have text "Push hook event"' do
         expect(rendered_content).to have_text('Push hook event')
       end
 
@@ -341,7 +346,8 @@ RSpec.describe WorkflowRunRowComponent, type: :component do
                status: 'fail',
                token: workflow_token,
                request_headers: request_headers,
-               request_payload: request_payload)
+               request_payload: request_payload,
+               hook_event: nil)
       end
       let(:request_payload) { {} }
       let(:request_headers) do
@@ -351,7 +357,7 @@ RSpec.describe WorkflowRunRowComponent, type: :component do
       end
 
       it 'does not blow up' do
-        expect(rendered_content).to have_text('Fake event')
+        expect(rendered_content).to have_text('Unknown event')
       end
     end
   end

--- a/src/api/spec/db/data/backfill_scm_vendor_and_hook_event_in_workflow_run_spec.rb
+++ b/src/api/spec/db/data/backfill_scm_vendor_and_hook_event_in_workflow_run_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+require Rails.root.join('db/data/20230620110143_backfill_scm_vendor_and_hook_event_in_workflow_run.rb')
+
+RSpec.describe BackfillScmVendorAndHookEventInWorkflowRun, type: :migration do
+  describe 'up' do
+    let(:request_headers) do
+      <<~END_OF_HEADERS
+        HTTP_X_GITLAB_EVENT: Push Hook
+      END_OF_HEADERS
+    end
+    # Simulate old workflow runs' entries where scm_vendor and hook_event where nil
+    let!(:github_workflow_run) { create(:workflow_run, scm_vendor: nil, hook_event: nil) }
+    let!(:gitlab_workflow_run) { create(:workflow_run, request_headers: request_headers, scm_vendor: nil, hook_event: nil) }
+    # Simulate new workflow run entry where scm_vendor and hook_event was set in creation time
+    let!(:gitea_workflow_run) { create(:workflow_run, scm_vendor: 'gitea', hook_event: 'push') }
+
+    subject { BackfillScmVendorAndHookEventInWorkflowRun.new.up }
+
+    before do
+      subject
+    end
+
+    it 'backfill all the expected fields' do
+      expect(WorkflowRun.where(scm_vendor: nil).count).to eq(0)
+      expect(WorkflowRun.where(hook_event: nil).count).to eq(0)
+    end
+
+    it 'fills the first workflow run with GitHub data' do
+      expect(github_workflow_run.reload.scm_vendor).to eq('github')
+      expect(github_workflow_run.reload.hook_event).to eq('pull_request')
+    end
+
+    it 'fills the second workflow run with GitLab data' do
+      expect(gitlab_workflow_run.reload.scm_vendor).to eq('gitlab')
+      expect(gitlab_workflow_run.reload.hook_event).to eq('Push Hook')
+    end
+
+    it 'keeps the Gitea data in the third workflow run' do
+      expect(gitea_workflow_run.reload.scm_vendor).to eq('gitea')
+      expect(gitea_workflow_run.reload.hook_event).to eq('push')
+    end
+  end
+end

--- a/src/api/spec/factories/workflow_runs.rb
+++ b/src/api/spec/factories/workflow_runs.rb
@@ -1,6 +1,8 @@
 FactoryBot.define do
   factory :workflow_run do
     token { create(:workflow_token) }
+    scm_vendor { 'github' }
+    hook_event { 'pull_request' }
     request_headers do
       <<~END_OF_HEADERS
         HTTP_X_GITHUB_EVENT: pull_request
@@ -42,6 +44,7 @@ FactoryBot.define do
         end
       end
       trait :push do
+        hook_event { 'push' }
         request_headers do
           <<~END_OF_HEADERS
             HTTP_X_GITHUB_EVENT: push
@@ -52,6 +55,7 @@ FactoryBot.define do
         end
       end
       trait :tag_push do
+        hook_event { 'push' }
         request_headers do
           <<~END_OF_HEADERS
             HTTP_X_GITHUB_EVENT: push
@@ -115,6 +119,8 @@ FactoryBot.define do
 
   # GitLab
   factory :workflow_run_gitlab, parent: :workflow_run do
+    scm_vendor { 'gitlab' }
+    hook_event { 'Merge Request Hook' }
     request_headers do
       <<~END_OF_HEADERS
         HTTP_X_GITLAB_EVENT: Merge Request Hook
@@ -145,6 +151,7 @@ FactoryBot.define do
         end
       end
       trait :push do
+        hook_event { 'Push Hook' }
         request_headers do
           <<~END_OF_HEADERS
             HTTP_X_GITLAB_EVENT: Push Hook
@@ -155,6 +162,7 @@ FactoryBot.define do
         end
       end
       trait :tag_push do
+        hook_event { 'Tag Push Hook' }
         request_headers do
           <<~END_OF_HEADERS
             HTTP_X_GITLAB_EVENT: Tag Push Hook
@@ -168,12 +176,16 @@ FactoryBot.define do
 
     factory :workflow_run_gitlab_running do
       status { 'running' }
+      scm_vendor { 'gitlab' }
+      hook_event { 'Merge Request Hook' }
       response_body { nil }
       response_url { nil }
     end
 
     factory :workflow_run_gitlab_failed do
       status { 'fail' }
+      scm_vendor { 'gitlab' }
+      hook_event { 'Merge Request Hook' }
       response_body do
         <<~END_OF_RESPONSE_BODY
           <status code="unknown">

--- a/src/api/spec/models/workflow_run_spec.rb
+++ b/src/api/spec/models/workflow_run_spec.rb
@@ -88,26 +88,4 @@ RSpec.describe WorkflowRun, vcr: true do
       end
     end
   end
-
-  describe '#scm_vendor' do
-    let(:workflow_run) { create(:workflow_run, request_headers: headers) }
-
-    subject { workflow_run.scm_vendor }
-
-    context 'when event is from GitHub' do
-      let(:headers) { "HTTP_X_GITHUB_EVENT_TYPE: pull_request\nHTTP_X_GITHUB_EVENT: pull_request\nHTTP_ACCEPT: application/xml" }
-
-      it 'identifies GitHub' do
-        expect(subject).to be(:github)
-      end
-    end
-
-    context 'when event is from Gitea' do
-      let(:headers) { "HTTP_X_GITEA_EVENT: pull_request\nHTTP_X_GITHUB_EVENT_TYPE: pull_request\nHTTP_X_GITHUB_EVENT: pull_request\nHTTP_ACCEPT: application/xml" }
-
-      it 'identifies Gitea' do
-        expect(subject).to be(:gitea)
-      end
-    end
-  end
 end


### PR DESCRIPTION
We are extending the WorkflowRun model to make it easier to query by relevant data that helps us debug failed integrations.

The SCM vendor and the hook event are key for us to query. They are now stored in the `workflow_runs` table.

This PR includes a data migration to backfill those values taking the data from `WorkflowRun#request_headers`. 

Nothing changed in the UI as we were displaying that information already:

![Workflow-Run-23-Open-Build-Service](https://github.com/openSUSE/open-build-service/assets/2581944/b8e25377-2f35-46e6-8f81-c91c78742dd0)


Based on #14509 