### PR TITLE
Fix links to dependant packages in package binary page

### DIFF
--- a/src/api/app/views/webui/package/binary.html.haml
+++ b/src/api/app/views/webui/package/binary.html.haml
@@ -16,4 +16,4 @@
                                             project: @project,
                                             package: @package,
                                             repository: @repository,
-                                            architecture: @arch }
+                                            architecture: @architecture }


### PR DESCRIPTION
Fixes #13746

How to test it
1. Create a package, let's say `hello_world`.
2. Create another package, let's say `bye_world`. Add a `Requires: hello_world` in bye_world.spec.
3. Build both packages.
4. Go to `hello_world`, in the `Build results` click on one of the `Architectures` successfully built, you get the `Repository State` page.
5. Click on the `Details` link on one of the `rpm`s. You get the `Detailed Information` page regarding the binary you clicked on.
6. Click on the link under the `Required By` column in the `Provides` table.
![image](https://github.com/openSUSE/open-build-service/assets/2650/a090d6ba-6be0-4dc1-8694-f8abb7222c46)
7. The link **now works** and will get you the `Detailed Information` page regarding the other binary.


