### PR TITLE
Update the dist spec to the new file upload workflow

### DIFF
--- a/dist/t/spec/features/0040_package_spec.rb
+++ b/dist/t/spec/features/0040_package_spec.rb
@@ -26,10 +26,8 @@ RSpec.describe 'Package', type: :feature do
       click_link('Your Home Project')
     end
     click_link('hello_world')
-    click_link('Add File')
-    attach_file('file', File.expand_path('../fixtures/hello_world.spec', __dir__), make_visible: true)
-    click_button('Add File')
-    expect(page).to have_content("The file 'hello_world.spec' has been successfully saved.")
+    attach_file('files', File.expand_path('../fixtures/hello_world.spec', __dir__), make_visible: true)
+    expect(page).to have_content('hello_world.spec have been successfully saved.')
   end
 
   it 'should be able to branch' do


### PR DESCRIPTION
The way to upload files changed a while back to support uploading multiple files. This is meant to update the dist specs to catch up to that change.