### PR TITLE
Fetch bugowners from the devel package in the controller as well

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -56,7 +56,7 @@ class Webui::PackageController < Webui::WebuiController
     @srcmd5 = params[:srcmd5]
     @revision_parameter = params[:rev]
 
-    @bugowners_mail = (@package.bugowner_emails + @project.bugowner_emails).uniq
+    @bugowners_mail = bugowners_emails
     @revision = params[:rev]
     @failures = 0
 
@@ -700,5 +700,10 @@ class Webui::PackageController < Webui::WebuiController
       opts[k] = params[k] if params[k].present?
     end
     opts
+  end
+
+  def bugowners_emails
+    @package.develpackage&.bugowner_emails.presence || @package.bugowner_emails.presence ||
+      @package.develpackage&.project&.bugowner_emails.presence || @project.bugowner_emails.presence || []
   end
 end

--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -56,7 +56,7 @@ class Webui::PackageController < Webui::WebuiController
     @srcmd5 = params[:srcmd5]
     @revision_parameter = params[:rev]
 
-    @bugowners_mail = bugowners_emails
+    @bugowners_mail = @package.bugowner_emails
     @revision = params[:rev]
     @failures = 0
 
@@ -700,10 +700,5 @@ class Webui::PackageController < Webui::WebuiController
       opts[k] = params[k] if params[k].present?
     end
     opts
-  end
-
-  def bugowners_emails
-    @package.develpackage&.bugowner_emails.presence || @package.bugowner_emails.presence ||
-      @package.develpackage&.project&.bugowner_emails.presence || @project.bugowner_emails.presence || []
   end
 end

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -1318,6 +1318,13 @@ class Package < ApplicationRecord
     PackageBuildReason.new(data)
   end
 
+  def bugowner_emails
+    (develpackage&.relationships&.bugowners_with_email.presence ||
+      relationships.bugowners_with_email.presence ||
+      develpackage&.project&.relationships&.bugowners_with_email.presence ||
+      project.relationships.bugowners_with_email.presence)&.pluck(:email) || []
+  end
+
   def event_parameters
     { project: project.name, package: name }
   end


### PR DESCRIPTION
This is intended to enable both package's and devel package's bugowners to be mentioned in bugzilla link, so that report bug link shows when there's a bugowner in a devel package only, and to make the developers of the package aware of the issue.

Fixes #14987 