### PR TITLE
Introduces remote package support for Package.get_by_project_and_name

### DIFF
--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -511,6 +511,7 @@ Naming/MemoizedInstanceVariableName:
   Exclude:
     - 'app/controllers/application_controller.rb'
     - 'app/lib/authenticator.rb'
+    - 'app/controllers/concerns/triggerable.rb'
 
 # Offense count: 8
 # Configuration parameters: EnforcedStyle, AllowedPatterns.

--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -31,14 +31,6 @@ class Webui::PackageController < Webui::WebuiController
   end
 
   def show
-    # FIXME: Remove this statement when scmsync is fully supported
-    if @project.scmsync.present?
-      flash[:error] = "Package sources for project #{@project.name} are received through scmsync.
-                       This is not yet fully supported by the OBS frontend"
-      redirect_back_or_to project_show_path(@project)
-      return
-    end
-
     if @spider_bot
       params.delete(:rev)
       params.delete(:srcmd5)

--- a/src/api/app/controllers/webui/packages/files_controller.rb
+++ b/src/api/app/controllers/webui/packages/files_controller.rb
@@ -17,7 +17,7 @@ module Webui
         @expand = params[:expand]
         @addeditlink = false
 
-        if User.possibly_nobody.can_modify?(@package) && @rev.blank? && @package.scmsync.blank?
+        if User.possibly_nobody.can_modify?(@package) && @rev.blank? && @package.scmsynced?
           files = @package.dir_hash({ rev: @rev, expand: @expand }.compact).elements('entry')
           if (file = files.find { |f| f['name'] == @filename }.presence)
             @addeditlink = editable_file?(@filename, file['size'].to_i)

--- a/src/api/app/models/bs_request_action.rb
+++ b/src/api/app/models/bs_request_action.rb
@@ -968,9 +968,9 @@ class BsRequestAction < ApplicationRecord
       end
 
       if defined?(tpkg) && tpkg
-        if tpkg.scmsync.present?
+        if tpkg.scmsynced?
           raise RequestRejected,
-                "The target package #{target_project} #{target_package} is managed in an external SCM: #{tpkg.scmsync}"
+                "The target package #{target_project} #{target_package} is managed in an external SCM: #{tpkg.scmsync || tpkg.project.scmsync}"
         end
 
         a = tpkg.find_attribute('OBS', 'RejectRequests')

--- a/src/api/app/models/bs_request_action_submit.rb
+++ b/src/api/app/models/bs_request_action_submit.rb
@@ -95,7 +95,7 @@ class BsRequestActionSubmit < BsRequestAction
 
     # cleanup source project
     if relink_source && sourceupdate != 'noupdate'
-      if Package.find_by_project_and_name(source_project, source_package).scmsync.blank?
+      if Package.find_by_project_and_name(source_project, source_package).scmsynced?
         # source package got used as devel package, link it to the target
         # re-create it via branch , but keep current content...
         options = { comment: "initialized devel package after accepting #{bs_request.number}",

--- a/src/api/app/models/concerns/package_scmsync.rb
+++ b/src/api/app/models/concerns/package_scmsync.rb
@@ -1,0 +1,7 @@
+module PackageScmsync
+  extend ActiveSupport::Concern
+
+  def scmsynced?
+    scmsync.present? || project.scmsync.present?
+  end
+end

--- a/src/api/app/models/concerns/project_links.rb
+++ b/src/api/app/models/concerns/project_links.rb
@@ -2,7 +2,11 @@ module ProjectLinks
   extend ActiveSupport::Concern
 
   included do
-    has_many :linking_to, -> { order(:position) }, class_name: 'LinkedProject', foreign_key: :db_project_id, dependent: :delete_all
+    has_many :linking_to, -> { order(:position) }, class_name: 'LinkedProject', foreign_key: :db_project_id, dependent: :delete_all do
+      def remote
+        where.not(linked_remote_project_name: nil)
+      end
+    end
     has_many :projects_linking_to, through: :linking_to, class_name: 'Project', source: :linked_db_project
     has_many :linked_by, -> { order(:position) }, class_name: 'LinkedProject', foreign_key: :linked_db_project_id, dependent: :delete_all
     has_many :linked_by_projects, through: :linked_by, class_name: 'Project', source: :project

--- a/src/api/app/models/concerns/scm_sync_enabled_step.rb
+++ b/src/api/app/models/concerns/scm_sync_enabled_step.rb
@@ -36,7 +36,7 @@ module ScmSyncEnabledStep
   end
 
   def scm_synced_package_url
-    Package.get_by_project_and_name(step_instructions[:source_project], step_instructions[:source_package]).try(:scmsync)
+    Package.get_by_project_and_name(step_instructions[:source_project], step_instructions[:source_package], follow_project_scmsync_links: false).try(:scmsync)
   rescue Project::Errors::UnknownObjectError, Package::Errors::UnknownObjectError
     nil
   end

--- a/src/api/app/models/service.rb
+++ b/src/api/app/models/service.rb
@@ -80,7 +80,7 @@ class Service
   end
 
   def save
-    raise ScmsyncReadOnly if package.scmsync.present?
+    raise ScmsyncReadOnly if package.scmsynced?
 
     if document.xpath('//services/service').empty?
       begin

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -478,8 +478,9 @@ class User < ApplicationRecord
   # FIXME: This should be a policy
   # package is instance of Package
   def can_modify_package?(package, ignore_lock = nil)
-    return false if package.nil? # happens with remote packages easily
     raise ArgumentError, "illegal parameter type to User#can_modify_package?: #{package.class.name}" unless package.is_a?(Package)
+
+    return false if package.readonly? # remote packages
     return false if !ignore_lock && package.is_locked?
     return true if is_admin?
     return true if has_global_permission?('change_package')

--- a/src/api/app/views/webui/package/_side_links.html.haml
+++ b/src/api/app/views/webui/package/_side_links.html.haml
@@ -22,7 +22,7 @@
     = render partial: 'webui/package/side_links/show_linkinfo', locals: { package: package, project: project,
                                                                                   linkinfo: linkinfo, revision: revision }
 
-  - if package.scmsync
+  - if package.scmsynced?
     = render partial: 'webui/package/side_links/show_scmsync', locals: { package: package }
 
   = render partial: 'extra_actions', locals: { project: project, package: package }

--- a/src/api/lib/tasks/dev.rake
+++ b/src/api/lib/tasks/dev.rake
@@ -219,7 +219,6 @@ namespace :dev do
       create(:project, name: 'linked_project', link_to: home_admin)
       create(:multibuild_package, project: home_admin, name: 'multibuild_package')
       create(:package_with_link, project: home_admin, name: 'linked_package')
-      create(:package_with_remote_link, project: home_admin, name: 'remotely_linked_package', remote_project_name: 'openSUSE.org:openSUSE:Factory', remote_package_name: 'aaa_base')
 
       # Trigger package builds for home:Admin
       home_admin.store
@@ -250,6 +249,9 @@ namespace :dev do
 
       # Create notifications by running the `dev:notifications:data` task two times
       Rake::Task['dev:notifications:data'].invoke(2)
+
+      # Create project link setups
+      Rake::Task['dev:project_links:data'].invoke
     end
   end
 end

--- a/src/api/lib/tasks/dev/project_links.rake
+++ b/src/api/lib/tasks/dev/project_links.rake
@@ -32,6 +32,15 @@ namespace :dev do
       create(:path_element, repository: repository, link: interconnect_repo)
       create(:linked_project, project: project, linked_remote_project_name: 'openSUSE.org:home:hennevogel:myfirstproject')
       project.store
+
+      # A Project that is scmsynced
+      project = create(:project, name: 'ProjectLinks:Scmsynced',
+                                 title: 'Has a link to an SCM',
+                                 description: 'Project Links to SCM',
+                                 scmsync: 'https://github.com/hennevogel/scmsync-project.git')
+      repository = create(:repository, name: 'openSUSE_Tumbleweed', architectures: ['x86_64'], project: project)
+      create(:path_element, repository: repository, link: interconnect_repo)
+      project.store
     end
   end
 end

--- a/src/api/lib/tasks/dev/project_links.rake
+++ b/src/api/lib/tasks/dev/project_links.rake
@@ -1,0 +1,37 @@
+namespace :dev do
+  namespace :project_links do
+    # https://github.com/openSUSE/open-build-service/wiki/Links
+    desc 'Create a couple of project link setups'
+    task data: :development_environment do
+      require 'factory_bot'
+      include FactoryBot::Syntax::Methods
+      # Make sure the interconnect to api.opensuse.org is there as we are using it...
+      interconnect = Project.find_by(name: 'openSUSE.org', remoteurl: 'https://api.opensuse.org/public')
+      interconnect ||= create(:remote_project, name: 'openSUSE.org', remoteurl: 'https://api.opensuse.org/public')
+      interconnect_repo = interconnect.repositories.find_by(name: 'snapshot', remote_project_name: 'openSUSE:Factory')
+      interconnect_repo ||= create(:repository, name: 'snapshot', remote_project_name: 'openSUSE:Factory', project: interconnect)
+      interconnect.store
+
+      # An empty Project that links to another Project and rebuilds its packages
+      local_linked_to_project = create(:project, name: 'Hans')
+      create(:package_with_files, name: 'ctris', project: local_linked_to_project)
+      local_linked_to_project.store
+      project = create(:project, name: 'ProjectLinks:LocalLinkedBuild',
+                                 title: 'Has a project link to a  local project and rebuilds its packages',
+                                 description: 'Project Links to Hans')
+      repository = create(:repository, name: 'openSUSE_Tumbleweed', linkedbuild: 'all', architectures: ['x86_64'], project: project)
+      create(:path_element, repository: repository, link: interconnect_repo)
+      create(:linked_project, project: project, linked_db_project: local_linked_to_project)
+      project.store
+
+      # An empty Project that links to a remote project and rebuilds its packages
+      project = create(:project, name: 'ProjectLinks:RemoteLinkedBuild',
+                                 title: 'Has a project link to a remote project and rebuilds its packages',
+                                 description: 'Project Link to openSUSE.org:home:hennevogel:myfirstproject')
+      repository = create(:repository, name: 'openSUSE_Tumbleweed', linkedbuild: 'all', architectures: ['x86_64'], project: project)
+      create(:path_element, repository: repository, link: interconnect_repo)
+      create(:linked_project, project: project, linked_remote_project_name: 'openSUSE.org:home:hennevogel:myfirstproject')
+      project.store
+    end
+  end
+end

--- a/src/api/spec/factories/packages.rb
+++ b/src/api/spec/factories/packages.rb
@@ -126,24 +126,6 @@ FactoryBot.define do
       end
     end
 
-    factory :package_with_remote_link do
-      transient do
-        remote_project_name { Faker::Lorem.word }
-        remote_package_name { Faker::Lorem.word }
-      end
-      after(:create) do |package, evaluator|
-        remote_project = create(:remote_project, name: evaluator.remote_project_name)
-        PackageKind.create(package_id: package.id, kind: 'link')
-        file_content = "<link package=\"#{evaluator.remote_package_name}\" project=\"#{remote_project.name}\" />"
-
-        if CONFIG['global_write_through']
-          Backend::Connection.put(
-            "/source/#{CGI.escape(package.project.name)}/#{CGI.escape(package.name)}/_link", file_content
-          )
-        end
-      end
-    end
-
     factory :package_with_binary do
       transient do
         target_file_name { 'bigfile_archive.tar.gz' }

--- a/src/api/spec/models/package_get_by_project_and_name_spec.rb
+++ b/src/api/spec/models/package_get_by_project_and_name_spec.rb
@@ -244,4 +244,35 @@ RSpec.describe Package, '#get_by_project_and_name' do
       end
     end
   end
+
+  context 'follow_project_scmsync_links' do
+    let(:project) { create(:project, name: 'project_1', scmsync: 'https://github.com/hennevogel/scmsync-project.git') }
+    let(:package) { build(:package, name: 'i_dont_exist') }
+
+    context 'enabled' do
+      let(:arguments) { { follow_project_scmsync_links: true } }
+
+      before do
+        # Mock Package.exists_on_backend?
+        allow(Backend::Connection).to receive(:get).and_return(true)
+      end
+
+      it 'returns a readonly package' do
+        expect(subject).to be_readonly
+      end
+    end
+
+    context 'disabled' do
+      let(:arguments) { { follow_project_scmsync_links: false } }
+
+      before do
+        # Mock Package.exists_on_backend?
+        allow(Backend::Connection).to receive(:get).and_raise(Backend::Error)
+      end
+
+      it 'raises' do
+        expect { subject }.to raise_error(Package::Errors::UnknownObjectError)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Instead of returning nil for packages that might be on remote or scmsync, check if they are known to the backend and return an in-memory, readonly package.

In the project [ProjectLinks:RemoteLinkedBuild](https://obs-reviewlab.opensuse.org/hennevogel-refactoringget_by_project_and_name/project/show/ProjectLinks:RemoteLinkedBuild) you should

- see `ctris` on the [monitor page](https://obs-reviewlab.opensuse.org/hennevogel-refactoringget_by_project_and_name/project/monitor/ProjectLinks:RemoteLinkedBuild)
- be able to [show `ctris`](https://obs-reviewlab.opensuse.org/hennevogel-refactoringget_by_project_and_name/package/show/ProjectLinks:RemoteLinkedBuild/ctris)
- and not be able to do anything else to the package

There are of course rough edges to the UI that would need to be hammered out...

