### PR TITLE
Correct the dist specs to use an existing Leap release

### DIFF
--- a/dist/t/spec/features/0030_project_spec.rb
+++ b/dist/t/spec/features/0030_project_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe 'Project', type: :feature do
     end
     click_link('Repositories')
     click_link('Add from a Distribution')
-    check('openSUSE Leap 15.3')
+    check('openSUSE Leap 15.5')
     visit current_path
-    expect(page).to have_checked_field('openSUSE Leap 15.3')
+    expect(page).to have_checked_field('openSUSE Leap 15.5')
   end
 end


### PR DESCRIPTION
15.3 no longer shows up in the distributions list, so it couldn't be selected no matter what.