### PR TITLE
API: show replies to inline comments

### DIFF
--- a/src/api/app/components/comment_component.rb
+++ b/src/api/app/components/comment_component.rb
@@ -22,7 +22,7 @@ class CommentComponent < ApplicationComponent
   end
 
   def body
-    return inline_comment_body if comment.commentable.is_a?(BsRequestAction)
+    return inline_comment_body if comment.commentable.is_a?(BsRequestAction) && comment.diff_ref.present?
 
     comment.body.delete("\u0000")
   end


### PR DESCRIPTION
Prevent from throwing an error for replies to inline comments. These comments don't fill the `diff_ref` field.

## For reviewers

- Create an inline comment for a submit request.
- Reply to this comment with another comment.
- Show the comments for that request using the API endpoint `GET /comments/request/{id}`