### PR TITLE
Remove redefined handler for `Backend::Error` exceptions

### DIFF
--- a/src/api/app/controllers/concerns/rescue_handler.rb
+++ b/src/api/app/controllers/concerns/rescue_handler.rb
@@ -6,10 +6,6 @@ module RescueHandler
       render_error status: 400, errorcode: 'invalid_record', message: exception.record.errors.full_messages.join('\n')
     end
 
-    rescue_from Backend::Error do |exception|
-      render_error status: exception.code, errorcode: 'uncaught_exception', message: exception.summary
-    end
-
     rescue_from Timeout::Error do |exception|
       render_error status: 408, errorcode: 'timeout_error', message: exception.message
     end


### PR DESCRIPTION
This was duplicated in [this commit](https://github.com/openSUSE/open-build-service/commit/b263c6d33d1a27dc8405c9cd1d8eea707c5f233c#diff-acb1d17436d6c7263161f60f57b01e0f4c12ae09ef956e31e1ff67f813891ac4R411-R428).