### PR TITLE
[backend] fix concatconfigs call in published_path

### DIFF
--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -5915,7 +5915,7 @@ sub published_path {
     $medium = "iso/$medium";
   } elsif ($medium) {
     my @path = expandsearchpath($projid, $repoid);
-    my $c = concatconfigs($projid, $cgi->{'repository'}, undef, @path);
+    my $c = concatconfigs($projid, $repoid, undef, @path);
     my $bconf = Build::read_config('noarch', [ split("\n", $c) ]);
     my %repotype;
     for (@{$bconf->{'repotype'} || []}) {


### PR DESCRIPTION
The old $cgi->{'repository'} seems to be a copy from getprojectsourceinfo(). It worked for all the normal published_path uses, but not if it is called from getproductrepositories(). So use the $repoid argument instead.