### PR TITLE
Align `is_moderator?` method and report pundit policies

### DIFF
--- a/src/api/app/controllers/webui/users/notifications_controller.rb
+++ b/src/api/app/controllers/webui/users/notifications_controller.rb
@@ -39,7 +39,7 @@ class Webui::Users::NotificationsController < Webui::WebuiController
           notifications: paginated_notifications,
           selected_filter: selected_filter,
           show_read_all_button: show_read_all_button?,
-          show_reports: Flipper.enabled?(:content_moderation, User.session) && User.session.is_moderator?
+          show_reports: ReportPolicy.new(User.session, Report).notify?
         }
       end
     end

--- a/src/api/app/jobs/send_event_emails_job.rb
+++ b/src/api/app/jobs/send_event_emails_job.rb
@@ -32,7 +32,7 @@ class SendEventEmailsJob < ApplicationJob
 
   def event_subscribers(event:)
     if event.is_a?(Event::CreateReport)
-      event.subscribers.filter_map { |subscriber| subscriber if Flipper.enabled?(:content_moderation, subscriber) && subscriber.is_moderator? }
+      event.subscribers.filter_map { |subscriber| subscriber if ReportPolicy.new(subscriber, Report).notify? }
     else
       event.subscribers
     end

--- a/src/api/app/models/event_subscription/form.rb
+++ b/src/api/app/models/event_subscription/form.rb
@@ -45,8 +45,9 @@ class EventSubscription
 
     def show_form_for_create_report_event?(event_class:, subscriber:)
       if event_class.name == 'Event::CreateReport'
-        return false unless subscriber.try(:is_moderator?)
-        return false unless Flipper.enabled?(:content_moderation, subscriber)
+        # There is no subscriber for the global subscription configuration
+        return false if subscriber.blank?
+        return false unless ReportPolicy.new(subscriber, Report).notify?
       end
 
       true

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -409,7 +409,7 @@ class User < ApplicationRecord
   end
 
   def is_moderator?
-    is_admin? || is_staff?
+    roles.exists?(title: 'Moderator')
   end
 
   def is_active?

--- a/src/api/app/policies/comment_policy.rb
+++ b/src/api/app/policies/comment_policy.rb
@@ -32,10 +32,10 @@ class CommentPolicy < ApplicationPolicy
     !(user.blank? || user.is_nobody? || record.user.is_nobody?)
   end
 
-  # Only logged-in Admins of Staff members can moderate comments
+  # Only logged-in Admins/Staff members or user with moderator role can moderate comments
   def moderate?
     return false if record.user.is_nobody? # soft-deleted comments
-    return true if user.try(:is_admin?) || user.try(:is_staff?)
+    return true if user.try(:is_moderator?) || user.try(:is_admin?) || user.try(:is_staff?)
 
     false
   end

--- a/src/api/app/policies/comment_policy.rb
+++ b/src/api/app/policies/comment_policy.rb
@@ -35,6 +35,7 @@ class CommentPolicy < ApplicationPolicy
   # Only logged-in Admins/Staff members or user with moderator role can moderate comments
   def moderate?
     return false if record.user.is_nobody? # soft-deleted comments
+    return false if user == record.user
     return true if user.try(:is_moderator?) || user.try(:is_admin?) || user.try(:is_staff?)
 
     false

--- a/src/api/app/policies/decision_policy.rb
+++ b/src/api/app/policies/decision_policy.rb
@@ -2,6 +2,6 @@ class DecisionPolicy < ApplicationPolicy
   def create?
     return false unless Flipper.enabled?(:content_moderation, user)
 
-    user.is_admin? || user.is_moderator?
+    user.is_moderator? || user.is_admin? || user.is_staff?
   end
 end

--- a/src/api/app/policies/report_policy.rb
+++ b/src/api/app/policies/report_policy.rb
@@ -21,4 +21,12 @@ class ReportPolicy < ApplicationPolicy
       !UserPolicy.new(user, record.reportable).update?
     end
   end
+
+  def notify?
+    return false unless Flipper.enabled?(:content_moderation, user)
+    return true if User.moderators.blank? && (user.is_admin? || user.is_staff?)
+    return true if user.is_moderator?
+
+    false
+  end
 end

--- a/src/api/app/services/notification_service/notifier.rb
+++ b/src/api/app/services/notification_service/notifier.rb
@@ -61,6 +61,12 @@ module NotificationService
       true
     end
 
+    def create_report_notification?(event:, subscriber:)
+      return false if event.is_a?(Event::CreateReport) && !ReportPolicy.new(subscriber, Report).notify?
+
+      true
+    end
+
     def notifiable_exists?
       # We need this check because the notification is created in a delayed job.
       # So the notifiable object could have been removed in the meantime.
@@ -69,15 +75,6 @@ module NotificationService
 
       notifiable_id = @event.parameters_for_notification[:notifiable_id]
       notifiable_type.exists?(notifiable_id)
-    end
-
-    def create_report_notification?(event:, subscriber:)
-      if event.is_a?(Event::CreateReport)
-        return false unless Flipper.enabled?(:content_moderation, subscriber)
-        return false unless subscriber.is_moderator?
-      end
-
-      true
     end
   end
 end

--- a/src/api/spec/factories/users.rb
+++ b/src/api/spec/factories/users.rb
@@ -45,6 +45,10 @@ FactoryBot.define do
         roles { [Role.find_by_title('Staff')] }
       end
 
+      factory :moderator do
+        roles { [Role.find_by_title('Moderator')] }
+      end
+
       factory :user_with_groups do
         after(:create) do |user|
           create(:group, users: [user])

--- a/src/api/spec/policies/comment_policy_spec.rb
+++ b/src/api/spec/policies/comment_policy_spec.rb
@@ -176,6 +176,14 @@ RSpec.describe CommentPolicy do
         expect(subject).to permit(staff_user, comment)
       end
     end
+
+    context 'when the user has the moderator role assigned' do
+      let(:user_with_moderator_role) { create(:moderator) }
+
+      it 'can moderate comments' do
+        expect(subject).to permit(user_with_moderator_role, comment)
+      end
+    end
   end
   # rubocop:enable RSpec/RepeatedExample
 end


### PR DESCRIPTION
In the beginning of the content_moderation feature we considered
user that have the admin or stuff roles to be moderator. But now
we have the dedicated moderator role. So we only should check
for that in the `is_moderator?` method and leave the rest to
the pundit policies.

The authorization logic about if a user should receive notifications
for reports is spread over several places.
Lets move it to a policy to avoid duplication and confusion.

Also in the moderate comment policy we didn't considered the moderator role, 
only staff and admin users. 