### PR TITLE
Fix filter order for set_influxdb_data

### DIFF
--- a/src/api/app/controllers/webui/webui_controller.rb
+++ b/src/api/app/controllers/webui/webui_controller.rb
@@ -14,10 +14,10 @@ class Webui::WebuiController < ActionController::Base
   include Webui::ElisionsHelper
   protect_from_forgery
 
-  before_action :set_influxdb_data
   before_action :setup_view_path
   before_action :check_user
   before_action :check_anonymous
+  before_action :set_influxdb_data
   before_action :require_configuration
   before_action :current_announcement
   after_action :clean_cache


### PR DESCRIPTION
In 253fce629160e96a74381230e93e0a0a10d0966c @hennevogel  moved setting influx tags into set_influxdb_data. But in WebuiController the filter was running *before* check_user so User.session was *always* nil.
    
That means for webui requests, both beta and anonymous tags have been wrong since that time. oops... :-(

