### PR TITLE
Avoid duplicated gem diff comments

### DIFF
--- a/.github/workflows/comment_diffend_io_links_to_pr.yml
+++ b/.github/workflows/comment_diffend_io_links_to_pr.yml
@@ -25,3 +25,4 @@ jobs:
         with:
           filePath: comment_text_and_pr_number/comment_text.txt
           pr_number: ${{ env.pr_number }}
+          comment_tag: comment_with_diffend_io_links


### PR DESCRIPTION
By using the `comment_tag` the github action `actions-comment-pull-request` will update an existing comment over creating a new one. This avoids flooding the depfu PR's with comment when they are updated multiple times.

For reference https://github.com/thollander/actions-comment-pull-request#update-a-comment