### PR TITLE
[backend] split BSXML::issues from BSXML::sourcediff

### DIFF
--- a/src/backend/BSXML.pm
+++ b/src/backend/BSXML.pm
@@ -1292,6 +1292,17 @@ our $repoinfo_id = [
 	'downloadurl',
 ];
 
+our $issues = [
+    'issues' =>
+	 [[ 'issue' =>
+		'state',
+		'tracker',
+		'name',
+		'label',
+		'url',
+	 ]]
+];
+
 our $sourcediff = [
     'sourcediff' =>
 	'key',
@@ -1330,15 +1341,7 @@ our $sourcediff = [
               ],
          ]],
       ],
-      [ 'issues' =>
-	 [[ 'issue' =>
-		'state',
-		'tracker',
-		'name',
-		'label',
-		'url',
-	 ]]
-      ],
+      $issues,
 ];
 
 our $request = [


### PR DESCRIPTION
We need it when requesting issues for a given text. Should have been in commit 31007e944f37d171ae17d9a7997aa871665d656f