### PR TITLE
Tell people about Pundit errors in WorkflowRun

### DIFF
--- a/src/api/app/controllers/trigger_workflow_controller.rb
+++ b/src/api/app/controllers/trigger_workflow_controller.rb
@@ -23,8 +23,12 @@ class TriggerWorkflowController < TriggerController
           @workflow_run.update_as_failed(render_error(status: 400, message: validation_errors.to_sentence))
         end
       end
+    # We always want to return 200 in the request. Because a lot of things in `Workflow`` can go wrong outside this request cycle.
+    # People need to have a look at their `WorkflowRun` to see how `Workflow` went.
     rescue APIError => e
       @workflow_run.update_as_failed(render_error(status: e.status, errorcode: e.errorcode, message: e.message))
+    rescue Pundit::NotAuthorizedError => e
+      @workflow_run.update_as_failed(e.message)
     end
   end
 

--- a/src/api/app/models/workflow.rb
+++ b/src/api/app/models/workflow.rb
@@ -136,12 +136,7 @@ class Workflow
 
     target_project_names = processable_steps.map(&:target_project_name).uniq.compact
 
-    begin
-      Project.where(name: target_project_names).destroy_all
-    rescue Project::Errors::UnknownObjectError, Pundit::NotAuthorizedError => e
-      workflow_run.update_as_failed(e.message)
-      raise e
-    end
+    Project.where(name: target_project_names).destroy_all
   end
 
   # TODO: Extract this into a service


### PR DESCRIPTION
We started to use Pundit a lot in the various `Workflow::Step`. Authorization failures that happen inside the `Workflow` should be reflected in the `WorkflowRun` and not in the request cycle.

Also: As the `TriggerWorkflowController` takes care about APIErrors and Pundit now, we don't need to handle those exceptions in `Workflow.destroy_target_projects`.