### PR TITLE
Enable Restart on failure for delayed queue

### DIFF
--- a/dist/systemd/obs-delayedjob-queue-consistency_check.service
+++ b/dist/systemd/obs-delayedjob-queue-consistency_check.service
@@ -12,6 +12,7 @@ ExecStart = @@OBS_BUNDLE_BIN@@ exec script/delayed_job.api.rb --queue=consistenc
 ExecStop =  @@OBS_BUNDLE_BIN@@ exec script/delayed_job.api.rb --queue=consistency_check stop -i 1050
 Type = forking
 PIDFile = @@OBS_API_PREFIX@@/tmp/pids/delayed_job.1050.pid
+Restart=on-failure
 
 [Install]
 WantedBy = obs-api-support.target

--- a/dist/systemd/obs-delayedjob-queue-default.service
+++ b/dist/systemd/obs-delayedjob-queue-default.service
@@ -12,6 +12,7 @@ ExecStart = @@OBS_BUNDLE_BIN@@ exec script/delayed_job.api.rb --queue=default st
 ExecStop =  @@OBS_BUNDLE_BIN@@ exec script/delayed_job.api.rb --queue=default stop -i 1030
 Type = forking
 PIDFile = @@OBS_API_PREFIX@@/tmp/pids/delayed_job.1030.pid
+Restart=on-failure
 
 [Install]
 WantedBy = obs-api-support.target

--- a/dist/systemd/obs-delayedjob-queue-issuetracking.service
+++ b/dist/systemd/obs-delayedjob-queue-issuetracking.service
@@ -12,6 +12,7 @@ ExecStart = @@OBS_BUNDLE_BIN@@ exec script/delayed_job.api.rb --queue=issuetrack
 ExecStop  = @@OBS_BUNDLE_BIN@@ exec script/delayed_job.api.rb --queue=issuetracking stop -i 1010
 Type = forking
 PIDFile = @@OBS_API_PREFIX@@/tmp/pids/delayed_job.1010.pid
+Restart=on-failure
 
 [Install]
 WantedBy = obs-api-support.target

--- a/dist/systemd/obs-delayedjob-queue-mailers.service
+++ b/dist/systemd/obs-delayedjob-queue-mailers.service
@@ -12,6 +12,7 @@ ExecStart = @@OBS_BUNDLE_BIN@@ exec script/delayed_job.api.rb --queue=mailers st
 ExecStop  = @@OBS_BUNDLE_BIN@@ exec script/delayed_job.api.rb --queue=mailers stop -i 1020
 Type = forking
 PIDFile = @@OBS_API_PREFIX@@/tmp/pids/delayed_job.1020.pid
+Restart=on-failure
 
 [Install]
 WantedBy = obs-api-support.target

--- a/dist/systemd/obs-delayedjob-queue-project_log_rotate.service
+++ b/dist/systemd/obs-delayedjob-queue-project_log_rotate.service
@@ -12,6 +12,7 @@ ExecStart = @@OBS_BUNDLE_BIN@@ exec script/delayed_job.api.rb --queue=project_lo
 ExecStop  = @@OBS_BUNDLE_BIN@@ exec script/delayed_job.api.rb --queue=project_log_rotate stop -i 1040
 Type = forking
 PIDFile = @@OBS_API_PREFIX@@/tmp/pids/delayed_job.1040.pid
+Restart=on-failure
 
 [Install]
 WantedBy = obs-api-support.target

--- a/dist/systemd/obs-delayedjob-queue-quick@.service
+++ b/dist/systemd/obs-delayedjob-queue-quick@.service
@@ -12,6 +12,7 @@ ExecStart = @@OBS_BUNDLE_BIN@@ exec script/delayed_job.api.rb --queue=quick star
 ExecStop  = @@OBS_BUNDLE_BIN@@ exec script/delayed_job.api.rb --queue=quick stop -i %i
 Type = forking
 PIDFile = @@OBS_API_PREFIX@@/tmp/pids/delayed_job.%i.pid
+Restart=on-failure
 
 [Install]
 WantedBy = obs-api-support.target

--- a/dist/systemd/obs-delayedjob-queue-releasetracking.service
+++ b/dist/systemd/obs-delayedjob-queue-releasetracking.service
@@ -12,6 +12,7 @@ ExecStart = @@OBS_BUNDLE_BIN@@ exec script/delayed_job.api.rb --queue=releasetra
 ExecStop  = @@OBS_BUNDLE_BIN@@ exec script/delayed_job.api.rb --queue=releasetracking stop -i 1000
 Type = forking
 PIDFile = @@OBS_API_PREFIX@@/tmp/pids/delayed_job.1000.pid
+Restart=on-failure
 
 [Install]
 WantedBy = obs-api-support.target

--- a/dist/systemd/obs-delayedjob-queue-scm.service
+++ b/dist/systemd/obs-delayedjob-queue-scm.service
@@ -12,6 +12,7 @@ ExecStart = @@OBS_BUNDLE_BIN@@ exec script/delayed_job.api.rb --queue=scm start 
 ExecStop  = @@OBS_BUNDLE_BIN@@ exec script/delayed_job.api.rb --queue=scm stop -i 1070
 Type = forking
 PIDFile = @@OBS_API_PREFIX@@/tmp/pids/delayed_job.1070.pid
+Restart=on-failure
 
 [Install]
 WantedBy = obs-api-support.target

--- a/dist/systemd/obs-delayedjob-queue-staging.service
+++ b/dist/systemd/obs-delayedjob-queue-staging.service
@@ -12,6 +12,7 @@ ExecStart = @@OBS_BUNDLE_BIN@@ exec script/delayed_job.api.rb --queue=staging st
 ExecStop  = @@OBS_BUNDLE_BIN@@ exec script/delayed_job.api.rb --queue=staging stop -i 1060
 Type = forking
 PIDFile = @@OBS_API_PREFIX@@/tmp/pids/delayed_job.1060.pid
+Restart=on-failure
 
 [Install]
 WantedBy = obs-api-support.target


### PR DESCRIPTION
We observed three failed delayed queue services when the database connection went away during maintenance. This needed a manual restart that I want to avoid with this patch.

docs: https://www.freedesktop.org/software/systemd/man/systemd.service.html#Restart=