### PR TITLE
Expand workflow run with payload info

### DIFF
--- a/src/api/app/components/workflow_run_row_component.rb
+++ b/src/api/app/components/workflow_run_row_component.rb
@@ -8,7 +8,7 @@ class WorkflowRunRowComponent < ApplicationComponent
     @status = workflow_run.status
     @hook_event = workflow_run.hook_event || 'unknown'
     @hook_action = workflow_run.hook_action
-    @repository_name = workflow_run.repository_name
+    @repository_name = workflow_run.repository_full_name
     @repository_url = workflow_run.repository_url
     @event_source_name = workflow_run.event_source_name
     @event_source_url = workflow_run.event_source_url

--- a/src/api/app/controllers/concerns/scm_webhook_headers_data_extractor.rb
+++ b/src/api/app/controllers/concerns/scm_webhook_headers_data_extractor.rb
@@ -1,0 +1,36 @@
+module ScmWebhookHeadersDataExtractor
+  extend ActiveSupport::Concern
+
+  def set_scm_event
+    @gitlab_event = request.env['HTTP_X_GITLAB_EVENT']
+    # Gitea contains the Github headers as well, so we have to check that the Gitea ones are
+    # not present for Github
+    @github_event = request.env['HTTP_X_GITHUB_EVENT'] unless request.env['HTTP_X_GITEA_EVENT']
+    @gitea_event = request.env['HTTP_X_GITEA_EVENT']
+  end
+
+  def scm_vendor
+    if @gitlab_event
+      'gitlab'
+    elsif @github_event
+      'github'
+    elsif @gitea_event
+      'gitea'
+    end
+  end
+
+  def hook_event
+    @github_event || @gitlab_event || @gitea_event
+  end
+
+  def extract_generic_event_type
+    # We only have filters for push, tag_push, and pull_request
+    if hook_event == 'Push Hook' || payload.fetch('ref', '').match('refs/heads')
+      'push'
+    elsif hook_event == 'Tag Push Hook' || payload.fetch('ref', '').match('refs/tag')
+      'tag_push'
+    elsif hook_event.in?(['pull_request', 'Merge Request Hook'])
+      'pull_request'
+    end
+  end
+end

--- a/src/api/lib/tasks/dev/workflows.rake
+++ b/src/api/lib/tasks/dev/workflows.rake
@@ -74,5 +74,5 @@ end
 # If the name of the project created by the workflow is "home:Iggy:iggy:hello_world:PR-68", its postfix
 # is "iggy:hello_world:PR-68". This is the only information we can extract from the workflow_run.
 def target_project_name_postfix(workflow_run)
-  ":#{workflow_run.repository_name.tr('/', ':')}:PR-#{workflow_run.event_source_name}" if workflow_run.repository_name && workflow_run.event_source_name
+  ":#{workflow_run.repository_owner}:#{workflow_run.repository_name}:PR-#{workflow_run.event_source_name}" if workflow_run.repository_name && workflow_run.event_source_name
 end

--- a/src/api/spec/lib/tasks/workflows_spec.rb
+++ b/src/api/spec/lib/tasks/workflows_spec.rb
@@ -6,45 +6,17 @@ RSpec.describe 'workflows' do
   include_context 'rake'
 
   let!(:admin_user) { create(:admin_user, login: 'Admin') }
-  let(:github_request_payload_closed) do
-    <<~END_OF_REQUEST
-      {
-        "action": "closed",
-        "pull_request": {
-          "number": 2
-        },
-        "project": {
-          "path_with_namespace": "iggy/hello_world"
-        }
-      }
-    END_OF_REQUEST
-  end
-  let(:gitlab_request_payload_merge) do
-    <<~END_OF_REQUEST
-      {
-        "object_kind": "merge_request",
-        "event_type": "merge_request",
-        "object_attributes": {
-          "iid": 3,
-          "action": "merge"
-        },
-        "project": {
-          "path_with_namespace": "iggy/test"
-        }
-      }
-    END_OF_REQUEST
-  end
-
   let!(:project_iggy_hello_world_pr1) { create(:project, name: 'home:Iggy:iggy:hello_world:PR-1') }
   let!(:project_iggy_hello_world_pr2) { create(:project, name: 'home:Iggy:iggy:hello_world:PR-2') }
   let!(:project_iggy_test_pr3) { create(:project, name: 'home:Iggy:iggy:test:PR-3') }
 
-  let!(:workflow_run_running_pr_opened) { create(:workflow_run_github_running) }
-  let!(:workflow_run_succeeded_pr_opened) { create(:workflow_run_github_succeeded, :pull_request_opened) }
-  let!(:workflow_run_failed_pr_opened) { create(:workflow_run_github_failed) }
-  let!(:workflow_run_running_pr_closed) { create(:workflow_run_github_running, request_payload: github_request_payload_closed) }
-  let!(:another_workflow_run_running_pr_closed) { create(:workflow_run_github_running, request_payload: github_request_payload_closed) }
-  let!(:workflow_run_running_pr_merge) { create(:workflow_run_gitlab_running, request_payload: gitlab_request_payload_merge) }
+  let!(:workflow_run_running_pr_opened) { create(:workflow_run, repository_owner: 'iggy', repository_name: 'hello_world') }
+  let!(:workflow_run_succeeded_pr_opened) { create(:workflow_run, :success, repository_owner: 'iggy', repository_name: 'hello_world') }
+  let!(:workflow_run_failed_pr_opened) { create(:workflow_run, :failed, repository_owner: 'iggy', repository_name: 'hello_world') }
+
+  let!(:workflow_run_running_pr_closed) { create(:workflow_run, :pull_request_closed, repository_owner: 'iggy', repository_name: 'hello_world', event_source_name: 1) }
+  let!(:another_workflow_run_running_pr_closed) { create(:workflow_run, :pull_request_closed, repository_owner: 'iggy', repository_name: 'hello_world', event_source_name: 2) }
+  let!(:workflow_run_running_pr_merge) { create(:workflow_run_gitlab, :pull_request_merged, repository_owner: 'iggy', repository_name: 'hello_world', event_source_name: 3) }
 
   describe 'cleanup_non_closed_projects' do
     let(:task) { 'dev:workflows:cleanup_non_closed_projects' }

--- a/src/api/spec/models/token/workflow_spec.rb
+++ b/src/api/spec/models/token/workflow_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Token::Workflow do
   describe '#call' do
     let(:token_user) { create(:confirmed_user, :with_home, login: 'Iggy') }
     let(:workflow_token) { create(:workflow_token, executor: token_user) }
-    let(:workflow_run) { create(:workflow_run, token: workflow_token) }
+    let(:workflow_run) { create(:workflow_run, token: workflow_token, response_url: 'https://example.com') }
 
     context 'without a payload' do
       it do

--- a/src/api/spec/queries/workflow_runs_finder_spec.rb
+++ b/src/api/spec/queries/workflow_runs_finder_spec.rb
@@ -3,15 +3,15 @@ require 'rails_helper'
 RSpec.describe WorkflowRunsFinder do
   let(:workflow_token) { create(:workflow_token) }
   # GitHub
-  let!(:workflow_run_github_push) { create(:workflow_run_github_succeeded, :push, token: workflow_token) }
-  let!(:workflow_run_github_tag_push) { create(:workflow_run_github_succeeded, :tag_push, token: workflow_token) }
-  let!(:workflow_run_github_pull_request_opened) { create(:workflow_run_github_succeeded, :pull_request_opened, token: workflow_token) }
-  let!(:workflow_run_github_pull_request_closed) { create(:workflow_run_github_succeeded, :pull_request_closed, token: workflow_token) }
+  let!(:workflow_run_github_push) { create(:workflow_run, :push, :succeeded, token: workflow_token) }
+  let!(:workflow_run_github_tag_push) { create(:workflow_run, :tag_push, :succeeded, token: workflow_token) }
+  let!(:workflow_run_github_pull_request_opened) { create(:workflow_run, :succeeded, token: workflow_token) }
+  let!(:workflow_run_github_pull_request_closed) { create(:workflow_run, :succeeded, :pull_request_closed, token: workflow_token) }
   # GitLab
-  let!(:workflow_run_gitlab_push) { create(:workflow_run_gitlab_succeeded, :push, token: workflow_token) }
-  let!(:workflow_run_gitlab_tag_push) { create(:workflow_run_gitlab_succeeded, :tag_push, token: workflow_token) }
-  let!(:workflow_run_gitlab_pull_request_opened) { create(:workflow_run_gitlab_succeeded, :pull_request_opened, token: workflow_token) }
-  let!(:workflow_run_gitlab_pull_request_closed) { create(:workflow_run_gitlab_succeeded, :pull_request_closed, token: workflow_token) }
+  let!(:workflow_run_gitlab_push) { create(:workflow_run_gitlab, :push, :succeeded, token: workflow_token) }
+  let!(:workflow_run_gitlab_tag_push) { create(:workflow_run_gitlab, :tag_push, :succeeded, token: workflow_token) }
+  let!(:workflow_run_gitlab_pull_request_opened) { create(:workflow_run_gitlab, :succeeded, token: workflow_token) }
+  let!(:workflow_run_gitlab_pull_request_closed) { create(:workflow_run_gitlab, :succeeded, :pull_request_closed, token: workflow_token) }
 
   before do
     ['success', 'running', 'fail'].each do |status|

--- a/src/api/spec/support/files/request_payload_gitlab_pull_request_merged.json
+++ b/src/api/spec/support/files/request_payload_gitlab_pull_request_merged.json
@@ -1,0 +1,11 @@
+{
+  "object_kind": "merge_request",
+  "event_type": "merge_request",
+  "object_attributes": {
+    "iid": 3,
+    "action": "merge"
+  },
+  "project": {
+    "path_with_namespace": "iggy/test"
+  }
+}


### PR DESCRIPTION
Extract some of the important information that is in the SCM webhook HTTP request (headers/body) into `WorkflowRun` attributes so they are easier to query.
