### PR TITLE
When reporting an object, display a link to the Code of Conduct

### DIFF
--- a/src/api/app/components/report_component.html.haml
+++ b/src/api/app/components/report_component.html.haml
@@ -6,6 +6,12 @@
       .modal-body
         %p.wrap-text.confirmation-text= confirmation_text
 
+        - if Configuration.code_of_conduct.present?
+          %p.wrap-text
+            You may want to read the
+            = link_to 'Code of Conduct', code_of_conduct_index_path, target: '_blank'
+            page first.
+
         = form_for(Report.new, url: reports_path, method: :post, remote: true) do |form|
           = hidden_field_tag :link_id
           = hidden_field_tag :modal_id, modal_id


### PR DESCRIPTION
Depends on #14911.

**Before:**
![Screenshot from 2023-09-18 14-58-38](https://github.com/openSUSE/open-build-service/assets/24919/e23b190a-5925-4cbf-97b2-a9dd99346c23)

**After:**
![Screenshot from 2023-09-18 14-58-02](https://github.com/openSUSE/open-build-service/assets/24919/c1fe0e0e-5979-4437-8ae8-b6ad29764279)
