### PR TITLE
Show the most relevant information of the current action in the dropdown

### DIFF
--- a/src/api/app/views/webui/request/_actions_details.html.haml
+++ b/src/api/app/views/webui/request/_actions_details.html.haml
@@ -12,7 +12,7 @@
       .dropdown#request-actions
         %button.btn.btn-outline-primary.btn-sm.dropdown-toggle.rounded-0{ 'aria-expanded' => 'false', 'data-bs-toggle' => 'dropdown',
                                                                           :type => 'button', 'data-boundary' => 'viewport' }
-          Select Action
+          = action[:name]
         %ul.dropdown-menu.dropdown-menu-start.scrollable-dropdown.pt-0
           %li.card-header.px-1.sticky-top
             %h6.dropdown-header

--- a/src/api/spec/features/webui/requests/submissions_spec.rb
+++ b/src/api/spec/features/webui/requests/submissions_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe 'Requests_Submissions', js: true, vcr: true do
           login receiver
           visit request_show_path(bs_request.number)
 
-          expect(page).to have_text('Select Action')
+          expect(page).to have_text(bs_request.bs_request_actions.first[:name])
           expect(page).to have_text('Next')
           expect(page).to have_text("(of #{bs_request.bs_request_actions.count})")
           expect(page).to have_css('.bg-staging')


### PR DESCRIPTION
The same information was used for the tab titles of the actions in [the former UI](https://github.com/openSUSE/open-build-service/blob/master/src/api/app/views/webui/request/show.html.haml#L34). Users should be familiar with that information as the most important one to distinguish request actions. 

This addresses one of the point mentioned in https://github.com/openSUSE/open-build-service/issues/14440

# Before
![image](https://github.com/openSUSE/open-build-service/assets/7080830/e5041a23-a5f4-4a5c-ad6b-9b2387d42af5)

# After

![image](https://github.com/openSUSE/open-build-service/assets/7080830/3d6aa40e-3a36-48ca-b671-76e305a4a0f7)
