### PR TITLE
Core component: modal

### DIFF
--- a/src/api/app/assets/stylesheets/webui/modals.scss
+++ b/src/api/app/assets/stylesheets/webui/modals.scss
@@ -1,4 +1,7 @@
 .modal {
+  font-size: var(--bs-body-font-size);
+  color: $body-color;
+
   .modal-header h5 {
     color: $body-color;
     overflow-x: hidden;

--- a/src/api/app/components/modal_component.html.haml
+++ b/src/api/app/components/modal_component.html.haml
@@ -1,0 +1,17 @@
+= button
+
+.modal.fade{ id: "#{@modal_id}-modal",
+             tabindex: -1,
+             role: 'dialog',
+             aria: { labelledby: "#{@modal_id}-modal-label", hidden: 'true' }
+           }
+  .modal-dialog.modal-dialog-centered{ role: 'document' }
+    .modal-content
+      - if header?
+        .modal-header
+          %h5.wrap-text.modal-title{ id: "#{@modal_id}-modal-label" }= header
+      .modal-body
+        = content
+      - if footer?
+        .modal-footer
+          = footer

--- a/src/api/app/components/modal_component.rb
+++ b/src/api/app/components/modal_component.rb
@@ -1,0 +1,21 @@
+class ModalComponent < ApplicationComponent
+  renders_one :header
+  renders_one :footer
+
+  def initialize(modal_id:, modal_button_data: {})
+    super
+
+    @modal_id = modal_id
+    @modal_button_data = modal_button_data
+  end
+
+  def button
+    return if @modal_button_data.empty?
+
+    render(ButtonComponent.new(type: @modal_button_data[:type] || 'secondary',
+                               text: @modal_button_data[:text],
+                               icon_type: @modal_button_data[:icon],
+                               button_data: { 'bs-toggle': 'modal',
+                                              'bs-target': "##{@modal_id}-modal" }))
+  end
+end

--- a/src/api/spec/components/modal_component_spec.rb
+++ b/src/api/spec/components/modal_component_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe ModalComponent, type: :component do
+  describe '#modal_object' do
+    context 'creating a modal header, footer and button slots content' do
+      before do
+        component = described_class.new(modal_id: 'simple', modal_button_data: { text: 'Open modal dialog' })
+        component.with_header { 'Simple modal header' }
+        component.with_footer { 'Footer modal dialog' }
+
+        render_inline(component)
+      end
+
+      it 'renders the content for the header slot' do
+        expect(rendered_content).to have_text('Simple modal header', count: 1)
+      end
+
+      it 'renders the content for the footer slot' do
+        expect(rendered_content).to have_text('Footer modal dialog', count: 1)
+      end
+
+      it 'renders the content for the button slot' do
+        expect(rendered_content).to have_text('Open modal dialog', count: 1)
+      end
+    end
+  end
+end

--- a/src/api/spec/components/previews/modal_component_preview.rb
+++ b/src/api/spec/components/previews/modal_component_preview.rb
@@ -1,0 +1,37 @@
+class ModalComponentPreview < ViewComponent::Preview
+  def simple_modal_with_button
+    render(ModalComponent.new(modal_id: 'simple',
+                              modal_button_data: { text: 'Open modal dialog',
+                                                   type: 'info',
+                                                   icon: 'fa fa-eye' })) do |component|
+      component.with_header { tag.span('Simple modal header') }
+      component.with_footer do
+        tag.button('Cancel',
+                   class: 'btn btn-outline-danger',
+                   data: { 'bs-dismiss': 'modal' })
+           .concat(tag.button('Simple button', class: 'btn btn-success'))
+      end
+      tag.span('Simple modal content')
+    end
+  end
+
+  def simple_modal_with_icon_button
+    render(ModalComponent.new(modal_id: 'simple',
+                              modal_button_data: { type: 'warning',
+                                                   icon: 'fa fa-eye' })) do |component|
+      component.with_header { tag.span('Simple modal header') }
+      component.with_footer { tag.button('Simple button', class: 'btn btn-warning') }
+      tag.span('Simple modal content')
+    end
+  end
+
+  def simple_modal_with_text_button
+    render(ModalComponent.new(modal_id: 'simple',
+                              modal_button_data: { type: 'info',
+                                                   text: 'Open modal dialog' })) do |component|
+      component.with_header { tag.span('Simple modal header') }
+      component.with_footer { tag.button('Simple button', class: 'btn btn-success') }
+      tag.span('Simple modal content')
+    end
+  end
+end


### PR DESCRIPTION
Introduce modal core [component](https://viewcomponent.org/) in order to standardize and reuse it.

Previews available at http://obs-reviewlab.opensuse.org/ncounter-modal-core-components/rails/view_components/modal_component

Same as https://github.com/openSUSE/open-build-service/pull/15030