### PR TITLE
Show diff comments in the Web UI, non-beta

### DIFF
--- a/src/api/app/views/webui/comment/_comment_list.html.haml
+++ b/src/api/app/views/webui/comment/_comment_list.html.haml
@@ -1,3 +1,6 @@
+- if commentable.is_a?(BsRequest)
+  - Comment.without_parent.where(commentable: BsRequestAction.where(bs_request: commentable)).includes(:user).each do |comment|
+    = render partial: 'webui/comment/content', locals: { comment: comment, commentable: commentable, level: 1 }
 - commentable.comments.without_parent.includes(:user).each do |comment|
   = render partial: 'webui/comment/content', locals: { comment: comment, commentable: commentable, level: 1 }
 

--- a/src/api/app/views/webui/comment/_content.html.haml
+++ b/src/api/app/views/webui/comment/_content.html.haml
@@ -8,8 +8,18 @@
       wrote
       = link_to("#comment-#{comment.id}", title: I18n.l(comment.created_at.utc), name: "comment-#{comment.id}") do
         = render TimeComponent.new(time: comment.created_at)
+    - if level == 1 && comment.commentable.is_a?(BsRequestAction)
+      - sourcediff = comment.commentable.bs_request.webui_actions(action_id: comment.commentable, diffs: true, cacheonly: 1).first[:sourcediff].first
+      - unless sourcediff[:error]
+        :ruby
+          target = "#{comment.commentable.target_project}/#{comment.commentable.target_package}"
+          file_index, line_number = comment.diff_ref.match(/diff_([0-9]+)_n([0-9]+)/).captures
+          filename = sourcediff['filenames'][file_index.to_i]
+        %p
+          %i Inline comment for target: '#{target}', file: '#{filename}', and line: #{line_number}.
     = render_as_markdown(comment)
-    = render partial: 'webui/comment/reply', locals: { comment: comment, level: 0, commentable: commentable }
+    - unless comment.commentable.is_a?(BsRequestAction)
+      = render partial: 'webui/comment/reply', locals: { comment: comment, level: 0, commentable: commentable }
     - if level <= 3
       - comment.children.includes(:user).each do |children|
         = render partial: 'webui/comment/content', locals: { comment: children, commentable: commentable, level: level + 1 }


### PR DESCRIPTION
After diff comments were introduced within the beta program, users not in the beta program weren't able to see diff comments in the web interface.

### Before

![Screenshot from 2023-07-05 13-18-45](https://github.com/openSUSE/open-build-service/assets/24919/a8ddd4cc-56d4-41bb-95a5-667250872690)

### After

![Screenshot from 2023-07-05 13-17-25](https://github.com/openSUSE/open-build-service/assets/24919/9d72f3f8-e81d-4538-87db-bc93afb6b4a1)

