### PR TITLE
Upgrade CircleCI base image to Leap 15.4

### DIFF
--- a/.circleci/conditional_config.yml
+++ b/.circleci/conditional_config.yml
@@ -134,7 +134,7 @@ aliases:
 jobs:
   pipeline_settings:
     docker:
-      - image: opensuse/leap:15.3
+      - image: opensuse/leap:15.4
     steps:
       - run: echo "run-apidocs-linter is << pipeline.parameters.run-apidocs-linter >>"
       - run: echo "run-backend-tests is << pipeline.parameters.run-backend-tests >>"


### PR DESCRIPTION
We have switched our production, test, and development environments to Leap 15.4 since some time ago.