### PR TITLE
Don't send metrics of start times of daemons

### DIFF
--- a/src/api/app/jobs/worker_measurements_job.rb
+++ b/src/api/app/jobs/worker_measurements_job.rb
@@ -57,10 +57,9 @@ class WorkerMeasurementsJob < ApplicationJob
       partition = daemon.parent.values.first
       type = daemon.attributes['type'].value
       state = daemon.attributes['state'].value
-      starttime = daemon.attributes['starttime'].value
       arch = daemon.attributes['arch']
       arch = (arch.nil? ? '' : ",arch=#{arch.value}")
-      RabbitmqBus.send_to_bus('metrics', "backend_daemon_status,partition=#{partition},type=#{type},state=#{state}#{arch} starttime=#{starttime}")
+      RabbitmqBus.send_to_bus('metrics', "backend_daemon_status,partition=#{partition},type=#{type},state=#{state}#{arch} count=1")
     end
   end
 end


### PR DESCRIPTION
We still don't use the start time of daemons. We count the ocurrences of daemons instead.

Fixes #14677.

After deploying this fix, this panel should be modified: https://obs-measure.opensuse.org/d/Oh-R4b1Vz/bernhard-s-experiments?orgId=1&viewPanel=29