### PR TITLE
[api] implement package fork command

### DIFF
--- a/docs/api/api/api.txt
+++ b/docs/api/api/api.txt
@@ -712,6 +712,22 @@ Parameters:
 XmlResult: status
 
 
+POST /source/<project>/<package>?cmd=fork&scmsync=url
+
+  Create a fork of a package taking the source from the scmsync parameter.
+  The target project is by default below home:<user>:branches namespace.
+  The target project will be setup to include the source project repository setup.
+  The source project must exists, the source package may not exist.
+
+Parameters:
+  scmsync: string, required, specifies checkout url for the source
+  target_project: target project name, optional (default home:<user>:branches:<project>)
+  add_repositories_rebuild: use defined rebuild policy for new repos ("transitive", "direct" or "local") or copy it from the source project ("copy")
+  add_repositories_block: use defined block policy for new repos
+
+XmlResult: status
+
+
 POST /source/<project>/<package>?cmd=set_flag
   Modify or set a defined flag for package
 

--- a/src/api/public/apidocs/OBS-v2.10.50.yaml
+++ b/src/api/public/apidocs/OBS-v2.10.50.yaml
@@ -283,6 +283,8 @@ paths:
 
   /source?cmd=branch:
     $ref: 'paths/source_branch.yaml'
+  /source?cmd=fork:
+    $ref: 'paths/source_fork.yaml'
   /source?cmd=createmaintenanceincident:
     $ref: 'paths/source_createmaintenanceincident.yaml'
   /source?cmd=orderkiwirepos:

--- a/src/api/public/apidocs/paths/source_fork.yaml
+++ b/src/api/public/apidocs/paths/source_fork.yaml
@@ -1,0 +1,78 @@
+post:
+  summary: Create a fork of a package taking the source from the scmsync parameter
+  description: |
+    Create a fork of a package taking the source from the scmsync parameter.
+    The target project is by default below home:<user>:branches namespace.
+    The target project will be setup to include the source project repository setup.
+    The source project must exists, the source package may not exist.
+  security:
+    - basic_authentication: []
+  parameters:
+    - $ref: '../components/parameters/project_name.yaml'
+    - $ref: '../components/parameters/package_name.yaml'
+    - name: scmsync
+      description: Checkout url for the source
+      in: query
+      required: true
+      schema:
+        type: string
+    - name: target_project
+      description: target project name, optional (default home:<user>:branches:<project>)
+      in: query
+      schema:
+        type: string
+    - name: add_repositories_rebuild
+      in: query
+      schema:
+        type: string
+        enum:
+          - transitive
+          - direct
+          - local
+          - copy
+      description: Set one of the defined rebuild policies for new repositories (`transitive`, `direct` or `local`) or copy it from the source project (`copy`)
+    - in: query
+      name: add_repositories_block
+      schema:
+        type: string
+        enum:
+          - all
+          - local
+          - never
+      description: Set to use defined block policy for new repositories.
+
+  responses:
+    '200':
+      description: ok
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          example:
+            code: ok
+            summary: Ok
+            data:
+              - home:Admin
+              - hello_world
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '404':
+      description: Not Found
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                xml:
+                  attribute: true
+              summary:
+                type: string
+            xml:
+              name: status
+          example:
+            code: not_found
+            summary: project not found
+  tags:
+    - Sources


### PR DESCRIPTION
This can be used to create a test build setup for a scmsync package based on an existing project.

The base package may or may not exist. May or may not use scmsync.

This is mainly implemented inside of BranchPackage class intentionaly, even when this is no source branch technically. But many api parts like repository setup can be shared this way.