### PR TITLE
Fix kiwi_image association in Kiwi::Package model

### DIFF
--- a/src/api/app/models/kiwi/package.rb
+++ b/src/api/app/models/kiwi/package.rb
@@ -1,7 +1,7 @@
 module Kiwi
   class Package < ApplicationRecord
     belongs_to :package_group, optional: true
-    has_one :kiwi_image, through: :package_groups
+    has_one :kiwi_image, source: :image, through: :package_group
 
     validates :name, presence: { message: 'can\'t be blank' }
 


### PR DESCRIPTION
### Having

```ruby
[1] pry(main)> Kiwi::Package.find(3).package_group.image
  Kiwi::Package Load (0.3ms)  SELECT `kiwi_packages`.* FROM `kiwi_packages` WHERE `kiwi_packages`.`id` = 3 LIMIT 1
  Kiwi::PackageGroup Load (0.4ms)  SELECT `kiwi_package_groups`.* FROM `kiwi_package_groups` WHERE `kiwi_package_groups`.`id` = 2 LIMIT 1
  Kiwi::Image Load (0.3ms)  SELECT `kiwi_images`.* FROM `kiwi_images` WHERE `kiwi_images`.`id` = 1 LIMIT 1
=> #<Kiwi::Image:0x00007f20e2689188
 id: 1,
 name: "minimal-container-image",
 md5_last_revision: "72e9c1a7931aa189a038a5e1fbcc212d",
 created_at: Fri, 14 Jul 2023 13:40:06.000000000 UTC +00:00,
 updated_at: Fri, 14 Jul 2023 13:40:31.817526000 UTC +00:00,
 use_project_repositories: true>
[2] pry(main)> 
```

### Before, calling `kiwi_image` of a Kiwi::Package object failed
```ruby
[3] pry(main)> Kiwi::Package.find(3).kiwi_image
  Kiwi::Package Load (0.5ms)  SELECT `kiwi_packages`.* FROM `kiwi_packages` WHERE `kiwi_packages`.`id` = 3 LIMIT 1
ActiveRecord::HasManyThroughAssociationNotFoundError: Could not find the association :package_groups in model Kiwi::Package
Did you mean?  package_group
from /usr/lib64/ruby/gems/3.1.0/gems/activerecord-7.0.4.3/lib/active_record/reflection.rb:944:in `check_validity!'
[4] pry(main)> 
```

### After, calling `kiwi_image` of a Kiwi::Package object works
```ruby
[1] pry(main)> Kiwi::Package.find(3).kiwi_image
  Kiwi::Package Load (0.4ms)  SELECT `kiwi_packages`.* FROM `kiwi_packages` WHERE `kiwi_packages`.`id` = 3 LIMIT 1
  Kiwi::Image Load (0.4ms)  SELECT `kiwi_images`.* FROM `kiwi_images` INNER JOIN `kiwi_package_groups` ON `kiwi_images`.`id` = `kiwi_package_groups`.`image_id` WHERE `kiwi_package_groups`.`id` = 2 LIMIT 1
=> #<Kiwi::Image:0x00007f0465c7b170
 id: 1,
 name: "minimal-container-image",
 md5_last_revision: "72e9c1a7931aa189a038a5e1fbcc212d",
 created_at: Fri, 14 Jul 2023 13:40:06.000000000 UTC +00:00,
 updated_at: Fri, 14 Jul 2023 13:40:31.817526000 UTC +00:00,
 use_project_repositories: true>
[2] pry(main)> 
```