### PR TITLE
Save more header content to WorkflowRun

### DIFF
--- a/src/api/app/controllers/concerns/scm_webhook_headers_data_extractor.rb
+++ b/src/api/app/controllers/concerns/scm_webhook_headers_data_extractor.rb
@@ -23,6 +23,14 @@ module ScmWebhookHeadersDataExtractor
     @github_event || @gitlab_event || @gitea_event
   end
 
+  def extract_event_uuid
+    request.env['HTTP_X_GITHUB_DELIVERY'] || request.env['HTTP_X_GITLAB_EVENT_UUID']
+  end
+
+  def extract_webhook_id
+    request.env['HTTP_X_GITHUB_HOOK_ID']
+  end
+
   def extract_generic_event_type
     # We only have filters for push, tag_push, and pull_request
     if hook_event == 'Push Hook' || payload.fetch('ref', '').match('refs/heads')

--- a/src/api/app/controllers/trigger_workflow_controller.rb
+++ b/src/api/app/controllers/trigger_workflow_controller.rb
@@ -45,13 +45,15 @@ class TriggerWorkflowController < TriggerController
   def create_workflow_run
     raise Trigger::Errors::InvalidToken, 'Wrong token type. Please use workflow tokens only.' unless @token.is_a?(Token::Workflow)
 
-    request_headers = request.headers.to_h.keys.map { |k| "#{k}: #{request.headers[k]}" if k.match?(/^HTTP_/) }.compact.join("\n")
+    request_headers = request.headers.to_h.select {|key, _value| key.starts_with?('HTTP_X') }
     @workflow_run = @token.workflow_runs.create(request_headers: request_headers,
                                                 request_payload: request.body.read,
                                                 workflow_configuration_path: @token.workflow_configuration_path,
                                                 workflow_configuration_url: @token.workflow_configuration_url,
                                                 scm_vendor: scm_vendor,
                                                 hook_event: hook_event,
+                                                event_uuid: extract_event_uuid,
+                                                webhook_id: extract_webhook_id,
                                                 hook_action: extract_hook_action,
                                                 repository_name: extract_repository_name,
                                                 repository_owner: extract_repository_owner,

--- a/src/api/app/models/workflow_run.rb
+++ b/src/api/app/models/workflow_run.rb
@@ -16,6 +16,7 @@ class WorkflowRun < ApplicationRecord
   ].freeze
 
   validates :scm_vendor, :response_url,
+            :event_uuid, :webhook_id,
             :workflow_configuration_path, :workflow_configuration_url,
             :hook_event, :hook_action, :generic_event_type,
             :repository_name, :repository_owner, :event_source_name, length: { maximum: 255 }
@@ -90,6 +91,7 @@ end
 #
 #  id                          :integer          not null, primary key
 #  event_source_name           :string(255)
+#  event_uuid                  :string(255)
 #  generic_event_type          :string(255)
 #  hook_action                 :string(255)
 #  hook_event                  :string(255)
@@ -106,6 +108,7 @@ end
 #  created_at                  :datetime         not null
 #  updated_at                  :datetime         not null
 #  token_id                    :integer          not null, indexed
+#  webhook_id                  :string(255)
 #
 # Indexes
 #

--- a/src/api/db/data/20230626141554_backfill_workflow_run_payload_data.rb
+++ b/src/api/db/data/20230626141554_backfill_workflow_run_payload_data.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class BackfillWorkflowRunPayloadData < ActiveRecord::Migration[7.0]
+  include ScmWebhookHeadersDataExtractor
+
+  def up
+    WorkflowRun.where.not(request_headers: '').in_batches do |workflow_runs|
+      workflow_runs.each do |workflow_run|
+        @workflow_run = workflow_run
+        workflow_run.event_uuid = extract_event_uuid
+        workflow_run.webhook_id = extract_webhook_id
+        workflow_run.save!
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+  def request
+    @workflow_run.request_headers
+  end
+end

--- a/src/api/db/migrate/20230626120227_add_ids_to_workflow_run.rb
+++ b/src/api/db/migrate/20230626120227_add_ids_to_workflow_run.rb
@@ -1,0 +1,6 @@
+class AddIdsToWorkflowRun < ActiveRecord::Migration[7.0]
+  def change
+    add_column :workflow_runs, :event_uuid, :string
+    add_column :workflow_runs, :webhook_id, :string
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_21_071327) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_26_120227) do
   create_table "architectures", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "name", null: false, collation: "utf8mb3_general_ci"
     t.boolean "available", default: false
@@ -1124,6 +1124,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_21_071327) do
     t.string "repository_owner"
     t.string "event_source_name"
     t.string "generic_event_type"
+    t.string "event_uuid"
+    t.string "webhook_id"
     t.index ["token_id"], name: "index_workflow_runs_on_token_id"
   end
 


### PR DESCRIPTION
event_uuid: Set by all vendors, helps to identify the exact webhook event that caused this workflow to run

webhook_id: Set only be github so far, help to identify the webhook that caused this workflow to run