### PR TITLE
Avoid inheriting github payload in gitea's pull_request

### DIFF
--- a/src/api/app/models/gitea_payload/pull_request.rb
+++ b/src/api/app/models/gitea_payload/pull_request.rb
@@ -1,21 +1,15 @@
 # This class is used in TriggerControllerService::ScmExtractor to handle pull requests events coming from Gitea.
-# It's basically the same than the pull requests coming from Github but with some customizations on top.
-class GiteaPayload::PullRequest < GithubPayload::PullRequest
+class GiteaPayload::PullRequest < GiteaPayload
   def payload
-    super.merge(scm: 'gitea',
-                http_url: http_url,
-                api_endpoint: api_endpoint)
-  end
-
-  private
-
-  def http_url
-    webhook_payload.dig(:repository, :clone_url)
-  end
-
-  def api_endpoint
-    url = URI.parse(http_url)
-
-    "#{url.scheme}://#{url.host}"
+    default_payload.merge(
+      event: 'pull_request',
+      commit_sha: webhook_payload.dig(:pull_request, :head, :sha),
+      pr_number: webhook_payload[:number],
+      source_branch: webhook_payload.dig(:pull_request, :head, :ref),
+      target_branch: webhook_payload.dig(:pull_request, :base, :ref),
+      action: webhook_payload[:action],
+      source_repository_full_name: webhook_payload.dig(:pull_request, :head, :repo, :full_name),
+      target_repository_full_name: webhook_payload.dig(:pull_request, :base, :repo, :full_name)
+    )
   end
 end


### PR DESCRIPTION
This finishes the former work of not inheriting github payload in gitea classes.