### PR TITLE
Fix button visibility condition

### DIFF
--- a/src/api/app/views/webui/package/revisions.html.haml
+++ b/src/api/app/views/webui/package/revisions.html.haml
@@ -18,7 +18,7 @@
               %i Revision #{revision} not found
       - unless params['show_all']
         = paginate @revisions, views_prefix: 'webui'
-        - unless @revisions.total_pages == 1 && !User.session
+        - unless @revisions.total_pages == 1 || !User.session
           .text-center= link_to('Show all',
                                 package_view_revisions_path(project: @project, package: @package, show_all: 1),
                                 class: 'btn btn-sm btn-secondary')


### PR DESCRIPTION
One of the conditions is enough to hide the show_all button

Scenario fixed: when pagination pages are just 1 and the user is logged in, the condition was returning `false` because of the `&&`, so the show_all button was visible. But this is wrong because there is no pagination and all the revisions are already visible in the first page.

Before (no pagination, but `Show all` button is visible)
![image](https://github.com/openSUSE/open-build-service/assets/7080830/9af215d2-2f06-4e64-9a35-9550d88d84ec)


After (no pagination and `Show all` button is **not** visible)
![image](https://github.com/openSUSE/open-build-service/assets/7080830/65d6942e-2384-4623-bbde-75cbc2799b14)
 
