### PR TITLE
Use the request changes link for changes comments

### DIFF
--- a/src/api/app/components/bs_request_comment_component.html.haml
+++ b/src/api/app/components/bs_request_comment_component.html.haml
@@ -30,7 +30,7 @@
         = link_to request_show_path(number: action.bs_request, request_action_id: action) do
           = action.uniq_key
         >
-        = link_to request_show_path(number: action.bs_request, request_action_id: action, anchor: comment.diff_ref) do
+        = link_to request_changes_path(number: action.bs_request, request_action_id: action, anchor: comment.diff_ref) do
           = render(DiffSubjectComponent.new(state: diff['state'], old_filename: diff.dig('old', 'name'), new_filename: diff.dig('new', 'name')))
       = render(DiffComponent.new(diff: diff.dig('diff', '_content'), range:))
     .comment-bubble-content


### PR DESCRIPTION
To make it possible for people to actually get to the changes that are mentioned, it's nice to actually link to the correct page. This was omitted when splitting up pages.