### PR TITLE
Avoid sending empty partition metric

### DIFF
--- a/src/api/app/jobs/worker_measurements_job.rb
+++ b/src/api/app/jobs/worker_measurements_job.rb
@@ -54,7 +54,7 @@ class WorkerMeasurementsJob < ApplicationJob
 
   def send_daemon_metrics
     @workerstatus.xpath('//partition/daemon').each do |daemon|
-      partition = daemon.parent.values.first
+      partition = daemon.parent.values.first || 'main'
       type = daemon.attributes['type'].value
       state = daemon.attributes['state'].value
       arch = daemon.attributes['arch']


### PR DESCRIPTION
Telegraf can't parse it when partition is empty for 'backend_daemon_status'. It will be 'main' in such cases.