### PR TITLE
Fix error messages returned for not found parameters

### DIFF
--- a/src/api/app/controllers/status/required_checks_controller.rb
+++ b/src/api/app/controllers/status/required_checks_controller.rb
@@ -81,11 +81,18 @@ class Status::RequiredChecksController < ApplicationController
   def checkable
     return @project unless params[:repository_name]
 
-    repo = @project.repositories.find_by!(name: params[:repository_name])
+    repo = @project.repositories.find_by(name: params[:repository_name])
+    raise NotFoundError, "Couldn't find repository '#{params[:repository_name]}'" if repo.nil?
+
     return repo unless params[:architecture_name]
 
-    architecture = Architecture.find_by!(name: params[:architecture_name])
-    repo.repository_architectures.find_by!(architecture: architecture)
+    architecture = Architecture.find_by(name: params[:architecture_name])
+    raise NotFoundError, "Couldn't find architecture '#{params[:architecture_name]}'" if architecture.nil?
+
+    repo_architecture = repo.repository_architectures.find_by(architecture: architecture)
+    raise NotFoundError, "Couldn't find architecture '#{architecture}'" if repo_architecture.nil?
+
+    repo_architecture
   end
 
   # Use callbacks to share common setup or constraints between actions.


### PR DESCRIPTION
Fixes #14471.

## After the changes

### Non existing repository
```
> curl -u Admin:opensuse "http://localhost:3000/status_reports/built_repositories/home:Admin/openSUSE_Tumbleweedd/x86_64f/required_checks"
<status code="not_found">
  <summary>Couldn't find repository 'openSUSE_Tumbleweedd'</summary>
</status>
```

### Non existing architecture
```
> curl -u Admin:opensuse "http://localhost:3000/status_reports/built_repositories/home:Admin/openSUSE_Tumbleweed/x86_64f/required_checks"
<status code="not_found">
  <summary>Couldn't find architecture 'x86_64f'</summary>
</status>
```

### Existing architecture, but not defined in the project
```
> curl -u Admin:opensuse "http://localhost:3000/status_reports/built_repositories/home:Admin/openSUSE_Tumbleweed/i586/required_checks"
<status code="not_found">
  <summary>Couldn't find architecture 'i586'</summary>
</status>
```
