### PR TITLE
Request description as part of the conversation history

### DIFF
--- a/src/api/app/assets/stylesheets/webui/collapsible-text.scss
+++ b/src/api/app/assets/stylesheets/webui/collapsible-text.scss
@@ -29,6 +29,15 @@
       }
     }
   }
+
+  .obs-collapsible-textbox.full-width {
+    max-width: none;
+    width: 100%;
+
+    .show-content {
+      @extend .mt-0;
+    }
+  }
 }
 
 #description-text {

--- a/src/api/app/views/webui/request/beta_show.html.haml
+++ b/src/api/app/views/webui/request/beta_show.html.haml
@@ -16,91 +16,93 @@
                   actions_count: @supported_actions.count, active_tab: @active_tab }
     .container.p-4
       .row
-        .col-md-12
-          .d-flex.justify-content-between.mb-4
-            #description-text
-              - if @bs_request.description.present?
-                = render partial: 'webui/shared/collapsible_text', locals: { text: @bs_request.description }
-              - else
-                %i No description set
-      .row
-        = render partial: 'webui/request/beta_show_tabs/conversation_aside',
-                locals: { bs_request: @bs_request,
-                  my_open_reviews: @my_open_reviews,
-                  request_reviews: @request_reviews,
-                  package_maintainers: @package_maintainers,
-                  project_maintainers: @project_maintainers,
-                  show_project_maintainer_hint: @show_project_maintainer_hint }
+        .col-md-4.order-md-2.order-sm-1.mb-4
+          = render partial: 'webui/request/beta_show_tabs/conversation_aside',
+                  locals: { bs_request: @bs_request,
+                    my_open_reviews: @my_open_reviews,
+                    request_reviews: @request_reviews,
+                    package_maintainers: @package_maintainers,
+                    project_maintainers: @project_maintainers,
+                    show_project_maintainer_hint: @show_project_maintainer_hint }
 
-        .col-md-8.order-md-1.order-sm-2#comments-list
-          %h4.list-group.mb-4 Comments & Request History
-          .timeline.pb-2.ms-3{ data: { comment_counter: local_assigns[:comment_counter_id] } }
-            .timeline-item
-              .d-inline-flex
-                %i.fas.fa-lg.fa-code-commit.text-dark
-                - creator = User.find_by_login(@bs_request.creator) || User.nobody
-                = image_tag_for(creator, size: 35, custom_class: 'rounded-circle bg-light border border-gray-400 avatars-counter')
-                %p
-                  = link_to(realname_with_login(creator), user_path(creator))
-                  created this request
-                  = link_to('#request-creation', title: I18n.l(@bs_request.created_at.utc), name: 'request-creation') do
-                    = render TimeComponent.new(time: @bs_request.created_at)
-                  - if @bs_request.superseding.any?
-                    superseding
-                    - @bs_request.superseding.each do |superseded_request|
-                      = link_to("request ##{superseded_request.number}", request_show_path(superseded_request.number, anchor: 'overview'))
+        .col-md-8.order-md-1.order-sm-2
+          .row
+            #comments-list
+              .timeline.pb-2.ms-3{ data: { comment_counter: local_assigns[:comment_counter_id] } }
+                .timeline-item.mb-4.border.border-gray-200.rounded-3.bg-white.p-4#description-text
+                  - if @bs_request.description.present?
+                    %h4.list-group.mb-2 Description
+                    = render partial: 'webui/shared/collapsible_text', locals: { text: @bs_request.description, extra_css_classes: 'full-width' }
+                  - else
+                    %i No description set
 
-            - @bs_request.superseding.each do |superseding_request|
-              .timeline-item.pb-4
-                = link_to('#collapse-superseding', class: 'd-flex align-items-center',
-                    data: { 'bs-toggle': 'collapse' },
-                    aria: { expanded: false, controls: 'collapse-superseding' }) do
-                  %i.timeline-break.expander>
-                  %i.timeline-offset.collapser>
+                %h4.list-group.mb-4.ms-3 Comments & History
+                .timeline-item
+                  .d-inline-flex
+                    %i.fas.fa-lg.fa-code-commit.text-dark
+                    - creator = User.find_by_login(@bs_request.creator) || User.nobody
+                    = image_tag_for(creator, size: 35, custom_class: 'rounded-circle bg-light border border-gray-400 avatars-counter')
+                    %p
+                      = link_to(realname_with_login(creator), user_path(creator))
+                      created this request
+                      = link_to('#request-creation', title: I18n.l(@bs_request.created_at.utc), name: 'request-creation') do
+                        = render TimeComponent.new(time: @bs_request.created_at)
+                      - if @bs_request.superseding.any?
+                        superseding
+                        - @bs_request.superseding.each do |superseded_request|
+                          = link_to("request ##{superseded_request.number}", request_show_path(superseded_request.number, anchor: 'overview'))
 
-                  %i.fas.fa-fw.fa-chevron-right.expander.me-1{ title: 'Show history' }>
-                  %i.fas.fa-fw.fa-chevron-down.collapser.me-1{ title: 'Hide history' }>
-                  %span.expander
-                    Expand history from superseded request ##{superseding_request.number}
-                  %span.collapser
-                    Collapse history from superseded request ##{superseding_request.number}
-              .collapse.mb-4#collapse-superseding
-                = render BsRequestActivityTimelineComponent.new(bs_request: superseding_request,
+                - @bs_request.superseding.each do |superseding_request|
+                  .timeline-item.pb-4
+                    = link_to('#collapse-superseding', class: 'd-flex align-items-center',
+                        data: { 'bs-toggle': 'collapse' },
+                        aria: { expanded: false, controls: 'collapse-superseding' }) do
+                      %i.timeline-break.expander>
+                      %i.timeline-offset.collapser>
+
+                      %i.fas.fa-fw.fa-chevron-right.expander.me-1{ title: 'Show history' }>
+                      %i.fas.fa-fw.fa-chevron-down.collapser.me-1{ title: 'Hide history' }>
+                      %span.expander
+                        Expand history from superseded request ##{superseding_request.number}
+                      %span.collapser
+                        Collapse history from superseded request ##{superseding_request.number}
+                  .collapse.mb-4#collapse-superseding
+                    = render BsRequestActivityTimelineComponent.new(bs_request: superseding_request,
+                                                                    request_reviews_for_non_staging_projects: @request_reviews)
+
+                = render BsRequestActivityTimelineComponent.new(bs_request: @bs_request,
                                                                 request_reviews_for_non_staging_projects: @request_reviews)
 
-            = render BsRequestActivityTimelineComponent.new(bs_request: @bs_request,
-                                                            request_reviews_for_non_staging_projects: @request_reviews)
+              .comment_new
+                = render partial: 'webui/comment/new', locals: { commentable: @bs_request }
+              %hr
 
-          .comment_new
-            = render partial: 'webui/comment/new', locals: { commentable: @bs_request }
-          %hr
+              - if @bs_request.accept_at.present?
+                .alert.alert-warning.p-2
+                  %i.fas.fa-exclamation-triangle
+                  %span The current request
+                  - if BsRequest::FINAL_REQUEST_STATES.include?(@bs_request.state)
+                    %span
+                      was
+                      %strong auto-accepted
+                      at
+                      %span{ title: "#{I18n.l @bs_request.accept_at}" }
+                      = succeed '.' do
+                        = I18n.l @bs_request.accept_at, format: :only_date
+                  - elsif @bs_request.accept_at.past?
+                    %span
+                      will be
+                      %strong auto-accepted
+                      after all the reviews are submitted.
+                  - else
+                    will be
+                    %strong auto-accepted
+                    = render TimeComponent.new(time: @bs_request.accept_at)
 
-          - if @bs_request.accept_at.present?
-            .alert.alert-warning.p-2
-              %i.fas.fa-exclamation-triangle
-              %span The current request
-              - if BsRequest::FINAL_REQUEST_STATES.include?(@bs_request.state)
-                %span
-                  was
-                  %strong auto-accepted
-                  at
-                  %span{ title: "#{I18n.l @bs_request.accept_at}" }
-                  = succeed '.' do
-                    = I18n.l @bs_request.accept_at, format: :only_date
-              - elsif @bs_request.accept_at.past?
-                %span
-                  will be
-                  %strong auto-accepted
-                  after all the reviews are submitted.
-              - else
-                will be
-                %strong auto-accepted
-                = render TimeComponent.new(time: @bs_request.accept_at)
-
-          = render AccordionReviewsComponent.new(@request_reviews, @bs_request)
-          = render RequestDecisionComponent.new(bs_request: @bs_request, action: @action,
-                                                is_target_maintainer: @is_target_maintainer,
-                                                is_author: @is_author)
+              = render AccordionReviewsComponent.new(@request_reviews, @bs_request)
+              = render RequestDecisionComponent.new(bs_request: @bs_request, action: @action,
+                                                    is_target_maintainer: @is_target_maintainer,
+                                                    is_author: @is_author)
   = render DeleteConfirmationDialogComponent.new(modal_id: 'delete-comment-modal',
                                                  method: :delete,
                                                  options: { modal_title: 'Delete comment?', remote: true })

--- a/src/api/app/views/webui/request/beta_show_tabs/_conversation_aside.html.haml
+++ b/src/api/app/views/webui/request/beta_show_tabs/_conversation_aside.html.haml
@@ -1,15 +1,14 @@
-.col-md-4.order-md-2.order-sm-1.mb-4#side-links
+#side-links
   -# REVIEWERS
   - if request_reviews.present?
-    .mt-4
-      .text-end
-        = render AddReviewDropdownComponent.new(bs_request: bs_request, user: User.session, my_open_reviews: my_open_reviews)
-      = render AddReviewCollapsibleComponent.new
-      .mb-2
-        %h6
-          Reviewers
-      .mb-4
-        = render partial: 'webui/request/beta_show_tabs/review_summary', collection: request_reviews, as: :review
+    .text-end
+      = render AddReviewDropdownComponent.new(bs_request: bs_request, user: User.session, my_open_reviews: my_open_reviews)
+    = render AddReviewCollapsibleComponent.new
+    .mb-2
+      %h6
+        Reviewers
+    .mb-4
+      = render partial: 'webui/request/beta_show_tabs/review_summary', collection: request_reviews, as: :review
   - if policy(bs_request).add_reviews?
     = render partial: 'webui/request/beta_show_tabs/ask_for_review'
 


### PR DESCRIPTION
In the scope of highlighting more the `BsRequest` description, it is a fact that the description itself is the _initial comment_ of the request, so it is the root from where the history starts.

With this PR the description has its own title and box, and the history timeline starts from this box.
By doing this, the aside column with all the other information (reviewers, maintainers, etc) are aligned with the top of the Conversation tab panel.

# Before
![image](https://github.com/openSUSE/open-build-service/assets/7080830/81669458-f6b7-40bd-b805-7ebd011125b8)


# After
![image](https://github.com/openSUSE/open-build-service/assets/7080830/b5093e12-f137-46ca-bca1-b67bf98d5b7a)

