### PR TITLE
Revisions pagination info

### DIFF
--- a/src/api/app/views/webui/package/revisions.html.haml
+++ b/src/api/app/views/webui/package/revisions.html.haml
@@ -23,11 +23,10 @@
         .col-auto
           = page_entries_info @revisions, entry_name: 'revision'
 
-      - unless params['show_all']
-        - unless @revisions.total_pages == 1 || !User.session
-          .text-center.mt-4= link_to('Show all',
-                                package_view_revisions_path(project: @project, package: @package, show_all: 1),
-                                class: 'btn btn-sm btn-secondary')
+      - unless params['show_all'] || @revisions.total_pages == 1 || !User.session
+        .text-center.mt-4= link_to('Show all',
+                              package_view_revisions_path(project: @project, package: @package, show_all: 1),
+                              class: 'btn btn-sm btn-secondary')
     - else
       %p
         %i No commits exists yet.

--- a/src/api/app/views/webui/package/revisions.html.haml
+++ b/src/api/app/views/webui/package/revisions.html.haml
@@ -6,7 +6,7 @@
   .card-body
     %h3= @pagetitle
     - if @revisions.present?
-      .list-group
+      .list-group.mt-4
         - @revisions.each do |revision|
           .list-group-item{ id: "commit_item_#{revision}" }
             - commit = @package.commit(revision)

--- a/src/api/app/views/webui/package/revisions.html.haml
+++ b/src/api/app/views/webui/package/revisions.html.haml
@@ -4,9 +4,7 @@
   = render(partial: 'webui/package/tabs', locals: { project: @project, package: @package })
 
   .card-body
-    %h3
-      = @pagetitle
-      %span.badge.bg-primary= @revisions.count
+    %h3= @pagetitle
     - if @revisions.present?
       .list-group
         - @revisions.each do |revision|
@@ -16,10 +14,18 @@
               = render(partial: 'commit_item', locals: { project: @project, package: @package, revision: revision, commit: commit })
             - else
               %i Revision #{revision} not found
+
+      .row.justify-content-center.mt-2
+        .col-auto
+          = paginate @revisions, views_prefix: 'webui'
+
+      .row.justify-content-center.mt-2
+        .col-auto
+          = page_entries_info @revisions, entry_name: 'revision'
+
       - unless params['show_all']
-        = paginate @revisions, views_prefix: 'webui'
         - unless @revisions.total_pages == 1 || !User.session
-          .text-center= link_to('Show all',
+          .text-center.mt-4= link_to('Show all',
                                 package_view_revisions_path(project: @project, package: @package, show_all: 1),
                                 class: 'btn btn-sm btn-secondary')
     - else


### PR DESCRIPTION
The badge counter in the Revisions page title is buggy:
- it contains the number of the elements visible in the page (i.e. if we are at page 2 of a list of 25 elements with 10 items per page, it reports `10` because it counts the paginated slice only)
- how many items are shown in the page (paginated or not) is not a property to deliver in the title as a badge
- all about pagination should be forwarded and managed by Kaminari

Before
![image](https://github.com/openSUSE/open-build-service/assets/7080830/c5bc844c-24ec-4330-9721-c510ddeb4420)


After
(1) 
![image](https://github.com/openSUSE/open-build-service/assets/7080830/6091a0b8-3449-43c2-a5d1-f45f97919e16)

(2)
![image](https://github.com/openSUSE/open-build-service/assets/7080830/470c3dcc-ff1b-45c5-9ae9-1318c48f1050)
