### PR TITLE
Never report on Tag Push events

### DIFF
--- a/src/api/app/models/workflow/step/branch_package_step.rb
+++ b/src/api/app/models/workflow/step/branch_package_step.rb
@@ -29,8 +29,7 @@ class Workflow::Step::BranchPackageStep < Workflow::Step
 
     scm_synced? ? set_scmsync_on_target_package : add_branch_request_file(package: target_package)
 
-    # SCMs don't support statuses for tags, so we don't need to report back in this case
-    Workflows::ScmEventSubscriptionCreator.new(token, workflow_run, scm_webhook, target_package).call unless scm_webhook.tag_push_event?
+    Workflows::ScmEventSubscriptionCreator.new(token, workflow_run, scm_webhook, target_package).call
 
     target_package
   end

--- a/src/api/app/models/workflow/step/link_package_step.rb
+++ b/src/api/app/models/workflow/step/link_package_step.rb
@@ -18,8 +18,7 @@ class Workflow::Step::LinkPackageStep < Workflow::Step
 
     set_scmsync_on_target_package if scm_synced?
 
-    # SCMs don't support statuses for tags, so we don't need to report back in this case
-    Workflows::ScmEventSubscriptionCreator.new(token, workflow_run, scm_webhook, target_package).call unless scm_webhook.tag_push_event?
+    Workflows::ScmEventSubscriptionCreator.new(token, workflow_run, scm_webhook, target_package).call
 
     target_package
   end

--- a/src/api/app/services/workflows/scm_event_subscription_creator.rb
+++ b/src/api/app/services/workflows/scm_event_subscription_creator.rb
@@ -8,6 +8,9 @@ module Workflows
     end
 
     def call
+      # SCMs don't support commit status for tags, so we don't need to report back in this case
+      return if @scm_webhook.tag_push_event?
+
       ['Event::BuildFail', 'Event::BuildSuccess'].each do |build_event|
         EventSubscription.find_or_create_by!(eventtype: build_event,
                                              # We pass a valid value, but we don't need this.


### PR DESCRIPTION
SCMs don't support statuses for tags, so we don't need to report back in ANY case