### PR TITLE
Implement better notifications for report decisions

### DIFF
--- a/src/api/app/components/notification_action_description_component.rb
+++ b/src/api/app/components/notification_action_description_component.rb
@@ -30,11 +30,11 @@ class NotificationActionDescriptionComponent < ApplicationComponent
       when 'Event::BuildFail'
         "Build was triggered because of #{@notification.event_payload['reason']}"
       when 'Event::CreateReport'
-        "User '#{@notification.notifiable.user.login}' created a report for a #{@notification.event_payload['reportable_type']} for the following reason:"
+        "'#{@notification.notifiable.user.login}' created a report for a #{@notification.event_payload['reportable_type']} for the following reason:"
       when 'Event::ClearedDecision'
-        "User '#{@notification.notifiable.moderator.login}' cleared a report for #{@notification.notifiable.reports.first.reportable} for the following reason:"
+        "'#{@notification.notifiable.moderator.login}' cleared a report for #{@notification.notifiable.reports.first.reportable} for the following reason:"
       when 'Event::FavoredDecision'
-        "User '#{@notification.notifiable.moderator.login}' favored a report for #{@notification.notifiable.reports.first.reportable} for the following reason:"
+        "'#{@notification.notifiable.moderator.login}' favored a report for #{@notification.notifiable.reports.first.reportable} for the following reason:"
       end
     end
   end

--- a/src/api/app/components/notification_action_description_component.rb
+++ b/src/api/app/components/notification_action_description_component.rb
@@ -30,11 +30,13 @@ class NotificationActionDescriptionComponent < ApplicationComponent
       when 'Event::BuildFail'
         "Build was triggered because of #{@notification.event_payload['reason']}"
       when 'Event::CreateReport'
-        "'#{@notification.notifiable.user.login}' created a report for a #{@notification.event_payload['reportable_type']} for the following reason:"
+        "'#{@notification.notifiable.user.login}' created a report for a #{@notification.event_payload['reportable_type'].downcase}. This is the reason:"
       when 'Event::ClearedDecision'
-        "'#{@notification.notifiable.moderator.login}' cleared a report for #{@notification.notifiable.reports.first.reportable} for the following reason:"
+        class_name = @notification.notifiable.reports.first.reportable.class.name.downcase
+        "'#{@notification.notifiable.moderator.login}' decided to clear the report about the #{class_name}. This is the reason:"
       when 'Event::FavoredDecision'
-        "'#{@notification.notifiable.moderator.login}' favored a report for #{@notification.notifiable.reports.first.reportable} for the following reason:"
+        class_name = @notification.notifiable.reports.first.reportable.class.name.downcase
+        "'#{@notification.notifiable.moderator.login}' decided to favor the report about the #{class_name}. This is the reason:"
       end
     end
   end

--- a/src/api/app/components/notification_action_description_component.rb
+++ b/src/api/app/components/notification_action_description_component.rb
@@ -13,6 +13,7 @@ class NotificationActionDescriptionComponent < ApplicationComponent
   end
 
   # rubocop:disable Metrics/CyclomaticComplexity
+  # rubocop:disable Metrics/BlockLength
   def call
     tag.div(class: ['smart-overflow']) do
       case @notification.event_type
@@ -34,9 +35,20 @@ class NotificationActionDescriptionComponent < ApplicationComponent
           concat(tag.p("User '#{@notification.notifiable.user.login}' created a report for a #{@notification.event_payload['reportable_type']} for the following reason:"))
           concat(tag.p(@notification.event_payload['reason']))
         end
+      when 'Event::ClearedDecision'
+        capture do
+          concat(tag.p("User '#{@notification.notifiable.moderator.login}' cleared a report for #{@notification.notifiable.reports.first.reportable} for the following reason:"))
+          concat(tag.p(@notification.notifiable.reason))
+        end
+      when 'Event::FavoredDecision'
+        capture do
+          concat(tag.p("User '#{@notification.notifiable.moderator.login}' favored a report for #{@notification.notifiable.reports.first.reportable} for the following reason:"))
+          concat(tag.p(@notification.notifiable.reason))
+        end
       end
     end
   end
+  # rubocop:enable Metrics/BlockLength
   # rubocop:enable Metrics/CyclomaticComplexity
 
   private

--- a/src/api/app/components/notification_action_description_component.rb
+++ b/src/api/app/components/notification_action_description_component.rb
@@ -13,7 +13,6 @@ class NotificationActionDescriptionComponent < ApplicationComponent
   end
 
   # rubocop:disable Metrics/CyclomaticComplexity
-  # rubocop:disable Metrics/BlockLength
   def call
     tag.div(class: ['smart-overflow']) do
       case @notification.event_type
@@ -31,24 +30,14 @@ class NotificationActionDescriptionComponent < ApplicationComponent
       when 'Event::BuildFail'
         "Build was triggered because of #{@notification.event_payload['reason']}"
       when 'Event::CreateReport'
-        capture do
-          concat(tag.p("User '#{@notification.notifiable.user.login}' created a report for a #{@notification.event_payload['reportable_type']} for the following reason:"))
-          concat(tag.p(@notification.event_payload['reason']))
-        end
+        "User '#{@notification.notifiable.user.login}' created a report for a #{@notification.event_payload['reportable_type']} for the following reason:"
       when 'Event::ClearedDecision'
-        capture do
-          concat(tag.p("User '#{@notification.notifiable.moderator.login}' cleared a report for #{@notification.notifiable.reports.first.reportable} for the following reason:"))
-          concat(tag.p(@notification.notifiable.reason))
-        end
+        "User '#{@notification.notifiable.moderator.login}' cleared a report for #{@notification.notifiable.reports.first.reportable} for the following reason:"
       when 'Event::FavoredDecision'
-        capture do
-          concat(tag.p("User '#{@notification.notifiable.moderator.login}' favored a report for #{@notification.notifiable.reports.first.reportable} for the following reason:"))
-          concat(tag.p(@notification.notifiable.reason))
-        end
+        "User '#{@notification.notifiable.moderator.login}' favored a report for #{@notification.notifiable.reports.first.reportable} for the following reason:"
       end
     end
   end
-  # rubocop:enable Metrics/BlockLength
   # rubocop:enable Metrics/CyclomaticComplexity
 
   private

--- a/src/api/app/components/notification_component.rb
+++ b/src/api/app/components/notification_component.rb
@@ -18,6 +18,8 @@ class NotificationComponent < ApplicationComponent
       tag.i(class: ['fas', helpers.build_status_icon(:failed)], title: 'Package notification')
     when 'Report'
       tag.i(class: ['fas', 'fa-flag'], title: 'Report notification')
+    when 'Decision'
+      tag.i(class: ['fas', 'fa-clipboard-check'], title: 'Report decision')
     else
       tag.i(class: ['fas', 'fa-user-tag'], title: 'Relationship notification')
     end

--- a/src/api/app/components/notification_excerpt_component.rb
+++ b/src/api/app/components/notification_excerpt_component.rb
@@ -14,6 +14,8 @@ class NotificationExcerptComponent < ApplicationComponent
              @notifiable.description.to_s # description can be nil
            when 'Comment'
              helpers.render_without_markdown(@notifiable.body)
+           when 'Report', 'Decision'
+             @notifiable.reason
            else
              ''
            end

--- a/src/api/app/components/notification_notifiable_link_component.rb
+++ b/src/api/app/components/notification_notifiable_link_component.rb
@@ -44,7 +44,7 @@ class NotificationNotifiableLinkComponent < ApplicationComponent
       arch = @notification.event_payload['arch']
       "Package #{package} on #{project} project failed to build against #{repository} / #{arch}"
     when 'Event::CreateReport'
-      "Report for a #{@notification.event_payload['reportable_type']} Created"
+      "Report for a #{@notification.event_payload['reportable_type']}"
     when 'Event::ClearedDecision'
       # All reports should point to the same reportable. We will take care of that here:
       # https://trello.com/c/xrjOZGa7/45-ensure-all-reports-of-a-decision-point-to-the-same-reportable

--- a/src/api/app/components/notification_notifiable_link_component.rb
+++ b/src/api/app/components/notification_notifiable_link_component.rb
@@ -44,17 +44,17 @@ class NotificationNotifiableLinkComponent < ApplicationComponent
       arch = @notification.event_payload['arch']
       "Package #{package} on #{project} project failed to build against #{repository} / #{arch}"
     when 'Event::CreateReport'
-      "Report for a #{@notification.event_payload['reportable_type'].downcase} created"
+      "Report for a #{@notification.event_payload['reportable_type']} Created"
     when 'Event::ClearedDecision'
       # All reports should point to the same reportable. We will take care of that here:
       # https://trello.com/c/xrjOZGa7/45-ensure-all-reports-of-a-decision-point-to-the-same-reportable
       report = @notification.notifiable.reports.first
-      "Cleared #{report.reportable.class.name.downcase} report"
+      "Cleared #{report.reportable.class.name} Report"
     when 'Event::FavoredDecision'
       # All reports should point to the same reportable. We will take care of that here:
       # https://trello.com/c/xrjOZGa7/45-ensure-all-reports-of-a-decision-point-to-the-same-reportable
       report = @notification.notifiable.reports.first
-      "Favored #{report.reportable.class.name.downcase} report"
+      "Favored #{report.reportable.class.name} Report"
     end
   end
   # rubocop:enable Metrics/CyclomaticComplexity

--- a/src/api/app/models/decision.rb
+++ b/src/api/app/models/decision.rb
@@ -22,7 +22,7 @@ class Decision < ApplicationRecord
   end
 
   def event_parameters
-    { id: id, moderator_id: moderator.id, reason: reason }
+    { id: id, moderator_id: moderator.id, reason: reason, reportable_type: reports.first.class.name }
   end
 end
 

--- a/src/api/app/models/decision.rb
+++ b/src/api/app/models/decision.rb
@@ -22,7 +22,7 @@ class Decision < ApplicationRecord
   end
 
   def event_parameters
-    { id: id, moderator_id: moderator.id, reason: reason, reportable_type: reports.first.class.name }
+    { id: id, moderator_id: moderator.id, reason: reason, reportable_type: reports.first.reportable.class.name }
   end
 end
 

--- a/src/api/app/models/event/cleared_decision.rb
+++ b/src/api/app/models/event/cleared_decision.rb
@@ -3,7 +3,7 @@ module Event
     receiver_roles :reporter
     self.description = 'Reported content has been cleared'
 
-    payload_keys :id, :reason, :moderator_id
+    payload_keys :id, :reason, :moderator_id, :reportable_type
 
     def parameters_for_notification
       super.merge(notifiable_type: 'Decision')

--- a/src/api/app/models/event/favored_decision.rb
+++ b/src/api/app/models/event/favored_decision.rb
@@ -3,7 +3,7 @@ module Event
     receiver_roles :reporter, :offender
     self.description = 'Reported content has been favored'
 
-    payload_keys :id, :reason, :moderator_id
+    payload_keys :id, :reason, :moderator_id, :reportable_type
 
     def parameters_for_notification
       super.merge(notifiable_type: 'Decision')

--- a/src/api/lib/tasks/dev/reports.rake
+++ b/src/api/lib/tasks/dev/reports.rake
@@ -37,8 +37,7 @@ namespace :dev do
 
       Report.find_each do |report|
         # Reports with even id will be 'cleared' (0). Those with odd id will be 'favor' (1).
-        decision = Decision.create!(reason: "Just because! #{report.id}", moderator: admin, kind: (report.id % 2))
-        decision.reports << report
+        Decision.create!(reason: "Just because! #{report.id}", moderator: admin, kind: (report.id % 2), reports: [report])
       end
 
       # The same decision applies to more than one report about the same object/reportable.

--- a/src/api/spec/components/notification_action_description_component_spec.rb
+++ b/src/api/spec/components/notification_action_description_component_spec.rb
@@ -186,7 +186,7 @@ RSpec.describe NotificationActionDescriptionComponent, type: :component do
 
       it 'renders a div containing who created a report and for what' do
         expect(rendered_content).to have_css('div.smart-overflow',
-                                             text: "User '#{notification.notifiable.user.login}' created a report for a Comment for the following reason:Because reasons.")
+                                             text: "'#{notification.notifiable.user.login}' created a report for a comment. This is the reason:")
       end
     end
   end

--- a/src/api/spec/components/notification_action_description_component_spec.rb
+++ b/src/api/spec/components/notification_action_description_component_spec.rb
@@ -190,4 +190,32 @@ RSpec.describe NotificationActionDescriptionComponent, type: :component do
       end
     end
   end
+
+  context 'when the notification is for an Event::ClearedDecision' do
+    let(:notification) do
+      create(:notification, :cleared_decision)
+    end
+
+    before { render_inline(described_class.new(notification)) }
+
+    it 'renders the information about the cleared decision' do
+      expect(rendered_content).to have_css('div.smart-overflow',
+                                           text: "'#{notification.notifiable.moderator}' decided to clear the report about " \
+                                                 "the #{notification.notifiable.reports.first.reportable.class.name.downcase}. This is the reason:")
+    end
+  end
+
+  context 'when the notification is for an Event::FavoredDecision' do
+    let(:notification) do
+      create(:notification, :favored_decision)
+    end
+
+    before { render_inline(described_class.new(notification)) }
+
+    it 'renders the information about the favored decision' do
+      expect(rendered_content).to have_css('div.smart-overflow',
+                                           text: "'#{notification.notifiable.moderator}' decided to favor the report about " \
+                                                 "the #{notification.notifiable.reports.first.reportable.class.name.downcase}. This is the reason:")
+    end
+  end
 end

--- a/src/api/spec/components/notification_notifiable_link_component_spec.rb
+++ b/src/api/spec/components/notification_notifiable_link_component_spec.rb
@@ -112,4 +112,30 @@ RSpec.describe NotificationNotifiableLinkComponent, type: :component do
       expect(rendered_content).to have_link('Report for a Comment', href: "/package/show/#{project.name}/#{package.name}?notification_id=#{notification.id}#comments-list")
     end
   end
+
+  context 'for a decision notification with the event Event::ClearedDecision' do
+    let(:notification) { create(:notification, :cleared_decision) }
+    let(:package) { notification.notifiable.reports.first.reportable.commentable }
+
+    before do
+      render_inline(described_class.new(notification))
+    end
+
+    it 'renders a link to the reportable' do
+      expect(rendered_content).to have_link('Cleared Comment Report', href: "/package/show/#{package.project.name}/#{package.name}?notification_id=#{notification.id}#comments-list")
+    end
+  end
+
+  context 'for a decision notification with the event Event::FavoredDecision' do
+    let(:notification) { create(:notification, :favored_decision) }
+    let(:package) { notification.notifiable.reports.first.reportable.commentable }
+
+    before do
+      render_inline(described_class.new(notification))
+    end
+
+    it 'renders a link to the reportable' do
+      expect(rendered_content).to have_link('Favored Comment Report', href: "/package/show/#{package.project.name}/#{package.name}?notification_id=#{notification.id}#comments-list")
+    end
+  end
 end

--- a/src/api/spec/components/notification_notifiable_link_component_spec.rb
+++ b/src/api/spec/components/notification_notifiable_link_component_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe NotificationNotifiableLinkComponent, type: :component do
     end
 
     it 'renders a link to the reported content' do
-      expect(rendered_content).to have_link('Report for a comment created', href: "/package/show/#{project.name}/#{package.name}?notification_id=#{notification.id}#comments-list")
+      expect(rendered_content).to have_link('Report for a Comment', href: "/package/show/#{project.name}/#{package.name}?notification_id=#{notification.id}#comments-list")
     end
   end
 end

--- a/src/api/spec/factories/decisions.rb
+++ b/src/api/spec/factories/decisions.rb
@@ -1,0 +1,18 @@
+FactoryBot.define do
+  factory :decision do
+    moderator factory: [:user]
+    reason { Faker::Markdown.emphasis }
+
+    after(:build) do |decision|
+      decision.reports << create(:report, reason: 'This is spam!')
+    end
+
+    trait :cleared do
+      kind { 'cleared' }
+    end
+
+    trait :favor do
+      kind { 'favor' }
+    end
+  end
+end

--- a/src/api/spec/factories/notification.rb
+++ b/src/api/spec/factories/notification.rb
@@ -82,6 +82,24 @@ FactoryBot.define do
         notification.event_payload['reason'] ||= evaluator.reason
       end
     end
+
+    trait :cleared_decision do
+      event_type { 'Event::ClearedDecision' }
+      notifiable { association(:decision, :cleared) }
+
+      after(:build) do |notification|
+        notification.event_payload['reportable_type'] ||= notification.notifiable.reports.first.reportable.class.to_s
+      end
+    end
+
+    trait :favored_decision do
+      event_type { 'Event::FavoredDecision' }
+      notifiable { association(:decision, :favor) }
+
+      after(:build) do |notification|
+        notification.event_payload['reportable_type'] ||= notification.notifiable.reports.first.reportable.class.to_s
+      end
+    end
   end
 
   factory :rss_notification, parent: :notification do


### PR DESCRIPTION
The original PR started with a bare-bones implementation of the notification for Decisions. This PR is an improved view for those notifications

![report_and_decision_notifications](https://github.com/openSUSE/open-build-service/assets/2581944/fe6b8f63-90f2-4fb8-980a-85550e2672fd)

Notifications about cleared and favor decisions look like this:

![Screenshot 2023-09-29 at 10-41-49 Open Build Service](https://github.com/openSUSE/open-build-service/assets/2581944/ca3af582-3a97-4e88-a971-9c85bea53b2d)


Follows up https://github.com/openSUSE/open-build-service/pull/14967

## How to test
1. The default test data has some decision notifications, so if you log in with Iggy (the reporter) and go into [the notification area](https://obs-reviewlab.opensuse.org/danidoni-implement-better-notifications-for-report-decisions/my/notifications?type=unread) and scroll down, you'll see some.