### PR TITLE
[backend] Scmsync: ignore url when comparing the package meta

### DIFF
--- a/src/backend/BSSrcServer/Scmsync.pm
+++ b/src/backend/BSSrcServer/Scmsync.pm
@@ -128,7 +128,7 @@ sub sync_package {
   }
   my $oldpack = BSRevision::readpack_local($projid, $packid, 1);
 
-  if ($undeleted || !$oldpack || !BSUtil::identical($pack, $oldpack)) {
+  if ($undeleted || !$oldpack || !BSUtil::identical($pack, $oldpack, $pack->{'scmsync'} ? { 'url' => 1 } : undef)) {
     print "scmsync: update $projid/$packid\n";
     putpackage($cgi, $projid, $packid, $pack);
     my %except = map {$_ => 1} qw{title description devel person group url};


### PR DESCRIPTION
The scm bridge puts the project's scmsync url into the meta url entry, which leads to package meta commits for all packages if the project git changes.