### PR TITLE
Prevent issues for missing categories

### DIFF
--- a/src/api/app/models/report.rb
+++ b/src/api/app/models/report.rb
@@ -20,8 +20,10 @@ class Report < ApplicationRecord
 
   scope :without_decision, -> { where(decision: nil) }
 
+  # TODO: remove the first part of the condition `category.present?`. It's a temprary patch to
+  # avoid problems during deployment.
   def reason
-    return category.humanize if category != 'other'
+    return category.humanize if category.present? && (category != 'other')
 
     super
   end


### PR DESCRIPTION
Right after deployment, the reference server had issues because of missing categories. The issues were momentary.

As the same deployment will be done in other instances soon, we better prevent them from having the same issues. While we go on researching what was wrong with the migration (which set default values).

Related to #15004