### PR TITLE
Create default subscription to report events for moderators

### DIFF
--- a/src/api/db/data/20231016113740_create_default_subscription_for_report_events.rb
+++ b/src/api/db/data/20231016113740_create_default_subscription_for_report_events.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateDefaultSubscriptionForReportEvents < ActiveRecord::Migration[7.0]
+  def up
+    EventSubscription.create!(eventtype: Event::ReportForProject.name, channel: :web, receiver_role: :moderator, enabled: true)
+    EventSubscription.create!(eventtype: Event::ReportForPackage.name, channel: :web, receiver_role: :moderator, enabled: true)
+    EventSubscription.create!(eventtype: Event::ReportForComment.name, channel: :web, receiver_role: :moderator, enabled: true)
+    EventSubscription.create!(eventtype: Event::ReportForUser.name, channel: :web, receiver_role: :moderator, enabled: true)
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/src/api/db/data_schema.rb
+++ b/src/api/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20231004134538)
+DataMigrate::Data.define(version: 20231016113740)


### PR DESCRIPTION
Users with the moderator role should receive notification for report related events.