### PR TITLE
Introduce notifications for decisions on moderated objects

### DIFF
--- a/src/api/app/components/notification_avatars_component.rb
+++ b/src/api/app/components/notification_avatars_component.rb
@@ -9,6 +9,7 @@ class NotificationAvatarsComponent < ApplicationComponent
 
   private
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def avatar_objects
     @avatar_objects ||= case @notification.notifiable_type
                         when 'Comment'
@@ -17,11 +18,14 @@ class NotificationAvatarsComponent < ApplicationComponent
                           [User.find_by(login: @notification.event_payload['who'])]
                         when 'Report'
                           [User.find(@notification.event_payload['user_id'])]
+                        when 'Decision'
+                          [User.find(@notification.event_payload['moderator_id'])]
                         else
                           reviews = @notification.notifiable.reviews
                           reviews.select(&:new?).map(&:reviewed_by) + User.where(login: @notification.notifiable.creator)
                         end
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   def avatars_to_display
     avatar_objects.first(MAXIMUM_DISPLAYED_AVATARS).reverse

--- a/src/api/app/models/decision.rb
+++ b/src/api/app/models/decision.rb
@@ -9,6 +9,21 @@ class Decision < ApplicationRecord
     cleared: 0,
     favor: 1
   }
+
+  after_create :create_event
+
+  def create_event
+    case kind
+    when 'cleared'
+      Event::ClearedDecision.create(event_parameters)
+    else
+      Event::FavoredDecision.create(event_parameters)
+    end
+  end
+
+  def event_parameters
+    { id: id, moderator_id: moderator.id, reason: reason }
+  end
 end
 
 # == Schema Information

--- a/src/api/app/models/event/base.rb
+++ b/src/api/app/models/event/base.rb
@@ -18,7 +18,9 @@ module Event
       'Event::CommentForRequest' => 'Receive notifications of comments created on a request for which you are...',
       'Event::RelationshipCreate' => "Receive notifications when someone adds you or your group to a project or package with any of these roles: #{Role.local_roles.to_sentence}.",
       'Event::RelationshipDelete' => "Receive notifications when someone removes you or your group from a project or package with any of these roles: #{Role.local_roles.to_sentence}.",
-      'Event::CreateReport' => 'Receive notifications for reported content.'
+      'Event::CreateReport' => 'Receive notifications for reported content.',
+      'Event::ClearedDecision' => 'Receive notifications for cleared report decisions.',
+      'Event::FavoredDecision' => 'Receive notifications for favored report decisions.'
     }.freeze
 
     class << self

--- a/src/api/app/models/event/base.rb
+++ b/src/api/app/models/event/base.rb
@@ -273,6 +273,28 @@ module Event
       User.admins.or(User.staff)
     end
 
+    def reporters
+      decision = Decision.find(payload['id'])
+      decision.reports.map(&:user)
+    end
+
+    def offenders
+      decision = Decision.find(payload['id'])
+      reportables = decision.reports.map(&:reportable)
+      reportables.map do |reportable|
+        case reportable
+        when Package, Project
+          reportable.maintainers
+        when User
+          reportable
+        when BsRequest
+          User.find_by(login: reportable.creator)
+        when Comment
+          reportable.user
+        end
+      end
+    end
+
     def _roles(role, project, package = nil)
       return [] unless project
 

--- a/src/api/app/models/event/cleared_decision.rb
+++ b/src/api/app/models/event/cleared_decision.rb
@@ -1,0 +1,12 @@
+module Event
+  class ClearedDecision < Base
+    receiver_roles :reporter
+    self.description = 'Reported content has been cleared'
+
+    payload_keys :id, :reason, :moderator_id
+
+    def parameters_for_notification
+      super.merge(notifiable_type: 'Decision')
+    end
+  end
+end

--- a/src/api/app/models/event/favored_decision.rb
+++ b/src/api/app/models/event/favored_decision.rb
@@ -1,0 +1,12 @@
+module Event
+  class FavoredDecision < Base
+    receiver_roles :reporter, :offender
+    self.description = 'Reported content has been favored'
+
+    payload_keys :id, :reason, :moderator_id
+
+    def parameters_for_notification
+      super.merge(notifiable_type: 'Decision')
+    end
+  end
+end

--- a/src/api/app/models/event_subscription.rb
+++ b/src/api/app/models/event_subscription.rb
@@ -44,7 +44,7 @@ class EventSubscription < ApplicationRecord
     in: [:maintainer, :bugowner, :reader, :source_maintainer, :target_maintainer,
          :reviewer, :commenter, :creator, :watcher, :source_watcher, :target_watcher,
          :package_watcher, :target_package_watcher, :source_package_watcher, :request_watcher, :any_role,
-         :moderator]
+         :moderator, :reporter, :offender]
   }
 
   scope :for_eventtype, ->(eventtype) { where(eventtype: eventtype) }

--- a/src/api/app/queries/outdated_notifications_finder/decision.rb
+++ b/src/api/app/queries/outdated_notifications_finder/decision.rb
@@ -1,0 +1,10 @@
+class OutdatedNotificationsFinder::Decision
+  def initialize(scope, parameters)
+    @scope = scope
+    @parameters = parameters
+  end
+
+  def call
+    @scope.where(notifiable_type: 'Decision', notifiable_id: @parameters['notifiable_id'])
+  end
+end

--- a/src/api/app/services/notification_service/web_channel.rb
+++ b/src/api/app/services/notification_service/web_channel.rb
@@ -6,7 +6,8 @@ module NotificationService
       'Comment' => OutdatedNotificationsFinder::Comment,
       'Project' => OutdatedNotificationsFinder::Project,
       'Package' => OutdatedNotificationsFinder::Package,
-      'Report' => OutdatedNotificationsFinder::Report
+      'Report' => OutdatedNotificationsFinder::Report,
+      'Decision' => OutdatedNotificationsFinder::Decision
     }.freeze
 
     def initialize(subscription, event)

--- a/src/api/app/services/notified_projects.rb
+++ b/src/api/app/services/notified_projects.rb
@@ -26,7 +26,7 @@ class NotifiedProjects
       @notifiable.project
     when 'Project'
       @notifiable
-    when 'Report'
+    when 'Report', 'Decision'
       []
     end
   end

--- a/src/api/lib/tasks/dev/reports.rake
+++ b/src/api/lib/tasks/dev/reports.rake
@@ -28,6 +28,11 @@ namespace :dev do
 
       puts 'Taking decisions regarding some reports'
 
+      # This automatically subscribes everyone to the cleared and favored decision events
+      EventSubscription.create!(eventtype: Event::ClearedDecision.name, channel: :web, receiver_role: :reporter, enabled: true)
+      EventSubscription.create!(eventtype: Event::FavoredDecision.name, channel: :web, receiver_role: :reporter, enabled: true)
+      EventSubscription.create!(eventtype: Event::FavoredDecision.name, channel: :web, receiver_role: :offender, enabled: true)
+
       admin = User.get_default_admin
 
       Report.find_each do |report|


### PR DESCRIPTION
This PR wires up the events and subscriptions required to get a notification when a Moderator makes a Decision about some Report.

It features very basic notifications, the actual notification is fleshed out in #14976 

The filters required for the notification screen are going to be implemented in #14975 

![offender_and_reporters_receive_notifications](https://github.com/openSUSE/open-build-service/assets/2581944/100ee14e-ddd9-4067-a3e7-f42d63e6a04c)
