### PR TITLE
[dist] obsapisetup: create openssl key with 4096

### DIFF
--- a/dist/setup-appliance.sh
+++ b/dist/setup-appliance.sh
@@ -344,7 +344,7 @@ function check_server_key {
   # reuse signing key even if hostname changed
   if [ ! -e $backenddir/certs/server.key ]; then
       install -d -m 0700 $backenddir/certs
-      openssl genrsa -out $backenddir/certs/server.key 1024 2>/dev/null
+      openssl genrsa -out $backenddir/certs/server.key 4096 2>/dev/null
   fi
 }
 ###############################################################################


### PR DESCRIPTION
This is required since opensuse 15.4. Otherwise apache will fail with a config error