### PR TITLE
Ensure that the scmsync url is updated on pushes in forks

### DIFF
--- a/src/api/app/models/concerns/scm_sync_enabled_step.rb
+++ b/src/api/app/models/concerns/scm_sync_enabled_step.rb
@@ -4,6 +4,12 @@ module ScmSyncEnabledStep
     parsed_scmsync_url = Addressable::URI.parse(scmsync_url)
     parsed_scmsync_url.fragment = scm_webhook.payload[:commit_sha]
 
+    # We must adjust the url path in case when the payload contains a source repo.
+    # This happens for push events in forks of the origin package.
+    if payload[:source_repository_full_name]
+      parsed_scmsync_url.path = "/#{payload[:source_repository_full_name]}"
+    end
+
     # if we use scmsync to sync a whole project, then each package will be
     # fetched from a subdirectory
     if scm_synced_project?


### PR DESCRIPTION
This should fix https://github.com/openSUSE/open-build-service/issues/14776, but I am really unsure whether it actually does…