### PR TITLE
Unify link creation in reportables helper

### DIFF
--- a/src/api/app/components/notification_notifiable_link_component.rb
+++ b/src/api/app/components/notification_notifiable_link_component.rb
@@ -1,5 +1,6 @@
-# rubocop:disable Metrics/ClassLength
 class NotificationNotifiableLinkComponent < ApplicationComponent
+  include Webui::ReportablesHelper
+
   def initialize(notification)
     super
 
@@ -95,10 +96,10 @@ class NotificationNotifiableLinkComponent < ApplicationComponent
                                                                        repository: @notification.event_payload['repository'], arch: @notification.event_payload['arch'])
     when 'Event::CreateReport'
       reportable = @notification.notifiable.reportable
-      link_for_reportables(reportable)
+      link_for_reportables(reportable:, notification: @notification)
     when 'Event::ClearedDecision', 'Event::FavoredDecision'
       reportable = @notification.notifiable.reports.first.reportable
-      link_for_reportables(reportable)
+      link_for_reportables(reportable:, notification: @notification)
     end
   end
   # rubocop:enable Metrics/CyclomaticComplexity
@@ -112,38 +113,4 @@ class NotificationNotifiableLinkComponent < ApplicationComponent
       @notification.notifiable.commentable
     end
   end
-
-  def link_for_reportables(reportable)
-    case @notification.event_payload['reportable_type']
-    when 'Comment'
-      link_for_commentables_on_reportables(commentable: reportable.commentable)
-    when 'Package'
-      Rails.application.routes.url_helpers.package_show_path(package: reportable,
-                                                             project: reportable.project,
-                                                             notification_id: @notification.id,
-                                                             anchor: 'comments-list')
-    when 'Project'
-      Rails.application.routes.url_helpers.project_show_path(reportable, notification_id: @notification.id, anchor: 'comments-list')
-    when 'User'
-      Rails.application.routes.url_helpers.user_path(reportable)
-    end
-  end
-
-  def link_for_commentables_on_reportables(commentable:)
-    case commentable
-    when BsRequest
-      Rails.application.routes.url_helpers.request_show_path(commentable.number, notification_id: @notification.id, anchor: 'comments-list')
-    when BsRequestAction
-      Rails.application.routes.url_helpers.request_show_path(number: commentable.bs_request.number, request_action_id: commentable.id,
-                                                             notification_id: @notification.id, anchor: 'tab-pane-changes')
-    when Package
-      Rails.application.routes.url_helpers.package_show_path(package: commentable,
-                                                             project: commentable.project,
-                                                             notification_id: @notification.id,
-                                                             anchor: 'comments-list')
-    when Project
-      Rails.application.routes.url_helpers.project_show_path(commentable, notification_id: @notification.id, anchor: 'comments-list')
-    end
-  end
 end
-# rubocop:enable Metrics/ClassLength

--- a/src/api/app/helpers/webui/reportables_helper.rb
+++ b/src/api/app/helpers/webui/reportables_helper.rb
@@ -1,34 +1,66 @@
 module Webui::ReportablesHelper
   include Webui::WebuiHelper
 
-  def link_to_reportables(payload:, host:)
-    reportable = Report.find(payload['id']).reportable
-    case payload['reportable_type']
-    when 'Comment'
-      link_to_commentables_on_reportables(commentable: reportable.commentable, host: host)
-    when 'Package'
-      link_to("#{reportable.name}", Rails.application.routes.url_helpers.package_show_path(package: reportable, project: reportable.project,
-                                                                                           anchor: 'comments-list', only_path: false, host: host))
-    when 'Project'
-      link_to("#{reportable.name}", Rails.application.routes.url_helpers.project_show_path(reportable, anchor: 'comments-list', only_path: false, host: host))
-    when 'User'
-      link_to("#{reportable.login}", Rails.application.routes.url_helpers.user_path(reportable, only_path: false, host: host))
+  def link_to_reportables(reportable:, host: nil)
+    case reportable
+    when Comment
+      link_to_commentables_on_reportables(commentable: reportable.commentable, host:)
+    when Package, Project
+      link_to("#{reportable.name}", link_for_reportables(reportable:, host:))
+    when User
+      link_to("#{reportable.login}", link_for_reportables(reportable:, host:))
     end
   end
 
-  def link_to_commentables_on_reportables(commentable:, host:)
+  def link_to_commentables_on_reportables(commentable:, host: nil)
     case commentable
     when BsRequest
-      link_to("Request #{commentable.number}", Rails.application.routes.url_helpers.request_show_path(commentable.number, anchor: 'comments-list', only_path: false, host: host))
+      link_to("Request #{commentable.number}", link_for_commentables_on_reportables(commentable:, host:))
     when BsRequestAction
-      link_to("Request #{commentable.bs_request.number}", Rails.application.routes.url_helpers.request_show_path(number: commentable.bs_request.number,
-                                                                                                                 request_action_id: commentable.id,
-                                                                                                                 anchor: 'tab-pane-changes', only_path: false, host: host))
-    when Package
-      link_to("#{commentable.name}", Rails.application.routes.url_helpers.package_show_path(package: commentable, project: commentable.project,
-                                                                                            anchor: 'comments-list', only_path: false, host: host))
-    when Project
-      link_to("#{commentable.name}", Rails.application.routes.url_helpers.project_show_path(commentable, anchor: 'comments-list', only_path: false, host: host))
+      link_to("Request #{commentable.bs_request.number}", link_for_commentables_on_reportables(commentable:, host:))
+    when Package, Project
+      link_to("#{commentable.name}", link_for_commentables_on_reportables(commentable:, host:))
     end
+  end
+
+  def link_for_reportables(reportable:, host: nil, notification: nil)
+    case reportable
+    when Comment
+      link_for_commentables_on_reportables(commentable: reportable.commentable, host:, notification:)
+    when Package
+      Rails.application.routes.url_helpers.package_show_path({ package: reportable,
+                                                               project: reportable.project,
+                                                               notification_id: notification&.id,
+                                                               anchor: 'comments-list' }.merge(opts_for_reportables(host)))
+    when Project
+      Rails.application.routes.url_helpers.project_show_path(reportable, { notification_id: notification&.id, anchor: 'comments-list' }.merge(opts_for_reportables(host)))
+    when User
+      Rails.application.routes.url_helpers.user_path(reportable, opts_for_reportables(host))
+    end
+  end
+
+  def link_for_commentables_on_reportables(commentable:, host: nil, notification: nil)
+    case commentable
+    when BsRequest
+      Rails.application.routes.url_helpers.request_show_path(commentable.number, { notification_id: notification&.id, anchor: 'comments-list' }.merge(opts_for_reportables(host)))
+    when BsRequestAction
+      Rails.application.routes.url_helpers.request_show_path({ number: commentable.bs_request.number, request_action_id: commentable.id,
+                                                               notification_id: notification&.id, anchor: 'tab-pane-changes' }.merge(opts_for_reportables(host)))
+    when Package
+      Rails.application.routes.url_helpers.package_show_path({ package: commentable,
+                                                               project: commentable.project,
+                                                               notification_id: notification&.id,
+                                                               anchor: 'comments-list' }.merge(opts_for_reportables(host)))
+    when Project
+      Rails.application.routes.url_helpers.project_show_path(commentable, { notification_id: notification&.id, anchor: 'comments-list' }.merge(opts_for_reportables(host)))
+    end
+  end
+
+  private
+
+  def opts_for_reportables(host)
+    return {} unless host
+
+    { only_path: false, host: }
   end
 end

--- a/src/api/app/views/event_mailer/create_report.html.haml
+++ b/src/api/app/views/event_mailer/create_report.html.haml
@@ -4,4 +4,4 @@
 %p
   = event['reason']
 %p
-  = link_to_reportables(payload: event, host: @host)
+  = link_to_reportables(reportable: Report.find(event['id']).reportable, host: @host)


### PR DESCRIPTION
This moves the code around in order to unify how the links are created for the reportable notifications