### PR TITLE
Exclude vendor/bundle/ subdirectory from HAML linter

### DIFF
--- a/src/api/.haml-lint.yml
+++ b/src/api/.haml-lint.yml
@@ -18,3 +18,6 @@ linters:
     enabled: true
     exclude:
       - 'app/views/webui/users/new.html.haml'
+
+exclude:
+- 'vendor/bundle/**/*'


### PR DESCRIPTION
Otherwise it fails in CircleCI.

Kudos to @danidoni, who reported it.

Related to #14638.