### PR TITLE
Use `destroy_all` over `delete_all` in `mark_as_spammer` method

### DIFF
--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -658,7 +658,7 @@ class User < ApplicationRecord
 
   def mark_as_spammer!
     message = "User account got marked as spammer by #{User.session!}"
-    comments.delete_all
+    comments.destroy_all
     self.adminnote = message
     self.state = 'deleted'
     save!


### PR DESCRIPTION
Currently when we mark a user as spammer we delete the comments associated with the user using `delete_all`.
But this doesn't instantiate the comments first, so it doesn't delete the notification that are assoicated with the comments. We have set the `dependent: :destroy` on the `has_many :comments` on the user model, which defaults to `:delete_all` on a collection proxy, which doesn't call the `destroy` method on the comment. Therefore we have to use the `destroy_all` method.

See: https://api.rubyonrails.org/v7.0.7.2/classes/ActiveRecord/Associations/CollectionProxy.html#method-i-delete_all

Fixes #14874