### PR TITLE
Remove 'wipe' from the list of valid package commands

### DIFF
--- a/src/api/app/controllers/source_controller.rb
+++ b/src/api/app/controllers/source_controller.rb
@@ -153,7 +153,7 @@ class SourceController < ApplicationController
                       'remove_flag', 'set_flag', 'undelete', 'runservice', 'waitservice',
                       'mergeservice', 'commit', 'commitfilelist', 'createSpecFileTemplate',
                       'deleteuploadrev', 'linktobranch', 'updatepatchinfo', 'getprojectservices',
-                      'unlock', 'release', 'importchannel', 'wipe', 'rebuild', 'collectbuildenv',
+                      'unlock', 'release', 'importchannel', 'rebuild', 'collectbuildenv',
                       'instantiate', 'addcontainers', 'addchannels', 'enablechannel']
 
     @command = params[:cmd]

--- a/src/api/public/apidocs/OBS-v2.10.50.yaml
+++ b/src/api/public/apidocs/OBS-v2.10.50.yaml
@@ -410,8 +410,6 @@ paths:
     $ref: 'paths/source_project_name_package_name_cmd_updatepatchinfo.yaml'
   /source/{project_name}/{package_name}?cmd=waitservice:
     $ref: 'paths/source_project_name_package_name_cmd_waitservice.yaml'
-  /source/{project_name}/{package_name}?cmd=wipe:
-    $ref: 'paths/source_project_name_package_name_cmd_wipe.yaml'
   /source/{project_name}/{package_name}?view=info:
     $ref: 'paths/source_project_name_package_name_view_info.yaml'
 

--- a/src/api/public/apidocs/paths/source_project_name_package_name_cmd_wipe.yaml
+++ b/src/api/public/apidocs/paths/source_project_name_package_name_cmd_wipe.yaml
@@ -1,9 +1,0 @@
-post:
-  deprecated: true
-  summary: Wipe package build results.
-  description: |
-    Wipe all build results of this package. This endpoint
-    is broken and will be removed.
-    See [`POST /build/{project_name}?cmd=wipe`](#/Build/post_build__project_name__cmd_wipe).
-  tags:
-    - Sources - Packages

--- a/src/api/test/functional/source_controller_test.rb
+++ b/src/api/test/functional/source_controller_test.rb
@@ -785,8 +785,6 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     assert_response 403
     post '/build/home:Iggy?cmd=wipe'
     assert_response 403
-    post '/source/home:Iggy/TestLinkPack?cmd=wipe'
-    assert_response 403
 
     # check branching from a locked project
     post '/source/home:Iggy/TestLinkPack', params: { cmd: 'branch' }


### PR DESCRIPTION
Before we throw an the internal exception _"undefined method `package_command_wipe'"_.

The method `package_command_wipe` was never implemented.

Now, calls to API endpoints like `POST /source/home:my_user/my_package?cmd=wipe` result in:
```
<status code="illegal_request">
  <summary>invalid_command</summary>
</status>
```

Fixes #13996.