### PR TITLE
Allow object deletion despite of reports

### DIFF
--- a/src/api/app/models/report.rb
+++ b/src/api/app/models/report.rb
@@ -13,10 +13,10 @@ end
 #
 #  id              :bigint           not null, primary key
 #  reason          :text(65535)
-#  reportable_type :string(255)      not null, indexed => [reportable_id]
+#  reportable_type :string(255)      indexed => [reportable_id]
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
-#  reportable_id   :integer          not null, indexed => [reportable_type]
+#  reportable_id   :integer          indexed => [reportable_type]
 #  user_id         :integer          not null, indexed
 #
 # Indexes

--- a/src/api/app/models/report.rb
+++ b/src/api/app/models/report.rb
@@ -4,7 +4,7 @@ class Report < ApplicationRecord
   validates :reportable_type, length: { maximum: 255 }
 
   belongs_to :user, optional: false
-  belongs_to :reportable, polymorphic: true, optional: false
+  belongs_to :reportable, polymorphic: true, optional: true
 end
 
 # == Schema Information

--- a/src/api/db/migrate/20230915162740_make_reports_reportables_nullable.rb
+++ b/src/api/db/migrate/20230915162740_make_reports_reportables_nullable.rb
@@ -1,0 +1,6 @@
+class MakeReportsReportablesNullable < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :reports, :reportable_type, true
+    change_column_null :reports, :reportable_id, true
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_07_111316) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_15_162740) do
   create_table "architectures", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "name", null: false
     t.boolean "available", default: false
@@ -855,8 +855,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_07_111316) do
 
   create_table "reports", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
-    t.string "reportable_type", null: false
-    t.integer "reportable_id", null: false
+    t.string "reportable_type"
+    t.integer "reportable_id"
     t.text "reason"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
When a moderator reports any misconduct on any object like comment, project, package or user and then decides to delete that object, we don't want to delete the associated report but nullify it. That's only possible if the database allows it.