### PR TITLE
Pass API requests with a valid `view` parameter to the backend

### DIFF
--- a/src/api/app/controllers/source_project_controller.rb
+++ b/src/api/app/controllers/source_project_controller.rb
@@ -33,8 +33,10 @@ class SourceProjectController < SourceController
         return
       when 'issues'
         render_project_issues
-      else
+      when 'info'
         pass_to_backend
+      else
+        raise InvalidParameterError, "'#{params[:view]}' is not a valid 'view' parameter value."
       end
       return
     end


### PR DESCRIPTION
This PR improves the error message returned when the `view` parameter has not a valid value for `GET /source/{project_name}` API endpoint requests.

To see the permited values the `view` parameter can be passed to the backend take a look at the backend router, [here](https://github.com/openSUSE/open-build-service/blob/81eca94d4516ac656c842a6e0f845963f88dda09/src/backend/bs_srcserver#L7648).

Fixes #8797.

## Before

```
> curl -u Admin:opensuse "http://localhost:3000/source/home:Admin?view"
<status code="400">
  <summary>unknown parameter 'view'</summary>
</status>
```

## After

```
> curl -u Admin:opensuse "http://localhost:3000/source/home:Admin?view"
<status code="invalid_parameter">
  <summary>Parameter 'view' doesn't accept value ''</summary>
</status>
```
