### PR TITLE
Refactoring: use ButtonComponent

### DIFF
--- a/src/api/app/components/accordion_reviews_component.html.haml
+++ b/src/api/app/components/accordion_reviews_component.html.haml
@@ -2,11 +2,11 @@
   - if @declined_reviews_count.positive?
     .accordion-item
       %h2.accordion-header#heading-declined-reviews
-        = button_tag(class: 'accordion-button',
-                     data: { 'bs-toggle': 'collapse', 'bs-target': '#collapse-declined-reviews' },
-                     aria: { expanded: 'true', controls: 'collapse-declined-reviews' }) do
-          %i.fas.fa-fw.fa-sm.fa-times.text-danger.align-middle.pe-4
-          = pluralize(@declined_reviews_count, 'Declined Review')
+        = render(ButtonComponent.new( css_custom: 'accordion-button',
+                                      text: pluralize(@declined_reviews_count, 'Declined Review'),
+                                      icon_type: 'times fas fa-fw fa-sm text-danger align-middle pe-4',
+                                      button_data: { 'bs-toggle': 'collapse', 'bs-target': '#collapse-declined-reviews' },
+                                      aria_data: { expanded: 'true', controls: 'collapse-declined-reviews' }))
       .accordion-collapse.collapse.show#collapse-declined-reviews{ 'aria-labelledby': 'heading-declined-reviews' }
         .accordion-body
           = render partial: 'webui/request/beta_show_tabs/review_summary', collection: @declined_reviews, as: :review
@@ -14,11 +14,11 @@
   - if @pending_reviews_count.positive?
     .accordion-item
       %h2.accordion-header#heading-pending-reviews
-        = button_tag(class: 'accordion-button',
-                     data: { 'bs-toggle': 'collapse', 'bs-target': '#collapse-pending-reviews' },
-                     aria: { expanded: 'true', controls: 'collapse-pending-reviews' }) do
-          %i.fas.fa-fw.fa-2xs.fa-circle.text-warning.align-middle.pe-4
-          = pluralize(@pending_reviews_count, 'Pending Review')
+        = render(ButtonComponent.new( css_custom: 'accordion-button',
+                                      text: pluralize(@pending_reviews_count, 'Pending Review'),
+                                      icon_type: 'circle fas fa-fw fa-2xs text-warning align-middle pe-4',
+                                      button_data: { 'bs-toggle': 'collapse', 'bs-target': '#collapse-pending-reviews' },
+                                      aria_data: { expanded: 'true', controls: 'collapse-pending-reviews' }))
       .accordion-collapse.collapse.show#collapse-pending-reviews{ 'aria-labelledby': 'heading-pending-reviews' }
         .accordion-body
           = render partial: 'webui/request/beta_show_tabs/review_summary', collection: @pending_reviews, as: :review
@@ -26,11 +26,11 @@
   - if @accepted_reviews_count.positive?
     .accordion-item
       %h2.accordion-header#heading-accepted-reviews
-        = button_tag(class: 'accordion-button collapsed',
-                     data: { 'bs-toggle': 'collapse', 'bs-target': '#collapse-accepted-reviews' },
-                     aria: { expanded: 'false', controls: 'collapse-accepted-reviews' }) do
-          %i.fas.fa-fw.fa-sm.fa-check.text-primary.align-middle.pe-4
-          = pluralize(@accepted_reviews_count, 'Accepted Review')
+        = render(ButtonComponent.new( css_custom: 'accordion-button collapsed',
+                                      text: pluralize(@accepted_reviews_count, 'Accepted Review'),
+                                      icon_type: 'check fas fa-fw fa-sm text-primary align-middle pe-4',
+                                      button_data: { 'bs-toggle': 'collapse', 'bs-target': '#collapse-accepted-reviews' },
+                                      aria_data: { expanded: 'false', controls: 'collapse-accepted-reviews' }))
       .accordion-collapse.collapse#collapse-accepted-reviews{ 'aria-labelledby': 'heading-accepted-reviews' }
         .accordion-body
           = render partial: 'webui/request/beta_show_tabs/review_summary', collection: @accepted_reviews, as: :review

--- a/src/api/app/components/button_component.html.haml
+++ b/src/api/app/components/button_component.html.haml
@@ -1,3 +1,3 @@
-%button.btn{ class: css_style, data: @button_data }
+%button.btn{ id: @id, class: css_style, data: @button_data }
   %i.fa{ class: icon }
   %span= @text

--- a/src/api/app/components/button_component.html.haml
+++ b/src/api/app/components/button_component.html.haml
@@ -1,3 +1,3 @@
-%button.btn{ id: @id, class: css_style, data: @button_data, aria: @aria_data }
+%button.btn{ id: @id, class: css_style, data: @button_data, aria: @aria_data, type: @html_type }
   %i.fa{ class: icon }
   %span= @text

--- a/src/api/app/components/button_component.html.haml
+++ b/src/api/app/components/button_component.html.haml
@@ -1,3 +1,3 @@
-%button.btn{ id: @id, class: css_style, data: @button_data }
+%button.btn{ id: @id, class: css_style, data: @button_data, aria: @aria_data }
   %i.fa{ class: icon }
   %span= @text

--- a/src/api/app/components/button_component.html.haml
+++ b/src/api/app/components/button_component.html.haml
@@ -1,3 +1,3 @@
-%button.btn{ id: @id, class: css_style, data: @button_data, aria: @aria_data, type: @html_type }
+%button.btn{ id: @id, class: css_style, data: @button_data, aria: @aria_data, type: @html_type, disabled: @html_disabled}
   %i.fa{ class: icon }
   %span= @text

--- a/src/api/app/components/button_component.html.haml
+++ b/src/api/app/components/button_component.html.haml
@@ -1,3 +1,3 @@
-%button.btn{ id: @id, class: css_style, data: @button_data, aria: @aria_data, type: @html_type, disabled: @html_disabled}
+%button.btn{ id: @id, class: css_style, data: @button_data, aria: @aria_data, type: @html_type, disabled: @html_disabled, value: @html_value}
   %i.fa{ class: icon }
   %span= @text

--- a/src/api/app/components/button_component.html.haml
+++ b/src/api/app/components/button_component.html.haml
@@ -1,3 +1,4 @@
-%button.btn{ id: @id, class: css_style, data: @button_data, aria: @aria_data, type: @html_type, disabled: @html_disabled, value: @html_value}
+%button.btn{ id: @id, class: css_style, data: @button_data, aria: @aria_data,
+             type: @html_type, disabled: @html_disabled, value: @html_value, title: @title }
   %i.fa{ class: icon }
   %span= @text

--- a/src/api/app/components/button_component.rb
+++ b/src/api/app/components/button_component.rb
@@ -1,7 +1,7 @@
 class ButtonComponent < ApplicationComponent
   renders_one :text
 
-  def initialize(type: nil, id: nil, text: nil, css_custom: '', icon_type: nil, button_data: {}, aria_data: {})
+  def initialize(type: nil, id: nil, text: nil, css_custom: '', icon_type: nil, button_data: {}, aria_data: {}, html_type: nil)
     super
 
     @type = type
@@ -10,6 +10,7 @@ class ButtonComponent < ApplicationComponent
     @css_custom = css_custom
     @icon_type = icon_type
     @button_data = button_data
+    @html_type = html_type
   end
 
   def css_style

--- a/src/api/app/components/button_component.rb
+++ b/src/api/app/components/button_component.rb
@@ -1,10 +1,11 @@
 class ButtonComponent < ApplicationComponent
   renders_one :text
 
-  def initialize(type: nil, text: nil, css_custom: '', icon_type: nil, button_data: {})
+  def initialize(type: nil, id: nil, text: nil, css_custom: '', icon_type: nil, button_data: {})
     super
 
     @type = type
+    @id = id
     @text = text
     @css_custom = css_custom
     @icon_type = icon_type

--- a/src/api/app/components/button_component.rb
+++ b/src/api/app/components/button_component.rb
@@ -1,7 +1,7 @@
 class ButtonComponent < ApplicationComponent
   renders_one :text
 
-  def initialize(type: nil, id: nil, text: nil, css_custom: '', icon_type: nil, button_data: {})
+  def initialize(type: nil, id: nil, text: nil, css_custom: '', icon_type: nil, button_data: {}, aria_data: {})
     super
 
     @type = type

--- a/src/api/app/components/button_component.rb
+++ b/src/api/app/components/button_component.rb
@@ -1,7 +1,7 @@
 class ButtonComponent < ApplicationComponent
   renders_one :text
 
-  def initialize(type: nil, id: nil, text: nil, css_custom: '', icon_type: nil, button_data: {}, aria_data: {}, html_type: nil)
+  def initialize(type: nil, id: nil, text: nil, css_custom: '', icon_type: nil, button_data: {}, aria_data: {}, html_type: nil, html_disabled: nil)
     super
 
     @type = type
@@ -11,6 +11,7 @@ class ButtonComponent < ApplicationComponent
     @icon_type = icon_type
     @button_data = button_data
     @html_type = html_type
+    @html_disabled = html_disabled
   end
 
   def css_style

--- a/src/api/app/components/button_component.rb
+++ b/src/api/app/components/button_component.rb
@@ -1,7 +1,9 @@
 class ButtonComponent < ApplicationComponent
   renders_one :text
 
-  def initialize(type: nil, id: nil, text: nil, css_custom: '', icon_type: nil, button_data: {}, aria_data: {}, html_type: nil, html_disabled: nil)
+  def initialize( type: nil, id: nil, text: nil, css_custom: '', icon_type: nil,
+                  button_data: {}, aria_data: {}, html_type: nil, html_disabled: nil,
+                  html_value: nil)
     super
 
     @type = type
@@ -12,6 +14,7 @@ class ButtonComponent < ApplicationComponent
     @button_data = button_data
     @html_type = html_type
     @html_disabled = html_disabled
+    @html_value = html_value
   end
 
   def css_style

--- a/src/api/app/components/button_component.rb
+++ b/src/api/app/components/button_component.rb
@@ -1,9 +1,9 @@
 class ButtonComponent < ApplicationComponent
   renders_one :text
 
-  def initialize( type: nil, id: nil, text: nil, css_custom: '', icon_type: nil,
-                  button_data: {}, aria_data: {}, html_type: nil, html_disabled: nil,
-                  html_value: nil)
+  def initialize(type: nil, id: nil, text: nil, css_custom: '', icon_type: nil,
+                 button_data: {}, aria_data: {}, html_type: nil, html_disabled: nil,
+                 html_value: nil, title: nil)
     super
 
     @type = type
@@ -15,6 +15,7 @@ class ButtonComponent < ApplicationComponent
     @html_type = html_type
     @html_disabled = html_disabled
     @html_value = html_value
+    @title = title
   end
 
   def css_style

--- a/src/api/app/components/workflow_run_filter_input_component.html.haml
+++ b/src/api/app/components/workflow_run_filter_input_component.html.haml
@@ -6,6 +6,9 @@
     = text_field_tag(text.parameterize.underscore, '',
                       class: 'form-control form-control-sm mx-2',
                       placeholder: placeholder, value: selected_input_filter)
-    = button_tag(text.parameterize.underscore, type: 'submit', title: 'Filter!',
-                  class: "btn btn-sm px-3 btn-light border") do
-      %i.fas.fa-magnifying-glass
+    = render(ButtonComponent.new( type: 'light',
+                                  css_custom: 'btn-sm px-3 border',
+                                  text: text.parameterize.underscore,
+                                  icon_type: 'magnifying-glass fas',
+                                  html_type: 'submit',
+                                  title: 'Filter!'))

--- a/src/api/app/views/webui/architectures/index.html.haml
+++ b/src/api/app/views/webui/architectures/index.html.haml
@@ -9,10 +9,19 @@
     %p
       Toggle the availability of architectures.
     .mb-3
-      = button_tag('All', type: 'submit', class: 'btn btn-outline-primary filter-button me-1', value: true,
-        data: { remote: true, url: bulk_update_availability_path(archs: { all: true }), method: :patch })
-      = button_tag('None', type: 'submit', class: 'btn btn-outline-primary filter-button me-1', value: false,
-        data: { remote: true, url: bulk_update_availability_path(archs: { all: false }), method: :patch })
+      = render(ButtonComponent.new( type: 'outline-primary',
+                                    css_custom: 'filter-button me-1',
+                                    text: 'All',
+                                    button_data: { remote: true, url: bulk_update_availability_path(archs: { all: true }), method: :patch },
+                                    html_type: 'submit',
+                                    html_value: true))
+
+      = render(ButtonComponent.new( type: 'outline-primary',
+                                    css_custom: 'filter-button me-1',
+                                    text: 'None',
+                                    button_data: { remote: true, url: bulk_update_availability_path(archs: { all: false }), method: :patch },
+                                    html_type: 'submit',
+                                    html_value: false))
       %i.fas.fa-spinner.invisible
     .mb-3.d-flex.flex-wrap
       - @architectures.each do |arch|

--- a/src/api/app/views/webui/comment/_comment_field.html.haml
+++ b/src/api/app/views/webui/comment/_comment_field.html.haml
@@ -29,13 +29,10 @@ data: { preview_message_url: preview_comments_path, message_body_param: 'comment
         - when :post
           = f.submit 'Add comment', class: 'btn btn-primary me-2', data: { disable_with: 'Creating comment...' }, disabled: true
           - if !comment.parent_id && CommentLockPolicy.new(User.session, commentable).create?
-            = button_tag(type: 'button', class: 'btn btn-warning', data: { 'bs-toggle': 'modal', 'bs-target': "##{modal_id}-modal" }) do
-              - if commentable.comment_lock.blank?
-                %i.fa.fa-lock
-                Lock comments
-              - else
-                %i.fa.fa-unlock
-                Unlock comments
+            = render(ButtonComponent.new(type: 'warning',
+                                         text: commentable.comment_lock.blank? ? 'Lock comments' : 'Unlock comments',
+                                         button_data: { 'bs-toggle': 'modal', 'bs-target': "##{modal_id}-modal" },
+                                         icon_type: commentable.comment_lock.blank? ? 'lock' : 'unlock'))
         - when :put
           = f.submit 'Update comment', class: 'btn btn-primary me-2', data: { disable_with: 'Updating comment...' }
         - if has_cancel

--- a/src/api/app/views/webui/user/_edit_account_form.html.haml
+++ b/src/api/app/views/webui/user/_edit_account_form.html.haml
@@ -24,5 +24,8 @@
       You are behind a proxy. You can modify other data related to your profile by
       = link_to(' this link.', account_edit_link)
   .mb-3.text-end
-    = button_tag 'Cancel', id: 'cancel-in-place-editing', class: 'cancel btn btn-outline-danger px-4'
+    = render(ButtonComponent.new( type: 'outline-danger',
+                                  id: 'cancel-in-place-editing',
+                                  css_custom: 'cancel px-4',
+                                  text: 'Cancel'))
     = submit_tag('Update', class: 'btn btn-primary px-4')


### PR DESCRIPTION
Note: this is rebased and depend on https://github.com/openSUSE/open-build-service/pull/15073

Unify buttons using `ButtonComponent` over:
- `button_tag(...`
- `tag.button(...`
- `%button...`