### PR TITLE
Make use of newly introduced traits in dev tasks

### DIFF
--- a/src/api/lib/tasks/dev/workflows.rake
+++ b/src/api/lib/tasks/dev/workflows.rake
@@ -15,20 +15,20 @@ namespace :dev do
       workflow_token = Token::Workflow.find_by(description: 'Testing token') || create(:workflow_token, executor: admin, description: 'Testing token')
 
       # GitHub
-      create(:workflow_run_github_running, token: workflow_token)
-      create(:workflow_run_github_failed, token: workflow_token)
-      create(:workflow_run_github_succeeded, :push, token: workflow_token)
-      create(:workflow_run_github_succeeded, :tag_push, token: workflow_token)
-      create(:workflow_run_github_succeeded, :pull_request_opened, token: workflow_token)
-      create(:workflow_run_github_succeeded, :pull_request_closed, token: workflow_token)
+      create(:workflow_run, token: workflow_token)
+      create(:workflow_run, :failed, token: workflow_token)
+      create(:workflow_run, :succeeded, :push, token: workflow_token)
+      create(:workflow_run, :succeeded, :tag_push, token: workflow_token)
+      create(:workflow_run, :succeeded, token: workflow_token)
+      create(:workflow_run, :succeeded, :pull_request_closed, token: workflow_token)
 
       # GitLab
-      create(:workflow_run_gitlab_running, token: workflow_token)
-      create(:workflow_run_gitlab_failed, token: workflow_token)
-      create(:workflow_run_gitlab_succeeded, :push, token: workflow_token)
-      create(:workflow_run_gitlab_succeeded, :tag_push, token: workflow_token)
-      create(:workflow_run_gitlab_succeeded, :pull_request_opened, token: workflow_token)
-      create(:workflow_run_gitlab_succeeded, :pull_request_closed, token: workflow_token)
+      create(:workflow_run_gitlab, token: workflow_token)
+      create(:workflow_run_gitlab, :failed, token: workflow_token)
+      create(:workflow_run_gitlab, :succeeded, :push, token: workflow_token)
+      create(:workflow_run_gitlab, :succeeded, :tag_push, token: workflow_token)
+      create(:workflow_run_gitlab, :succeeded, token: workflow_token)
+      create(:workflow_run_gitlab, :succeeded, :pull_request_closed, token: workflow_token)
 
       workflow_runs_with_artifacts = WorkflowRun.where(status: 'success')
 


### PR DESCRIPTION
Fix `dev:test_data:create` task.


<details>
<summary>Otherwise we receive the following errors:</summary>

```
> bin/rake dev:test_data:create
To use retry middleware with Faraday v2.0+, install `faraday-retry` gem
Dropped database 'api_development'
Dropped database 'api_test'
Created database 'api_development'
Created database 'api_test'
Seeding architectures table...
Seeding roles table...
Seeding users table...
Seeding roles_users table...
Seeding static_permissions table...
Seeding static permissions for admin role in roles_static_permissions table...
Seeding static permissions for maintainer role in roles_static_permissions table...
Seeding static permissions for reader role in roles_static_permissions table...
Seeding static permissions for downloader role in roles_static_permissions table...
Seeding attrib_namespaces table...
Seeding attrib_types table...
Seeding issue trackers ...
Enable feature toggles for their group
Writing issue trackers into backend
Creating workflow token and workflow runs...
rake aborted!
KeyError: Factory not registered: "workflow_run_github_running"
Did you mean?  "workflow_run_gitlab"
/obs/src/api/lib/tasks/dev/workflows.rake:18:in `block (3 levels) in <top (required)>'
/obs/src/api/lib/tasks/dev.rake:222:in `block (3 levels) in <top (required)>'

Caused by:
KeyError: key not found: "workflow_run_github_running"
Did you mean?  "workflow_run_gitlab"
/obs/src/api/lib/tasks/dev/workflows.rake:18:in `block (3 levels) in <top (required)>'
/obs/src/api/lib/tasks/dev.rake:222:in `block (3 levels) in <top (required)>'
Tasks: TOP => dev:workflows:create_workflow_runs
(See full trace by running task with --trace)
>
```
</details>

Related to: #14527.