### PR TITLE
Document `GET /build/.../_buildenv` and `_statistics` API endpoints

### DIFF
--- a/src/api/public/apidocs/OBS-v2.10.50.yaml
+++ b/src/api/public/apidocs/OBS-v2.10.50.yaml
@@ -131,6 +131,8 @@ paths:
     $ref: 'paths/build_project_name_repository_name_architecture_name_package_name.yaml'
   /build/{project_name}/{repository_name}/{architecture_name}/{package_name}/_log:
     $ref: 'paths/build_project_name_repository_name_architecture_name_package_name_log.yaml'
+  /build/{project_name}/{repository_name}/{architecture_name}/{package_name}/_buildenv:
+    $ref: 'paths/build_project_name_repository_name_architecture_name_package_name_buildenv.yaml'
   /build/{project_name}/{repository_name}/{architecture_name}/{package_name}/_buildinfo:
     $ref: 'paths/build_project_name_repository_name_architecture_name_package_name_buildinfo.yaml'
   /build/{project_name}/{repository_name}/{architecture_name}/{package_name}/_status:

--- a/src/api/public/apidocs/OBS-v2.10.50.yaml
+++ b/src/api/public/apidocs/OBS-v2.10.50.yaml
@@ -143,6 +143,8 @@ paths:
     $ref: 'paths/build_project_name_repository_name_architecture_name_package_name_reason.yaml'
   /build/{project_name}/{repository_name}/{architecture_name}/{package_name}/_jobstatus:
     $ref: 'paths/build_project_name_repository_name_architecture_name_package_name_jobstatus.yaml'
+  /build/{project_name}/{repository_name}/{architecture_name}/{package_name}/_statistics:
+    $ref: 'paths/build_project_name_repository_name_architecture_name_package_name_statistics.yaml'
   /build/{project_name}/{repository_name}/{architecture_name}/{package_name}/{file_name}:
     $ref: 'paths/build_project_name_repository_name_architecture_name_package_name_file_name.yaml'
   /build/{project_name}/{repository_name}/{architecture_name}/{package_name}/{file_name}?view=fileinfo:

--- a/src/api/public/apidocs/components/schemas/buildenv.yaml
+++ b/src/api/public/apidocs/components/schemas/buildenv.yaml
@@ -1,0 +1,73 @@
+type: object
+properties:
+  project:
+    type: string
+    example: 'home:Admin'
+    xml:
+      attribute: true
+  repository:
+    type: string
+    example: 'openSUSE_Tumbleweed'
+    xml:
+      attribute: true
+  package:
+    type: string
+    example: 'ctris'
+    xml:
+      attribute: true
+  arch:
+    type: string
+    example: 'i586'
+  srcmd5:
+    type: string
+    example: '6b7c8d9cb5c5d36453c1dc8e102016b1'
+  verifymd5:
+    type: string
+    example: '6b7c8d9cb5c5d36453c1dc8e102016b1'
+  versrel:
+    type: string
+    example: '0.42.1-3'
+  bcnt:
+    type: string
+    example: '2'
+  release:
+    type: string
+    example: '3.2'
+  config:
+    type: string
+    example: |
+      %define _project home:enavarro_suse
+
+      ### from openSUSE:Factory
+      %define _repository ports
+
+      Macros:
+      %vendor obs://build.opensuse.org/home:enavarro_suse
+      %_download_url https://download.opensuse.org/repositories
+      %_project home:enavarro_suse
+  bdep:
+    type: object
+    properties:
+      name:
+        type: string
+        example: 'liblua5_4-5'
+        xml:
+          attribute: true
+      hdrmd5:
+        type: string
+        example: 4f50c1ea427e184620686ded4baa3097
+        xml:
+          attribute: true
+      project:
+        type: string
+        example: 'openSUSE:Tumbleweed'
+        xml:
+          attribute: true
+      repository:
+        type: string
+        example: dod
+        xml:
+          attribute: true
+
+xml:
+  name: 'buildinfo'

--- a/src/api/public/apidocs/components/schemas/buildstatistics.yaml
+++ b/src/api/public/apidocs/components/schemas/buildstatistics.yaml
@@ -1,0 +1,154 @@
+type: object
+properties:
+  disk:
+    type: object
+    properties:
+      usage:
+        type: object
+        properties:
+          size:
+            type: object
+            properties:
+              # FIXME: 'content' attribute missing due to https://github.com/OAI/OpenAPI-Specification/issues/630
+              # This happens for all `size` and `time` elements in this schema
+              unit:
+                type: string
+                xml:
+                  attribute: true
+          io_requests:
+            type: string
+          io_sectors:
+            type: string
+  memory:
+    type: object
+    properties:
+      usage:
+        type: object
+        properties:
+          size:
+            type: object
+            properties:
+              unit:
+                type: string
+                xml:
+                  attribute: true
+  times:
+    type: object
+    properties:
+      total:
+        type: object
+        properties:
+          time:
+            type: object
+            properties:
+              unit:
+                type: string
+                xml:
+                  attribute: true
+      preinstall:
+        type: object
+        properties:
+          time:
+            type: object
+            properties:
+              unit:
+                type: string
+                xml:
+                  attribute: true
+      install:
+        type: object
+        properties:
+          time:
+            type: object
+            properties:
+              unit:
+                type: string
+                xml:
+                  attribute: true
+      main:
+        type: object
+        properties:
+          time:
+            type: object
+            properties:
+              unit:
+                type: string
+                xml:
+                  attribute: true
+      postchecks:
+        type: object
+        properties:
+          time:
+            type: object
+            properties:
+              unit:
+                type: string
+                xml:
+                  attribute: true
+      rpmlint:
+        type: object
+        properties:
+          time:
+            type: object
+            properties:
+              unit:
+                type: string
+                xml:
+                  attribute: true
+      buildcmp:
+        type: object
+        properties:
+          time:
+            type: object
+            properties:
+              unit:
+                type: string
+                xml:
+                  attribute: true
+      deltarpms:
+        type: object
+        properties:
+          time:
+            type: object
+            properties:
+              unit:
+                type: string
+                xml:
+                  attribute: true
+      download:
+        type: object
+        properties:
+          time:
+            type: object
+            properties:
+              unit:
+                type: string
+                xml:
+                  attribute: true
+      cpusteal:
+        type: object
+        properties:
+          time:
+            type: object
+            properties:
+              unit:
+                type: string
+                xml:
+                  attribute: true
+  download:
+    type: object
+    properties:
+      size:
+        type: object
+        properties:
+          unit:
+            type: string
+            xml:
+              attribute: true
+      binaries:
+        type: string
+      cachehits:
+        type: string
+
+xml:
+  name: 'buildstatistics'

--- a/src/api/public/apidocs/paths/build_project_name_repository_name_architecture_name_package_name_buildenv.yaml
+++ b/src/api/public/apidocs/paths/build_project_name_repository_name_architecture_name_package_name_buildenv.yaml
@@ -1,0 +1,34 @@
+get:
+  summary: Return the environment information for the last performed build.
+  description: Get specifics of the environment information for the last performed build.
+  security:
+    - basic_authentication: []
+  parameters:
+    - $ref: '../components/parameters/project_name.yaml'
+    - $ref: '../components/parameters/repository_name.yaml'
+    - $ref: '../components/parameters/architecture_name.yaml'
+    - $ref: '../components/parameters/package_name.yaml'
+  responses:
+    '200':
+      description: OK. The request has succeeded.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/buildenv.yaml'
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '404':
+      description: |
+        Error: Not Found
+
+        XML Schema used for body validation: [status.xsd](../schema/status.xsd)
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          example:
+            code: 'unknown_project'
+            summary: 'Project not found: 1'
+
+  tags:
+    - Build

--- a/src/api/public/apidocs/paths/build_project_name_repository_name_architecture_name_package_name_statistics.yaml
+++ b/src/api/public/apidocs/paths/build_project_name_repository_name_architecture_name_package_name_statistics.yaml
@@ -1,0 +1,57 @@
+get:
+  summary: Return build statistics from the last performed build.
+  description: Get specifics of build statistics from the last performed build.
+  security:
+    - basic_authentication: []
+  parameters:
+    - $ref: '../components/parameters/project_name.yaml'
+    - $ref: '../components/parameters/repository_name.yaml'
+    - $ref: '../components/parameters/architecture_name.yaml'
+    - $ref: '../components/parameters/package_name.yaml'
+  responses:
+    '200':
+      description: OK. The request has succeeded.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/buildstatistics.yaml'
+          example:
+            disk:
+              usage:
+                size:
+                  unit: M
+                io_requests: 7750
+                io_sectors: 1248010
+            memory:
+              usage:
+                size:
+                  unit: M
+            times:
+              total:
+                time:
+                  unit: s
+              preinstall:
+                time:
+                  unit: s
+            download:
+              size:
+                unit: k
+              binaries: 5
+              cachehits: 131
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '404':
+      description: |
+        Error: Not Found
+
+        XML Schema used for body validation: [status.xsd](../schema/status.xsd)
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          example:
+            code: 'unknown_project'
+            summary: 'Project not found: 1'
+
+  tags:
+    - Build


### PR DESCRIPTION
## For reviewers

You can access a preview of the documented API endpoints in the review-app with the following links:
- [_buildenv](https://obs-reviewlab.opensuse.org/eduardoj-apidocsbuild_package_builenv_statistics/apidocs/index#/Build/get_build__project_name___repository_name___architecture_name___package_name___buildenv)
- [_statistics](https://obs-reviewlab.opensuse.org/eduardoj-apidocsbuild_package_builenv_statistics/apidocs/index#/Build/get_build__project_name___repository_name___architecture_name___package_name___statistics)