### PR TITLE
Switch deprecated API route to retrieve worker statuses

### DIFF
--- a/dist/elastic_build_service_manager.py
+++ b/dist/elastic_build_service_manager.py
@@ -236,7 +236,7 @@ def fetch_metrics(elastic_build_hosts, job_status):
     osc.conf.get_config()
     api = osc.conf.config['apiurl']
 
-    apitest = osc.core.http_GET(api + '/build/_workerstatus')
+    apitest = osc.core.http_GET(api + '/worker/_status')
     dom = minidom.parseString(apitest.read())
 
     # store all idle workers


### PR DESCRIPTION
See deprecated API route in the documentation: https://api.opensuse.org/apidocs/#/Build/get_build__workerstatus

Found while researching a fix for #14677.