### PR TITLE
[backend] move cycle blocked setting into handlecycle

### DIFF
--- a/src/backend/BSSched/BuildJob/Package.pm
+++ b/src/backend/BSSched/BuildJob/Package.pm
@@ -101,16 +101,6 @@ sub check {
   my $incycle = $ctx->{'incycle'};
   my @blocked = grep {$notready->{$dep2src->{$_}}} @$edeps;
   @blocked = () if $repo->{'block'} && $repo->{'block'} eq 'never';
-  # check if cycle builds are in progress
-  if ($incycle == 3) {
-    push @blocked, 'cycle' unless @blocked;
-    if ($ctx->{'verbose'}) {
-      print "      - $packid ($buildtype)\n";
-      print "        blocked by cycle builds ($blocked[0]...)\n";
-    }
-    splice(@blocked, 10, scalar(@blocked), '...') if @blocked > 10;
-    return ('blocked', join(', ', @blocked));
-  }
   # prune cycle packages from blocked
   if ($incycle > 1) {
     my $cyclevel = $ctx->{'cyclevel'};

--- a/src/backend/BSSched/Checker.pm
+++ b/src/backend/BSSched/Checker.pm
@@ -952,8 +952,12 @@ sub handlecycle {
     $packid = shift @$cpacks;
     $cycpass->{$packid} = -2;			# set pass2 endmarker
   } elsif ($incycle == 3) {
-    unshift @$cpacks, @cycp;
-    $packid = shift @$cpacks;
+    my $notready = $ctx->{'notready'};
+    my $pkg2src = $ctx->{'pkg2src'} || {};
+    if (grep {$notready->{$pkg2src->{$_} || $_}} @cycp) {
+      $notready->{$pkg2src->{$_} || $_} ||= 1 for @cycp;
+    }
+    return (undef, 3);
   }
   return ($packid, $incycle);
 }
@@ -1057,7 +1061,7 @@ sub checkpkgs {
     my $incycle = 0;
     if ($cychash{$packid}) {
       ($packid, $incycle) = handlecycle($ctx, $packid, \@cpacks, \%cycpass);
-      next if $packstatus{$packid} && $packstatus{$packid} ne 'done' && $packstatus{$packid} ne 'succeeded' && $packstatus{$packid} ne 'failed'; # already decided
+      next if !$packid || ($packstatus{$packid} && $packstatus{$packid} ne 'done' && $packstatus{$packid} ne 'succeeded' && $packstatus{$packid} ne 'failed'); # already decided
     }
     $ctx->{'incycle'} = $incycle;
 


### PR DESCRIPTION
The old location does not work, it just sets every package from a build cycle to the blocked state.