### PR TITLE
Split up report event class

### DIFF
--- a/src/api/app/components/notification_action_description_component.rb
+++ b/src/api/app/components/notification_action_description_component.rb
@@ -29,7 +29,8 @@ class NotificationActionDescriptionComponent < ApplicationComponent
         "#{@user} removed #{@recipient} as #{@role} of #{@target_object}"
       when 'Event::BuildFail'
         "Build was triggered because of #{@notification.event_payload['reason']}"
-      when 'Event::CreateReport'
+      # TODO: Remove `Event::CreateReport` after all existing records are migrated to the new STI classes
+      when 'Event::CreateReport', 'Event::ReportForProject', 'Event::ReportForPackage', 'Event::ReportForComment', 'Event::ReportForUser'
         "'#{@notification.notifiable.user.login}' created a report for a #{@notification.event_payload['reportable_type'].downcase}. This is the reason:"
       when 'Event::ClearedDecision'
         class_name = @notification.notifiable.reports.first.reportable.class.name.downcase

--- a/src/api/app/components/notification_notifiable_link_component.rb
+++ b/src/api/app/components/notification_notifiable_link_component.rb
@@ -43,7 +43,8 @@ class NotificationNotifiableLinkComponent < ApplicationComponent
       repository = @notification.event_payload['repository']
       arch = @notification.event_payload['arch']
       "Package #{package} on #{project} project failed to build against #{repository} / #{arch}"
-    when 'Event::CreateReport'
+    # TODO: Remove `Event::CreateReport` after all existing records are migrated to the new STI classes
+    when 'Event::CreateReport', 'Event::ReportForProject', 'Event::ReportForPackage', 'Event::ReportForComment', 'Event::ReportForUser'
       "Report for a #{@notification.event_payload['reportable_type']}"
     when 'Event::ClearedDecision'
       # All reports should point to the same reportable. We will take care of that here:

--- a/src/api/app/helpers/webui/reportables_helper.rb
+++ b/src/api/app/helpers/webui/reportables_helper.rb
@@ -1,3 +1,4 @@
+# TODO: Remove this helper after all `Event::CreateReport` records are migrated to the STI report classes
 module Webui::ReportablesHelper
   include Webui::WebuiHelper
 

--- a/src/api/app/jobs/send_event_emails_job.rb
+++ b/src/api/app/jobs/send_event_emails_job.rb
@@ -31,7 +31,8 @@ class SendEventEmailsJob < ApplicationJob
   end
 
   def event_subscribers(event:)
-    if event.is_a?(Event::CreateReport)
+    # TODO: Remove `Event::CreateReport` after all existing records are migrated to the new STI classes
+    if event.is_a?(Event::CreateReport) || event.is_a?(Event::Report)
       event.subscribers.filter_map { |subscriber| subscriber if ReportPolicy.new(subscriber, Report).notify? }
     else
       event.subscribers

--- a/src/api/app/models/event/base.rb
+++ b/src/api/app/models/event/base.rb
@@ -18,7 +18,10 @@ module Event
       'Event::CommentForRequest' => 'Receive notifications of comments created on a request for which you are...',
       'Event::RelationshipCreate' => "Receive notifications when someone adds you or your group to a project or package with any of these roles: #{Role.local_roles.to_sentence}.",
       'Event::RelationshipDelete' => "Receive notifications when someone removes you or your group from a project or package with any of these roles: #{Role.local_roles.to_sentence}.",
-      'Event::CreateReport' => 'Receive notifications for reported content.',
+      'Event::ReportForComment' => 'Receive notifications for reported comments.',
+      'Event::ReportForPackage' => 'Receive notifications for reported packages.',
+      'Event::ReportForProject' => 'Receive notifications for reported projects.',
+      'Event::ReportForUser' => 'Receive notifications for reported users.',
       'Event::ClearedDecision' => 'Receive notifications for cleared report decisions.',
       'Event::FavoredDecision' => 'Receive notifications for favored report decisions.'
     }.freeze
@@ -36,7 +39,8 @@ module Event
         ['Event::BuildFail', 'Event::ServiceFail', 'Event::ReviewWanted', 'Event::RequestCreate',
          'Event::RequestStatechange', 'Event::CommentForProject', 'Event::CommentForPackage',
          'Event::CommentForRequest',
-         'Event::RelationshipCreate', 'Event::RelationshipDelete', 'Event::CreateReport'].map(&:constantize)
+         'Event::RelationshipCreate', 'Event::RelationshipDelete',
+         'Event::ReportForComment', 'Event::ReportForPackage', 'Event::ReportForProject', 'Event::ReportForUser'].map(&:constantize)
       end
 
       def classnames

--- a/src/api/app/models/event/create_report.rb
+++ b/src/api/app/models/event/create_report.rb
@@ -1,3 +1,4 @@
+# TODO: Remove `Event::CreateReport` after all existing records are migrated to the new STI classes
 module Event
   class CreateReport < Base
     receiver_roles :moderator

--- a/src/api/app/models/event/report.rb
+++ b/src/api/app/models/event/report.rb
@@ -1,0 +1,12 @@
+module Event
+  class Report < Base
+    receiver_roles :moderator
+    self.description = 'Report for inappropriate content has been created'
+
+    payload_keys :id, :user_id, :reportable_id, :reportable_type, :reason
+
+    def parameters_for_notification
+      super.merge(notifiable_type: 'Report')
+    end
+  end
+end

--- a/src/api/app/models/event/report_for_comment.rb
+++ b/src/api/app/models/event/report_for_comment.rb
@@ -1,5 +1,7 @@
 module Event
   class ReportForComment < Report
     self.description = 'Report for a comment has been created'
+    payload_keys :commentable_type, :bs_request_number, :bs_request_action_id,
+                 :project_name, :package_name
   end
 end

--- a/src/api/app/models/event/report_for_comment.rb
+++ b/src/api/app/models/event/report_for_comment.rb
@@ -1,0 +1,5 @@
+module Event
+  class ReportForComment < Report
+    self.description = 'Report for a comment has been created'
+  end
+end

--- a/src/api/app/models/event/report_for_package.rb
+++ b/src/api/app/models/event/report_for_package.rb
@@ -1,5 +1,6 @@
 module Event
   class ReportForPackage < Report
     self.description = 'Report for a package has been created'
+    payload_keys :package_name, :project_name
   end
 end

--- a/src/api/app/models/event/report_for_package.rb
+++ b/src/api/app/models/event/report_for_package.rb
@@ -1,0 +1,5 @@
+module Event
+  class ReportForPackage < Report
+    self.description = 'Report for a package has been created'
+  end
+end

--- a/src/api/app/models/event/report_for_project.rb
+++ b/src/api/app/models/event/report_for_project.rb
@@ -1,5 +1,6 @@
 module Event
   class ReportForProject < Report
     self.description = 'Report for a project has been created'
+    payload_keys :project_name
   end
 end

--- a/src/api/app/models/event/report_for_project.rb
+++ b/src/api/app/models/event/report_for_project.rb
@@ -1,0 +1,5 @@
+module Event
+  class ReportForProject < Report
+    self.description = 'Report for a project has been created'
+  end
+end

--- a/src/api/app/models/event/report_for_user.rb
+++ b/src/api/app/models/event/report_for_user.rb
@@ -1,0 +1,5 @@
+module Event
+  class ReportForUser < Report
+    self.description = 'Report for a user has been created'
+  end
+end

--- a/src/api/app/models/event/report_for_user.rb
+++ b/src/api/app/models/event/report_for_user.rb
@@ -1,5 +1,6 @@
 module Event
   class ReportForUser < Report
     self.description = 'Report for a user has been created'
+    payload_keys :user_login
   end
 end

--- a/src/api/app/models/event_subscription/for_channel_form.rb
+++ b/src/api/app/models/event_subscription/for_channel_form.rb
@@ -1,7 +1,8 @@
 class EventSubscription
   class ForChannelForm
     DISABLE_FOR_EVENTS = ['Event::ServiceFail'].freeze
-    DISABLE_RSS_FOR_EVENTS = ['Event::CreateReport'].freeze
+    DISABLE_RSS_FOR_EVENTS = ['Event::ReportForProject', 'Event::ReportForPackage',
+                              'Event::ReportForComment', 'Event::ReportForUser'].freeze
 
     attr_reader :name, :subscription
 

--- a/src/api/app/models/event_subscription/form.rb
+++ b/src/api/app/models/event_subscription/form.rb
@@ -44,7 +44,7 @@ class EventSubscription
     end
 
     def show_form_for_create_report_event?(event_class:, subscriber:)
-      if event_class.name == 'Event::CreateReport'
+      if event_class.name.in?(['Event::ReportForProject', 'Event::ReportForPackage', 'Event::ReportForComment', 'Event::ReportForUser'])
         # There is no subscriber for the global subscription configuration
         return false if subscriber.blank?
         return false unless ReportPolicy.new(subscriber, Report).notify?

--- a/src/api/app/models/report.rb
+++ b/src/api/app/models/report.rb
@@ -31,7 +31,16 @@ class Report < ApplicationRecord
   private
 
   def create_event
-    Event::CreateReport.create(event_parameters)
+    case reportable_type
+    when 'Comment'
+      Event::ReportForComment.create(event_parameters)
+    when 'Package'
+      Event::ReportForPackage.create(event_parameters)
+    when 'Project'
+      Event::ReportForProject.create(event_parameters)
+    when 'User'
+      Event::ReportForUser.create(event_parameters)
+    end
   end
 
   def event_parameters

--- a/src/api/app/models/report.rb
+++ b/src/api/app/models/report.rb
@@ -33,18 +33,34 @@ class Report < ApplicationRecord
   def create_event
     case reportable_type
     when 'Comment'
-      Event::ReportForComment.create(event_parameters)
+      Event::ReportForComment.create(event_parameters_for_comment(commentable: reportable.commentable))
     when 'Package'
-      Event::ReportForPackage.create(event_parameters)
+      Event::ReportForPackage.create(event_parameters.merge(package_name: reportable.name,
+                                                            project_name: reportable.project.name))
     when 'Project'
-      Event::ReportForProject.create(event_parameters)
+      Event::ReportForProject.create(event_parameters.merge(project_name: reportable.name))
     when 'User'
-      Event::ReportForUser.create(event_parameters)
+      Event::ReportForUser.create(event_parameters.merge(user_login: reportable.login))
     end
   end
 
   def event_parameters
     { id: id, user_id: user_id, reportable_id: reportable_id, reportable_type: reportable_type, reason: reason }
+  end
+
+  def event_parameters_for_comment(commentable:)
+    case commentable
+    when BsRequest
+      event_parameters.merge(commentable_type: commentable.class.name, bs_request_number: commentable.number)
+    when BsRequestAction
+      event_parameters.merge(commentable_type: commentable.class.name, bs_request_number: commentable.bs_request.number,
+                             bs_request_action_id: commentable.id)
+    when Package
+      event_parameters.merge(commentable_type: commentable.class.name, package_name: commentable.name,
+                             project_name: commentable.project.name)
+    when Project
+      event_parameters.merge(commentable_type: commentable.class.name, project_name: commentable.name)
+    end
   end
 end
 

--- a/src/api/app/queries/notifications_finder.rb
+++ b/src/api/app/queries/notifications_finder.rb
@@ -3,7 +3,11 @@ class NotificationsFinder
     @relation = if Flipper.enabled?(:content_moderation, User.session)
                   relation.order(created_at: :desc)
                 else
-                  relation.where.not(event_type: ['Event::CreateReport', 'Event::ClearedDecision', 'Event::FavoredDecision']).order(created_at: :desc)
+                  # TODO: Remove `Event::CreateReport` after all existing records are migrated to the new STI classes
+                  relation.where.not(event_type: ['Event::CreateReport',
+                                                  'Event::ReportForProject', 'Event::ReportForPackage',
+                                                  'Event::ReportForComment', 'Event::ReportForUser',
+                                                  'Event::ClearedDecision', 'Event::FavoredDecision']).order(created_at: :desc)
                 end
   end
 
@@ -44,7 +48,10 @@ class NotificationsFinder
   end
 
   def for_reports
-    @relation.where(event_type: ['Event::CreateReport', 'Event::ClearedDecision', 'Event::FavoredDecision'], delivered: false)
+    # TODO: Remove `Event::CreateReport` after all existing records are migrated to the new STI classes
+    @relation.where(event_type: ['Event::CreateReport', 'Event::ReportForProject', 'Event::ReportForPackage',
+                                 'Event::ReportForComment', 'Event::ReportForUser',
+                                 'Event::ClearedDecision', 'Event::FavoredDecision'], delivered: false)
   end
 
   # rubocop:disable Metrics/CyclomaticComplexity

--- a/src/api/app/services/notification_service/notifier.rb
+++ b/src/api/app/services/notification_service/notifier.rb
@@ -1,5 +1,6 @@
 module NotificationService
   class Notifier
+    # TODO: Remove `Event::CreateReport` after all existing records are migrated to the new STI classes
     EVENTS_TO_NOTIFY = ['Event::BuildFail',
                         'Event::RequestStatechange',
                         'Event::RequestCreate',
@@ -10,6 +11,10 @@ module NotificationService
                         'Event::RelationshipCreate',
                         'Event::RelationshipDelete',
                         'Event::CreateReport',
+                        'Event::ReportForProject',
+                        'Event::ReportForPackage',
+                        'Event::ReportForComment',
+                        'Event::ReportForUser',
                         'Event::ClearedDecision',
                         'Event::FavoredDecision'].freeze
     CHANNELS = [:web, :rss].freeze
@@ -25,7 +30,12 @@ module NotificationService
       web: NotificationService::WebChannel,
       rss: NotificationService::RSSChannel
     }.freeze
+    # TODO: Remove `Event::CreateReport` after all existing records are migrated to the new STI classes
     REJECTED_FOR_RSS = ['Event::CreateReport',
+                        'Event::ReportForProject',
+                        'Event::ReportForPackage',
+                        'Event::ReportForComment',
+                        'Event::ReportForUser',
                         'Event::ClearedDecision',
                         'Event::FavoredDecision'].freeze
 
@@ -62,7 +72,8 @@ module NotificationService
     end
 
     def create_report_notification?(event:, subscriber:)
-      return false if event.is_a?(Event::CreateReport) && !ReportPolicy.new(subscriber, Report).notify?
+      # TODO: Remove `Event::CreateReport` after all existing records are migrated to the new STI classes
+      return false if (event.is_a?(Event::CreateReport) || event.is_a?(Event::Report)) && !ReportPolicy.new(subscriber, Report).notify?
 
       true
     end

--- a/src/api/app/views/event_mailer/create_report.html.haml
+++ b/src/api/app/views/event_mailer/create_report.html.haml
@@ -1,3 +1,4 @@
+//TODO: Remove this view after all `Event::CreateReport` records are migrated to the STI report classes
 %p
   = User.find(event['user_id']).login
   reported a #{event['reportable_type'].downcase} for the following reason:

--- a/src/api/app/views/event_mailer/report_for_comment.html.haml
+++ b/src/api/app/views/event_mailer/report_for_comment.html.haml
@@ -1,0 +1,19 @@
+%p
+  = User.find(event['user_id']).login
+  reported a #{event['reportable_type'].downcase} for the following reason:
+%p
+  = event['reason']
+%p
+  - case event['commentable_type']
+  - when 'BsRequest'
+    = link_to("Request #{event['bs_request_number']}", request_show_url(event['bs_request_number'],
+                                                                         anchor: 'comments-list', only_path: false, host: @host))
+  - when 'BsRequestAction'
+    = link_to("Request #{event['bs_request_number']}", request_show_url(number: event['bs_request_number'],
+                                                                         request_action_id: event['bs_request_action_id'],
+                                                                         anchor: 'tab-pane-changes', only_path: false, host: @host))
+  - when 'Package'
+    = link_to("#{event['package_name']}", package_show_url(package: event['package_name'], project: event['project_name'],
+                                                            anchor: 'comments-list', only_path: false, host: @host))
+  - when 'Project'
+    = link_to("#{event['project_name']}", project_show_url(event['project_name'], anchor: 'comments-list', only_path: false, host: @host))

--- a/src/api/app/views/event_mailer/report_for_package.html.haml
+++ b/src/api/app/views/event_mailer/report_for_package.html.haml
@@ -1,0 +1,8 @@
+%p
+  = User.find(event['user_id']).login
+  reported a #{event['reportable_type'].downcase} for the following reason:
+%p
+  = event['reason']
+%p
+  = link_to("#{event['package_name']}", package_show_url(package: event['package_name'], project: event['project_name'],
+                                                          anchor: 'comments-list', only_path: false, host: @host))

--- a/src/api/app/views/event_mailer/report_for_project.html.haml
+++ b/src/api/app/views/event_mailer/report_for_project.html.haml
@@ -1,0 +1,9 @@
+%p
+  = User.find(event['user_id']).login
+  reported a #{event['reportable_type'].downcase} for the following reason:
+%p
+  = event['reason']
+%p
+  = link_to("#{event['project_name']}", project_show_url(event['project_name'],
+                                                         anchor: 'comments-list',
+                                                         only_path: false, host: @host))

--- a/src/api/app/views/event_mailer/report_for_user.html.haml
+++ b/src/api/app/views/event_mailer/report_for_user.html.haml
@@ -1,0 +1,7 @@
+%p
+  = User.find(event['user_id']).login
+  reported a #{event['reportable_type'].downcase} for the following reason:
+%p
+  = event['reason']
+%p
+  = link_to("#{event['user_login']}", user_url(event['user_login'], only_path: false, host: @host))

--- a/src/api/lib/tasks/dev/rake_support.rb
+++ b/src/api/lib/tasks/dev/rake_support.rb
@@ -50,7 +50,12 @@ module RakeSupport
     create(:event_subscription_comment_for_request, channel: :web, user: user, receiver_role: 'target_maintainer')
     create(:event_subscription_relationship_create, channel: :web, user: user, receiver_role: 'any_role')
     create(:event_subscription_relationship_delete, channel: :web, user: user, receiver_role: 'any_role')
+    # TODO: Remove `Event::CreateReport` after all existing records are migrated to the new STI classes
     create(:event_subscription_create_report, channel: :web, user: user)
+    create(:event_subscription_report_for_project, channel: :web, user: user)
+    create(:event_subscription_report_for_package, channel: :web, user: user)
+    create(:event_subscription_report_for_comment, channel: :web, user: user)
+    create(:event_subscription_report_for_user, channel: :web, user: user)
 
     user.groups.each do |group|
       create(:event_subscription_request_created, channel: :web, user: nil, group: group, receiver_role: 'target_maintainer')

--- a/src/api/spec/factories/event_subscriptions.rb
+++ b/src/api/spec/factories/event_subscriptions.rb
@@ -78,8 +78,41 @@ FactoryBot.define do
       group { nil }
     end
 
+    # TODO: Remove `Event::CreateReport` after all existing records are migrated to the new STI classes
     factory :event_subscription_create_report do
       eventtype { 'Event::CreateReport' }
+      receiver_role { 'moderator' }
+      channel { :instant_email }
+      user
+      group { nil }
+    end
+
+    factory :event_subscription_report_for_project do
+      eventtype { 'Event::ReportForProject' }
+      receiver_role { 'moderator' }
+      channel { :instant_email }
+      user
+      group { nil }
+    end
+
+    factory :event_subscription_report_for_package do
+      eventtype { 'Event::ReportForPackage' }
+      receiver_role { 'moderator' }
+      channel { :instant_email }
+      user
+      group { nil }
+    end
+
+    factory :event_subscription_report_for_comment do
+      eventtype { 'Event::ReportForComment' }
+      receiver_role { 'moderator' }
+      channel { :instant_email }
+      user
+      group { nil }
+    end
+
+    factory :event_subscription_report_for_user do
+      eventtype { 'Event::ReportForUser' }
       receiver_role { 'moderator' }
       channel { :instant_email }
       user

--- a/src/api/spec/mailers/event_mailer_spec.rb
+++ b/src/api/spec/mailers/event_mailer_spec.rb
@@ -252,13 +252,16 @@ RSpec.describe EventMailer, :vcr do
       end
     end
 
+    # TODO: Remove this test after all `Event::CreateReport` records are migrated to the STI report classes
     context 'for an event of type Event::CreateReport' do
       let(:admin) { create(:admin_user) }
       let!(:subscription) { create(:event_subscription_create_report, user: admin) }
       let(:mail) { EventMailer.with(subscribers: Event::CreateReport.last.subscribers, event: Event::CreateReport.last).notification_email.deliver_now }
 
       before do
-        create(:report, reason: 'Because reasons')
+        report = create(:report, reason: 'Because reasons')
+        Event::CreateReport.create({ id: report.id, user_id: report.user_id, reportable_id: report.reportable_id,
+                                     reportable_type: report.reportable_type, reason: report.reason })
       end
 
       it 'gets delivered' do

--- a/src/api/spec/mailers/event_mailer_spec.rb
+++ b/src/api/spec/mailers/event_mailer_spec.rb
@@ -278,6 +278,104 @@ RSpec.describe EventMailer, :vcr do
       end
     end
 
+    context 'for an event of type Event::ReportForProject' do
+      let(:admin) { create(:admin_user) }
+      let!(:subscription) { create(:event_subscription_report_for_project, user: admin) }
+      let(:mail) { EventMailer.with(subscribers: Event::ReportForProject.last.subscribers, event: Event::ReportForProject.last).notification_email.deliver_now }
+      let(:project) { create(:project, name: 'foo') }
+
+      before do
+        create(:report, reportable: project, reason: 'Because reasons')
+      end
+
+      it 'gets delivered' do
+        expect(ActionMailer::Base.deliveries).to include(mail)
+      end
+
+      it 'contains the correct text' do
+        expect(mail.body.encoded).to include('reported a project for the following reason:')
+        expect(mail.body.encoded).to include('Because reasons')
+      end
+
+      it 'renders link to the project page' do
+        expect(mail.body.encoded).to include('<a href="https://build.example.com/project/show/foo#comments-list">foo</a>')
+      end
+    end
+
+    context 'for an event of type Event::ReportForPackage' do
+      let(:admin) { create(:admin_user) }
+      let!(:subscription) { create(:event_subscription_report_for_package, user: admin) }
+      let(:mail) { EventMailer.with(subscribers: Event::ReportForPackage.last.subscribers, event: Event::ReportForPackage.last).notification_email.deliver_now }
+      let(:project) { create(:project, name: 'foo') }
+      let(:package) { create(:package, name: 'bar', project: project) }
+
+      before do
+        create(:report, reportable: package, reason: 'Because reasons')
+      end
+
+      it 'gets delivered' do
+        expect(ActionMailer::Base.deliveries).to include(mail)
+      end
+
+      it 'contains the correct text' do
+        expect(mail.body.encoded).to include('reported a package for the following reason:')
+        expect(mail.body.encoded).to include('Because reasons')
+      end
+
+      it 'renders link to the package page' do
+        expect(mail.body.encoded).to include('<a href="https://build.example.com/package/show/foo/bar#comments-list">bar</a>')
+      end
+    end
+
+    context 'for an event of type Event::ReportForUser' do
+      let(:admin) { create(:admin_user) }
+      let!(:subscription) { create(:event_subscription_report_for_user, user: admin) }
+      let(:mail) { EventMailer.with(subscribers: Event::ReportForUser.last.subscribers, event: Event::ReportForUser.last).notification_email.deliver_now }
+      let(:user) { create(:user, login: 'hans') }
+
+      before do
+        create(:report, reportable: user, reason: 'Because reasons')
+      end
+
+      it 'gets delivered' do
+        expect(ActionMailer::Base.deliveries).to include(mail)
+      end
+
+      it 'contains the correct text' do
+        expect(mail.body.encoded).to include('reported a user for the following reason:')
+        expect(mail.body.encoded).to include('Because reasons')
+      end
+
+      it 'renders link to the user page' do
+        expect(mail.body.encoded).to include('<a href="https://build.example.com/users/hans">hans</a>')
+      end
+    end
+
+    context 'for an event of type Event::ReportForComment' do
+      let(:admin) { create(:admin_user) }
+      let!(:subscription) { create(:event_subscription_report_for_comment, user: admin) }
+      let(:mail) { EventMailer.with(subscribers: Event::ReportForComment.last.subscribers, event: Event::ReportForComment.last).notification_email.deliver_now }
+      let(:project) { create(:project, name: 'foo') }
+      let(:comment) { create(:comment_project, commentable: project) }
+
+      before do
+        create(:report, reportable: comment, reason: 'Because reasons')
+      end
+
+      it 'gets delivered' do
+        expect(ActionMailer::Base.deliveries).to include(mail)
+      end
+
+      it 'contains the correct text' do
+        expect(mail.body.encoded).to include('reported a comment for the following reason:')
+        expect(mail.body.encoded).to include('Because reasons')
+      end
+
+      it 'renders link to the page of the comment' do
+        expect(mail.body.encoded).to include('<a href="https://build.example.com/project/show/foo#comments-list">foo</a>')
+      end
+    end
+
     context 'when the subscriber has no email' do
       let(:group) { create(:group, email: nil) }
       let(:event) { Event::RequestCreate.first }


### PR DESCRIPTION
This is the first PR to split up the events created by reports. The code still supports the old implementation of the `Event::CreateReport` class. But after this PR is merged we won't produce new records with this anymore, but instead the new STI event classes.
This enables us to safely deploy those changes, then migrate existing records first and finally remove the old implementation.

HOW TO TEST THIS:

1. Create some test data with `bundle exec rake dev:test_data:create`
2. The rake task will produce some reports and corresponding notifications
3. Check that notifications are still produced and the links on those are still working
4. Check the subscription form, it won't show the subscription option for the `Event::CreateReport` anymore, but should show the new ones
