### PR TITLE
[backend] drop leading ./ from path to deb

### DIFF
--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -943,6 +943,13 @@ sub compress_and_rename {
   my ($tmpfile, $file) =@_;
   if (-s $tmpfile) {
     unlink($file);
+    # drop leading ./ from path to deb
+    open(my $f, "<", $tmpfile) or die $!;
+    my @lines=<$f>;
+    s,^Filename: \./,Filename: , foreach @lines;
+    open($f, ">", $tmpfile) or die $!;
+    print $f @lines;
+    close($f);
     link($tmpfile, $file);
     qsystem('gzip', '-9', '-n', '-f', $tmpfile) && print "    gzip $tmpfile failed: $?\n";
     unlink($tmpfile);


### PR DESCRIPTION
in bs_publish we drop a leading `./` from the path to deb
to allow apt to download packages from an OBS repo that was synced to S3 which is a key-value store that does not ignore `./` in a path

Fixes #14691