### PR TITLE
Wider button for table request link

### DIFF
--- a/src/api/app/assets/stylesheets/webui/datatables.scss
+++ b/src/api/app/assets/stylesheets/webui/datatables.scss
@@ -26,7 +26,7 @@ table.dataTable.table-sm {
 }
 
 .table-hover tbody tr:hover {
-  background-color: $gray-300;
+  background-color: $gray-100;
 }
 
 #projects-datatable_wrapper .dataTables_paginate {

--- a/src/api/app/assets/stylesheets/webui/requests.scss
+++ b/src/api/app/assets/stylesheets/webui/requests.scss
@@ -55,6 +55,15 @@
   left: -2px;
 }
 
+.request_link {
+  @extend .d-block;
+  @extend .btn;
+  @extend .btn-link;
+  @extend .border;
+  max-width: 90px;
+  margin: auto;
+}
+
 @include media-breakpoint-up(sm) {
   .order-sm-1 {
     order: 1;

--- a/src/api/app/views/webui/shared/bs_requests/index.json.erb
+++ b/src/api/app/views/webui/shared/bs_requests/index.json.erb
@@ -14,10 +14,10 @@
           "<%= escape_javascript(new_or_update_request(row)) %>",
           "<%= escape_javascript(row.priority) %>",
           "<%= escape_javascript(link_to(
-            '<span class="fa-stack">
+            '<span class="fa-stack half-font-size me-2">
                <i class="far fa-file fa-stack-2x"></i>
                <i class="fas fa-search fa-stack-1x"></i>
-             </span>'.html_safe,
+             </span><span class="text-nowrap">View</span>'.html_safe,
             request_show_path(row.number),
             { title: "Show request ##{row.number}", class: :request_link })) %>"
         <% end %>


### PR DESCRIPTION
A follow-up based on this nice contribution and useful conversation: https://github.com/openSUSE/open-build-service/pull/14908

It's not yet the final state of course, those tables implementation needs to be refactored (or dropped in favor of something else), but for now this PR provides a button with an icon and a text with sufficient area easy to click on

**Before**:
![request-button-before](https://github.com/openSUSE/open-build-service/assets/7080830/29dcdb3b-dfa3-4b77-9405-062b24cbeaa3)

**After**:
![request-button-after](https://github.com/openSUSE/open-build-service/assets/7080830/1355fc2f-032a-41af-af60-241699919a3d)

