### PR TITLE
Disable partial inserts in active record

### DIFF
--- a/src/api/config/application.rb
+++ b/src/api/config/application.rb
@@ -109,6 +109,10 @@ module OBSApi
     config.active_record.cache_versioning = true
     config.active_record.collection_cache_versioning = false
 
+    # Disable partial writes to avoid causing incorrect values
+    # to be inserted when changing the default value of a column.
+    config.active_record.partial_inserts = false
+
     config.action_controller.action_on_unpermitted_parameters = :raise
 
     config.action_dispatch.rescue_responses['Backend::Error'] = 500


### PR DESCRIPTION
This being enabled causes strong migrations to complain about a dangerous operation while migrating our older migration, when linting the migrations or generating schema.rb