### PR TITLE
Use version '1.1' for OBS SCM/CI workflows

### DIFF
--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -1,3 +1,4 @@
+version: '1.1'
 testbuild:
   steps:
     - branch_package:


### PR DESCRIPTION
After introducing versioning for the SCM/CI workflows, let's use the latest version ourselfs.