### PR TITLE
README.md: use Leap 15.4 instead of 15.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ If that is not for you because you have some special needs for your setup (e.g. 
 
 After finishing the installation of your base system, follow these steps:
 
-1. Add the OBS software repository with zypper. Please be aware, that the needed URL differs, depending on your Base Operating System. We use openSUSE Leap 15.1 in this example.
+1. Add the OBS software repository with zypper. Please be aware, that the needed URL differs, depending on your Base Operating System. We use openSUSE Leap 15.4 in this example.
 
     ```shell
-    zypper ar -f https://download.opensuse.org/repositories/OBS:/Server:/2.10/openSUSE_15.1/OBS:Server:2.10.repo
+    zypper ar -f https://download.opensuse.org/repositories/OBS:/Server:/2.10/15.4/OBS:Server:2.10.repo
     ```
 
 2. Install the package


### PR DESCRIPTION
- use Leap 15.4 instead of 15.1
- use new repository naming pattern (`15.4` instead of `openSUSE_15.1`)