### PR TITLE
Workflow run menu enhancements

### DIFF
--- a/src/api/app/components/workflow_run_filter_component.html.haml
+++ b/src/api/app/components/workflow_run_filter_component.html.haml
@@ -9,11 +9,11 @@
                                                                <p><b>Succeeded: </b>Workflow run execution was successful</p>
                                                                <p><b>Running: </b>Workflow run is still in progress</p>
                                                                <p><b>Failed: </b>Workflow run failed at some point</p>' } }
-  = render WorkflowRunFilterLinkComponent.new(token: @token, text: 'Succeeded', amount: @count['success'],
+  = render WorkflowRunFilterLinkComponent.new(token: @token, text: 'Succeeded', amount: @count['success'], icon: 'fas fa-check text-primary',
                                               filter_item: { status: 'success' }, selected_filter: @selected_filter)
-  = render WorkflowRunFilterLinkComponent.new(token: @token, text: 'Running', amount: @count['running'],
+  = render WorkflowRunFilterLinkComponent.new(token: @token, text: 'Running', amount: @count['running'], icon: 'fas fa-running',
                                               filter_item: { status: 'running' }, selected_filter: @selected_filter)
-  = render WorkflowRunFilterLinkComponent.new(token: @token, text: 'Failed', amount: @count['fail'],
+  = render WorkflowRunFilterLinkComponent.new(token: @token, text: 'Failed', amount: @count['fail'], icon: 'fas fa-exclamation-triangle text-danger',
                                               filter_item: { status: 'fail' }, selected_filter: @selected_filter)
 .list-group.list-group-flush.mt-5.mb-2
   %h5.mx-3

--- a/src/api/app/components/workflow_run_filter_link_component.html.haml
+++ b/src/api/app/components/workflow_run_filter_link_component.html.haml
@@ -1,4 +1,8 @@
-= link_to(token_workflow_runs_path(@token, @filter_item), class: "list-group-item list-group-item-action #{css_for_link}") do
-  = @text
+= link_to(token_workflow_runs_path(@token, @filter_item),
+          class: "list-group-item list-group-item-action #{css_for_link} d-flex justify-content-between") do
+  %span
+    - if @icon != ''
+      %i.me-1{ class: "#{@icon} #{css_for_icon}" }
+    = @text
   - if @amount.positive?
     %span.badge.align-text-top.ms-2{ class: css_for_badge_color }>= @amount

--- a/src/api/app/components/workflow_run_filter_link_component.html.haml
+++ b/src/api/app/components/workflow_run_filter_link_component.html.haml
@@ -5,4 +5,4 @@
       %i.me-1{ class: "#{@icon} #{css_for_icon}" }
     = @text
   - if @amount.positive?
-    %span.badge.align-text-top.ms-2{ class: css_for_badge_color }>= @amount
+    %span= @amount

--- a/src/api/app/components/workflow_run_filter_link_component.html.haml
+++ b/src/api/app/components/workflow_run_filter_link_component.html.haml
@@ -1,8 +1,7 @@
 = link_to(token_workflow_runs_path(@token, @filter_item),
           class: "list-group-item list-group-item-action #{css_for_link} d-flex justify-content-between") do
   %span
-    - if @icon != ''
-      %i.me-1{ class: "#{@icon} #{css_for_icon}" }
+    = icon_tag
     = @text
   - if @amount.positive?
     %span= @amount

--- a/src/api/app/components/workflow_run_filter_link_component.rb
+++ b/src/api/app/components/workflow_run_filter_link_component.rb
@@ -14,8 +14,8 @@ class WorkflowRunFilterLinkComponent < ApplicationComponent
     workflow_run_filter_matches? ? 'active' : ''
   end
 
-  def css_for_icon
-    workflow_run_filter_matches? ? 'text-light' : ''
+  def icon_tag
+    tag.i(class: ['me-1', @icon, ('text-light' if workflow_run_filter_matches?)]) if @icon != ''
   end
 
   private

--- a/src/api/app/components/workflow_run_filter_link_component.rb
+++ b/src/api/app/components/workflow_run_filter_link_component.rb
@@ -14,10 +14,6 @@ class WorkflowRunFilterLinkComponent < ApplicationComponent
     workflow_run_filter_matches? ? 'active' : ''
   end
 
-  def css_for_badge_color
-    workflow_run_filter_matches? ? 'text-bg-light' : 'text-bg-primary'
-  end
-
   def css_for_icon
     workflow_run_filter_matches? ? 'text-light' : ''
   end

--- a/src/api/app/components/workflow_run_filter_link_component.rb
+++ b/src/api/app/components/workflow_run_filter_link_component.rb
@@ -1,5 +1,5 @@
 class WorkflowRunFilterLinkComponent < ApplicationComponent
-  def initialize(text:, filter_item:, selected_filter:, token:, amount:)
+  def initialize(text:, filter_item:, selected_filter:, token:, amount:, icon: '')
     super
 
     @text = text
@@ -7,6 +7,7 @@ class WorkflowRunFilterLinkComponent < ApplicationComponent
     @selected_filter = selected_filter
     @amount = amount || 0
     @token = token
+    @icon = icon
   end
 
   def css_for_link
@@ -15,6 +16,10 @@ class WorkflowRunFilterLinkComponent < ApplicationComponent
 
   def css_for_badge_color
     workflow_run_filter_matches? ? 'text-bg-light' : 'text-bg-primary'
+  end
+
+  def css_for_icon
+    workflow_run_filter_matches? ? 'text-light' : ''
   end
 
   private


### PR DESCRIPTION
Little improvements on the workflow_run filters menu:
- use the icon of the status type (already in use in the list of entries) in the related filter link
- do not use a badge for the counter of each type, just show a lighter number
- align the counter of each type to the right

Before:
![image](https://github.com/openSUSE/open-build-service/assets/7080830/fa229608-03c3-46bf-8e2c-e88d130f6550)

After:
![image](https://github.com/openSUSE/open-build-service/assets/7080830/6a3316be-0338-4927-b606-2e3a7295b3ab)
