### PR TITLE
Create a default subscription for Decision-related events

### DIFF
--- a/src/api/db/data/20231004134538_create_a_default_subscription_for_decision_related_events.rb
+++ b/src/api/db/data/20231004134538_create_a_default_subscription_for_decision_related_events.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateADefaultSubscriptionForDecisionRelatedEvents < ActiveRecord::Migration[7.0]
+  def up
+    # This automatically subscribes everyone to the cleared and favored decision events
+    EventSubscription.create!(eventtype: Event::ClearedDecision.name, channel: :web, receiver_role: :reporter, enabled: true)
+    EventSubscription.create!(eventtype: Event::FavoredDecision.name, channel: :web, receiver_role: :reporter, enabled: true)
+    EventSubscription.create!(eventtype: Event::FavoredDecision.name, channel: :web, receiver_role: :offender, enabled: true)
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/src/api/db/data_schema.rb
+++ b/src/api/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20230920125132)
+DataMigrate::Data.define(version: 20231004134538)


### PR DESCRIPTION
We need to have everyone subscribed automatically to FavoredDecision and ClearedDecision events.