### PR TITLE
Use the strings instead of symbols in BsRequestActionTabVisibility

### DIFF
--- a/src/api/app/models/bs_request_action_tab_visibility.rb
+++ b/src/api/app/models/bs_request_action_tab_visibility.rb
@@ -1,5 +1,5 @@
 class BsRequestActionTabVisibility
-  CHANGES_TABS = [:submit, :maintenance_incident, :maintenance_release].freeze
+  CHANGES_TABS = ['submit', 'maintenance_incident', 'maintenance_release'].freeze
 
   def initialize(bs_request_action)
     @action = bs_request_action


### PR DESCRIPTION
We used symbols instead of strings for that array, this only works with direct comparisons and not for checking the contents of the array with `in?`, this fixes #14590