### PR TITLE
[backend] always remove events from the active list when pausing

### DIFF
--- a/src/backend/BSWatcher.pm
+++ b/src/backend/BSWatcher.pm
@@ -554,6 +554,7 @@ sub rpc_recv_forward_data_handler {
     # too full! wait till there is more room
     #print "stay=".@stay.", leave=".@leave.", blocking\n";
     $rev->{'paused'} = 1;
+    BSEvents::rem($rev);
     return 0;
   }
 
@@ -595,6 +596,7 @@ sub rpc_recv_forward_data_handler {
     }
     # too full! wait till there is more room
     $rev->{'paused'} = 1;
+    BSEvents::rem($rev);
     return 0;
   }
 
@@ -678,6 +680,7 @@ sub rpc_recv_forward_setup {
     BSEvents::add($jev, $conf->{'replstream_timeout'} || 0);
   } else {
     $jev->{'paused'} = 1;
+    BSEvents::rem($jev);
   }
 }
 


### PR DESCRIPTION
Otherwise we might end up in an inconsistent state and add events twice, leading to a assertion error.