### PR TITLE
Save the workflow yaml content into the workflow run

### DIFF
--- a/src/api/app/models/workflow_run.rb
+++ b/src/api/app/models/workflow_run.rb
@@ -20,6 +20,7 @@ class WorkflowRun < ApplicationRecord
             :hook_event, :hook_action, :generic_event_type,
             :repository_name, :repository_owner, :event_source_name, length: { maximum: 255 }
   validates :request_headers, :status, presence: true
+  validates :workflow_configuration, length: { maximum: 65_535 }
 
   belongs_to :token, class_name: 'Token::Workflow', optional: true
   has_many :artifacts, class_name: 'WorkflowArtifactsPerStep', dependent: :destroy
@@ -101,6 +102,7 @@ end
 #  response_url                :string(255)
 #  scm_vendor                  :string(255)
 #  status                      :integer          default("running"), not null
+#  workflow_configuration      :text(65535)
 #  workflow_configuration_path :string(255)
 #  workflow_configuration_url  :string(255)
 #  created_at                  :datetime         not null

--- a/src/api/db/migrate/20230626092852_add_workflow_configuration_to_workflow_runs.rb
+++ b/src/api/db/migrate/20230626092852_add_workflow_configuration_to_workflow_runs.rb
@@ -1,0 +1,5 @@
+class AddWorkflowConfigurationToWorkflowRuns < ActiveRecord::Migration[7.0]
+  def change
+    add_column :workflow_runs, :workflow_configuration, :text
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_21_071327) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_26_092852) do
   create_table "architectures", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "name", null: false, collation: "utf8mb3_general_ci"
     t.boolean "available", default: false
@@ -1124,6 +1124,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_21_071327) do
     t.string "repository_owner"
     t.string "event_source_name"
     t.string "generic_event_type"
+    t.text "workflow_configuration"
     t.index ["token_id"], name: "index_workflow_runs_on_token_id"
   end
 


### PR DESCRIPTION
Having the actual Workflow configuration stored may help debug what happened when a Workflow Run fails.