### PR TITLE
Reuse existing event subscription to notify SCMs back

### DIFF
--- a/src/api/app/services/workflows/scm_event_subscription_creator.rb
+++ b/src/api/app/services/workflows/scm_event_subscription_creator.rb
@@ -16,9 +16,9 @@ module Workflows
                                              channel: 'scm',
                                              enabled: true,
                                              token: @token,
-                                             package: @package,
-                                             workflow_run: @workflow_run).tap do |subscription|
-          subscription.update!(payload: @scm_webhook.payload) # The payload is updated regardless of whether the subscription already existed or not.
+                                             package: @package).tap do |subscription|
+          # Set payload and workflow_run regardless of whether the subscription already existed or not
+          subscription.update!(workflow_run: @workflow_run, payload: @scm_webhook.payload)
         end
       end
     end


### PR DESCRIPTION
When including the workflow run in the query, we do not get any EventSubscription back, then the `create` part of the `find_or_create_by` kicks in and we end up having tons of notifications.

Follows up https://github.com/openSUSE/open-build-service/pull/14666

How to test this:
- [Set up your environment](https://github.com/openSUSE/open-build-service/wiki/Better-SCM-CI-Integration-Testing), but don't trigger the workflow yet.
- Use a `workflows.yml` like [this one](https://github.com/openSUSE/open-build-service/wiki/Better-SCM-CI-Integration-Workflows#rebuild-a-package) to trigger a Rebuild.
- Tweak the package so the building fails (I use an `exit(1)` in the `%build` phase)
- Push some changes against your default branch, let the workflow finish and you should get a :x: next to the commit telling you the build failed.
- Fix the package spec so it builds successfully.
- Push another change, let the workflow finish and you should get a :heavy_check_mark:  next to the commit telling you the build succeeded.
- Before this change the older commit would change to :heavy_check_mark: also. Now it stays as failed :x:.