### PR TITLE
Introduces workflow run payload fields

### DIFF
--- a/src/api/app/controllers/concerns/scm_webhook_payload_data_extractor.rb
+++ b/src/api/app/controllers/concerns/scm_webhook_payload_data_extractor.rb
@@ -1,0 +1,51 @@
+module ScmWebhookPayloadDataExtractor
+  extend ActiveSupport::Concern
+
+  SOURCE_NAME_PAYLOAD_MAPPING = {
+    'pull_request' => ['pull_request', 'number'],
+    'Merge Request Hook' => ['object_attributes', 'iid'],
+    'push' => ['head_commit', 'id'],
+    'Push Hook' => ['commits', 0, 'id']
+  }.freeze
+
+  def payload
+    request_body = request.body.read
+    raise Trigger::Errors::BadSCMPayload if request_body.blank?
+
+    begin
+      JSON.parse(request_body)
+    rescue JSON::ParserError
+      raise Trigger::Errors::BadSCMPayload
+    end
+  end
+
+  def extract_hook_action
+    return payload['action'] if pull_request_with_allowed_action
+    return payload.dig('object_attributes', 'action') if merge_request_with_allowed_action
+  end
+
+  def extract_repository_name
+    payload.dig('repository', 'name') || # For GitHub and Gitea
+      payload.dig('project', 'path_with_namespace')&.split('/')&.last # For GitLab
+  end
+
+  def extract_repository_owner
+    payload.dig('repository', 'owner', 'login') || # For GitHub and Gitea
+      payload.dig('project', 'path_with_namespace')&.split('/')&.first # For GitLab
+  end
+
+  def extract_event_source_name
+    path = SOURCE_NAME_PAYLOAD_MAPPING[hook_event]
+    payload.dig(*path) if path
+  end
+
+  def pull_request_with_allowed_action
+    hook_event == 'pull_request' &&
+      SCMWebhook::ALLOWED_PULL_REQUEST_ACTIONS.include?(payload['action'])
+  end
+
+  def merge_request_with_allowed_action
+    hook_event == 'Merge Request Hook' &&
+      SCMWebhook::ALLOWED_MERGE_REQUEST_ACTIONS.include?(payload.dig('object_attributes', 'action'))
+  end
+end

--- a/src/api/app/models/workflow_run.rb
+++ b/src/api/app/models/workflow_run.rb
@@ -22,7 +22,10 @@ class WorkflowRun < ApplicationRecord
     :state, :status_options
   ].freeze
 
-  validates :response_url, :workflow_configuration_path, :workflow_configuration_url, :scm_vendor, :hook_event, length: { maximum: 255 }
+  validates :scm_vendor, :response_url,
+            :workflow_configuration_path, :workflow_configuration_url,
+            :hook_event, :hook_action, :generic_event_type,
+            :repository_name, :repository_owner, :event_source_name, length: { maximum: 255 }
   validates :request_headers, :status, presence: true
 
   belongs_to :token, class_name: 'Token::Workflow', optional: true
@@ -125,7 +128,12 @@ end
 # Table name: workflow_runs
 #
 #  id                          :integer          not null, primary key
+#  event_source_name           :string(255)
+#  generic_event_type          :string(255)
+#  hook_action                 :string(255)
 #  hook_event                  :string(255)
+#  repository_name             :string(255)
+#  repository_owner            :string(255)
 #  request_headers             :text(65535)      not null
 #  request_payload             :text(4294967295) not null
 #  response_body               :text(65535)

--- a/src/api/db/data/20230623122537_backfill_workflow_run_payload_data.rb
+++ b/src/api/db/data/20230623122537_backfill_workflow_run_payload_data.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class BackfillWorkflowRunPayloadData < ActiveRecord::Migration[7.0]
+  include ScmWebhookPayloadDataExtractor
+
+  def up
+    WorkflowRun.where(hook_action: nil).in_batches do |workflow_runs|
+      workflow_runs.each do |workflow_run|
+        @workflow_run = workflow_run
+        workflow_run.hook_action = extract_hook_action
+        workflow_run.repository_name = extract_repository_name
+        workflow_run.repository_owner = extract_repository_owner
+        workflow_run.event_source_name = extract_event_source_name
+        workflow_run.save!
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+  def payload
+    @workflow_run.payload
+  end
+
+  def hook_event
+    @workflow_run.hook_event
+  end
+end

--- a/src/api/db/data_schema.rb
+++ b/src/api/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20230620110143)
+DataMigrate::Data.define(version: 20230623122537)

--- a/src/api/db/migrate/20230621071327_add_payload_data_to_workflow_run.rb
+++ b/src/api/db/migrate/20230621071327_add_payload_data_to_workflow_run.rb
@@ -1,0 +1,9 @@
+class AddPayloadDataToWorkflowRun < ActiveRecord::Migration[7.0]
+  def change
+    add_column :workflow_runs, :hook_action, :string
+    add_column :workflow_runs, :repository_name, :string
+    add_column :workflow_runs, :repository_owner, :string
+    add_column :workflow_runs, :event_source_name, :string
+    add_column :workflow_runs, :generic_event_type, :string
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_16_154316) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_21_071327) do
   create_table "architectures", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "name", null: false, collation: "utf8mb3_general_ci"
     t.boolean "available", default: false
@@ -1119,6 +1119,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_16_154316) do
     t.string "workflow_configuration_url"
     t.string "scm_vendor"
     t.string "hook_event"
+    t.string "hook_action"
+    t.string "repository_name"
+    t.string "repository_owner"
+    t.string "event_source_name"
+    t.string "generic_event_type"
     t.index ["token_id"], name: "index_workflow_runs_on_token_id"
   end
 

--- a/src/api/spec/support/files/request_payload_github_pull_request_opened.json
+++ b/src/api/spec/support/files/request_payload_github_pull_request_opened.json
@@ -4,7 +4,10 @@
     "number": 1
   },
   "repository": {
-    "full_name": "iggy/hello_world",
-    "html_url": "https://github.com"
+    "name": "hello_world",
+    "html_url": "https://github.com",
+    "owner": {
+      "login": "iggy"
+    }
   }
 }

--- a/src/api/spec/support/files/request_payload_github_push.json
+++ b/src/api/spec/support/files/request_payload_github_push.json
@@ -10,10 +10,12 @@
   "repository": {
     "id": 371734220,
     "name": "hello_world",
-    "full_name": "iggy/hello_world",
     "html_url": "https://github.com/iggy/hello_world",
     "url": "https://github.com/iggy/hello_world",
     "git_url": "git://github.com/iggy/hello_world.git",
-    "master_branch": "master"
+    "master_branch": "master",
+    "owner": {
+      "login": "iggy"
+    }
   }
 }

--- a/src/api/spec/support/files/request_payload_github_tag_push.json
+++ b/src/api/spec/support/files/request_payload_github_tag_push.json
@@ -10,9 +10,11 @@
   "repository": {
     "id": 371734220,
     "name": "hello_world",
-    "full_name": "iggy/hello_world",
     "html_url": "https://github.com/iggy/hello_world",
     "url": "https://github.com/iggy/hello_world",
-    "git_url": "git://github.com/iggy/hello_world.git"
+    "git_url": "git://github.com/iggy/hello_world.git",
+    "owner": {
+      "login": "iggy"
+    }
   }
 }


### PR DESCRIPTION
Extend workflow_run DB table to store data from the payload. Extracted from #14527 so we can run this online.

1. We create the fields in the database
2. Getters are still using the `request_payload` field to fetch the data
3. Setters are the default from AR
4. Data migration to backfill data from payload field
5. Getters will [be removed](https://github.com/openSUSE/open-build-service/pull/14527/commits/114aaccc8b9ab2d4333af88fbbc8ed21e3f96629) once the second PR is merged