### PR TITLE
Show diff comments in the API endpoint `GET /comments/request/id`

### DIFF
--- a/src/api/app/controllers/comments_controller.rb
+++ b/src/api/app/controllers/comments_controller.rb
@@ -2,7 +2,9 @@ class CommentsController < ApplicationController
   before_action :find_obj, only: [:index, :create]
 
   def index
-    @comments = @obj.comments.includes(:user).order(:id)
+    comments = @obj.comments.includes(:user)
+    comments += @obj.bs_request_actions.flat_map { |a| a.comments.includes(:user) } if @obj.is_a?(BsRequest)
+    @comments = comments.sort_by(&:id)
   end
 
   def create

--- a/src/api/spec/cassettes/CommentsController/GET_show/of_a_bs_request_action_inline_comment_/with_an_inline_comment/1_1_4_1_1.yml
+++ b/src/api/spec/cassettes/CommentsController/GET_show/of_a_bs_request_action_inline_comment_/with_an_inline_comment/1_1_4_1_1.yml
@@ -1,0 +1,131 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/source/source_project/source_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '301'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="source_package" rev="34" vrev="34" srcmd5="fbe538d1db5286a734396cf98593e76f">
+          <entry name="_config" md5="7cc1c193402c5cb8738e99777b33a485" size="70" mtime="1688462844"/>
+          <entry name="somefile.txt" md5="8bc8b279be5b9899070591b779e593e4" size="22" mtime="1688460416"/>
+        </directory>
+  recorded_at: Tue, 04 Jul 2023 09:46:34 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/source_project/source_package?cacheonly=1&cmd=diff&expand=1&filelimit=10000&opackage=target_package&oproject=target_project&tarlimit=10000&view=xml&withissues=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '1121'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="90fa13f3f7bb51f8cedc424fb76337a9">
+          <old project="target_project" package="target_package" rev="2" srcmd5="08a08b1dc8b730e9fa505fe0fe626773"/>
+          <new project="source_project" package="source_package" rev="34" srcmd5="fbe538d1db5286a734396cf98593e76f"/>
+          <files>
+            <file state="changed">
+              <old name="_config" md5="aaa5d30a52fef01334039e4606954b44" size="69"/>
+              <new name="_config" md5="7cc1c193402c5cb8738e99777b33a485" size="70"/>
+              <diff lines="5">@@ -1,1 +1,1 @@
+        -Saepe quos dicta. Dolor aspernatur at. Sapiente perferendis voluptas.
+        \ No newline at end of file
+        +Aut necessitatibus aspernatur. Inventore amet iure. Et commodi minima.
+        \ No newline at end of file
+        </diff>
+            </file>
+            <file state="changed">
+              <old name="somefile.txt" md5="11a31b90d280a13710401556a3256e44" size="23"/>
+              <new name="somefile.txt" md5="8bc8b279be5b9899070591b779e593e4" size="22"/>
+              <diff lines="5">@@ -1,1 +1,1 @@
+        -# This will be replaced
+        \ No newline at end of file
+        +# This is the new text
+        \ No newline at end of file
+        </diff>
+            </file>
+          </files>
+          <issues>
+          </issues>
+        </sourcediff>
+  recorded_at: Tue, 04 Jul 2023 09:46:34 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/target_project/target_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '299'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="target_package" rev="2" vrev="2" srcmd5="08a08b1dc8b730e9fa505fe0fe626773">
+          <entry name="_config" md5="aaa5d30a52fef01334039e4606954b44" size="69" mtime="1688462844"/>
+          <entry name="somefile.txt" md5="11a31b90d280a13710401556a3256e44" size="23" mtime="1688460222"/>
+        </directory>
+  recorded_at: Tue, 04 Jul 2023 09:46:34 GMT
+recorded_with: VCR 6.2.0

--- a/src/api/spec/cassettes/CommentsController/GET_show/of_a_bs_request_action_inline_comment_/with_an_inline_comment_of_a_removed_target_package/1_1_4_2_1.yml
+++ b/src/api/spec/cassettes/CommentsController/GET_show/of_a_bs_request_action_inline_comment_/with_an_inline_comment_of_a_removed_target_package/1_1_4_2_1.yml
@@ -1,0 +1,107 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/source/source_project/source_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '301'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="source_package" rev="34" vrev="34" srcmd5="fbe538d1db5286a734396cf98593e76f">
+          <entry name="_config" md5="7cc1c193402c5cb8738e99777b33a485" size="70" mtime="1688462844"/>
+          <entry name="somefile.txt" md5="8bc8b279be5b9899070591b779e593e4" size="22" mtime="1688460416"/>
+        </directory>
+  recorded_at: Tue, 04 Jul 2023 12:21:01 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/source_project/source_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '301'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="source_package" rev="34" vrev="34" srcmd5="fbe538d1db5286a734396cf98593e76f">
+          <entry name="_config" md5="7cc1c193402c5cb8738e99777b33a485" size="70" mtime="1688462844"/>
+          <entry name="somefile.txt" md5="8bc8b279be5b9899070591b779e593e4" size="22" mtime="1688460416"/>
+        </directory>
+  recorded_at: Tue, 04 Jul 2023 12:21:01 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/source_project/source_package?cacheonly=1&cmd=diff&expand=1&filelimit=10000&orev=0&rev=34&tarlimit=10000&view=xml&withissues=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 412
+      message: diff not yet in cache
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '120'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="412">
+          <summary>diff not yet in cache</summary>
+          <details>412 diff not yet in cache</details>
+        </status>
+  recorded_at: Tue, 04 Jul 2023 12:21:01 GMT
+recorded_with: VCR 6.2.0

--- a/src/api/spec/factories/bs_request_actions.rb
+++ b/src/api/spec/factories/bs_request_actions.rb
@@ -13,7 +13,6 @@ FactoryBot.define do
     factory :bs_request_action_submit, class: 'BsRequestActionSubmit' do
       type { 'submit' }
 
-      # This is used by the dev.rake task to create a BsRequestAction with a diff
       factory :bs_request_action_submit_with_diff, class: 'BsRequestActionSubmit' do
         transient do
           source_project_name { 'source_project' }


### PR DESCRIPTION
After diff comments were introduced within the beta program, users of the API weren't able to list diff comments.

With the changes proposed, these could be examples of responses of calling the `GET /comments/request/id` API endpoint:

1) Example of a response performed in the development environment. The text of the comment is modified for inline comments:
```xml
<comments request="10">
  <comment who="Admin" when="2023-07-03 10:56:52 UTC" id="9">Inline comment for target: 'home:Admin/another_package_with_diff_1688381711', file: 'README.txt', and line: 4:

In this README.txt file I would prefer `# Content` instead of `# New content`.</comment>
  <comment who="Admin" when="2023-07-03 10:57:11 UTC" id="10">Inline comment for target: 'home:Admin/another_package_with_diff_1688381711', file: 'source_package_with_multiple_submit_request_and_diff
_1688381712.spec', and line: 14:

Line 13 of this .spec file... `%build`... ok.</comment>
  <comment who="Admin" when="2023-07-03 10:57:29 UTC" id="11">Well, thats nice.</comment>
  <comment who="Admin" when="2023-07-03 10:57:41 UTC" id="12" parent="11">Sure that's nice!</comment>
</comments>
```

2) Example of a response of a request with an inline comment where the target package is removed. The text of comment is not modified:

```xml
<comments request="17">
  <comment who="Admin" when="2023-07-03 12:25:58 UTC" id="13">Makes things more clear.</comment>
</comments>
```