### PR TITLE
Add maximum length validation for package url

### DIFF
--- a/src/api/.database_consistency.todo.yml
+++ b/src/api/.database_consistency.todo.yml
@@ -1502,9 +1502,6 @@ Package:
   token:
     MissingIndexChecker:
       enabled: false
-  url:
-    LengthConstraintChecker:
-      enabled: false
 PackageIssue:
   id:
     PrimaryKeyTypeChecker:

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -98,6 +98,7 @@ class Package < ApplicationRecord
   validates :name, presence: true, length: { maximum: 200 }
   validates :releasename, length: { maximum: 200 }
   validates :title, length: { maximum: 250 }
+  validates :url, length: { maximum: 255 }
   validates :description, length: { maximum: 65_535 }
   validates :project_id, uniqueness: {
     scope: :name,


### PR DESCRIPTION
Fixes #14544.

### After the changes

![Peek 2023-10-13 12-55-add-package-url-validation](https://github.com/openSUSE/open-build-service/assets/24919/1cbcbeaf-0ce1-4b6c-b56e-acd404c6f1c4)
