### PR TITLE
Initial implementation of reports feature

### DIFF
--- a/src/api/app/assets/javascripts/webui/application.js
+++ b/src/api/app/assets/javascripts/webui/application.js
@@ -66,3 +66,4 @@
 //= require webui/add_file.js
 //= require chartkick
 //= require Chart.bundle
+//= require webui/report.js

--- a/src/api/app/assets/javascripts/webui/report.js
+++ b/src/api/app/assets/javascripts/webui/report.js
@@ -1,0 +1,40 @@
+function collectReportModalsAndSetValues() { // jshint ignore:line
+  $.each(modalIdsForReport(), function( _index, modalId ) {
+    setValuesOnReportDialog(modalId);
+  });
+}
+
+// TODO: This function is overlapping with the function in delete_confirmation_dialog.js#modalIds
+function modalIdsForReport() {
+  var targets = $('a[data-bs-toggle="modal"][data-bs-target^="#report"]').toArray().map(
+    function(e) { return $(e).data('bs-target');
+  });
+
+  return $.unique(targets);
+}
+
+function setValuesOnReportDialog(modalId) {
+  $(modalId).on('show.bs.modal', function (event) {
+    var link = $(event.relatedTarget);
+    var modal = $(this);
+
+    if (typeof(link.data('modal-title')) !== 'undefined') {
+      modal.find('.modal-title').text(link.data('modal-title'));
+    }
+
+    if (typeof(link.data('reportable-id')) !== 'undefined') {
+      modal.find('#report_reportable_id').val(link.data('reportable-id'));
+    }
+
+    if (typeof(link.data('reportable-type')) !== 'undefined') {
+      modal.find('#report_reportable_type').val(link.data('reportable-type'));
+    }
+
+    modal.find('#link_id').val(link.attr('id'));
+  });
+}
+
+/* exported hideReportButton */
+function hideReportButton(element) {
+  $(element).addClass('d-none');
+}

--- a/src/api/app/components/report_component.html.haml
+++ b/src/api/app/components/report_component.html.haml
@@ -1,0 +1,27 @@
+.modal.fade{ id: "#{modal_id}", tabindex: -1, role: 'dialog', aria: { labelledby: "#{modal_id}-label", hidden: true } }
+  .modal-dialog.modal-dialog-centered{ role: 'document' }
+    .modal-content
+      .modal-header
+        %h5.wrap-text.modal-title{ id: "#{modal_id}-label" }= modal_title
+      .modal-body
+        %p.wrap-text.confirmation-text= confirmation_text
+
+        = form_for(Report.new, url: reports_path, method: :post, remote: true) do |form|
+          = hidden_field_tag :link_id
+          = hidden_field_tag :modal_id, modal_id
+          = form.hidden_field :reportable_id
+          = form.hidden_field :reportable_type
+          .mb-3
+            = form.label('Reason:')
+            = form.text_area(:reason, class: 'form-control')
+            .text-muted
+              Please include any additional information here.
+          .modal-footer
+            %a.btn.btn-sm.btn-outline-secondary.px-4{ data: { 'bs-dismiss': 'modal' } }
+              Cancel
+            = submit_tag('Submit', class: 'btn btn-sm btn-primary px-4')
+
+:javascript
+  $(document).ready(function() {
+    collectReportModalsAndSetValues();
+  });

--- a/src/api/app/components/report_component.rb
+++ b/src/api/app/components/report_component.rb
@@ -1,0 +1,24 @@
+# rubocop:disable ViewComponent/MissingPreviewFile
+# frozen_string_literal: true
+
+class ReportComponent < ApplicationComponent
+  attr_accessor :modal_id, :modal_title
+
+  def initialize(modal_id:, options: {})
+    super
+
+    @modal_id = modal_id
+    @object_type = options[:object_type]
+    @modal_title = options[:modal_title]
+    @user = options[:user]
+  end
+
+  def confirmation_text
+    "Are you sure you want to report this #{@object_type.class.name.downcase}?"
+  end
+
+  def render?
+    Flipper.enabled?(:content_moderation, @user)
+  end
+end
+# rubocop:enable ViewComponent/MissingPreviewFile

--- a/src/api/app/controllers/webui/reports_controller.rb
+++ b/src/api/app/controllers/webui/reports_controller.rb
@@ -1,0 +1,29 @@
+class Webui::ReportsController < Webui::WebuiController
+  before_action :require_login
+  after_action :verify_authorized
+
+  def create
+    user = User.session!
+    report = user.submitted_reports.new(report_params)
+    authorize report
+
+    @link_id = params[:link_id]
+    @modal_id = params[:modal_id]
+
+    if report.save
+      flash[:success] = "#{report.reportable_type} reported successfully"
+    else
+      flash[:error] = report.errors.full_messages.to_sentence
+    end
+
+    respond_to do |format|
+      format.js
+    end
+  end
+
+  private
+
+  def report_params
+    params.require(:report).permit(:reason, :reportable_id, :reportable_type)
+  end
+end

--- a/src/api/app/models/comment.rb
+++ b/src/api/app/models/comment.rb
@@ -18,6 +18,7 @@ class Comment < ApplicationRecord
 
   has_many :children, dependent: :destroy, class_name: 'Comment', foreign_key: 'parent_id'
   has_many :notifications, as: :notifiable, dependent: :delete_all
+  has_many :reports, as: :reportable, dependent: :nullify
 
   extend ActsAsTree::TreeWalker
   acts_as_tree order: 'created_at'

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -53,6 +53,7 @@ class Package < ApplicationRecord
   has_many :target_of_bs_requests, through: :target_of_bs_request_actions, source: :bs_request
 
   has_many :watched_items, as: :watchable, dependent: :destroy
+  has_many :reports, as: :reportable, dependent: :nullify
 
   before_update :update_activity
   after_update :convert_to_symsync

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -80,6 +80,7 @@ class Project < ApplicationRecord
 
   has_many :notified_projects, dependent: :destroy
   has_many :notifications, through: :notified_projects
+  has_many :reports, as: :reportable, dependent: :nullify
 
   default_scope { where.not('projects.id' => Relationship.forbidden_project_ids) }
 

--- a/src/api/app/models/report.rb
+++ b/src/api/app/models/report.rb
@@ -1,0 +1,30 @@
+# Report class flags abusive content, be it projects, packages, users or comments
+class Report < ApplicationRecord
+  validates :reason, length: { maximum: 65_535 }
+  validates :reportable_type, length: { maximum: 255 }
+
+  belongs_to :user, optional: false
+  belongs_to :reportable, polymorphic: true, optional: false
+end
+
+# == Schema Information
+#
+# Table name: reports
+#
+#  id              :bigint           not null, primary key
+#  reason          :text(65535)
+#  reportable_type :string(255)      not null, indexed => [reportable_id]
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  reportable_id   :integer          not null, indexed => [reportable_type]
+#  user_id         :integer          not null, indexed
+#
+# Indexes
+#
+#  index_reports_on_reportable  (reportable_type,reportable_id)
+#  index_reports_on_user_id     (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -61,6 +61,8 @@ class User < ApplicationRecord
   has_many :acknowledged_status_messages, through: :status_message_acknowledgements, class_name: 'StatusMessage', source: 'status_message'
 
   has_many :disabled_beta_features, dependent: :destroy
+  has_many :reports, as: :reportable, dependent: :nullify
+  has_many :submitted_reports, class_name: 'Report'
 
   scope :confirmed, -> { where(state: 'confirmed') }
   scope :all_without_nobody, -> { where.not(login: NOBODY_LOGIN) }

--- a/src/api/app/policies/report_policy.rb
+++ b/src/api/app/policies/report_policy.rb
@@ -1,0 +1,34 @@
+class ReportPolicy < ApplicationPolicy
+  attr_reader :user, :record, :reportable
+
+  def initialize(user, record)
+    super(user, record)
+
+    @user = user
+    @record = record
+    @reportable = record.reportable
+  end
+
+  def show?
+    user.is_admin? || record.user == user
+  end
+
+  def create?
+    return false unless Flipper.enabled?(:content_moderation, user)
+
+    # We don't want reports twice...
+    return false if user.submitted_reports.where(reportable: reportable).any?
+
+    # We don't want reports for things you can change yourself...
+    case reportable.class.name
+    when 'Package'
+      !PackagePolicy.new(user, reportable).update?
+    when 'Project'
+      !ProjectPolicy.new(user, reportable).update?
+    when 'Comment'
+      !CommentPolicy.new(user, reportable).update?
+    when 'User'
+      !UserPolicy.new(user, reportable).update?
+    end
+  end
+end

--- a/src/api/app/views/webui/comment/_reply.html.haml
+++ b/src/api/app/views/webui/comment/_reply.html.haml
@@ -15,6 +15,15 @@
       = link_to('#', data: { 'bs-toggle': 'modal', 'bs-target': "#delete-comment-modal-#{comment.id}" },
                 class: 'delete_link btn btn-outline-danger', title: 'Delete comment') do
         Delete
+  - if policy(Report.new(reportable: comment)).create?
+    %li.list-inline-item
+      = link_to('#', class: 'btn btn-outline-dark', id: "js-comment-#{comment.id}",
+            data: { 'bs-toggle': 'modal',
+                    'bs-target': '#report-comment-modal',
+                    'modal-title': "Report comment from #{comment.user}",
+                    'reportable-type': comment.class.name,
+                    'reportable-id': comment.id }) do
+        Report
 - if policy(comment).reply?
   .collapse{ id: "reply_form_of_#{comment.id}" }
     = render(partial: 'webui/comment/comment_field', locals: { form_method: :post,

--- a/src/api/app/views/webui/comment/_show.html.haml
+++ b/src/api/app/views/webui/comment/_show.html.haml
@@ -1,2 +1,4 @@
 .comments-list{ data: { comment_counter: local_assigns[:comment_counter_id] } }
   = render partial: 'webui/comment/comment_list', locals: { commentable: commentable }
+
+= render ReportComponent.new(modal_id: 'report-comment-modal', options: { object_type: 'Comment', user: User.session })

--- a/src/api/app/views/webui/package/_show_actions.html.haml
+++ b/src/api/app/views/webui/package/_show_actions.html.haml
@@ -26,3 +26,5 @@
       //TODO: only users w/o rights should see this, maintainers should get a different dialog:
     - if package.develpackage
       = render partial: 'webui/package/show_actions/request_devel_project_change', locals: { package: package, project: project }
+
+  = render partial: 'webui/package/show_actions/report_package', locals: { package: package }

--- a/src/api/app/views/webui/package/show.html.haml
+++ b/src/api/app/views/webui/package/show.html.haml
@@ -88,4 +88,6 @@
           comment_counter_id: "#comment-counter-package-#{@package.id}" }
 - if User.session && User.possibly_nobody.can_modify?(@package)
   = render partial: 'delete_dialog', locals: { project: @project, package: @package, cleanup_source: @cleanup_source }
+
+= render ReportComponent.new(modal_id: 'report-package-modal', options: { object_type: 'Package', user: User.session })
 -# haml-lint:enable ViewLength

--- a/src/api/app/views/webui/package/show_actions/_report_package.html.haml
+++ b/src/api/app/views/webui/package/show_actions/_report_package.html.haml
@@ -1,0 +1,10 @@
+- if policy(Report.new(reportable: package)).create?
+  %li.nav-item
+    = link_to('#', class: 'nav-link', id: "js-package-#{package.id}",
+          data: { 'bs-toggle': 'modal',
+                  'bs-target': '#report-package-modal',
+                  'modal-title': "Report package from #{package.name}",
+                  'reportable-type': package.class.name,
+                  'reportable-id': package.id }) do
+      %i.fas.fa-regular.fa-flag.fa-lg.me-2
+      %span.nav-item-name Report Package

--- a/src/api/app/views/webui/reports/create.js.erb
+++ b/src/api/app/views/webui/reports/create.js.erb
@@ -1,0 +1,5 @@
+$("#<%= @modal_id %>").modal('hide');
+$('#flash').html("<%= escape_javascript(render(partial: 'layouts/webui/flash'))%>")
+
+hideReportButton("#<%= @link_id %>");
+collectReportModalsAndSetValues();

--- a/src/api/app/views/webui/user/_basic_info.html.haml
+++ b/src/api/app/views/webui/user/_basic_info.html.haml
@@ -4,6 +4,15 @@
 
 .basic-info
   .d-flex.flex-row-reverse
+    - if policy(Report.new(reportable: user)).create?
+      = link_to('#', id: "js-user-#{user.id}", class: 'ps-2',
+            data: { 'bs-toggle': 'modal',
+                    'bs-target': '#report-user-modal',
+                    'modal-title': "Report #{user.login}",
+                    'reportable-type': user.class.name,
+                    'reportable-id': user.id }) do
+        %i.fas.fa-regular.fa-flag
+        %span.nav-item-name Report
     - if User.possibly_nobody.is_admin?
       = link_to('#', title: 'Delete user', class: 'ms-2', data: { 'bs-toggle': 'modal', 'bs-target': '#delete-user-modal' }) do
         %i.fas.fa-times-circle.text-danger
@@ -39,6 +48,7 @@
         %i.fas.fa-envelope.me-1
         = user.email
 
+= render ReportComponent.new(modal_id: 'report-user-modal', options: { object_type: 'User', user: User.session })
 
 :javascript
   $('#toggle-in-place-editing').on('click', function () {

--- a/src/api/config/initializers/flipper.rb
+++ b/src/api/config/initializers/flipper.rb
@@ -2,7 +2,8 @@
 # environment and review apps to test changes for those features. Rolled-out feature toggles aren't displayed anyway
 # to users in the web UI for beta features.
 ENABLED_FEATURE_TOGGLES = [
-  { name: :request_show_redesign, description: 'Redesign of the request pages to improve the collaboration workflow' }
+  { name: :request_show_redesign, description: 'Redesign of the request pages to improve the collaboration workflow' },
+  { name: :content_moderation, description: 'Reporting inappropriate content' }
 ].freeze
 
 Flipper.configure do

--- a/src/api/config/routes/webui_routes.rb
+++ b/src/api/config/routes/webui_routes.rb
@@ -428,4 +428,6 @@ OBSApi::Application.routes.draw do
       end
     end
   end
+
+  resources :reports, only: [:create], controller: 'webui/reports'
 end

--- a/src/api/db/migrate/20230907111316_create_reports.rb
+++ b/src/api/db/migrate/20230907111316_create_reports.rb
@@ -1,0 +1,11 @@
+class CreateReports < ActiveRecord::Migration[7.0]
+  def change
+    create_table :reports, id: :bigint do |t|
+      t.belongs_to :user, null: false, foreign_key: true, type: :integer
+      t.references :reportable, polymorphic: true, null: false, type: :integer
+      t.text :reason
+
+      t.timestamps
+    end
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_27_110437) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_07_111316) do
   create_table "architectures", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "name", null: false
     t.boolean "available", default: false
@@ -853,6 +853,17 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_27_110437) do
     t.index ["target_repository_id"], name: "index_release_targets_on_target_repository_id"
   end
 
+  create_table "reports", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.string "reportable_type", null: false
+    t.integer "reportable_id", null: false
+    t.text "reason"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["reportable_type", "reportable_id"], name: "index_reports_on_reportable"
+    t.index ["user_id"], name: "index_reports_on_user_id"
+  end
+
   create_table "repositories", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "db_project_id", null: false
     t.string "name", null: false, collation: "utf8mb4_bin"
@@ -1213,6 +1224,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_27_110437) do
   add_foreign_key "relationships", "users", name: "relationships_ibfk_2"
   add_foreign_key "release_targets", "repositories", column: "target_repository_id", name: "release_targets_ibfk_2"
   add_foreign_key "release_targets", "repositories", name: "release_targets_ibfk_1"
+  add_foreign_key "reports", "users"
   add_foreign_key "repositories", "projects", column: "db_project_id", name: "repositories_ibfk_1"
   add_foreign_key "repositories", "repositories", column: "hostsystem_id", name: "repositories_ibfk_2"
   add_foreign_key "repository_architectures", "architectures", name: "repository_architectures_ibfk_2"


### PR DESCRIPTION
This PR covers the implementation of the following things:

- [x]  Implementation of the Report model and its associations
- [x]  Implementation of flipper flag
- [x] Implementation of reporting a comment
- [x] Implementation of reporting a package
- [x] Implementation of reporting a user

There will be a follow-up PR #14898 for the remaining features i.e., 
- [Specs for report policy](https://github.com/openSUSE/open-build-service/pull/14909)
- [Implementation of reporting a project](https://github.com/openSUSE/open-build-service/pull/14898)
- ~Implementation of report listing view~
 