### PR TITLE
Create notifications for reported objects

### DIFF
--- a/src/api/app/components/notification_action_description_component.rb
+++ b/src/api/app/components/notification_action_description_component.rb
@@ -12,6 +12,7 @@ class NotificationActionDescriptionComponent < ApplicationComponent
     @target_object = [project, package].compact.join(' / ')
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def call
     tag.div(class: ['smart-overflow']) do
       case @notification.event_type
@@ -28,9 +29,15 @@ class NotificationActionDescriptionComponent < ApplicationComponent
         "#{@user} removed #{@recipient} as #{@role} of #{@target_object}"
       when 'Event::BuildFail'
         "Build was triggered because of #{@notification.event_payload['reason']}"
+      when 'Event::CreateReport'
+        capture do
+          concat(tag.p("User '#{@notification.notifiable.user.login}' created a report for a #{@notification.event_payload['reportable_type']} for the following reason:"))
+          concat(tag.p(@notification.event_payload['reason']))
+        end
       end
     end
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   private
 

--- a/src/api/app/components/notification_avatars_component.rb
+++ b/src/api/app/components/notification_avatars_component.rb
@@ -15,6 +15,8 @@ class NotificationAvatarsComponent < ApplicationComponent
                           commenters
                         when 'Project', 'Package'
                           [User.find_by(login: @notification.event_payload['who'])]
+                        when 'Report'
+                          [User.find(@notification.event_payload['user_id'])]
                         else
                           reviews = @notification.notifiable.reviews
                           reviews.select(&:new?).map(&:reviewed_by) + User.where(login: @notification.notifiable.creator)

--- a/src/api/app/components/notification_component.rb
+++ b/src/api/app/components/notification_component.rb
@@ -16,6 +16,8 @@ class NotificationComponent < ApplicationComponent
       tag.i(class: ['fas', 'fa-comments'], title: 'Comment notification')
     when 'Package'
       tag.i(class: ['fas', helpers.build_status_icon(:failed)], title: 'Package notification')
+    when 'Report'
+      tag.i(class: ['fas', 'fa-flag'], title: 'Report notification')
     else
       tag.i(class: ['fas', 'fa-user-tag'], title: 'Relationship notification')
     end

--- a/src/api/app/components/notification_filter_component.html.haml
+++ b/src/api/app/components/notification_filter_component.html.haml
@@ -19,6 +19,9 @@
                                                filter_item: { type: 'relationships_deleted' }, selected_filter: @selected_filter)
   = render NotificationFilterLinkComponent.new(text: 'Build Failures', amount: @count['build_failures'], icon: "fas fa-xmark text-danger",
                                                filter_item: { type: 'build_failures' }, selected_filter: @selected_filter)
+  = render NotificationFilterLinkComponent.new(text: 'Reports', amount: @count['reports'], icon: 'fas fa-flag',
+                                               filter_item: { type: 'reports' }, selected_filter: @selected_filter,
+                                               show_reports: @show_reports)
 
 - unless @projects_for_filter.empty?
   .list-group.list-group-flush.mt-5.mb-2

--- a/src/api/app/components/notification_filter_component.rb
+++ b/src/api/app/components/notification_filter_component.rb
@@ -1,7 +1,8 @@
 class NotificationFilterComponent < ApplicationComponent
-  def initialize(selected_filter:, projects_for_filter: ProjectsForFilterFinder.new.call, groups_for_filter: GroupsForFilterFinder.new.call)
+  def initialize(selected_filter:, show_reports: false, projects_for_filter: ProjectsForFilterFinder.new.call, groups_for_filter: GroupsForFilterFinder.new.call)
     super
 
+    @show_reports = show_reports
     @projects_for_filter = projects_for_filter
     @groups_for_filter = groups_for_filter
     @count = notifications_count
@@ -18,6 +19,7 @@ class NotificationFilterComponent < ApplicationComponent
     counted_notifications['relationships_created'] = finder.for_relationships_created.count
     counted_notifications['relationships_deleted'] = finder.for_relationships_deleted.count
     counted_notifications['build_failures'] = finder.for_failed_builds.count
+    counted_notifications['reports'] = finder.for_reports.count if @show_reports
     counted_notifications.merge!('unread' => User.session.unread_notifications)
   end
 end

--- a/src/api/app/components/notification_filter_link_component.rb
+++ b/src/api/app/components/notification_filter_link_component.rb
@@ -1,5 +1,5 @@
 class NotificationFilterLinkComponent < ApplicationComponent
-  def initialize(text:, filter_item:, selected_filter:, amount: 0, icon: '')
+  def initialize(text:, filter_item:, selected_filter:, amount: 0, icon: '', show_reports: false)
     super
 
     @text = text
@@ -7,6 +7,13 @@ class NotificationFilterLinkComponent < ApplicationComponent
     @selected_filter = selected_filter
     @amount = ensure_integer_amount(amount)
     @icon = icon
+    @show_reports = show_reports
+  end
+
+  def render?
+    return false if @filter_item[:type] == 'reports' && !@show_reports
+
+    true
   end
 
   def css_for_link

--- a/src/api/app/components/notification_notifiable_link_component.rb
+++ b/src/api/app/components/notification_notifiable_link_component.rb
@@ -112,7 +112,7 @@ class NotificationNotifiableLinkComponent < ApplicationComponent
     when 'Project'
       Rails.application.routes.url_helpers.project_show_path(reportable, notification_id: @notification.id, anchor: 'comments-list')
     when 'User'
-      Rails.application.routes.url_helpers.user_show_path(reportable, notification_id: @notification.id)
+      Rails.application.routes.url_helpers.user_path(reportable)
     end
   end
 

--- a/src/api/app/controllers/webui/users/notifications_controller.rb
+++ b/src/api/app/controllers/webui/users/notifications_controller.rb
@@ -1,6 +1,6 @@
 class Webui::Users::NotificationsController < Webui::WebuiController
   VALID_NOTIFICATION_TYPES = ['read', 'reviews', 'comments', 'requests', 'unread', 'incoming_requests', 'outgoing_requests', 'relationships_created', 'relationships_deleted',
-                              'build_failures'].freeze
+                              'build_failures', 'reports'].freeze
 
   # TODO: Remove this when we'll refactor kerberos_auth
   before_action :kerberos_auth
@@ -38,7 +38,8 @@ class Webui::Users::NotificationsController < Webui::WebuiController
         render partial: 'update', locals: {
           notifications: paginated_notifications,
           selected_filter: selected_filter,
-          show_read_all_button: show_read_all_button?
+          show_read_all_button: show_read_all_button?,
+          show_reports: Flipper.enabled?(:content_moderation, User.session) && User.session.is_moderator?
         }
       end
     end

--- a/src/api/app/helpers/webui/reportables_helper.rb
+++ b/src/api/app/helpers/webui/reportables_helper.rb
@@ -1,0 +1,34 @@
+module Webui::ReportablesHelper
+  include Webui::WebuiHelper
+
+  def link_to_reportables(payload:, host:)
+    reportable = Report.find(payload['id']).reportable
+    case payload['reportable_type']
+    when 'Comment'
+      link_to_commentables_on_reportables(commentable: reportable.commentable, host: host)
+    when 'Package'
+      link_to("#{reportable.name}", Rails.application.routes.url_helpers.package_show_path(package: reportable, project: reportable.project,
+                                                                                           anchor: 'comments-list', only_path: false, host: host))
+    when 'Project'
+      link_to("#{reportable.name}", Rails.application.routes.url_helpers.project_show_path(reportable, anchor: 'comments-list', only_path: false, host: host))
+    when 'User'
+      link_to("#{reportable.login}", Rails.application.routes.url_helpers.user_path(reportable, only_path: false, host: host))
+    end
+  end
+
+  def link_to_commentables_on_reportables(commentable:, host:)
+    case commentable
+    when BsRequest
+      link_to("Request #{commentable.number}", Rails.application.routes.url_helpers.request_show_path(commentable.number, anchor: 'comments-list', only_path: false, host: host))
+    when BsRequestAction
+      link_to("Request #{commentable.bs_request.number}", Rails.application.routes.url_helpers.request_show_path(number: commentable.bs_request.number,
+                                                                                                                 request_action_id: commentable.id,
+                                                                                                                 anchor: 'tab-pane-changes', only_path: false, host: host))
+    when Package
+      link_to("#{commentable.name}", Rails.application.routes.url_helpers.package_show_path(package: commentable, project: commentable.project,
+                                                                                            anchor: 'comments-list', only_path: false, host: host))
+    when Project
+      link_to("#{commentable.name}", Rails.application.routes.url_helpers.project_show_path(commentable, anchor: 'comments-list', only_path: false, host: host))
+    end
+  end
+end

--- a/src/api/app/mailers/event_mailer.rb
+++ b/src/api/app/mailers/event_mailer.rb
@@ -1,5 +1,6 @@
 class EventMailer < ActionMailer::Base
   helper 'webui/markdown'
+  helper 'webui/reportables'
   DefaultSender = Struct.new('DefaultSender', :email, :realname)
 
   before_action :set_configuration

--- a/src/api/app/models/event/base.rb
+++ b/src/api/app/models/event/base.rb
@@ -17,7 +17,8 @@ module Event
       'Event::CommentForPackage' => 'Receive notifications of comments created on a package for which you are...',
       'Event::CommentForRequest' => 'Receive notifications of comments created on a request for which you are...',
       'Event::RelationshipCreate' => "Receive notifications when someone adds you or your group to a project or package with any of these roles: #{Role.local_roles.to_sentence}.",
-      'Event::RelationshipDelete' => "Receive notifications when someone removes you or your group from a project or package with any of these roles: #{Role.local_roles.to_sentence}."
+      'Event::RelationshipDelete' => "Receive notifications when someone removes you or your group from a project or package with any of these roles: #{Role.local_roles.to_sentence}.",
+      'Event::CreateReport' => 'Receive notifications for reported content.'
     }.freeze
 
     class << self
@@ -33,7 +34,7 @@ module Event
         ['Event::BuildFail', 'Event::ServiceFail', 'Event::ReviewWanted', 'Event::RequestCreate',
          'Event::RequestStatechange', 'Event::CommentForProject', 'Event::CommentForPackage',
          'Event::CommentForRequest',
-         'Event::RelationshipCreate', 'Event::RelationshipDelete'].map(&:constantize)
+         'Event::RelationshipCreate', 'Event::RelationshipDelete', 'Event::CreateReport'].map(&:constantize)
       end
 
       def classnames
@@ -263,6 +264,10 @@ module Event
       return [] if bs_request.blank?
 
       bs_request.watched_items.includes(:user).map(&:user)
+    end
+
+    def moderators
+      User.includes(:roles).where(roles: { title: 'Admin' }).or(User.includes(:roles).where(roles: { title: 'Staff' }))
     end
 
     def _roles(role, project, package = nil)

--- a/src/api/app/models/event/create_report.rb
+++ b/src/api/app/models/event/create_report.rb
@@ -1,0 +1,12 @@
+module Event
+  class CreateReport < Base
+    receiver_roles :moderator
+    self.description = 'Report for inappropriate content has been created'
+
+    payload_keys :id, :user_id, :reportable_id, :reportable_type, :reason
+
+    def parameters_for_notification
+      super.merge(notifiable_type: 'Report')
+    end
+  end
+end

--- a/src/api/app/models/event_subscription.rb
+++ b/src/api/app/models/event_subscription.rb
@@ -16,7 +16,8 @@ class EventSubscription < ApplicationRecord
     package_watcher: 'Watching the package',
     source_package_watcher: 'Watching the source package',
     target_package_watcher: 'Watching the target package',
-    request_watcher: 'Watching the request'
+    request_watcher: 'Watching the request',
+    moderator: 'User with moderator role'
   }.freeze
 
   enum channel: {
@@ -42,7 +43,8 @@ class EventSubscription < ApplicationRecord
   validates :receiver_role, inclusion: {
     in: [:maintainer, :bugowner, :reader, :source_maintainer, :target_maintainer,
          :reviewer, :commenter, :creator, :watcher, :source_watcher, :target_watcher,
-         :package_watcher, :target_package_watcher, :source_package_watcher, :request_watcher, :any_role]
+         :package_watcher, :target_package_watcher, :source_package_watcher, :request_watcher, :any_role,
+         :moderator]
   }
 
   scope :for_eventtype, ->(eventtype) { where(eventtype: eventtype) }

--- a/src/api/app/models/event_subscription/for_channel_form.rb
+++ b/src/api/app/models/event_subscription/for_channel_form.rb
@@ -1,6 +1,7 @@
 class EventSubscription
   class ForChannelForm
     DISABLE_FOR_EVENTS = ['Event::ServiceFail'].freeze
+    DISABLE_RSS_FOR_EVENTS = ['Event::CreateReport'].freeze
 
     attr_reader :name, :subscription
 
@@ -18,7 +19,8 @@ class EventSubscription
     end
 
     def disabled_checkbox?
-      DISABLE_FOR_EVENTS.include?(@event.to_s) && (name == 'web' || name == 'rss')
+      (DISABLE_FOR_EVENTS.include?(@event.to_s) && (name == 'web' || name == 'rss')) ||
+        (DISABLE_RSS_FOR_EVENTS.include?(@event.to_s) && name == 'rss')
     end
 
     private

--- a/src/api/app/models/report.rb
+++ b/src/api/app/models/report.rb
@@ -7,6 +7,18 @@ class Report < ApplicationRecord
   belongs_to :reportable, polymorphic: true, optional: true
 
   belongs_to :decision, optional: true
+
+  after_create :create_event
+
+  private
+
+  def create_event
+    Event::CreateReport.create(event_parameters)
+  end
+
+  def event_parameters
+    { id: id, user_id: user_id, reportable_id: reportable_id, reportable_type: reportable_type, reason: reason }
+  end
 end
 
 # == Schema Information

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -408,6 +408,10 @@ class User < ApplicationRecord
     login == NOBODY_LOGIN
   end
 
+  def is_moderator?
+    is_admin? || is_staff?
+  end
+
   def is_active?
     return owner.is_active? if owner
 

--- a/src/api/app/queries/notifications_finder.rb
+++ b/src/api/app/queries/notifications_finder.rb
@@ -39,6 +39,10 @@ class NotificationsFinder
     @relation.where(event_type: 'Event::BuildFail', delivered: false)
   end
 
+  def for_reports
+    @relation.where(event_type: 'Event::CreateReport', delivered: false)
+  end
+
   # rubocop:disable Metrics/CyclomaticComplexity
   # We need to refactor this method, the `case` statement is way too big
   def for_notifiable_type(type = 'unread')
@@ -61,6 +65,8 @@ class NotificationsFinder
       notifications.for_relationships_deleted
     when 'build_failures'
       notifications.for_failed_builds
+    when 'reports'
+      notifications.for_reports
     else
       notifications.unread
     end

--- a/src/api/app/queries/outdated_notifications_finder/report.rb
+++ b/src/api/app/queries/outdated_notifications_finder/report.rb
@@ -1,0 +1,10 @@
+class OutdatedNotificationsFinder::Report
+  def initialize(scope, parameters)
+    @scope = scope
+    @parameters = parameters
+  end
+
+  def call
+    @scope.where(notifiable_type: 'Report', notifiable_id: @parameters['notifiable_id'])
+  end
+end

--- a/src/api/app/services/notification_service/notifier.rb
+++ b/src/api/app/services/notification_service/notifier.rb
@@ -31,6 +31,8 @@ module NotificationService
       return unless @event.eventtype.in?(EVENTS_TO_NOTIFY)
 
       CHANNELS.each do |channel|
+        next if channel == :rss && @event.eventtype == 'Event::CreateReport'
+
         @event.subscriptions(channel).each do |subscription|
           create_notification_per_subscription(subscription, channel)
         end

--- a/src/api/app/services/notification_service/web_channel.rb
+++ b/src/api/app/services/notification_service/web_channel.rb
@@ -5,7 +5,8 @@ module NotificationService
       'BsRequest' => OutdatedNotificationsFinder::BsRequest,
       'Comment' => OutdatedNotificationsFinder::Comment,
       'Project' => OutdatedNotificationsFinder::Project,
-      'Package' => OutdatedNotificationsFinder::Package
+      'Package' => OutdatedNotificationsFinder::Package,
+      'Report' => OutdatedNotificationsFinder::Report
     }.freeze
 
     def initialize(subscription, event)

--- a/src/api/app/services/notified_projects.rb
+++ b/src/api/app/services/notified_projects.rb
@@ -26,6 +26,8 @@ class NotifiedProjects
       @notifiable.project
     when 'Project'
       @notifiable
+    when 'Report'
+      []
     end
   end
   # rubocop:enable Metrics/CyclomaticComplexity

--- a/src/api/app/views/event_mailer/create_report.html.haml
+++ b/src/api/app/views/event_mailer/create_report.html.haml
@@ -1,0 +1,7 @@
+%p
+  = User.find(event['user_id']).login
+  reported a #{event['reportable_type'].downcase} for the following reason:
+%p
+  = event['reason']
+%p
+  = link_to_reportables(payload: event, host: @host)

--- a/src/api/app/views/webui/users/notifications/_update.js.erb
+++ b/src/api/app/views/webui/users/notifications/_update.js.erb
@@ -1,4 +1,4 @@
-$('#filters').html("<%= j(render NotificationFilterComponent.new(selected_filter: selected_filter)) %>");
+$('#filters').html("<%= j(render NotificationFilterComponent.new(selected_filter: selected_filter, show_reports: show_reports)) %>");
 $('#notifications-list').html("<%= j(render partial: 'notifications_list', locals: { notifications: notifications, selected_filter: selected_filter, show_read_all_button: show_read_all_button }) %>");
 $('#flash').html("<%= escape_javascript(render(layout: false, partial: 'layouts/webui/flash', object: flash)) %>");
 $('#top-notifications-counter, #bottom-notifications-counter').html("<%= escape_javascript(render partial: 'layouts/webui/unread_notifications_counter') %>");

--- a/src/api/app/views/webui/users/notifications/index.html.haml
+++ b/src/api/app/views/webui/users/notifications/index.html.haml
@@ -10,7 +10,8 @@
         Filtered by: #{params[:type]&.humanize || @filtered_project || 'Unread'}
         %i.float-end.mt-1.fa.fa-chevron-down#notifications-dropdown-trigger
       .collapse#filters
-        = render NotificationFilterComponent.new(selected_filter: @selected_filter)
+        = render NotificationFilterComponent.new(selected_filter: @selected_filter,
+                                                 show_reports: Flipper.enabled?(:content_moderation, User.session) && User.session.is_moderator? )
 
   .col-md-8.col-lg-9.px-0.px-md-3#notifications-list
     = render partial: 'notifications_list', locals: { notifications: @notifications,

--- a/src/api/spec/components/notification_action_description_component_spec.rb
+++ b/src/api/spec/components/notification_action_description_component_spec.rb
@@ -175,4 +175,19 @@ RSpec.describe NotificationActionDescriptionComponent, type: :component do
       end
     end
   end
+
+  context 'when the notification is for an Event::CreateReport' do
+    context 'with the recipient being a user' do
+      let(:notification) do
+        create(:notification, :create_report, originator: 'user_1', reason: 'Because reasons.')
+      end
+
+      before { render_inline(described_class.new(notification)) }
+
+      it 'renders a div containing who created a report and for what' do
+        expect(rendered_content).to have_selector('div.smart-overflow',
+                                                  text: "User '#{notification.notifiable.user.login}' created a report for a Comment for the following reason:Because reasons.")
+      end
+    end
+  end
 end

--- a/src/api/spec/components/notification_filter_component_spec.rb
+++ b/src/api/spec/components/notification_filter_component_spec.rb
@@ -25,6 +25,10 @@ RSpec.describe NotificationFilterComponent, type: :component do
     it "doesn't display group filters" do
       expect(rendered_content).not_to have_css('h5', text: 'Groups')
     end
+
+    it "doesn't display the Reports filter" do
+      expect(rendered_content).not_to have_link('Reports')
+    end
   end
 
   context 'with projects and groups notifications' do
@@ -52,6 +56,16 @@ RSpec.describe NotificationFilterComponent, type: :component do
     it 'displays group filters' do
       expect(rendered_content).to have_css('h5', text: 'Groups')
       expect(rendered_content).to have_link(group.title)
+    end
+  end
+
+  context 'when show reports is true' do
+    before do
+      render_inline(described_class.new(selected_filter: { type: 'unread' }, show_reports: true))
+    end
+
+    it 'displays the Reports filter' do
+      expect(rendered_content).to have_link('Reports')
     end
   end
 end

--- a/src/api/spec/components/notification_notifiable_link_component_spec.rb
+++ b/src/api/spec/components/notification_notifiable_link_component_spec.rb
@@ -98,4 +98,18 @@ RSpec.describe NotificationNotifiableLinkComponent, type: :component do
       expect(rendered_content).to have_link('Comment on Package', href: "/package/show/projet_de_societe/oui?notification_id=#{notification.id}#comments-list")
     end
   end
+
+  context 'for a report notification with the event Event::CreateReport' do
+    let(:notification) { create(:notification, :create_report) }
+    let(:project) { notification.notifiable.reportable.commentable.project }
+    let(:package) { notification.notifiable.reportable.commentable }
+
+    before do
+      render_inline(described_class.new(notification))
+    end
+
+    it 'renders a link to the reported content' do
+      expect(rendered_content).to have_link('Report for a comment created', href: "/package/show/#{project.name}/#{package.name}?notification_id=#{notification.id}#comments-list")
+    end
+  end
 end

--- a/src/api/spec/factories/event_subscriptions.rb
+++ b/src/api/spec/factories/event_subscriptions.rb
@@ -77,5 +77,13 @@ FactoryBot.define do
       user
       group { nil }
     end
+
+    factory :event_subscription_create_report do
+      eventtype { 'Event::CreateReport' }
+      receiver_role { 'moderator' }
+      channel { :instant_email }
+      user
+      group { nil }
+    end
   end
 end

--- a/src/api/spec/factories/notification.rb
+++ b/src/api/spec/factories/notification.rb
@@ -68,6 +68,20 @@ FactoryBot.define do
       event_type { 'Event::BuildFail' }
       notifiable factory: [:package]
     end
+
+    trait :create_report do
+      event_type { 'Event::CreateReport' }
+      notifiable factory: [:report]
+
+      transient do
+        reason { nil }
+      end
+
+      after(:build) do |notification, evaluator|
+        notification.event_payload['reportable_type'] ||= notification.notifiable.reportable.class.to_s.downcase
+        notification.event_payload['reason'] ||= evaluator.reason
+      end
+    end
   end
 
   factory :rss_notification, parent: :notification do

--- a/src/api/spec/factories/notification.rb
+++ b/src/api/spec/factories/notification.rb
@@ -78,7 +78,7 @@ FactoryBot.define do
       end
 
       after(:build) do |notification, evaluator|
-        notification.event_payload['reportable_type'] ||= notification.notifiable.reportable.class.to_s.downcase
+        notification.event_payload['reportable_type'] ||= notification.notifiable.reportable.class.to_s
         notification.event_payload['reason'] ||= evaluator.reason
       end
     end

--- a/src/api/spec/factories/reports.rb
+++ b/src/api/spec/factories/reports.rb
@@ -2,5 +2,6 @@ FactoryBot.define do
   factory :report do
     user
     reportable { association :comment_package }
+    reason { Faker::Markdown.emphasis }
   end
 end

--- a/src/api/spec/mailers/event_mailer_spec.rb
+++ b/src/api/spec/mailers/event_mailer_spec.rb
@@ -252,6 +252,29 @@ RSpec.describe EventMailer, :vcr do
       end
     end
 
+    context 'for an event of type Event::CreateReport' do
+      let(:admin) { create(:admin_user) }
+      let!(:subscription) { create(:event_subscription_create_report, user: admin) }
+      let(:mail) { EventMailer.with(subscribers: Event::CreateReport.last.subscribers, event: Event::CreateReport.last).notification_email.deliver_now }
+
+      before do
+        create(:report, reason: 'Because reasons')
+      end
+
+      it 'gets delivered' do
+        expect(ActionMailer::Base.deliveries).to include(mail)
+      end
+
+      it 'contains the correct text' do
+        expect(mail.body.encoded).to include('reported a comment for the following reason:')
+        expect(mail.body.encoded).to include('Because reasons')
+      end
+
+      it 'renders link to the users page' do
+        expect(mail.body.encoded).to include('<a href="https://build.example.com/">https://build.example.com/</a>')
+      end
+    end
+
     context 'when the subscriber has no email' do
       let(:group) { create(:group, email: nil) }
       let(:event) { Event::RequestCreate.first }


### PR DESCRIPTION
This PR introduces email and web notifications for users with the moderator role (for now "admin" and "staff") users
that participate in the "content_moderation" beta program.
RSS notifications are excluded for now.

![image](https://github.com/openSUSE/open-build-service/assets/22001671/1cc98607-d455-4e96-93c7-6b234c89d9ac)



