### PR TITLE
[backend] fix logic in notify_repservers call

### DIFF
--- a/src/backend/BSSrcServer/Service.pm
+++ b/src/backend/BSSrcServer/Service.pm
@@ -217,9 +217,9 @@ sub addrev_service {
   BSSrcrep::addmeta_serviceerror($projid, $packid, $servicemark, $error) if $error;
   notify_serviceresult($rev, $error);
   if ($packid eq '_project') {
-    $notify_repservers->('project', $projid) unless $rev->{'rev'} eq 'obsscm' || $error;
+    $notify_repservers->('project', $projid) if $rev->{'rev'} ne 'obsscm' || $error;
   } else {
-    $notify_repservers->('package', $projid, $packid) unless $rev->{'rev'} eq 'obsscm' || $error;
+    $notify_repservers->('package', $projid, $packid) if $rev->{'rev'} ne 'obsscm' || $error;
   }
 }
 


### PR DESCRIPTION
We need to notify the repservers if it was not a obsscm run *or* there was an error.