### PR TITLE
Stop setting options that are already default, II

### DIFF
--- a/src/api/app/controllers/issue_trackers_controller.rb
+++ b/src/api/app/controllers/issue_trackers_controller.rb
@@ -18,7 +18,7 @@ class IssueTrackersController < ApplicationController
   # GET /issue_trackers/<name>
   def show
     @issue_tracker = IssueTracker.find_by_name(params[:name])
-    render_error(status: 404, errorcode: 'not_found', message: "Unable to find issue tracker '#{params[:name]}'") && return unless @issue_tracker
+    render_error(status: 404, message: "Unable to find issue tracker '#{params[:name]}'") && return unless @issue_tracker
 
     respond_to do |format|
       format.xml  { render xml: @issue_tracker.to_xml(IssueTracker::DEFAULT_RENDER_PARAMS) }
@@ -75,7 +75,7 @@ class IssueTrackersController < ApplicationController
   # DELETE /issue_trackers/<name>
   def destroy
     @issue_tracker = IssueTracker.find_by_name(params[:name])
-    render_error(status: 404, errorcode: 'not_found', message: "Unable to find issue tracker '#{params[:name]}'") && return unless @issue_tracker
+    render_error(status: 404, message: "Unable to find issue tracker '#{params[:name]}'") && return unless @issue_tracker
 
     @issue_tracker.destroy
 

--- a/src/api/app/controllers/staging/staged_requests_controller.rb
+++ b/src/api/app/controllers/staging/staged_requests_controller.rb
@@ -69,11 +69,7 @@ class Staging::StagedRequestsController < Staging::StagingController
     @staging_project = @staging_workflow.staging_projects.find_by(name: params[:staging_project_name])
     return if @staging_project
 
-    render_error(
-      status: 404,
-      errorcode: 'not_found',
-      message: "Staging Project '#{params[:staging_project_name]}' not found in Staging: '#{@staging_workflow.project}'"
-    )
+    render_error status: 404, message: "Staging Project '#{params[:staging_project_name]}' not found in Staging: '#{@staging_workflow.project}'"
   end
 
   def check_overall_state

--- a/src/api/app/controllers/staging/staging_controller.rb
+++ b/src/api/app/controllers/staging/staging_controller.rb
@@ -5,22 +5,14 @@ module Staging
     def set_project
       @project = Project.get_by_name(params[:staging_workflow_project])
     rescue Project::UnknownObjectError
-      render_error(
-        status: 404,
-        errorcode: 'not_found',
-        message: "Project '#{params[:staging_workflow_project]}' not found."
-      )
+      render_error status: 404, message: "Project '#{params[:staging_workflow_project]}' not found."
     end
 
     def set_staging_workflow
       @staging_workflow = @project.staging
       return if @staging_workflow
 
-      render_error(
-        status: 404,
-        errorcode: 'not_found',
-        message: "Project #{@project} doesn't have an associated Staging Workflow"
-      )
+      render_error status: 404, message: "Project #{@project} doesn't have an associated Staging Workflow"
     end
 
     def set_xml_hash

--- a/src/api/app/controllers/status/required_checks_controller.rb
+++ b/src/api/app/controllers/status/required_checks_controller.rb
@@ -71,11 +71,7 @@ class Status::RequiredChecksController < ApplicationController
 
     return if @project
 
-    render_error(
-      status: 404,
-      errorcode: 'not_found',
-      message: "Project '#{params[:project_name]}' not found."
-    )
+    render_error status: 404, message: "Project '#{params[:project_name]}' not found."
   end
 
   def set_checkable
@@ -97,11 +93,7 @@ class Status::RequiredChecksController < ApplicationController
     @required_check = @checkable.required_checks.find(params[:id])
     return if @required_check
 
-    render_error(
-      status: 404,
-      errorcode: 'not_found',
-      message: "Unable to find required check with id '#{params[:id]}'"
-    )
+    render_error status: 404, message: "Unable to find required check with id '#{params[:id]}'"
   end
 
   def names


### PR DESCRIPTION
`errorcode` has a default value when `status` is `404`. Stop setting those options all over the app to their defaults again.

See [here](https://github.com/openSUSE/open-build-service/blob/004d2ff1f9ce1331a01e266163522d6da2e2591d/src/api/app/controllers/application_controller.rb#L151), where errorcode takes its default value.