### PR TITLE
Bootstrap fixes

### DIFF
--- a/src/api/app/assets/stylesheets/webui/cm2/bootstrap.scss
+++ b/src/api/app/assets/stylesheets/webui/cm2/bootstrap.scss
@@ -56,7 +56,7 @@
 
   .CodeMirror-gutters {
     background: $card-cap-bg;
-    border-right: $card-border-width solid $card-border-color;
+    border-right: var(--bs-card-border-width) solid var(--bs-card-border-color);
   }
   .CodeMirror-guttermarker { color: $text-muted; }
   .CodeMirror-guttermarker-subtle { color: $text-muted; }

--- a/src/api/app/assets/stylesheets/webui/coderay.scss
+++ b/src/api/app/assets/stylesheets/webui/coderay.scss
@@ -8,7 +8,7 @@ span.CodeRay { white-space: pre }
 .CodeRay .line-numbers {
   display: inline-block;
   background: $card-cap-bg;
-  border-right: $card-border-width solid $card-border-color;
+  border-right: var(--bs-border-width) solid var(--bs-border-color);
 }
 
 .CodeRay .line-numbers pre {

--- a/src/api/app/assets/stylesheets/webui/diff.scss
+++ b/src/api/app/assets/stylesheets/webui/diff.scss
@@ -19,8 +19,8 @@
     
   }
   overflow: auto;
-  border-bottom-left-radius: calc(#{$card-border-radius} - #{$card-border-width});
-  border-bottom-right-radius: calc(#{$card-border-radius} - #{$card-border-width});
+  border-bottom-left-radius: calc(var(--bs-border-radius) - var(--bs-border-width));
+  border-bottom-right-radius: calc(var(--bs-border-radius) - var(--bs-border-width));
   .diff {
     min-width: 100%;
     width: max-content;
@@ -32,7 +32,7 @@
         display: block;
         position: absolute;
         z-index: 1000;
-        margin-left: calc(2 * (var(--line-index-digits) + 2rem + #{$card-border-width}) + 0.5rem + #{$card-border-width});
+        margin-left: calc(2 * (var(--line-index-digits) + 2rem + var(--bs-border-width)) + 0.5rem + var(--bs-border-width));
         margin-top: -1.75rem;
       }
       .line-comment .fa-comment {
@@ -78,10 +78,10 @@
         .number {
           color: $text-muted;
           font-family: monospace;
-          width: calc(var(--line-index-digits) + 2rem + #{$card-border-width});
+          width: calc(var(--line-index-digits) + 2rem + var(--bs-border-width));
           text-align: right;
           padding: 0 1rem 0 0;
-          border-right: $card-border-width solid $card-border-color;
+          border-right: var(--bs-border-width) solid var(--bs-border-color);
           user-select: none;
         }
       }
@@ -92,16 +92,16 @@
         background-color: rgba($danger, 0.2)
       }
       &.range, &.comment {
-        border-bottom: $card-border-width solid $card-border-color;
-        border-top: $card-border-width solid $card-border-color;
+        border-bottom: var(--bs-border-width) solid var(--bs-border-color);
+        border-top: var(--bs-border-width) solid var(--bs-border-color);
         .offset {
           font-family: monospace;
-          padding-left: calc(4rem + (2 * var(--line-index-digits)) + #{$card-border-width});
+          padding-left: calc(4rem + (2 * var(--line-index-digits)) + var(--bs-border-width));
           position: sticky;
           left: 0;
           .text {
             padding-left: 1rem;
-            border-left: $card-border-width solid $card-border-color;
+            border-left: var(--bs-border-width) solid var(--bs-border-color);
           }
         }
       }

--- a/src/api/app/assets/stylesheets/webui/tabs.scss
+++ b/src/api/app/assets/stylesheets/webui/tabs.scss
@@ -5,7 +5,7 @@
   overflow: auto;
   white-space: nowrap;
   padding: 0.5rem 1rem 0rem 1rem;
-  margin-bottom: -$card-border-width;
+  margin-bottom: calc(-1 * var(--bs-border-width));
 
   a.scrollable-tab-link {
     display: inline-block;
@@ -27,7 +27,7 @@
 ul.scrollable-tabs {
   display: block;
   overflow-y: hidden;
-  margin-bottom: -$card-border-width;
+  margin-bottom: calc(-1 * var(--bs-border-width));
 
   li.scrollable-tab-link {
     display: inline-block;

--- a/src/api/app/views/webui/request/beta_show.html.haml
+++ b/src/api/app/views/webui/request/beta_show.html.haml
@@ -30,7 +30,7 @@
           .row
             .card.p-4#description-text
               - if @bs_request.description.present?
-                %h4.list-group.mb-4 Description
+                %h4.mb-4 Description
                 = render partial: 'webui/shared/collapsible_text', locals: { text: @bs_request.description, extra_css_classes: 'full-width' }
               - else
                 %i No description set

--- a/src/api/app/views/webui/request/beta_show.html.haml
+++ b/src/api/app/views/webui/request/beta_show.html.haml
@@ -37,7 +37,7 @@
 
             #comments-list
               .timeline.pb-2.ms-3{ data: { comment_counter: local_assigns[:comment_counter_id] } }
-                %h4.list-group.mb-4.ms-3 Comments & History
+                %h4.list-group.mb-4.ms-3.pt-3 Comments & History
                 .timeline-item
                   .d-inline-flex
                     %i.fas.fa-lg.fa-code-commit.text-dark


### PR DESCRIPTION
- no bottom border for the active tab
- no bottom border for the title header in the request description
- more space for the timeline title header


## Before
![before-bootstrap-fixes](https://github.com/openSUSE/open-build-service/assets/7080830/b74d6200-07f5-4294-86b3-52ba2058a369)


## After
![after-bootstrap-fixes](https://github.com/openSUSE/open-build-service/assets/7080830/de1527d9-86bf-41e6-ad12-ac9d035cecc3)
