### PR TITLE
Replace HamlLint::RubyExtractor

### DIFF
--- a/src/api/lib/haml-lint/custom_linters/set_pagetitle_in_view.rb
+++ b/src/api/lib/haml-lint/custom_linters/set_pagetitle_in_view.rb
@@ -23,7 +23,7 @@ module HamlLint
 
     # @param [HamlLint::Document] a parsed Haml document and its associated metadata
     def instance_variable_pagetitle_is_defined?(document)
-      parsed_ruby = HamlLint::RubyParser.new.parse(HamlLint::RubyExtractor.new.extract(document).source)
+      parsed_ruby = HamlLint::RubyParser.new.parse(HamlLint::RubyExtraction::ChunkExtractor.new.extract(document).source)
 
       parsed_ruby.each_descendant.find do |descendant_node|
         # Details on Abstract Syntax Tree from Parser gem: https://github.com/whitequark/parser/blob/11c7644365fe554217bb4670a4cbc905ab8504cd/doc/AST_FORMAT.md#to-instance-variable


### PR DESCRIPTION
Better use `HamlLint::RubyExtraction::ChunkExtractor` instead of `HamlLint::RubyExtractor`. The lastest haml_lint version removed `HamlLint::RubyExtractor`, and it's breaking [our Haml linting phase](https://app.circleci.com/pipelines/github/openSUSE/open-build-service/13199/workflows/592c3ad0-3bfc-42f2-a48c-f607186e3ab9/jobs/138485)

See [this PR](https://github.com/sds/haml-lint/pull/415) for more details