### PR TITLE
Fix error message for `GET /request/{id}` API endpoint

### DIFF
--- a/src/api/app/controllers/request_controller.rb
+++ b/src/api/app/controllers/request_controller.rb
@@ -54,7 +54,9 @@ class RequestController < ApplicationController
   # GET /request/:id
   def show
     required_parameters :id
-    req = BsRequest.find_by_number!(params[:id])
+    req = BsRequest.find_by(number: params[:id])
+    raise ActiveRecord::RecordNotFound, "Couldn't find Request with number '#{params[:id]}'" if req.nil?
+
     render xml: req.render_xml(params)
   end
 


### PR DESCRIPTION
Related to #15011.

## Before

```
> osc rq show 123456789
Server returned an error: HTTP Error 404: Not Found
Couldn't find BsRequest with [WHERE `bs_requests`.`number` = ?]
```

## After

```
> osc rq show 123456789
Server returned an error: HTTP Error 404: Not Found
Couldn't find Request with number '123456789'
```