### PR TITLE
Wrap all select boxes under the same div container

### DIFF
--- a/src/api/app/views/webui/request/beta_show_tabs/_rpm_lint_result.html.haml
+++ b/src/api/app/views/webui/request/beta_show_tabs/_rpm_lint_result.html.haml
@@ -4,8 +4,8 @@
       .col-auto
         = select_tag('rpmlint_repo_select', options_for_select(repository_list.sort),
                      class: 'form-select mb-3', onchange: 'updateRpmLintArchitectures()')
-      - repo_arch_hash.each do |repository, architectures|
-        .col-auto
+      .col-auto
+        - repo_arch_hash.each do |repository, architectures|
           = select_tag("rpmlint_arch_select_#{repository}", options_for_select(architectures.reverse),
                        class: 'rpmlint_arch_select form-select mb-3', onchange: 'updateRpmLintLog()')
 


### PR DESCRIPTION
For each repository there is one dedicated select box for the related architectures of each. Every time the repository changes, the related select box is shown, and all the others are hidden. Having them wrapped under the same `div` container fixes the bug that the visible architecture select box _seems to move around_ when the repo changes, but actually all the space is taken by all the hidden boxes and when the related one is shown it pops up at a different place.
In the same `div` instead, they place all at the top left position because the others are hidden.

This PR addresses one of the point mentioned in https://github.com/openSUSE/open-build-service/issues/14440

# Before
![before](https://github.com/openSUSE/open-build-service/assets/7080830/b56539fd-4ad2-4a66-9555-49eb852cea80)

![image](https://github.com/openSUSE/open-build-service/assets/7080830/860113c7-4507-4cfa-aa29-1a6d84fb8777)

# After
![after](https://github.com/openSUSE/open-build-service/assets/7080830/579f84f6-1b17-48c2-af38-81582e99b833)

![image](https://github.com/openSUSE/open-build-service/assets/7080830/11673f5a-25fd-444a-9d6a-02e69ed616fe)



# Note for developers
This PR fixes the behavior, but technically speaking, instead of having multiple architectures select boxes one per each repository, we should have on select box and update the options with the proper set for the selected repository. But I prefer to leave this up for a spin-off task anyway.