### PR TITLE
[api] allow to include request description issues

### DIFF
--- a/src/api/app/controllers/request_controller.rb
+++ b/src/api/app/controllers/request_controller.rb
@@ -187,6 +187,20 @@ class RequestController < ApplicationController
       end
     end
 
+    if params[:withdescriptionissues].present?
+      begin
+        data = Backend::Api::IssueTrackers.parse(req.description)
+      rescue Backend::Error
+        return
+      end
+
+      if xml_request
+        xml_request.at_xpath('//request').add_child(Nokogiri::XML(data).root)
+      else
+        diff_text += "Request Description issues:#{data}\n"
+      end
+    end
+
     if xml_request
       xml_request['actions'] = '0'
       render xml: xml_request.to_xml

--- a/src/api/app/lib/backend/api/issue_trackers.rb
+++ b/src/api/app/lib/backend/api/issue_trackers.rb
@@ -13,6 +13,10 @@ module Backend
       def self.list
         http_get('/issue_trackers')
       end
+
+      def self.parse(content)
+        http_post('/issue_trackers', params: { cmd: :issues }, data: content)
+      end
     end
   end
 end

--- a/src/api/public/apidocs/paths/request_id_cmd_diff.yaml
+++ b/src/api/public/apidocs/paths/request_id_cmd_diff.yaml
@@ -26,7 +26,10 @@ post:
         enum:
           - true
           - 1
-      description: Include parsed issues
+      description: Include parsed issues from referenced sources
+    - in: query
+      name: withdescriptionissues
+      description: Include parsed issues from request description
   responses:
     '200':
       description: OK

--- a/src/api/test/functional/request_controller_test.rb
+++ b/src/api/test/functional/request_controller_test.rb
@@ -2664,7 +2664,7 @@ class RequestControllerTest < ActionDispatch::IntegrationTest
                 <updatelink>true</updatelink>
               </options>
             </action>
-            <description>SUBMIT</description>
+            <description>SUBMIT bso#123</description>
             <state who='Iggy' name='new'/>
           </request>"
     post '/request?cmd=create', params: req
@@ -2678,6 +2678,11 @@ class RequestControllerTest < ActionDispatch::IntegrationTest
     post "/request/#{id}?cmd=diff&view=xml"
     assert_response :success
     assert_xml_tag(parent: { tag: 'file', attributes: { state: 'changed' } }, tag: 'old', attributes: { name: '_link' })
+
+    # Validate also the issue parsing of the description
+    post "/request/#{id}?cmd=diff&view=xml&withdescriptionissues=1"
+    assert_response :success
+    assert_xml_tag(parent: { tag: 'issues' }, tag: 'issue', attributes: { tracker: 'bso', name: '123' })
 
     # accept the request
     login_king

--- a/src/backend/BSXML.pm
+++ b/src/backend/BSXML.pm
@@ -1392,6 +1392,7 @@ our $request = [
           ],
           [ $sourcediff ],
      ]],
+     $issues,                # issues of request description
       [ 'submit' =>          # this is old style, obsolete by request, but still supported
 	  [ 'source' =>
 		'project',


### PR DESCRIPTION
Usually combined with view=xml and withissues=1. Some people have tooling to allow to write some issues in request description instead of sources.

jsc#OBS-272