### PR TITLE
feat: workflow build job add pending status support

### DIFF
--- a/src/api/app/models/workflow/step.rb
+++ b/src/api/app/models/workflow/step.rb
@@ -72,6 +72,10 @@ class Workflow::Step
     end
   end
 
+  def repositories
+    step_instructions[:repositories]
+  end
+
   protected
 
   def validate_step_instructions

--- a/src/api/spec/models/token/workflow_spec.rb
+++ b/src/api/spec/models/token/workflow_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Token::Workflow do
       let(:scm_extractor) { TriggerControllerService::SCMExtractor.new(scm, event, github_payload) }
       let(:scm_webhook) { SCMWebhook.new(payload: github_extractor_payload) }
       let(:yaml_downloader) { Workflows::YAMLDownloader.new(scm_webhook.payload, token: workflow_token) }
-      let(:yaml_file) { Rails.root.join('spec/support/files/workflows.yml').expand_path }
+      let(:yaml_file) { Rails.root.join('spec/support/files/workflows_with_repository_configuration.yml').expand_path }
       let(:yaml_to_workflows_service) { Workflows::YAMLToWorkflowsService.new(yaml_file: yaml_file, scm_webhook: scm_webhook, token: workflow_token, workflow_run: workflow_run) }
       let(:workflow) do
         Workflow.new(scm_webhook: scm_webhook, token: workflow_token,

--- a/src/api/spec/support/files/workflows_with_repository_configuration.yml
+++ b/src/api/spec/support/files/workflows_with_repository_configuration.yml
@@ -1,0 +1,22 @@
+workflow123:
+  steps:
+    - branch_package:
+        source_project: "test-project"
+        source_package: "test-package"
+        target_project: "test-target-project"
+    - configure_repositories:
+        project: "test-target-project"
+        repositories:
+          - name: "test-repository"
+            paths:
+              - target_project: "test-target-project"
+                target_repository: "test-repository"
+            architectures:
+              - x86_64
+
+  filters:
+    branches:
+      only:
+        - 'main'
+        - 'master'
+        - 'source'


### PR DESCRIPTION
When the repositories configuration is clearly defined in the workflow, the job list can be determined, so the pending status of the job can be added.