### PR TITLE
[backend] sync product xml spec

### DIFF
--- a/src/backend/BSProductXML.pm
+++ b/src/backend/BSProductXML.pm
@@ -203,6 +203,7 @@ our $product = [
              'milestone',   # alternative to betaversion, not causing a beta warning
              'mainproduct',
              'create_flavors',
+             'sync_build_counter', # default is true
              [ 'linguas' =>
                [],
                [[ 'language' => '_content' ]],


### PR DESCRIPTION
To add option for opt-out product build number syncing

New source based BcntSyncTag handling requires new source parsers, therefor update build script reference.