### PR TITLE
Notify only projects not already notified

### DIFF
--- a/src/api/db/data/20200421121610_backfill_notified_projects.rb
+++ b/src/api/db/data/20200421121610_backfill_notified_projects.rb
@@ -1,7 +1,10 @@
 class BackfillNotifiedProjects < ActiveRecord::Migration[6.0]
   def up
     Notification.where.not(notifiable_id: nil).where.not(notifiable_type: nil).find_each do |notification|
-      notification.projects << NotifiedProjects.new(notification).call
+      # We cannot add the projects to be notified twice, so we need to calculate
+      # the remainder of the projects that are not yet notified
+      projects_to_notify = NotifiedProjects.new(notification).call
+      notification.projects << (projects_to_notify - notification.projects)
     rescue ActiveRecord::RecordNotUnique
       # We don't have to do anything...
     end


### PR DESCRIPTION
Otherwise we get errors like this one:

    ActiveRecord::RecordInvalid: Validation failed: Notification These notification and project are already associated
    from /usr/lib64/ruby/gems/3.1.0/gems/activerecord-7.0.8/lib/active_record/validations.rb:80:in `raise_validation_error'