### PR TITLE
Create Isolated Migrations GitHub action

### DIFF
--- a/.github/workflows/isolated_migrations.yml
+++ b/.github/workflows/isolated_migrations.yml
@@ -1,0 +1,67 @@
+# GitHub action that checks:
+# - that the migrations and the related code changes are not in the same pull request
+# - that the schema.rb and data_schema.rb files are included in the pull request that introduces the corresponding migration
+# Based on https://github.com/marketplace/actions/changed-files
+
+name: Isolated Migrations
+
+on:
+  pull_request
+
+jobs:
+  check_changed_files:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Group files that have changed
+        id: changed-files-yaml
+        uses: tj-actions/changed-files@v39
+        with:
+          files_yaml: |
+            migrations:
+              - src/api/db/**
+            not_migrations:
+              - '!src/api/db/**'
+            schema_migrations:
+              - src/api/db/migrate/**
+            data_migrations:
+              - src/api/db/data/**
+            schema:
+              - src/api/db/schema.rb
+            data_schema:
+              - src/api/db/data_schema.rb
+
+      - name: List the files related to migrations that this PR changes
+        if: steps.changed-files-yaml.outputs.migrations_any_changed == 'true'
+        run: |
+          for file in ${{ steps.changed-files-yaml.outputs.migrations_all_changed_files }}; do
+            echo "- $file"
+          done
+
+      - name: List the files not related to migrations that this PR changes
+        if: steps.changed-files-yaml.outputs.not_migrations_any_changed == 'true'
+        run: |
+          for file in ${{ steps.changed-files-yaml.outputs.not_migrations_all_changed_files }}; do
+            echo "- $file"
+          done
+
+      - name: Check if the Pull Request contains code changes together with migrations
+        if: (steps.changed-files-yaml.outputs.migrations_any_changed == 'true') && (steps.changed-files-yaml.outputs.not_migrations_all_changed_files_count > 0)
+        run: |
+          echo "There are code changes together with migrations. Please split them into two Pull Requests"
+          exit 1
+
+      - name: Missing schema changes
+        if: (steps.changed-files-yaml.outputs.schema_migrations_any_changed == 'true') && (steps.changed-files-yaml.outputs.schema_any_changed == 'false')
+        run: |
+          echo "You introduced some schema migration, please introduce the schema.rb changes as well"
+          exit 1
+
+      - name: Missing data schema changes
+        if: (steps.changed-files-yaml.outputs.data_schema_migrations_any_changed == 'true') && (steps.changed-files-yaml.outputs.data_schema_any_changed == 'false')
+        run: |
+          echo "You introduced some data migrations, please introduce the data_schema.rb changes as well"
+          exit 1


### PR DESCRIPTION
Check if migrations and their related code changes are not included on the same pull request.
Check if the [schema.rb](url) and data_schema.rb files are included in the pull request that introduces a migration or data migration.

![Screenshot 2023-10-18 at 10-02-09 No name for job by saraycp · Pull Request #27 · saraycp_hello_world](https://github.com/openSUSE/open-build-service/assets/2581944/1044ba83-7bfb-4341-91c3-2c0789bfbc7a)

![Screenshot 2023-10-17 at 22-03-47 data_migration_only · saraycp_hello_world@c1e7860](https://github.com/openSUSE/open-build-service/assets/2581944/26e2b4e6-2aaa-4258-8772-d3045417a7f8)

You can see this GitHub action working on my [sandbox repository](https://github.com/saraycp/hello_world/pulls).
You will see a few pull requests representing the different scenarios we could have. For example, ["migration only"](https://github.com/saraycp/hello_world/pull/19) fails because the PR contains a migration but not the `schema.rb` changes.
