### PR TITLE
Extend user deletion webui

### DIFF
--- a/src/api/app/components/delete_confirmation_dialog_component.html.haml
+++ b/src/api/app/components/delete_confirmation_dialog_component.html.haml
@@ -5,8 +5,9 @@
         %h5.wrap-text.modal-title{ id: "#{modal_id}-label" }= modal_title
       .modal-body
         %p.wrap-text.confirmation-text= confirmation_text
-
         = form_tag(action, method: method, remote: remote) do
+          - if text_area?
+            = text_area
           .modal-footer
             %a.btn.btn-sm.btn-outline-secondary.px-4{ data: { 'bs-dismiss': 'modal' } }
               Cancel

--- a/src/api/app/components/delete_confirmation_dialog_component.rb
+++ b/src/api/app/components/delete_confirmation_dialog_component.rb
@@ -9,6 +9,8 @@
 class DeleteConfirmationDialogComponent < ApplicationComponent
   attr_accessor :modal_id, :method, :action, :modal_title, :confirmation_text, :remote
 
+  renders_one :text_area
+
   def initialize(modal_id:, method:, options: {})
     super
 

--- a/src/api/app/controllers/webui/users_controller.rb
+++ b/src/api/app/controllers/webui/users_controller.rb
@@ -92,7 +92,8 @@ class Webui::UsersController < Webui::WebuiController
 
   def destroy
     user = User.find_by(login: params[:login])
-    if user.delete
+
+    if user.delete!(adminnote: params[:adminnote])
       flash[:success] = "Marked user '#{user}' as deleted."
     else
       flash[:error] = "Marking user '#{user}' as deleted failed: #{user.errors.full_messages.to_sentence}"

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -658,17 +658,6 @@ class User < ApplicationRecord
     true
   end
 
-  def mark_as_spammer!
-    message = "User account got marked as spammer by #{User.session!}"
-    comments.destroy_all
-    self.adminnote = message
-    self.state = 'deleted'
-    save!
-    destroy_home_projects(reason: message)
-
-    true
-  end
-
   def destroy_home_projects(reason:)
     Project.where('name LIKE ?', "#{home_project_name}:%").or(Project.where(name: home_project_name)).find_each do |project|
       project.commit_opts = { comment: "#{reason}" }

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -639,15 +639,17 @@ class User < ApplicationRecord
     false
   end
 
-  def delete!
+  def delete!(adminnote: nil)
     # remove user data as much as possible
     # but we must NOT remove the information that the account did exist
     # or another user could take over the identity which can open security
     # issues (other infrastructur and systems using repositories)
 
+    self.adminnote = adminnote if adminnote.present?
     self.email = ''
     self.realname = ''
     self.state = 'deleted'
+    comments.destroy_all
     save!
 
     # wipe also all home projects

--- a/src/api/app/views/webui/user/_basic_info.html.haml
+++ b/src/api/app/views/webui/user/_basic_info.html.haml
@@ -3,12 +3,22 @@
            locals: { displayed_user: user, role_titles: role_titles, account_edit_link: account_edit_link }
 
 .basic-info
-  - if configuration.accounts_editable?(user) && policy(user).update?
-    .d-flex.flex-row-reverse
+  .d-flex.flex-row-reverse
+    - if User.possibly_nobody.is_admin?
+      = link_to('#', title: 'Delete user', class: 'ms-2', data: { 'bs-toggle': 'modal', 'bs-target': '#delete-user-modal' }) do
+        %i.fas.fa-times-circle.text-danger
+        %span.nav-item-name.text-danger Delete
+      = render DeleteConfirmationDialogComponent.new(modal_id: 'delete-user-modal', method: :delete,
+                                                     options: { modal_title: 'Delete user?', remote: false,
+                                                                confirmation_text: "Please confirm deletion of '#{user.login}'",
+                                                                action: user_path(user) }) do |component|
+        - component.with_text_area do
+          = label_tag('Adminnote', 'Admin note:', for: 'adminnote')
+          = text_area_tag(:adminnote, '', placeholder: 'Please explain the reason for the deletion...', class: 'form-control')
+    - if configuration.accounts_editable?(user) && policy(user).update?
       = link_to('javascript:void(0);', id: 'toggle-in-place-editing', remote: true, title: 'Edit Your Account') do
         %i.fas.fa-user-edit
         %span.nav-item-name Edit
-
   .row.mb-3.mb-md-0
     .col-4.col-sm-2.col-md-12.text-center
       = render(AvatarComponent.new(name: user.name, email: user.email, size: 200))

--- a/src/api/app/views/webui/users/index.html.haml
+++ b/src/api/app/views/webui/users/index.html.haml
@@ -27,7 +27,10 @@
     = render DeleteConfirmationDialogComponent.new(modal_id: 'delete-user-modal',
                                                    method: :delete,
                                                    options: { modal_title: 'Delete user?', remote: false,
-                                                              confirmation_text: sanitize(confirmation_text, tags: ['span']) })
+                                                              confirmation_text: sanitize(confirmation_text, tags: ['span']) }) do |component|
+      - component.with_text_area do
+        = label_tag('Adminnote', 'Admin note:', for: 'adminnote')
+        = text_area_tag(:adminnote, '', placeholder: 'Please explain the reason for the deletion...', class: 'form-control')
 
 - content_for :ready_function do
   :plain


### PR DESCRIPTION
- Aligns the behavior of the user `delete!` and `mark_as_spammer!` methods
- Add possibility to leave a admin note through the webui
- Add a link for user deletion to the user profile page (for admins only)

![image](https://github.com/openSUSE/open-build-service/assets/22001671/cd2ec6a3-4de2-4082-b08d-e5978713d868)
![image](https://github.com/openSUSE/open-build-service/assets/22001671/40362f15-c638-41f3-b768-ad56094186dc)
