### PR TITLE
Flaky test depends on page loading time: make it wait a bit longer

### DIFF
--- a/src/api/spec/features/webui/projects_spec.rb
+++ b/src/api/spec/features/webui/projects_spec.rb
@@ -185,8 +185,10 @@ RSpec.describe 'Projects', js: true, vcr: true do
       visit project_show_path(maintenance_project)
       click_link('Incidents')
       page.execute_script('window.scrollBy(0,50)')
+      # The next click fires a step that might take longer than expected
+      # therefore the test after that has a `wait` parameter with a sufficient amount of time to wait for it
       click_link('Create Maintenance Incident')
-      expect(page).to have_css('#project-title', text: "#{maintenance_project}:0")
+      expect(page).to have_css('#project-title', text: "#{maintenance_project}:0", wait: 12)
 
       # We can not create this via the Bootstrap UI, except by adding plain XML to the meta editor
       repository = create(:repository, project: Project.find_by(name: "#{project.name}:maintenance_project:0"), name: 'target')


### PR DESCRIPTION
https://app.circleci.com/pipelines/github/openSUSE/open-build-service/13047/workflows/19fde3a4-9d85-4ab6-93f8-6be2ec378a18/jobs/137231/tests

This is a flaky test because the `click_link('Create Maintenance Incident')` step fires up a possible slow code path that create a new `maintenance_project` and at the end it redirect to the page overview of the very new created project. If the creation and redirect are slow, the following step tries to test for the content of the landing page of the new project, which is not yet rendered, so it fails. Making it wait a bit longer for a reasonable time (the double of the default) should fix the flakiness.