### PR TITLE
Improve token creation error message

### DIFF
--- a/src/api/app/controllers/person/token_controller.rb
+++ b/src/api/app/controllers/person/token_controller.rb
@@ -14,9 +14,9 @@ module Person
     def create
       authorize @user, :update?
 
-      pkg = (Package.get_by_project_and_name(params[:project], params[:package]) if params[:project] || params[:package])
+      set_package
 
-      @token = Token.token_type(params[:operation]).create(description: params[:description], executor: @user, package: pkg, scm_token: params[:scm_token])
+      @token = Token.token_type(params[:operation]).create(description: params[:description], executor: @user, package: @package, scm_token: params[:scm_token])
       return if @token.valid?
 
       render_error status: 400,
@@ -40,6 +40,15 @@ module Person
 
     def set_user
       @user = User.find_by(login: params[:login]) || User.find_nobody!
+    end
+
+    def set_package
+      @package = nil
+      return unless params[:project] || params[:package]
+
+      raise MissingParameterError, 'The package and project parameters must be provided together.' unless params[:project] && params[:package]
+
+      @package = Package.get_by_project_and_name(params[:project], params[:package])
     end
   end
 end

--- a/src/api/spec/controllers/person/token_controller_spec.rb
+++ b/src/api/spec/controllers/person/token_controller_spec.rb
@@ -53,6 +53,32 @@ RSpec.describe Person::TokenController, vcr: false do
       end
     end
 
+    context 'called with only project parameter' do
+      before do
+        login user
+      end
+
+      subject { post :create, params: { login: user.login, project: user.home_project, operation: 'rebuild' }, format: :xml }
+
+      it 'does not create a token' do
+        expect { subject }.not_to(change { user.tokens.count })
+        expect(response).to have_http_status(:bad_request)
+      end
+    end
+
+    context 'called with only package parameter' do
+      before do
+        login user
+      end
+
+      subject { post :create, params: { login: user.login, package: 'test', operation: 'create' }, format: :xml }
+
+      it 'does not create a token' do
+        expect { subject }.not_to(change { user.tokens.count })
+        expect(response).to have_http_status(:bad_request)
+      end
+    end
+
     context 'called with project and package parameter' do
       let!(:package) { create(:package, project: user.home_project) }
 


### PR DESCRIPTION
Change response code to 400 Bad Request if either "project" or "package" parameters are missing in the `POST /person/<login>/token` request. Also provided a more meaningful response message to the user.

Fixes #14828