### PR TITLE
Remove rebuild workflow

### DIFF
--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -17,13 +17,3 @@ testbuild:
   filters:
     event: pull_request
 
-rebuild:
-  steps:
-    - trigger_services:
-        project: OBS:Server:2.10:Staging
-        package: obs-server
-  filters:
-    event: push
-    branches:
-      only:
-        - 2.10


### PR DESCRIPTION
We set the version inside our service to the last tag manually

https://github.com/openSUSE/open-build-service/wiki/OBS-Minor-Release-HOWTO#update-obs-server-package-in-staging

No need to rebuild this on every merge to 2.10