### PR TITLE
Gracefully handle WorkflowRuns without payload...

### DIFF
--- a/src/api/app/models/workflow_run.rb
+++ b/src/api/app/models/workflow_run.rb
@@ -61,7 +61,7 @@ class WorkflowRun < ApplicationRecord
   end
 
   def payload
-    JSON.parse(request_payload)
+    JSON.parse(request_payload.presence || {})
   rescue JSON::ParserError
     { payload: 'unparseable' }
   end

--- a/src/api/db/data/20230623122537_backfill_workflow_run_payload_data.rb
+++ b/src/api/db/data/20230623122537_backfill_workflow_run_payload_data.rb
@@ -21,7 +21,7 @@ class BackfillWorkflowRunPayloadData < ActiveRecord::Migration[7.0]
   end
 
   def payload
-    @workflow_run.payload
+    @workflow_run.payload.presence || {}
   end
 
   def hook_event


### PR DESCRIPTION
This is happening if we error out while trying to read the HTTP request body in
TriggerWorkflowController.

```
[4] pry(main)> WorkflowRun.where(request_payload: "").map(&:response_body).uniq
=> ["<status code=\"bad_request\">\n  <summary>Trigger::Errors::BadScmPayload</summary>\n</status>\n"]
```

https://github.com/openSUSE/open-build-service/blob/89097f782977526c1d9328c85d66a646484dc67c/src/api/app/controllers/concerns/scm_webhook_payload_data_extractor.rb#L11-L20