### PR TITLE
Improve minimum button size of requests link in tables

### DIFF
--- a/src/api/app/views/webui/shared/bs_requests/index.json.erb
+++ b/src/api/app/views/webui/shared/bs_requests/index.json.erb
@@ -14,7 +14,7 @@
           "<%= escape_javascript(new_or_update_request(row)) %>",
           "<%= escape_javascript(row.priority) %>",
           "<%= escape_javascript(link_to(
-            '<span class="fa-stack half-font-size">
+            '<span class="fa-stack">
                <i class="far fa-file fa-stack-2x"></i>
                <i class="fas fa-search fa-stack-1x"></i>
              </span>'.html_safe,


### PR DESCRIPTION
The current request listing requires to hit *exactly* the 15x18 pixel region to the icon to get into the detailed listing. nothing else in the whole line links to details. there is no sensible keyboard navigation either.

This improves it to roughly 30x36 which is still far away from the minimum recommended sizes for user interaction elements (44x44) but slightly less insane.