### PR TITLE
Handle moderation on comments

### DIFF
--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -182,6 +182,7 @@ Metrics/ClassLength:
     - 'app/controllers/request_controller.rb'
     - 'app/controllers/search_controller.rb'
     - 'app/controllers/source_controller.rb'
+    - 'app/controllers/webui/comments_controller.rb'
     - 'app/controllers/webui/kiwi/images_controller.rb'
     - 'app/controllers/webui/package_controller.rb'
     - 'app/controllers/webui/patchinfo_controller.rb'

--- a/src/api/app/assets/javascripts/webui/comment.js
+++ b/src/api/app/assets/javascripts/webui/comment.js
@@ -65,6 +65,18 @@ $(document).ready(function(){
     $(this).closest('.comments-thread').html(data.responseText);
   });
 
+  // This is being used to update the comment with the updated content after a moderation from the legacy request view
+  $('.comments-list').on('ajax:complete', '.moderate-form', function(_, data) {
+    var $commentsList = $(this).closest('.comments-list');
+
+    $commentsList.html(data.responseText);
+  });
+
+  // This is being used to update the comment with the updated content after a moderation from the beta request show view
+  $('.timeline,.diff').on('ajax:complete', '.moderate-form', function(_, data) {
+    $(this).closest('.comments-thread').html(data.responseText);
+  });
+
   // This is used to delete a comment from the legacy request view
   $('.comments-list').on('ajax:complete', '.delete-comment-form', function(_, data) {
     var $this = $(this),

--- a/src/api/app/components/bs_request_comment_component.html.haml
+++ b/src/api/app/components/bs_request_comment_component.html.haml
@@ -17,6 +17,9 @@
             = link_to("#edit_form_of_#{comment.id}", id: "edit_button_of_#{comment.id}", 'data-bs-toggle': 'collapse',
                       class: 'dropdown-item collapsed') do
               Edit
+          - if policy(comment).moderate?
+            = button_to(comment.moderated? ? 'Unmoderate' : 'Moderate', comment_moderate_path(comment),
+                        class: 'dropdown-item', remote: true, form_class: 'moderate-form', params: { moderation_state: !comment.moderated? })
           - if policy(comment).destroy?
             = link_to('#', data: { 'bs-toggle': 'modal',
                                    'bs-target': '#delete-comment-modal',

--- a/src/api/app/components/bs_request_comment_component.html.haml
+++ b/src/api/app/components/bs_request_comment_component.html.haml
@@ -17,9 +17,10 @@
             = link_to("#edit_form_of_#{comment.id}", id: "edit_button_of_#{comment.id}", 'data-bs-toggle': 'collapse',
                       class: 'dropdown-item collapsed') do
               Edit
-          - if policy(comment).moderate?
-            = button_to(comment.moderated? ? 'Unmoderate' : 'Moderate', comment_moderate_path(comment),
-                        class: 'dropdown-item', remote: true, form_class: 'moderate-form', params: { moderation_state: !comment.moderated? })
+          - if Flipper.enabled?(:content_moderation, User.session)
+            - if policy(comment).moderate?
+              = button_to(comment.moderated? ? 'Unmoderate' : 'Moderate', comment_moderate_path(comment),
+                          class: 'dropdown-item', remote: true, form_class: 'moderate-form', params: { moderation_state: !comment.moderated? })
           - if policy(comment).destroy?
             = link_to('#', data: { 'bs-toggle': 'modal',
                                    'bs-target': '#delete-comment-modal',

--- a/src/api/app/components/bs_request_comment_component.html.haml
+++ b/src/api/app/components/bs_request_comment_component.html.haml
@@ -19,7 +19,7 @@
               Edit
           - if Flipper.enabled?(:content_moderation, User.session)
             - if policy(comment).moderate?
-              = button_to(comment.moderated? ? 'Permit' : 'Moderate', comment_moderate_path(comment),
+              = button_to(comment.moderated? ? 'Permit' : 'Moderate', moderate_comment_path(comment),
                           class: 'dropdown-item', remote: true, form_class: 'moderate-form', params: { moderation_state: !comment.moderated? })
           - if policy(comment).destroy?
             = link_to('#', data: { 'bs-toggle': 'modal',

--- a/src/api/app/components/bs_request_comment_component.html.haml
+++ b/src/api/app/components/bs_request_comment_component.html.haml
@@ -19,7 +19,7 @@
               Edit
           - if Flipper.enabled?(:content_moderation, User.session)
             - if policy(comment).moderate?
-              = button_to(comment.moderated? ? 'Unmoderate' : 'Moderate', comment_moderate_path(comment),
+              = button_to(comment.moderated? ? 'Permit' : 'Moderate', comment_moderate_path(comment),
                           class: 'dropdown-item', remote: true, form_class: 'moderate-form', params: { moderation_state: !comment.moderated? })
           - if policy(comment).destroy?
             = link_to('#', data: { 'bs-toggle': 'modal',

--- a/src/api/app/controllers/webui/comments_controller.rb
+++ b/src/api/app/controllers/webui/comments_controller.rb
@@ -137,6 +137,7 @@ class Webui::CommentsController < Webui::WebuiController
     params.require(:comment).permit(:body, :parent_id, :diff_ref)
   end
 
+  # FIXME: Use this function for the rest of the actions
   def set_comment
     @comment = Comment.find(params[:id] || params[:comment_id])
   rescue ActiveRecord::RecordNotFound => e

--- a/src/api/app/controllers/webui/comments_controller.rb
+++ b/src/api/app/controllers/webui/comments_controller.rb
@@ -139,9 +139,8 @@ class Webui::CommentsController < Webui::WebuiController
 
   def set_comment
     @comment = Comment.find(params[:id] || params[:comment_id])
-    return if @comment.present?
-
-    flash[:error] = "Comment with id '#{params[:id]}' doesn't exist."
+  rescue ActiveRecord::RecordNotFound => e
+    flash[:error] = e.message
     render partial: 'layouts/webui/flash'
   end
 

--- a/src/api/app/controllers/webui/comments_controller.rb
+++ b/src/api/app/controllers/webui/comments_controller.rb
@@ -1,6 +1,7 @@
 class Webui::CommentsController < Webui::WebuiController
   before_action :require_login
   before_action :set_commented, only: :create
+  before_action :set_comment, only: :moderate
 
   def create
     if @commented.nil?
@@ -105,10 +106,43 @@ class Webui::CommentsController < Webui::WebuiController
     end
   end
 
+  def moderate
+    authorize @comment, :moderate?
+
+    state = ActiveModel::Type::Boolean.new.cast(params[:moderation_state])
+
+    status = if @comment.moderate(state)
+               flash.now[:success] = 'Comment moderated successfully.'
+               :ok
+             else
+               flash.now[:error] = "Failed to moderate comment: #{@comment.errors.full_messages.to_sentence}."
+               :unprocessable_entity
+             end
+
+    if Flipper.enabled?(:request_show_redesign, User.session) && ['BsRequest', 'BsRequestAction'].include?(@comment.commentable_type)
+      render(partial: 'webui/comment/beta/comments_thread',
+             locals: { comment: @comment.root, commentable: @comment.commentable, level: 1 },
+             status: status)
+    else
+      render(partial: 'webui/comment/comment_list',
+             locals: { commentable: @comment.commentable, diff_ref: @comment.root.diff_ref },
+             status: status,
+             root_comment: @comment.root)
+    end
+  end
+
   private
 
   def permitted_params
     params.require(:comment).permit(:body, :parent_id, :diff_ref)
+  end
+
+  def set_comment
+    @comment = Comment.find(params[:id] || params[:comment_id])
+    return if @comment.present?
+
+    flash[:error] = "Comment with id '#{params[:id]}' doesn't exist."
+    render partial: 'layouts/webui/flash'
   end
 
   def set_commented

--- a/src/api/app/models/comment.rb
+++ b/src/api/app/models/comment.rb
@@ -53,6 +53,16 @@ class Comment < ApplicationRecord
     parent && parent.user.is_nobody? && parent.children.empty?
   end
 
+  def moderated?
+    !!(moderated_at && moderator)
+  end
+
+  def moderate(state)
+    self.moderated_at = state ? Time.zone.now : nil
+    self.moderator = state ? User.session : nil
+    save!
+  end
+
   private
 
   def create_event

--- a/src/api/app/models/comment.rb
+++ b/src/api/app/models/comment.rb
@@ -103,20 +103,24 @@ end
 #  body             :text(65535)
 #  commentable_type :string(255)      indexed => [commentable_id]
 #  diff_ref         :string(255)
+#  moderated_at     :datetime
 #  created_at       :datetime
 #  updated_at       :datetime
 #  commentable_id   :integer          indexed => [commentable_type]
+#  moderator_id     :integer          indexed
 #  parent_id        :integer          indexed
 #  user_id          :integer          not null, indexed
 #
 # Indexes
 #
 #  index_comments_on_commentable_type_and_commentable_id  (commentable_type,commentable_id)
+#  moderated_comments_fk                                  (moderator_id)
 #  parent_id                                              (parent_id)
 #  user_id                                                (user_id)
 #
 # Foreign Keys
 #
-#  comments_ibfk_1  (user_id => users.id)
-#  comments_ibfk_4  (parent_id => comments.id)
+#  comments_ibfk_1        (user_id => users.id)
+#  comments_ibfk_4        (parent_id => comments.id)
+#  moderated_comments_fk  (moderator_id => users.id)
 #

--- a/src/api/app/models/comment.rb
+++ b/src/api/app/models/comment.rb
@@ -3,6 +3,7 @@ require 'set'
 class Comment < ApplicationRecord
   belongs_to :commentable, polymorphic: true # belongs to a Project, Package, BsRequest or BsRequestActionSubmit
   belongs_to :user, inverse_of: :comments
+  belongs_to :moderator, class_name: 'User', optional: true
 
   validates :body, presence: true
   # FIXME: this probably should be MEDIUMTEXT(16MB) instead of text (64KB)

--- a/src/api/app/models/comment.rb
+++ b/src/api/app/models/comment.rb
@@ -63,6 +63,12 @@ class Comment < ApplicationRecord
     save!
   end
 
+  def body
+    return "*This content was considered problematic and has been moderated at #{moderated_at} by @#{moderator}*" if moderated?
+
+    super
+  end
+
   private
 
   def create_event

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -64,6 +64,8 @@ class User < ApplicationRecord
   has_many :reports, as: :reportable, dependent: :nullify
   has_many :submitted_reports, class_name: 'Report'
 
+  has_many :moderated_comments, class_name: 'Comment', foreign_key: 'moderator_id'
+
   scope :confirmed, -> { where(state: 'confirmed') }
   scope :all_without_nobody, -> { where.not(login: NOBODY_LOGIN) }
   scope :not_deleted, -> { where.not(state: 'deleted') }

--- a/src/api/app/policies/comment_policy.rb
+++ b/src/api/app/policies/comment_policy.rb
@@ -32,9 +32,10 @@ class CommentPolicy < ApplicationPolicy
     !(user.blank? || user.is_nobody? || record.user.is_nobody?)
   end
 
-  # Only logged-in Admins can moderate non-deleted comments
+  # Only logged-in Admins of Staff members can moderate comments
   def moderate?
-    return true if user.try(:is_admin?) && !record.user.is_nobody?
+    return false if record.user.is_nobody? # soft-deleted comments
+    return true if user.try(:is_admin?) || user.try(:is_staff?)
 
     false
   end

--- a/src/api/app/policies/comment_policy.rb
+++ b/src/api/app/policies/comment_policy.rb
@@ -31,4 +31,11 @@ class CommentPolicy < ApplicationPolicy
   def reply?
     !(user.blank? || user.is_nobody? || record.user.is_nobody?)
   end
+
+  # Only logged-in Admins can moderate non-deleted comments
+  def moderate?
+    return true if user.try(:is_admin?) && !record.user.is_nobody?
+
+    false
+  end
 end

--- a/src/api/app/views/webui/comment/_reply.html.haml
+++ b/src/api/app/views/webui/comment/_reply.html.haml
@@ -18,7 +18,7 @@
   - if Flipper.enabled?(:content_moderation, User.session)
     - if policy(comment).moderate?
       %li.list-inline-item
-        = button_to(comment.moderated? ? 'Permit' : 'Moderate', comment_moderate_path(comment),
+        = button_to(comment.moderated? ? 'Permit' : 'Moderate', moderate_comment_path(comment),
                     class: 'btn btn-outline-secondary', remote: true, form_class: 'moderate-form', params: { moderation_state: !comment.moderated? })
   - if policy(Report.new(reportable: comment)).create?
     %li.list-inline-item

--- a/src/api/app/views/webui/comment/_reply.html.haml
+++ b/src/api/app/views/webui/comment/_reply.html.haml
@@ -18,7 +18,7 @@
   - if Flipper.enabled?(:content_moderation, User.session)
     - if policy(comment).moderate?
       %li.list-inline-item
-        = button_to(comment.moderated? ? 'Unmoderate' : 'Moderate', comment_moderate_path(comment),
+        = button_to(comment.moderated? ? 'Permit' : 'Moderate', comment_moderate_path(comment),
                     class: 'btn btn-outline-secondary', remote: true, form_class: 'moderate-form', params: { moderation_state: !comment.moderated? })
   - if policy(Report.new(reportable: comment)).create?
     %li.list-inline-item

--- a/src/api/app/views/webui/comment/_reply.html.haml
+++ b/src/api/app/views/webui/comment/_reply.html.haml
@@ -15,10 +15,11 @@
       = link_to('#', data: { 'bs-toggle': 'modal', 'bs-target': "#delete-comment-modal-#{comment.id}" },
                 class: 'delete_link btn btn-outline-danger', title: 'Delete comment') do
         Delete
-  - if policy(comment).moderate?
-    %li.list-inline-item
-      = button_to(comment.moderated? ? 'Unmoderate' : 'Moderate', comment_moderate_path(comment),
-                  class: 'btn btn-outline-secondary', remote: true, form_class: 'moderate-form', params: { moderation_state: !comment.moderated? })
+  - if Flipper.enabled?(:content_moderation, User.session)
+    - if policy(comment).moderate?
+      %li.list-inline-item
+        = button_to(comment.moderated? ? 'Unmoderate' : 'Moderate', comment_moderate_path(comment),
+                    class: 'btn btn-outline-secondary', remote: true, form_class: 'moderate-form', params: { moderation_state: !comment.moderated? })
   - if policy(Report.new(reportable: comment)).create?
     %li.list-inline-item
       = link_to('#', class: 'btn btn-outline-dark', id: "js-comment-#{comment.id}",

--- a/src/api/app/views/webui/comment/_reply.html.haml
+++ b/src/api/app/views/webui/comment/_reply.html.haml
@@ -15,6 +15,10 @@
       = link_to('#', data: { 'bs-toggle': 'modal', 'bs-target': "#delete-comment-modal-#{comment.id}" },
                 class: 'delete_link btn btn-outline-danger', title: 'Delete comment') do
         Delete
+  - if policy(comment).moderate?
+    %li.list-inline-item
+      = button_to(comment.moderated? ? 'Unmoderate' : 'Moderate', comment_moderate_path(comment),
+                  class: 'btn btn-outline-secondary', remote: true, form_class: 'moderate-form', params: { moderation_state: !comment.moderated? })
   - if policy(Report.new(reportable: comment)).create?
     %li.list-inline-item
       = link_to('#', class: 'btn btn-outline-dark', id: "js-comment-#{comment.id}",

--- a/src/api/config/routes/webui_routes.rb
+++ b/src/api/config/routes/webui_routes.rb
@@ -404,7 +404,10 @@ OBSApi::Application.routes.draw do
     end
 
     resources :comments, constraints: cons, only: [:create, :destroy, :update], controller: 'webui/comments' do
-      post 'moderate'
+      member do
+        post 'moderate'
+      end
+
       collection do
         post 'preview'
       end

--- a/src/api/config/routes/webui_routes.rb
+++ b/src/api/config/routes/webui_routes.rb
@@ -404,6 +404,7 @@ OBSApi::Application.routes.draw do
     end
 
     resources :comments, constraints: cons, only: [:create, :destroy, :update], controller: 'webui/comments' do
+      post 'moderate'
       collection do
         post 'preview'
       end

--- a/src/api/db/migrate/20230918161340_add_moderator_id_and_moderated_at_columns_to_comments.rb
+++ b/src/api/db/migrate/20230918161340_add_moderator_id_and_moderated_at_columns_to_comments.rb
@@ -1,0 +1,8 @@
+class AddModeratorIdAndModeratedAtColumnsToComments < ActiveRecord::Migration[7.0]
+  def change
+    add_column :comments, :moderated_at, :datetime
+
+    add_column :comments, :moderator_id, :integer
+    add_foreign_key :comments, :users, column: :moderator_id, name: 'moderated_comments_fk'
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_18_145812) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_18_161340) do
   create_table "architectures", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "name", null: false
     t.boolean "available", default: false
@@ -303,7 +303,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_18_145812) do
     t.string "commentable_type"
     t.integer "commentable_id"
     t.string "diff_ref"
+    t.datetime "moderated_at"
+    t.integer "moderator_id"
     t.index ["commentable_type", "commentable_id"], name: "index_comments_on_commentable_type_and_commentable_id"
+    t.index ["moderator_id"], name: "moderated_comments_fk"
     t.index ["parent_id"], name: "parent_id"
     t.index ["user_id"], name: "user_id"
   end
@@ -1181,6 +1184,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_18_145812) do
   add_foreign_key "channel_targets", "repositories", name: "channel_targets_ibfk_2"
   add_foreign_key "channels", "packages", name: "channels_ibfk_1"
   add_foreign_key "comments", "comments", column: "parent_id", name: "comments_ibfk_4"
+  add_foreign_key "comments", "users", column: "moderator_id", name: "moderated_comments_fk"
   add_foreign_key "comments", "users", name: "comments_ibfk_1"
   add_foreign_key "download_repositories", "repositories", name: "download_repositories_ibfk_1"
   add_foreign_key "event_subscriptions", "bs_requests"

--- a/src/api/spec/policies/comment_policy_spec.rb
+++ b/src/api/spec/policies/comment_policy_spec.rb
@@ -172,6 +172,14 @@ RSpec.describe CommentPolicy do
         expect(subject).not_to permit(other_user, comment_deleted)
       end
     end
+
+    context 'when the moderator is a staff member' do
+      let(:staff_user) { create(:staff_user) }
+
+      it 'an staff member can moderate comments' do
+        expect(subject).to permit(staff_user, comment)
+      end
+    end
   end
   # rubocop:enable RSpec/RepeatedExample
 end

--- a/src/api/spec/policies/comment_policy_spec.rb
+++ b/src/api/spec/policies/comment_policy_spec.rb
@@ -144,4 +144,34 @@ RSpec.describe CommentPolicy do
     end
   end
   # rubocop:enable RSpec/RepeatedExample
+
+  # rubocop:disable RSpec/RepeatedExample
+  permissions :moderate? do
+    it 'a not logged-in user cannot moderate comments' do
+      expect(subject).not_to permit(nil, comment)
+    end
+
+    it 'an anonymous user cannot moderate comments' do
+      expect(subject).not_to permit(anonymous_user, comment)
+    end
+
+    it 'a non-admin user cannot moderate comments' do
+      expect(subject).not_to permit(other_user, comment)
+    end
+
+    it 'an admin user can moderate comments' do
+      expect(subject).to permit(admin_user, comment)
+    end
+
+    context 'with a deleted comment' do
+      it 'an admin user is unable to moderate a deleted comment' do
+        expect(subject).not_to permit(admin_user, comment_deleted)
+      end
+
+      it 'an non-admin user is unable to moderate a deleted comment' do
+        expect(subject).not_to permit(other_user, comment_deleted)
+      end
+    end
+  end
+  # rubocop:enable RSpec/RepeatedExample
 end

--- a/src/api/spec/policies/comment_policy_spec.rb
+++ b/src/api/spec/policies/comment_policy_spec.rb
@@ -164,12 +164,8 @@ RSpec.describe CommentPolicy do
     end
 
     context 'with a deleted comment' do
-      it 'an admin user is unable to moderate a deleted comment' do
+      it 'no one is able to moderate a deleted comment' do
         expect(subject).not_to permit(admin_user, comment_deleted)
-      end
-
-      it 'an non-admin user is unable to moderate a deleted comment' do
-        expect(subject).not_to permit(other_user, comment_deleted)
       end
     end
 


### PR DESCRIPTION
We are introducing moderation on comments.

Moderators will be able to flag those comments, so a text like _"this comment was considered problematic ..."_ is going to be displayed instead of the original message.

![moderate](https://github.com/openSUSE/open-build-service/assets/2581944/7125234f-7aea-40b9-8bf4-9ba8a0ca1680)
