### PR TITLE
[backend] cross build: fix target build dependencies always being ins…

### DIFF
--- a/src/backend/BSSched/Checker.pm
+++ b/src/backend/BSSched/Checker.pm
@@ -783,6 +783,7 @@ sub expandandsort {
     my ($eok, @edeps);
     my $handler = $handlers{$buildtype};
     if ($cross && !$handler) {
+      # set split_hostdeps and make edeps the expanded sysroot
       my $splitdeps;
       ($splitdeps, $eok, @edeps) = BSSched::BuildJob::Package::expand_sysroot($bconf, $subpacks->{$info->{'name'}}, $info);
       $ctx->{'split_hostdeps'}->{$packid} = $splitdeps;


### PR DESCRIPTION
…talled native

We need to filter the dependencies before creating the build job.