### PR TITLE
Increase length limit of URL to upload a file

### DIFF
--- a/src/api/app/views/webui/packages/files/new.html.haml
+++ b/src/api/app/views/webui/packages/files/new.html.haml
@@ -18,7 +18,7 @@
             .mb-3.package-add-file
               %label{ for: :file_url }
                 %strong File URL:
-              = text_field_tag :file_url, '', size: 80, maxlength: 200, class: 'form-control', type: :url
+              = text_field_tag :file_url, '', size: 80, maxlength: 2000, class: 'form-control', type: :url
               %small.form-text.text-muted
                 URLs to src.rpm files will get extracted. URLs to git repositories will get stored in a tar ball.
             = submit_tag 'Add File', class: 'btn btn-sm btn-primary', id: :submit_button


### PR DESCRIPTION
Related to #14544.

## To reviewers

- Browse one package in the [review-app](http://obs-reviewlab.opensuse.org/eduardoj-fixissue_14544_2).
- Click on the "Add an empty file or service " link
- Enter a very long url in the "File URL:" field, greater than 200 characters.
- Confirm you are able to upload the file.

