### PR TITLE
Fix comments textarea resize by JS

### DIFF
--- a/src/api/app/assets/javascripts/webui/comment.js
+++ b/src/api/app/assets/javascripts/webui/comment.js
@@ -1,11 +1,9 @@
 function resizeTextarea(textarea) { // jshint ignore:line
-  var textLines = textarea.value.split('\n');
-  var neededRows = 1;
-  for (var x = 0; x < textLines.length; x++) {
-    if (textLines[x].length >= textarea.cols) neededRows += Math.floor(textLines[x].length / textarea.cols);
-  }
-  neededRows += textLines.length;
-  if (neededRows > textarea.rows) textarea.rows = neededRows;
+  var heightPerRow = Math.ceil(textarea.clientHeight / textarea.rows);
+  var linesOfText = Math.ceil(textarea.scrollHeight / heightPerRow);
+  var rowsToIncrease = linesOfText - textarea.rows;
+
+  textarea.rows += rowsToIncrease;
 }
 
 function updateCommentCounter(selector, count) {


### PR DESCRIPTION
Fixes: #14890

The former code relied on `textarea.cols` which always returned the same value, no matter if the textarea was wider or narrower. Therefore, it didn't match the actual line length.

The new code relies on `clientHeight` and `ScrollHeight` for resizing.

**Before:**

![wrong_textarea_resize](https://github.com/openSUSE/open-build-service/assets/2581944/5edb3e83-dd2d-42d7-9204-867bf73ba6c3)


**After:**

![fixed_textarea_resize](https://github.com/openSUSE/open-build-service/assets/2581944/08c2dc24-974e-4a9f-aaf2-5b24d5d5f46d)
