### PR TITLE
[2.10] [dist] obsstoragesetup: do not prompt before wipe

### DIFF
--- a/dist/obsstoragesetup
+++ b/dist/obsstoragesetup
@@ -284,7 +284,7 @@ case "$1" in
 						I=$(( $I + 1 ))
 				
 						lverr=$(mktemp)
-						if ! lvcreate --wipesignatures y --zero y -n worker_root_${I} -L ${OBS_WORKER_ROOT_SIZE}M OBS ${pvs[$(( $pv_idx + $o1 ))]} 2> $lverr; then
+						if ! lvcreate --wipesignatures y --yes --zero y -n worker_root_${I} -L ${OBS_WORKER_ROOT_SIZE}M OBS ${pvs[$(( $pv_idx + $o1 ))]} 2> $lverr; then
 							if [ $? -gt 0 ];then
 								echo "An error occured while creating LV"
 								cat $lverr
@@ -298,7 +298,7 @@ case "$1" in
 								exit
 							fi
 						else
- 				                        lvcreate --wipesignatures y --zero y -n worker_swap_${I} -L ${OBS_WORKER_SWAP_SIZE}M OBS ${pvs[$(( $pv_idx + $o2 ))]} || exit
+ 				                        lvcreate --wipesignatures y --yes --zero y -n worker_swap_${I} -L ${OBS_WORKER_SWAP_SIZE}M OBS ${pvs[$(( $pv_idx + $o2 ))]} || exit
 							if [ $? -gt 0 ];then
 								echo "An error occured while creating LV worker_swap_${I} "
 								exit 1
@@ -333,14 +333,14 @@ case "$1" in
 							DEVS="$DEVS ${pvs[$(( $I * $disks_per_instance + $J ))]}"
 						done
 	
-						lvcreate --wipesignatures y --zero y -n worker_root_${I} -i $disks_per_instance -L ${OBS_WORKER_ROOT_SIZE}M OBS $DEVS || exit
-				                lvcreate --wipesignatures y --zero y -n worker_swap_${I} -i $disks_per_instance -L ${OBS_WORKER_SWAP_SIZE}M OBS $DEVS || exit
+						lvcreate --wipesignatures y --yes --zero y -n worker_root_${I} -i $disks_per_instance -L ${OBS_WORKER_ROOT_SIZE}M OBS $DEVS || exit
+				                lvcreate --wipesignatures y --yes --zero y -n worker_swap_${I} -i $disks_per_instance -L ${OBS_WORKER_SWAP_SIZE}M OBS $DEVS || exit
 					done
 				fi
 
 				# Create cache partition on remaining space
 				#lvcreate -n cache -i $disks_per_instance -l 100%FREE OBS || exit
-				lvcreate --wipesignatures y --zero y -n cache -i $disks_per_instance -L "${OBS_WORKER_CACHE_SIZE}M" OBS || exit
+				lvcreate --wipesignatures y --zero y --yes -n cache -i $disks_per_instance -L "${OBS_WORKER_CACHE_SIZE}M" OBS || exit
 				mkfs -text4 /dev/OBS/cache || exit
 			fi
 		fi

--- a/dist/obsstoragesetup
+++ b/dist/obsstoragesetup
@@ -267,7 +267,7 @@ case "$1" in
 						I=$(( $I + 1 ))
 				
 						lverr=$(mktemp)
-						if ! lvcreate --wipesignatures y --zero y -n worker_root_${I} -L ${OBS_WORKER_ROOT_SIZE}M OBS ${pvs[$(( $pv_idx + $o1 ))]} 2> $lverr; then
+						if ! lvcreate --wipesignatures y --yes --zero y -n worker_root_${I} -L ${OBS_WORKER_ROOT_SIZE}M OBS ${pvs[$(( $pv_idx + $o1 ))]} 2> $lverr; then
 							if [ $? -gt 0 ];then
 								echo "An error occured while creating LV"
 								cat $lverr
@@ -281,7 +281,7 @@ case "$1" in
 								exit
 							fi
 						else
- 				                        lvcreate --wipesignatures y --zero y -n worker_swap_${I} -L ${OBS_WORKER_SWAP_SIZE}M OBS ${pvs[$(( $pv_idx + $o2 ))]} || exit
+ 				                        lvcreate --wipesignatures y --yes --zero y -n worker_swap_${I} -L ${OBS_WORKER_SWAP_SIZE}M OBS ${pvs[$(( $pv_idx + $o2 ))]} || exit
 							if [ $? -gt 0 ];then
 								echo "An error occured while creating LV worker_swap_${I} "
 								exit 1
@@ -316,14 +316,14 @@ case "$1" in
 							DEVS="$DEVS ${pvs[$(( $I * $disks_per_instance + $J ))]}"
 						done
 	
-						lvcreate --wipesignatures y --zero y -n worker_root_${I} -i $disks_per_instance -L ${OBS_WORKER_ROOT_SIZE}M OBS $DEVS || exit
-				                lvcreate --wipesignatures y --zero y -n worker_swap_${I} -i $disks_per_instance -L ${OBS_WORKER_SWAP_SIZE}M OBS $DEVS || exit
+						lvcreate --wipesignatures y --yes --zero y -n worker_root_${I} -i $disks_per_instance -L ${OBS_WORKER_ROOT_SIZE}M OBS $DEVS || exit
+				                lvcreate --wipesignatures y --yes --zero y -n worker_swap_${I} -i $disks_per_instance -L ${OBS_WORKER_SWAP_SIZE}M OBS $DEVS || exit
 					done
 				fi
 
 				# Create cache partition on remaining space
 				#lvcreate -n cache -i $disks_per_instance -l 100%FREE OBS || exit
-				lvcreate --wipesignatures y --zero y -n cache -i $disks_per_instance -L "${OBS_WORKER_CACHE_SIZE}M" OBS || exit
+				lvcreate --wipesignatures y --zero y --yes -n cache -i $disks_per_instance -L "${OBS_WORKER_CACHE_SIZE}M" OBS || exit
 				mkfs -text4 /dev/OBS/cache || exit
 			fi
 		fi


### PR DESCRIPTION
Backporting fixes from master to 2.10

According to lvcreate man, --wipesignature, "there is a prompt for each signature detected to confirm its wiping (unless --yes is used to override confirmations.)". However, obsstoragesetup is executed as a service and it will abort if an interactive prompt is requested.

The result is that workers are started without a proper storage and they will start to use rootfs, that might not be prepared to handle the amount of worker data.

Use --yes for lvcreate to avoid interactve prompts.

Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>
(cherry picked from commit 7fd2509ed1b1b3bfcab89d98ac004d7b306139b5)