### PR TITLE
Drop state from commit status context

### DIFF
--- a/src/api/app/services/gitea_status_reporter.rb
+++ b/src/api/app/services/gitea_status_reporter.rb
@@ -36,7 +36,7 @@ class GiteaStatusReporter < SCMExceptionHandler
       { context: 'OBS SCM/CI Workflow Integration started',
         target_url: Rails.application.routes.url_helpers.token_workflow_run_url(@workflow_run.token_id, @workflow_run.id, host: Configuration.obs_url) }
     elsif @event_type == 'Event::RequestStatechange'
-      { context: "OBS: Request #{@event_payload[:number]} - #{@event_payload[:state]}",
+      { context: "OBS: Request #{@event_payload[:number]}",
         target_url: Rails.application.routes.url_helpers.request_show_url(@event_payload[:number], host: Configuration.obs_url) }
     else
       { context: "OBS: #{@event_payload[:package]} - #{@event_payload[:repository]}/#{@event_payload[:arch]}",

--- a/src/api/app/services/github_status_reporter.rb
+++ b/src/api/app/services/github_status_reporter.rb
@@ -49,7 +49,7 @@ class GithubStatusReporter < SCMExceptionHandler
       { context: 'OBS SCM/CI Workflow Integration started',
         target_url: Rails.application.routes.url_helpers.token_workflow_run_url(@workflow_run.token_id, @workflow_run.id, host: Configuration.obs_url) }
     elsif @event_type == 'Event::RequestStatechange'
-      { context: "OBS: Request #{@event_payload[:number]} - #{@event_payload[:state]}",
+      { context: "OBS: Request #{@event_payload[:number]}",
         target_url: Rails.application.routes.url_helpers.request_show_url(@event_payload[:number], host: Configuration.obs_url) }
     else
       { context: "OBS: #{@event_payload[:package]} - #{@event_payload[:repository]}/#{@event_payload[:arch]}",

--- a/src/api/app/services/gitlab_status_reporter.rb
+++ b/src/api/app/services/gitlab_status_reporter.rb
@@ -40,7 +40,7 @@ class GitlabStatusReporter < SCMExceptionHandler
       { context: 'OBS SCM/CI Workflow Integration started',
         target_url: Rails.application.routes.url_helpers.token_workflow_run_url(@workflow_run.token_id, @workflow_run.id, host: Configuration.obs_url) }
     elsif @event_type == 'Event::RequestStatechange'
-      { context: "OBS: Request #{@event_payload[:number]} - #{@event_payload[:state]}",
+      { context: "OBS: Request #{@event_payload[:number]}",
         target_url: Rails.application.routes.url_helpers.request_show_url(@event_payload[:number], host: Configuration.obs_url) }
     else
       { context: "OBS: #{@event_payload[:package]} - #{@event_payload[:repository]}/#{@event_payload[:arch]}",

--- a/src/api/spec/services/gitea_status_reporter_spec.rb
+++ b/src/api/spec/services/gitea_status_reporter_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe GiteaStatusReporter, type: :service do
       let(:initial_report) { false }
       let(:status_options) do
         {
-          context: 'OBS: Request 1 - new',
+          context: 'OBS: Request 1',
           target_url: 'https://unconfigured.openbuildservice.org/request/show/1'
         }
       end

--- a/src/api/spec/services/github_status_reporter_spec.rb
+++ b/src/api/spec/services/github_status_reporter_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe GithubStatusReporter, type: :service do
         let(:initial_report) { false }
         let(:expected_status_options) do
           {
-            context: 'OBS: Request 1 - new',
+            context: 'OBS: Request 1',
             target_url: 'https://unconfigured.openbuildservice.org/request/show/1'
           }
         end

--- a/src/api/spec/services/gitlab_status_reporter_spec.rb
+++ b/src/api/spec/services/gitlab_status_reporter_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe GitlabStatusReporter, type: :service do
       let(:initial_report) { false }
       let(:status_options) do
         {
-          context: 'OBS: Request 1 - new',
+          context: 'OBS: Request 1',
           target_url: 'https://unconfigured.openbuildservice.org/request/show/1'
         }
       end


### PR DESCRIPTION
Can't have variable things like the requests state in the context. It is used to identify the commit status that has to be updated.