### PR TITLE
[backend] bs_notifyforward: disable multirequest mode when using https

### DIFF
--- a/src/backend/BSServerEvents.pm
+++ b/src/backend/BSServerEvents.pm
@@ -497,7 +497,7 @@ sub stream_read_handler {
     }
     if (!defined($r)) {
       if ($! == POSIX::EINTR || $! == POSIX::EWOULDBLOCK) {
-        BSEvents::add($ev);
+        BSEvents::add($ev) unless $ev->{'paused'};
         return;
       }
       print "stream_read_handler: $!\n";
@@ -580,7 +580,7 @@ sub stream_write_handler {
   my $r = syswrite($ev->{'fd'}, $ev->{'replbuf'}, $l);
   if (!defined($r)) {
     if ($! == POSIX::EINTR || $! == POSIX::EWOULDBLOCK) {
-      BSEvents::add($ev);
+      BSEvents::add($ev) unless $ev->{'paused'};
       return;
     }
     print "stream_write_handler: $!\n";

--- a/src/backend/BSWatcher.pm
+++ b/src/backend/BSWatcher.pm
@@ -713,7 +713,7 @@ sub rpc_recv_forward {
   $wev->{'datahandler'} = \&rpc_recv_forward_data_handler;
   $wev->{'closehandler'} = \&rpc_recv_forward_close_handler;
   $ev->{'handler'} = \&BSServerEvents::stream_read_handler;
-  BSEvents::add($ev);
+  BSEvents::add($ev) unless $ev->{'paused'};
   BSEvents::add($wev);	# do this last
 }
 

--- a/src/backend/bs_notifyforward
+++ b/src/backend/bs_notifyforward
@@ -161,7 +161,9 @@ sub forwardredis {
     'data' => BSUtil::tostorable($redisdata),
     'receiver' => \&ansreqreceiver,
   };
-  BSRPC::rpc($param, undef, 'multirequest=1');
+  my @args;
+  push @args, 'multirequest=1' if $BSConfig::srcserver =~ /^http:/;	# sock dup only works for http
+  BSRPC::rpc($param, undef, @args);
   markdone($markfd, $_) for @$markoffs;
   print "forwarded ".@$markoffs." redis notifications\n";
 }


### PR DESCRIPTION
Our naive socket dup does not work for TLS connections. We need to make BSRPC keep the socket instead. But for now, just disable the option.