### PR TITLE
Create event subscription for trigger service and rebuild package workflow steps

### DIFF
--- a/src/api/app/models/workflow/step/rebuild_package.rb
+++ b/src/api/app/models/workflow/step/rebuild_package.rb
@@ -20,6 +20,7 @@ class Workflow::Step::RebuildPackage < Workflow::Step
 
     Pundit.authorize(@token.executor, @token, :rebuild?)
     rebuild_package
+    create_or_update_subscriptions(@package)
   end
 
   def set_project_name

--- a/src/api/app/models/workflow/step/trigger_services.rb
+++ b/src/api/app/models/workflow/step/trigger_services.rb
@@ -22,6 +22,8 @@ class Workflow::Step::TriggerServices < Workflow::Step
     rescue Backend::NotFoundError => e
       raise NoSourceServiceDefined, "Package #{@project_name}/#{@package_name} does not have a source service defined: #{e.summary}"
     end
+
+    create_or_update_subscriptions(@package)
   end
 
   private


### PR DESCRIPTION
Until now we weren't notifying the SCM of the build status triggered by the Trigger Service or the Rebuild Package steps.

How to test this:
- [Set up your environment](https://github.com/openSUSE/open-build-service/wiki/Better-SCM-CI-Integration-Testing) to set up your environment, but don't trigger the workflow yet.
- Tweak the package so the building fails (I use an `exit(1)` in the `%build` phase)
- Use a `payload.json` like this one:
```
{
  "object_kind": "push",
  "before": "60cd89df0215ab64cff9b8076a4a3334dce71ba7",
  "after": "1873d25e0fb0c245e3ad75aadca1f69fdf5fd70b",
  "ref": "refs/heads/master",
  "project_id": 16871458,
  "project": {
    "id": 16871458,
    "name": "hello_world",
    "web_url": "https://github.com/danidoni/hello_world",
    "path_with_namespace": "danidoni/hello_world",
    "http_url": "https://github.com/danidoni/hello_world.git"
  },
  "commits": [
    {
      "id": "1873d25e0fb0c245e3ad75aadca1f69fdf5fd70b",
      "url": "https://github.com/danidoni/hello_world/-/commit/1873d25e0fb0c245e3ad75aadca1f69fdf5fd70b"
    }
  ],
  "repository": {
    "name": "hello_world",
    "url": "git@github.com:danidoni/hello_world.git",
    "homepage": "https://github.com/danidoni/hello_world",
    "full_name": "danidoni/hello_world"
 }
}
```
- Use a workflows.yml like [this one](https://github.com/openSUSE/open-build-service/wiki/Better-SCM-CI-Integration-Workflows#rebuild-a-package) to trigger a Rebuild.
- Set up a Github repository publicly reachable, e.g.: `https://github.com/danidoni/hello_world`. Replace the repository path in the payload above to match.
- Push some changes and get the commit of the change. Replace the commit id and url of the payload above to match.
- Trigger the workflow.
- Let the package build. It should end with a failed build.
- Go to the repository, in the commit list you should see an indication that the commit has failures (on GitHub there should be a red cross next to the commit id).