### PR TITLE
Fix "not_found" API responses

### DIFF
--- a/src/api/app/controllers/concerns/rescue_handler.rb
+++ b/src/api/app/controllers/concerns/rescue_handler.rb
@@ -42,8 +42,20 @@ module RescueHandler
       render_error status: 403, errorcode: 'modify_package_no_permission', message: exception.message
     end
 
-    rescue_from Backend::NotFoundError, ActiveRecord::RecordNotFound do |exception|
-      render_error message: exception.message, status: 404, errorcode: 'not_found'
+    rescue_from ActiveRecord::RecordNotFound do |exception|
+      render_error message: exception.message, status: 404
+    end
+
+    rescue_from Backend::NotFoundError do |exception|
+      parsed_response = Nokogiri::XML(exception.message).xpath('//summary')
+
+      summary = if parsed_response.present?
+                  parsed_response.first.content
+                else
+                  exception.message
+                end
+
+      render_error message: summary, status: 404
     end
   end
 end

--- a/src/api/public/apidocs/paths/source_project_name_cmd_undelete.yaml
+++ b/src/api/public/apidocs/paths/source_project_name_cmd_undelete.yaml
@@ -25,18 +25,12 @@ post:
         application/xml; charset=utf-8:
           schema:
             $ref: '../components/schemas/api_response.yaml'
-          example:
-            code: not_found
-            summary: |
-              <status code="not_found">
-                <summary>
-                  &lt;status code="404"&gt;
-                  &lt;summary&gt;project 'Sandbox' already exists&lt;/summary&gt;
-                  &lt;details&gt;404 project 'Sandbox' already exists&lt;/details&gt;
-                  &lt;/status&gt;
-                </summary>
-              </status>
-            description: Response when trying to "undelete" a project that was not deleted previously.
+          examples:
+            Not deleted project:
+              value:
+                code: 404
+                summary: project 'Sandbox' already exists
+              description: Response when trying to "undelete" a project that was not deleted previously.
     '401':
       $ref: '../components/responses/unauthorized.yaml'
   tags:

--- a/src/api/public/apidocs/paths/worker_cmd_checkconstraints.yaml
+++ b/src/api/public/apidocs/paths/worker_cmd_checkconstraints.yaml
@@ -104,11 +104,7 @@ post:
           schema:
             $ref: '../components/schemas/api_response.yaml'
           example:
-            code: 'not_found'
-            summary: |
-              &lt;status code="404"&gt;
-              &lt;summary&gt;repository 'home:Admin/openSUSE_Tumbleweed' has no architecture 'x86_64d'&lt;/summary&gt;
-              &lt;details&gt;404 repository 'home:Admin/openSUSE_Tumbleweed' has no architecture 'x86_64d'&lt;/details&gt;
-              &lt;/status&gt;
+            code: 404
+            summary: repository 'home:Admin/openSUSE_Tumbleweed' has no architecture 'x86_64d'
   tags:
     - Workers


### PR DESCRIPTION
For "Not Found" exceptions happening in the backend, return the `summary` section of that XML response.

Also, adapt the documentation accordingly.

## Before

![Screenshot from 2023-10-11 17-00-54](https://github.com/openSUSE/open-build-service/assets/24919/f2dd4d1c-82c4-40d3-9fa6-e7097e2a7779)

## After

![Screenshot from 2023-10-12 15-59-58](https://github.com/openSUSE/open-build-service/assets/24919/86d990d2-36a9-4033-b2b4-76fcad7704e5)

## For reviewers

Take a look at the 404 responses for the modified API endpoints in the review-app:
- [POST /source/{project_name}?cmd=undelete](https://obs-reviewlab.opensuse.org/eduardoj-fixapidocs_not_found_responses/apidocs/index#/Sources%20-%20Projects/post_source__project_name__cmd_undelete)
- [POST /worker?cmd=checkconstraints](https://obs-reviewlab.opensuse.org/eduardoj-fixapidocs_not_found_responses/apidocs/index#/Workers/post_worker_cmd_checkconstraints)
