### PR TITLE
Fix content-type header returned by `GET /worker/_status` API endpoint

### DIFF
--- a/src/api/app/controllers/worker/status_controller.rb
+++ b/src/api/app/controllers/worker/status_controller.rb
@@ -1,5 +1,5 @@
 class Worker::StatusController < ApplicationController
   def index
-    send_data(WorkerStatus.hidden.to_xml)
+    render xml: WorkerStatus.hidden
   end
 end


### PR DESCRIPTION
Change the headers returned by the `GET /worker/_status` endpoint.

### Headers returned before the proposed changes

```
Content-Type: application/octet-stream
Content-Disposition: attachment
Content-Transfer-Encoding: binary
```

### Headers returned after the proposed changes

```
Content-Type: application/xml; charset=utf-8
```

No `Content-Disposition` and `Content-Transfer-Encoding` headers returned.

Partially addresses #14478.

## To reviewers

- Perform the following API request before the changes of this pull request and after them, in your development environment:
```
curl -i -u Admin:opensuse -H 'Content-Type: application/xml; charset=utf-8' "http://localhost:3000/worker/_status"
```
- Check the headers returned.