### PR TITLE
Align elements properly so as not to take the entire height

### DIFF
--- a/src/api/app/components/chart_component.html.haml
+++ b/src/api/app/components/chart_component.html.haml
@@ -25,6 +25,6 @@
             .col-9.d-flex.flex-wrap.gap-1.justify-content-start
               - raw_data.each do |result|
                 - if result[:repository] == repo
-                  %span.ps-2.pe-2{ class: status_color(result[:status]),
+                  %span.ps-2.pe-2.align-self-start{ class: status_color(result[:status]),
                                         title: "#{result[:project_name]}/#{result[:package_name]}" }
                     = result[:architecture]


### PR DESCRIPTION
CSS class dropped by mistake in 2d8cddb893dba85a3037ee3b4ad571809b341b16

Before
![image](https://github.com/openSUSE/open-build-service/assets/7080830/f339a527-96df-47f1-affc-6444690f665f)

After
![image](https://github.com/openSUSE/open-build-service/assets/7080830/6f92537d-082d-40f9-96c9-7a91c31a26b5)
