### PR TITLE
[backend] support parsing text for issue tracker matchers

### DIFF
--- a/src/backend/BSSched/RPC.pm
+++ b/src/backend/BSSched/RPC.pm
@@ -357,13 +357,17 @@ sub xrpc_resume {
 
   # get result of rpc
   my $ret;
+  my $duration = time();
   eval { $ret = BSRPC::rpc($handle) };
   my $error;
   if ($@) {
-    warn $@;
     $error = $@;
     chomp $error;
+    warn("RPC $iw: $error ($handle->{'uri'})\n");
   }
+  $duration = time() - $duration;
+  warn("finishing RPC $iw took $duration seconds ($handle->{'uri'})\n") if $duration > 10;
+
   # run result handler
   die("no _resume set in handler $handle\n") unless $handle->{'_resume'};
   $handle->{'_resume'}->($handle->{'_ctx'}, $handle, $error, $ret);

--- a/src/backend/BSUtil.pm
+++ b/src/backend/BSUtil.pm
@@ -268,7 +268,9 @@ sub cleandir {
   my $ret = 1;
   return 1 unless -d $dir;
   for my $c (ls($dir)) {
-    if (! -l "$dir/$c" && -d _) {
+    my @s = lstat("$dir/$c");
+    if (! -l _ && -d _) {
+      chmod(0700, "$dir/$c") if ($s[2] & 0700) != 0700;	# set dirs to rxw
       cleandir("$dir/$c");
       $ret = undef unless rmdir("$dir/$c");
     } else {

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -6843,6 +6843,18 @@ sub getissuetrackers {
   return ($trackers, $BSXML::issue_trackers);
 }
 
+sub matchissues {
+  my ($cgi) = @_;
+  my $text = BSServer::read_data(100000000);
+  my $trackers = readxml("$BSConfig::bsdir/issuetrackers.xml", $BSXML::issue_trackers, 1) || {};
+  $trackers = BSSrcServer::Srcdiff::preparetrackers($trackers->{'issue-tracker'});
+  my %issues;
+  BSSrcServer::Srcdiff::issues($text, $trackers, \%issues);
+  my @issues = map {$issues{$_}} sort keys %issues;
+  BSSrcServer::Srcdiff::finalizeissues(@issues);
+  return ({ 'issue' => \@issues },  $BSXML::issues);
+}
+
 ####################################################################
 
 sub orderkiwirepos_for_prio {
@@ -7748,6 +7760,7 @@ my $dispatches = [
 
   # issue trackers
   'PUT:/issue_trackers' => \&putissuetrackers,
+  'POST:/issue_trackers cmd=issues' => \&matchissues,
   '/issue_trackers' => \&getissuetrackers,
 
   # build calls for binary files


### PR DESCRIPTION
You need to do a POST to /issue_trackers with query string cmd=issues and the body containing the text to be scanned.