### PR TITLE
Request build chart UI fixes

### DIFF
--- a/src/api/app/components/chart_component.html.haml
+++ b/src/api/app/components/chart_component.html.haml
@@ -3,7 +3,7 @@
   .m-4
     %h4
       Build results summary
-    - if distinct_repositories(raw_data).size > 6
+    - if distinct_repositories(raw_data).size > 5 || raw_data.size > 12
       = column_chart( chart_data(raw_data),
                       width: '100%',
                       height: '300px',

--- a/src/api/app/components/chart_component.html.haml
+++ b/src/api/app/components/chart_component.html.haml
@@ -22,9 +22,9 @@
           .row.mt-2
             %b.col-3
               = repo
-            .col-9.d-flex
+            .col-9.d-flex.flex-wrap.gap-1.justify-content-start
               - raw_data.each do |result|
                 - if result[:repository] == repo
-                  %span.ps-2.pe-2.ms-1.align-self-start{ class: status_color(result[:status]),
+                  %span.ps-2.pe-2{ class: status_color(result[:status]),
                                         title: "#{result[:project_name]}/#{result[:package_name]}" }
                     = result[:architecture]


### PR DESCRIPTION
1- Adjust threshold to decide whether to initialize the chart or the simplified UI.

2- Fix the wrapper for results of a single repository when they are many.

Before
![image](https://github.com/openSUSE/open-build-service/assets/7080830/8eace4b6-867b-4a1e-bbba-3702935d968f)

After
![image](https://github.com/openSUSE/open-build-service/assets/7080830/afc62bc5-15ea-4e26-a880-54920a4de144)


