### PR TITLE
Drops Package.get_by_project_and_name!

### DIFF
--- a/src/api/app/models/bs_request_action_submit.rb
+++ b/src/api/app/models/bs_request_action_submit.rb
@@ -128,10 +128,7 @@ class BsRequestActionSubmit < BsRequestAction
     initialize_devel_package = target_project.find_attribute('OBS', 'InitializeDevelPackage')
     return if target_package || !initialize_devel_package
 
-    opts = { follow_project_links: false }
-    source_package = Package.get_by_project_and_name!(source_project,
-                                                      self.source_package,
-                                                      opts)
+    source_package = Package.get_by_project_and_name(source_project, self.source_package, follow_project_links: false)
     return if User.session!.can_modify?(source_package)
 
     msg = 'No permission to initialize the source package as a devel package'

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -225,13 +225,6 @@ class Package < ApplicationRecord
     pkg
   end
 
-  def self.get_by_project_and_name!(project, package, opts = {})
-    pkg = get_by_project_and_name(project, package, opts)
-    raise UnknownObjectError, "Package not found: #{project}/#{package}" unless pkg
-
-    pkg
-  end
-
   # to check existens of a project (local or remote)
   def self.exists_by_project_and_name(project, package, opts = {})
     opts = { follow_project_links: true, allow_remote_packages: false, follow_multibuild: false }.merge(opts)


### PR DESCRIPTION
It's only used once and only with conditions where get_by_project_and_name won't return nil (remote packages).