### PR TITLE
Introduces ENV['RUNNING_MINITEST_WITH_DOCKER']

### DIFF
--- a/src/api/config/environments/test.rb
+++ b/src/api/config/environments/test.rb
@@ -104,6 +104,12 @@ if ENV['RUNNING_MINITEST']
   CONFIG['source_port'] = '3200'
 end
 
+if ENV['RUNNING_MINITEST_WITH_DOCKER']
+  ENV['BACKEND_STARTED'] = "1"
+  CONFIG['source_host'] = 'backend'
+  CONFIG['source_port'] = '5352'
+end
+
 # some defaults enforced
 CONFIG['apidocs_location'] = File.expand_path('../../docs/api/html/')
 

--- a/src/api/lib/tasks/dev.rake
+++ b/src/api/lib/tasks/dev.rake
@@ -33,6 +33,15 @@ namespace :dev do
     end
   end
 
+  task test_environment: :environment do
+    unless Rails.env.test?
+      puts "You are running this rake task in #{Rails.env} environment."
+      puts 'Please only run this task with RAILS_ENV=test'
+      puts 'otherwise it will destroy your database data.'
+      exit(1)
+    end
+  end
+
   desc 'Bootstrap the application'
   task :bootstrap, [:old_test_suite] => [:prepare, :environment] do |_t, args|
     args.with_defaults(old_test_suite: false)

--- a/src/api/lib/tasks/dev/minitest.rake
+++ b/src/api/lib/tasks/dev/minitest.rake
@@ -1,0 +1,30 @@
+namespace :dev do
+  namespace :minitest do
+    namespace :fixtures do
+      desc 'Create minitest fixtures in the database (as opposed to loading them with db:fixture:load)'
+      task create: :test_environment do
+        puts "\n\nMake sure you start with a fresh backend! Outside the container run..."
+        puts "docker-compose stop backend; docker-compose rm -f backend; docker-compose up -d backend\n\n"
+        puts 'Please also note this will drop your current test database'
+        puts "Confirm? Enter 'YES' to confirm:"
+        input = $stdin.gets.chomp
+        raise "Aborting... You entered: #{input} not YES" unless input == 'YES'
+
+        Rake::Task['db:drop'].invoke
+        Rake::Task['db:setup'].invoke
+        Rake::Task['db:fixtures:load'].invoke
+        # Enable writing to the backend
+        CONFIG['global_write_through'] = true
+        # Login default admin for syncing projects/packages to the backend
+        User.session = User.get_default_admin
+        # Rewrite interconnect url
+        Project.where(remoteurl: 'http://localhost:3200').map { |project| project.update!(remoteurl: 'http://backend:5352') }
+        # Sync all projects to the backend
+        Project.all.map(&:store)
+        # Sync all packages to the backend
+        # FIXME: Why do we have `_product:fixed-release` in the fixtures if you can't even store it?
+        Package.where.not(name: '_product:fixed-release').map(&:store)
+      end
+    end
+  end
+end

--- a/src/api/test/test_helper.rb
+++ b/src/api/test/test_helper.rb
@@ -34,7 +34,11 @@ Capybara.register_driver :rack_test do |app|
   Capybara::RackTest::Driver.new(app, headers: { 'HTTP_ACCEPT' => 'text/html' })
 end
 
-WebMock.disable_net_connect!(allow_localhost: true)
+if ENV['RUNNING_MINITEST_WITH_DOCKER']
+  WebMock.disable_net_connect!(allow: 'backend:5352')
+else
+  WebMock.disable_net_connect!(allow_localhost: true)
+end
 
 unless File.exist?('/proc')
   print 'ERROR: proc file system not mounted, aborting'
@@ -180,8 +184,6 @@ module Webui
       user = 'king'
       password = 'sunflower'
       opts[:do_assert] = false
-      # no idea why calling it twice would help
-      WebMock.disable_net_connect!(allow_localhost: true)
       visit new_session_path
       within('#loginform') do
         fill_in 'username', with: user
@@ -208,7 +210,11 @@ module Webui
       Minitest::Spec.new('MINE') unless Minitest::Spec.current
       Backend::Test.start
       @starttime = Time.now
-      WebMock.disable_net_connect!(allow_localhost: true)
+      if ENV['RUNNING_MINITEST_WITH_DOCKER']
+        WebMock.disable_net_connect!(allow: 'backend:5352')
+      else
+        WebMock.disable_net_connect!(allow_localhost: true)
+      end
       CONFIG['global_write_through'] = true
     end
 


### PR DESCRIPTION
Make it possible to run some (like ~97% as of this writing) minitest tests in the container based development environment against the backend that is running there.

```
$ rake dev:minitest:fixtures:create RAILS_ENV=test
$ export RUNNING_MINITEST_WITH_DOCKER=1
$ rake test TEST=test/functional/request_events_test.rb
```

Please be aware: If you are using this you'll be responsible for resetting the state of the backend. Like running
```
$ docker-compose stop backend
$ docker-compose rm -f backend
$ docker-compose up -d backend
```
before and after executing a test as the tests are optimized to be run once.

It'll also not work for tests that "mock" backend functionality. Like the ones using TestHelper.inject_build_job or doing something with OBS_BACKEND_TEMP.
```
$ grep -Hrl OBS_BACKEND_TEMP test
test/functional/zzz_post_consistency_test.rb
test/functional/build_controller_test.rb
test/functional/channel_maintenance_test.rb
test/functional/published_controller_test.rb
test/functional/backend_test.rb
test/functional/maintenance_test.rb
test/functional/source_controller_test.rb
$ grep -Hrl inject_build_job test
test/functional/release_management_test.rb
test/functional/product_test.rb
test/functional/search_controller_test.rb
test/functional/channel_maintenance_test.rb
test/functional/kgraft_maintenance_test.rb
test/functional/maintenance_test.rb
```