### PR TITLE
Introduces new ContainerPublished event

### DIFF
--- a/src/api/app/models/event/container_published.rb
+++ b/src/api/app/models/event/container_published.rb
@@ -1,0 +1,26 @@
+module Event
+  class ContainerPublished < Base
+    self.message_bus_routing_key = 'container.published'
+    self.description = 'Container image was published'
+    payload_keys :project, :repo, :buildid, :container
+  end
+end
+
+# == Schema Information
+#
+# Table name: events
+#
+#  id          :bigint           not null, primary key
+#  eventtype   :string(255)      not null, indexed
+#  mails_sent  :boolean          default(FALSE), indexed
+#  payload     :text(65535)
+#  undone_jobs :integer          default(0)
+#  created_at  :datetime         indexed
+#  updated_at  :datetime
+#
+# Indexes
+#
+#  index_events_on_created_at  (created_at)
+#  index_events_on_eventtype   (eventtype)
+#  index_events_on_mails_sent  (mails_sent)
+#


### PR DESCRIPTION
An event if a container image is published to a registry.

Jira feature [OBS-243](https://jira.suse.com/browse/OBS-243)