### PR TITLE
Introduces Architecture.to_param

### DIFF
--- a/src/api/app/models/architecture.rb
+++ b/src/api/app/models/architecture.rb
@@ -53,6 +53,10 @@ class Architecture < ApplicationRecord
     name
   end
 
+  def to_param
+    name
+  end
+
   private
 
   def discard_cache


### PR DESCRIPTION
We use architecture around 30 times in our routes. Not once by id AFAICS...