### PR TITLE
[backend] BSRPC: reduce dns cache ttl to one hour

### DIFF
--- a/src/backend/BSRPC.pm
+++ b/src/backend/BSRPC.pm
@@ -36,6 +36,7 @@ our $useragent = 'BSRPC 0.9.1';
 our $noproxy;
 our $logtimeout;
 our $autoheaders;
+our $dnscachettl = 3600;
 
 our $ssl_keyfile;
 our $ssl_certfile;
@@ -227,7 +228,7 @@ sub lookuphost {
       $hostaddr = sockaddr_in(0, $hostaddr) if $hostaddr;
     }
     return undef unless $hostaddr;
-    $cache->{$host} = [ $hostaddr, time() + 24 * 3600 ] if $cache;
+    $cache->{$host} = [ $hostaddr, time() + $dnscachettl ] if $cache;
   }
   if (defined($port)) {
     if (sockaddr_family($hostaddr) == AF_INET6) {

--- a/src/backend/bs_dodup
+++ b/src/backend/bs_dodup
@@ -34,6 +34,8 @@ use Build::Modules;
 
 use strict;
 
+$BSRPC::logtimeout = 1;         # see better errors
+
 my $bsdir = $BSConfig::bsdir || "/srv/obs";
 my $reporoot = "$bsdir/build";
 my $rundir = "$bsdir/run";


### PR DESCRIPTION
And also make rpc timeouts log the url in bs_dodup.