### PR TITLE
Allow maintainers to view reports on their packages, projects and requests

### DIFF
--- a/src/api/app/components/reports_modal_component.html.haml
+++ b/src/api/app/components/reports_modal_component.html.haml
@@ -12,13 +12,14 @@
             = render TimeComponent.new(time: report.created_at)
           .ms-4
             = report.reason
-      = form_for(Decision.new, url: decisions_path, method: :post) do |form|
-        .modal-body
-          %h5 Decision
-          = form.label(:reason)
-          = form.text_area(:reason, class: 'form-control mb-3', required: true, placeholder: 'Reason for the decision')
-          = form.select(:kind, Decision.kinds.keys, {}, class: 'form-select')
-        .modal-footer
-          - reports.each do |report|
-            = form.hidden_field(:report_ids, multiple: true, value: report.id)
-          = submit_tag('Submit', class: 'btn btn-primary')
+      - if policy(Decision.new).create?
+        = form_for(Decision.new, url: decisions_path, method: :post) do |form|
+          .modal-body
+            %h5 Decision
+            = form.label(:reason)
+            = form.text_area(:reason, class: 'form-control mb-3', required: true, placeholder: 'Reason for the decision')
+            = form.select(:kind, Decision.kinds.keys, {}, class: 'form-select')
+          .modal-footer
+            - reports.each do |report|
+              = form.hidden_field(:report_ids, multiple: true, value: report.id)
+            = submit_tag('Submit', class: 'btn btn-primary')

--- a/src/api/app/policies/comment_policy.rb
+++ b/src/api/app/policies/comment_policy.rb
@@ -12,14 +12,7 @@ class CommentPolicy < ApplicationPolicy
     # Users can always delete their own comments
     return true if user == record.user
 
-    case record.commentable_type
-    when 'Package'
-      user.has_local_permission?('change_package', record.commentable)
-    when 'Project'
-      user.has_local_permission?('change_project', record.commentable)
-    when 'BsRequest'
-      record.commentable.is_target_maintainer?(user)
-    end
+    maintainer?
   end
 
   def update?
@@ -39,5 +32,16 @@ class CommentPolicy < ApplicationPolicy
     return true if user.try(:is_moderator?) || user.try(:is_admin?) || user.try(:is_staff?)
 
     false
+  end
+
+  def maintainer?
+    case record.commentable_type
+    when 'Package'
+      user.has_local_permission?('change_package', record.commentable)
+    when 'Project'
+      user.has_local_permission?('change_project', record.commentable)
+    when 'BsRequest'
+      record.commentable.is_target_maintainer?(user)
+    end
   end
 end

--- a/src/api/app/policies/report_policy.rb
+++ b/src/api/app/policies/report_policy.rb
@@ -1,6 +1,9 @@
 class ReportPolicy < ApplicationPolicy
   def show?
-    user.is_admin? || record.user == user
+    return true if user.is_admin? || user.is_moderator? || user.is_staff?
+    return true if record.user == user
+
+    CommentPolicy.new(user, record.reportable).maintainer? if record.reportable_type == 'Comment'
   end
 
   def create?


### PR DESCRIPTION
Displays the reports modal without the decision form and displays the reports notice for them in order to trigger it.