### PR TITLE
Get notified about failed WorkflowRuns

### DIFF
--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -1431,6 +1431,7 @@ ViewComponent/MissingPreviewFile:
     - 'app/components/workflow_run_header_component.rb'
     - 'app/components/workflow_run_request_action_filter_component.rb'
     - 'app/components/workflow_run_row_component.rb'
+    - 'app/components/workflow_run_status_badge_component.rb'
     - 'app/components/write_and_preview_component.rb'
 
 # Offense count: 2760

--- a/src/api/app/components/notification_avatars_component.rb
+++ b/src/api/app/components/notification_avatars_component.rb
@@ -20,6 +20,8 @@ class NotificationAvatarsComponent < ApplicationComponent
                           [User.find(@notification.event_payload['user_id'])]
                         when 'Decision'
                           [User.find(@notification.event_payload['moderator_id'])]
+                        when 'WorkflowRun'
+                          [Token.find(@notification.event_payload['token_id'])&.executor].compact
                         else
                           reviews = @notification.notifiable.reviews
                           reviews.select(&:new?).map(&:reviewed_by) + User.where(login: @notification.notifiable.creator)

--- a/src/api/app/components/notification_component.html.haml
+++ b/src/api/app/components/notification_component.html.haml
@@ -14,6 +14,8 @@
             = render TimeComponent.new(time: @notification.created_at)
           - if @notification.notifiable_type == 'BsRequest'
             = render BsRequestStateBadgeComponent.new(state: @notification.notifiable.state, css_class: 'ms-1')
+          - if @notification.notifiable_type == 'WorkflowRun'
+            = render WorkflowRunStatusBadgeComponent.new(status: @notification.notifiable.status, css_class: 'ms-1')
         .col-auto.actions.ms-auto.align-self-end.align-self-md-start
           = render NotificationMarkButtonComponent.new(@notification, @selected_filter, @page, @show_more)
       .row.mt-1.ps-sm-4

--- a/src/api/app/components/notification_component.rb
+++ b/src/api/app/components/notification_component.rb
@@ -20,6 +20,8 @@ class NotificationComponent < ApplicationComponent
       tag.i(class: ['fas', 'fa-flag'], title: 'Report notification')
     when 'Decision'
       tag.i(class: ['fas', 'fa-clipboard-check'], title: 'Report decision')
+    when 'WorkflowRun'
+      tag.i(class: ['fas', 'fa-book-open'], title: 'Workflow run')
     else
       tag.i(class: ['fas', 'fa-user-tag'], title: 'Relationship notification')
     end

--- a/src/api/app/components/notification_excerpt_component.rb
+++ b/src/api/app/components/notification_excerpt_component.rb
@@ -16,6 +16,8 @@ class NotificationExcerptComponent < ApplicationComponent
              helpers.render_without_markdown(@notifiable.body)
            when 'Report', 'Decision'
              @notifiable.reason
+           when 'WorkflowRun'
+             "In repository #{@notifiable.repository_full_name}"
            else
              ''
            end

--- a/src/api/app/components/notification_filter_component.html.haml
+++ b/src/api/app/components/notification_filter_component.html.haml
@@ -22,6 +22,8 @@
   = render NotificationFilterLinkComponent.new(text: 'Reports', amount: @count['reports'], icon: 'fas fa-flag',
                                                filter_item: { type: 'reports' }, selected_filter: @selected_filter,
                                                show_reports: @show_reports)
+  = render NotificationFilterLinkComponent.new(text: 'Workflow Runs', amount: @count['workflow_runs'], icon: 'fas fa-book-open',
+                                               filter_item: { type: 'workflow_runs' }, selected_filter: @selected_filter)
 
 - unless @projects_for_filter.empty?
   .list-group.list-group-flush.mt-5.mb-2

--- a/src/api/app/components/notification_filter_component.rb
+++ b/src/api/app/components/notification_filter_component.rb
@@ -20,6 +20,7 @@ class NotificationFilterComponent < ApplicationComponent
     counted_notifications['relationships_deleted'] = finder.for_relationships_deleted.count
     counted_notifications['build_failures'] = finder.for_failed_builds.count
     counted_notifications['reports'] = finder.for_reports.count if @show_reports
+    counted_notifications['workflow_runs'] = finder.for_workflow_runs.count
     counted_notifications.merge!('unread' => User.session.unread_notifications)
   end
 end

--- a/src/api/app/components/notification_notifiable_link_component.rb
+++ b/src/api/app/components/notification_notifiable_link_component.rb
@@ -56,6 +56,8 @@ class NotificationNotifiableLinkComponent < ApplicationComponent
       # https://trello.com/c/xrjOZGa7/45-ensure-all-reports-of-a-decision-point-to-the-same-reportable
       report = @notification.notifiable.reports.first
       "Favored #{report.reportable.class.name} Report"
+    when 'Event::WorkflowRunFail'
+      'Workflow Run'
     end
   end
   # rubocop:enable Metrics/CyclomaticComplexity
@@ -113,6 +115,8 @@ class NotificationNotifiableLinkComponent < ApplicationComponent
     when 'Event::ClearedDecision', 'Event::FavoredDecision'
       reportable = @notification.notifiable.reports.first.reportable
       link_for_reportables(reportable)
+    when 'Event::WorkflowRunFail'
+      Rails.application.routes.url_helpers.token_workflow_run_path(@notification.notifiable.token, @notification.notifiable)
     end
   end
   # rubocop:enable Metrics/CyclomaticComplexity

--- a/src/api/app/components/workflow_run_row_component.rb
+++ b/src/api/app/components/workflow_run_row_component.rb
@@ -1,5 +1,5 @@
 class WorkflowRunRowComponent < ApplicationComponent
-  attr_reader :workflow_run, :status, :hook_event, :hook_action, :repository_name, :repository_url, :event_source_name, :event_source_url
+  attr_reader :workflow_run, :status, :hook_event, :hook_action, :repository_name, :repository_url, :event_source_name, :event_source_url, :formatted_event_source_name
 
   def initialize(workflow_run:)
     super
@@ -12,15 +12,7 @@ class WorkflowRunRowComponent < ApplicationComponent
     @repository_url = workflow_run.repository_url
     @event_source_name = workflow_run.event_source_name
     @event_source_url = workflow_run.event_source_url
-  end
-
-  def formatted_event_source_name
-    case hook_event
-    when 'pull_request', 'Merge Request Hook'
-      "##{event_source_name}"
-    else
-      event_source_name
-    end
+    @formatted_event_source_name = workflow_run.formatted_event_source_name
   end
 
   def status_title

--- a/src/api/app/components/workflow_run_status_badge_component.rb
+++ b/src/api/app/components/workflow_run_status_badge_component.rb
@@ -1,0 +1,36 @@
+class WorkflowRunStatusBadgeComponent < ApplicationComponent
+  def initialize(status:, css_class: nil)
+    super
+
+    @status = status
+    @css_class = css_class
+  end
+
+  def call
+    content_tag(
+      :span,
+      tag.i(class: "fas fa-#{decode_status_icon} me-1").concat(@status),
+      class: ['badge', "bg-#{decode_status_color}", @css_class]
+    )
+  end
+
+  private
+
+  def decode_status_color
+    case @status
+    when 'fail'
+      'danger'
+    else
+      'dark'
+    end
+  end
+
+  def decode_status_icon
+    case @status
+    when 'fail'
+      'exclamation-triangle'
+    else
+      'book-open'
+    end
+  end
+end

--- a/src/api/app/controllers/webui/users/notifications_controller.rb
+++ b/src/api/app/controllers/webui/users/notifications_controller.rb
@@ -1,6 +1,6 @@
 class Webui::Users::NotificationsController < Webui::WebuiController
   VALID_NOTIFICATION_TYPES = ['read', 'reviews', 'comments', 'requests', 'unread', 'incoming_requests', 'outgoing_requests', 'relationships_created', 'relationships_deleted',
-                              'build_failures', 'reports'].freeze
+                              'build_failures', 'reports', 'workflow_runs'].freeze
 
   # TODO: Remove this when we'll refactor kerberos_auth
   before_action :kerberos_auth

--- a/src/api/app/models/event/base.rb
+++ b/src/api/app/models/event/base.rb
@@ -23,7 +23,8 @@ module Event
       'Event::ReportForProject' => 'Receive notifications for reported projects.',
       'Event::ReportForUser' => 'Receive notifications for reported users.',
       'Event::ClearedDecision' => 'Receive notifications for cleared report decisions.',
-      'Event::FavoredDecision' => 'Receive notifications for favored report decisions.'
+      'Event::FavoredDecision' => 'Receive notifications for favored report decisions.',
+      'Event::WorkflowRunFail' => 'Receive notifications for failed workflow runs on SCM/CI integration.'
     }.freeze
 
     class << self
@@ -40,7 +41,8 @@ module Event
          'Event::RequestStatechange', 'Event::CommentForProject', 'Event::CommentForPackage',
          'Event::CommentForRequest',
          'Event::RelationshipCreate', 'Event::RelationshipDelete',
-         'Event::ReportForComment', 'Event::ReportForPackage', 'Event::ReportForProject', 'Event::ReportForUser'].map(&:constantize)
+         'Event::ReportForComment', 'Event::ReportForPackage', 'Event::ReportForProject', 'Event::ReportForUser',
+         'Event::WorkflowRunFail'].map(&:constantize)
       end
 
       def classnames

--- a/src/api/app/models/event/workflow_run_fail.rb
+++ b/src/api/app/models/event/workflow_run_fail.rb
@@ -9,5 +9,9 @@ module Event
     def token_executors
       [Token.find_by(id: payload['token_id'], type: 'Token::Workflow')&.executor].compact
     end
+
+    def parameters_for_notification
+      super.merge(notifiable_type: 'WorkflowRun', notifiable_id: payload['id'])
+    end
   end
 end

--- a/src/api/app/models/event/workflow_run_fail.rb
+++ b/src/api/app/models/event/workflow_run_fail.rb
@@ -1,0 +1,13 @@
+module Event
+  class WorkflowRunFail < Base
+    self.message_bus_routing_key = 'workflow_run.fail'
+    self.description = 'Workflow run has failed'
+    payload_keys :id, :token_id
+
+    receiver_roles :token_executor
+
+    def token_executors
+      [Token.find_by(id: payload['token_id'], type: 'Token::Workflow')&.executor].compact
+    end
+  end
+end

--- a/src/api/app/models/event_subscription.rb
+++ b/src/api/app/models/event_subscription.rb
@@ -17,7 +17,8 @@ class EventSubscription < ApplicationRecord
     source_package_watcher: 'Watching the source package',
     target_package_watcher: 'Watching the target package',
     request_watcher: 'Watching the request',
-    moderator: 'User with moderator role'
+    moderator: 'User with moderator role',
+    token_executor: 'User who runs the workflow'
   }.freeze
 
   enum channel: {
@@ -44,7 +45,7 @@ class EventSubscription < ApplicationRecord
     in: [:maintainer, :bugowner, :reader, :source_maintainer, :target_maintainer,
          :reviewer, :commenter, :creator, :watcher, :source_watcher, :target_watcher,
          :package_watcher, :target_package_watcher, :source_package_watcher, :request_watcher, :any_role,
-         :moderator, :reporter, :offender]
+         :moderator, :reporter, :offender, :token_executor]
   }
 
   scope :for_eventtype, ->(eventtype) { where(eventtype: eventtype) }

--- a/src/api/app/models/event_subscription/for_channel_form.rb
+++ b/src/api/app/models/event_subscription/for_channel_form.rb
@@ -2,7 +2,8 @@ class EventSubscription
   class ForChannelForm
     DISABLE_FOR_EVENTS = ['Event::ServiceFail'].freeze
     DISABLE_RSS_FOR_EVENTS = ['Event::ReportForProject', 'Event::ReportForPackage',
-                              'Event::ReportForComment', 'Event::ReportForUser'].freeze
+                              'Event::ReportForComment', 'Event::ReportForUser',
+                              'Event::WorkflowRunFail'].freeze
 
     attr_reader :name, :subscription
 
@@ -21,7 +22,8 @@ class EventSubscription
 
     def disabled_checkbox?
       (DISABLE_FOR_EVENTS.include?(@event.to_s) && (name == 'web' || name == 'rss')) ||
-        (DISABLE_RSS_FOR_EVENTS.include?(@event.to_s) && name == 'rss')
+        (DISABLE_RSS_FOR_EVENTS.include?(@event.to_s) && name == 'rss') ||
+        (@event.to_s == 'Event::WorkflowRunFail' && name == 'instant_email') # TODO: remove as soon as the email channel is implemented
     end
 
     private

--- a/src/api/app/models/workflow_run.rb
+++ b/src/api/app/models/workflow_run.rb
@@ -99,6 +99,26 @@ class WorkflowRun < ApplicationRecord
     [workflow_configuration_url, workflow_configuration_path].filter_map(&:presence).first
   end
 
+  def formatted_event_source_name
+    case hook_event
+    when 'pull_request', 'Merge Request Hook'
+      "##{event_source_name}"
+    else
+      event_source_name
+    end
+  end
+
+  # Examples of summary:
+  #   Pull request #234, opened
+  #   Merge request hook #234, open
+  #   Push 0940857924387654354986745938675645365436
+  #   Tag push hook Unknown source
+  def summary
+    str = "#{hook_event&.humanize || 'unknown'} #{formatted_event_source_name}"
+    str += ", #{hook_action.humanize.downcase}" if hook_action.present?
+    str
+  end
+
   private
 
   def event_parameters

--- a/src/api/app/models/workflow_run.rb
+++ b/src/api/app/models/workflow_run.rb
@@ -43,7 +43,7 @@ class WorkflowRun < ApplicationRecord
   # Stores debug info to help figure out what went wrong when trying to save a Status in the SCM.
   # Marks the workflow run as failed also.
   def save_scm_report_failure(message, options)
-    update(status: 'fail') # set WorkflowRun status
+    update_as_failed(message)
     scm_status_reports.create(response_body: message,
                               request_parameters: JSON.generate(options.slice(*PERMITTED_OPTIONS)),
                               status: 'fail') # set SCMStatusReport status

--- a/src/api/app/queries/notifications_finder.rb
+++ b/src/api/app/queries/notifications_finder.rb
@@ -54,6 +54,10 @@ class NotificationsFinder
                                  'Event::ClearedDecision', 'Event::FavoredDecision'], delivered: false)
   end
 
+  def for_workflow_runs
+    @relation.where(event_type: 'Event::WorkflowRunFail', delivered: false)
+  end
+
   # rubocop:disable Metrics/CyclomaticComplexity
   # We need to refactor this method, the `case` statement is way too big
   def for_notifiable_type(type = 'unread')
@@ -78,6 +82,8 @@ class NotificationsFinder
       notifications.for_failed_builds
     when 'reports'
       notifications.for_reports
+    when 'workflow_runs'
+      notifications.for_workflow_runs
     else
       notifications.unread
     end

--- a/src/api/app/queries/outdated_notifications_finder/workflow_run.rb
+++ b/src/api/app/queries/outdated_notifications_finder/workflow_run.rb
@@ -1,0 +1,10 @@
+class OutdatedNotificationsFinder::WorkflowRun
+  def initialize(scope, parameters)
+    @scope = scope
+    @parameters = parameters
+  end
+
+  def call
+    @scope.where(notifiable_type: 'WorkflowRun', notifiable_id: @parameters['notifiable_id'])
+  end
+end

--- a/src/api/app/services/notification_service/notifier.rb
+++ b/src/api/app/services/notification_service/notifier.rb
@@ -16,7 +16,8 @@ module NotificationService
                         'Event::ReportForComment',
                         'Event::ReportForUser',
                         'Event::ClearedDecision',
-                        'Event::FavoredDecision'].freeze
+                        'Event::FavoredDecision',
+                        'Event::WorkflowRunFail'].freeze
     CHANNELS = [:web, :rss].freeze
     ALLOWED_NOTIFIABLE_TYPES = {
       'BsRequest' => ::BsRequest,
@@ -24,7 +25,8 @@ module NotificationService
       'Project' => ::Project,
       'Package' => ::Package,
       'Report' => ::Report,
-      'Decision' => ::Decision
+      'Decision' => ::Decision,
+      'WorkflowRun' => ::WorkflowRun
     }.freeze
     ALLOWED_CHANNELS = {
       web: NotificationService::WebChannel,
@@ -37,7 +39,8 @@ module NotificationService
                         'Event::ReportForComment',
                         'Event::ReportForUser',
                         'Event::ClearedDecision',
-                        'Event::FavoredDecision'].freeze
+                        'Event::FavoredDecision',
+                        'Event::WorkflowRunFail'].freeze
 
     def initialize(event)
       @event = event

--- a/src/api/app/services/notification_service/web_channel.rb
+++ b/src/api/app/services/notification_service/web_channel.rb
@@ -7,7 +7,8 @@ module NotificationService
       'Project' => OutdatedNotificationsFinder::Project,
       'Package' => OutdatedNotificationsFinder::Package,
       'Report' => OutdatedNotificationsFinder::Report,
-      'Decision' => OutdatedNotificationsFinder::Decision
+      'Decision' => OutdatedNotificationsFinder::Decision,
+      'WorkflowRun' => OutdatedNotificationsFinder::WorkflowRun
     }.freeze
 
     def initialize(subscription, event)

--- a/src/api/app/services/notified_projects.rb
+++ b/src/api/app/services/notified_projects.rb
@@ -26,7 +26,7 @@ class NotifiedProjects
       [@notifiable.project]
     when 'Project'
       [@notifiable]
-    when 'Report', 'Decision'
+    when 'Report', 'Decision', 'WorkflowRun'
       []
     end
   end

--- a/src/api/lib/tasks/dev/workflows.rake
+++ b/src/api/lib/tasks/dev/workflows.rake
@@ -14,6 +14,9 @@ namespace :dev do
 
       workflow_token = Token::Workflow.find_by(description: 'Testing token') || create(:workflow_token, executor: admin, description: 'Testing token')
 
+      # This automatically subscribes everyone to the workflow run related events
+      EventSubscription.create!(eventtype: Event::WorkflowRunFail.name, channel: :web, receiver_role: :token_executor, enabled: true)
+
       # GitHub
       create(:workflow_run, token: workflow_token)
       create(:workflow_run, :failed, token: workflow_token)

--- a/src/api/spec/models/event/workflow_run_fail_spec.rb
+++ b/src/api/spec/models/event/workflow_run_fail_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe Event::WorkflowRunFail do
+  describe '#token_executor' do
+    let(:token) { create(:workflow_token) }
+    let(:event) { Event::WorkflowRunFail.create(token_id: token.id) }
+
+    subject { event.token_executors }
+
+    it { expect(subject).to contain_exactly(token.executor) }
+
+    context 'when the token does not exist' do
+      before do
+        event
+        token.destroy
+      end
+
+      it { expect(subject).to be_empty }
+    end
+  end
+end

--- a/src/api/spec/models/workflow_run_spec.rb
+++ b/src/api/spec/models/workflow_run_spec.rb
@@ -64,6 +64,8 @@ RSpec.describe WorkflowRun, :vcr do
         subject
         expect(workflow_run.reload.status).to eql('fail')
       end
+
+      it { expect { subject }.to change(Event::WorkflowRunFail, :count).by(1) }
     end
 
     context 'when providing some other keys' do


### PR DESCRIPTION
Until now, users who set the SCM/CI integration with OBS had to check the workflow runs list, from time to time, to discover if some workflow runs failed.
From now on, they are going to receive notifications about the failed ones.

The subscriptions page includes the new type of event:

![Screenshot 2023-10-24 at 17-13-59 Open Build Service](https://github.com/openSUSE/open-build-service/assets/2581944/7588a4e7-ee39-4311-bccc-b6f29f32b2eb)

The new type of notifications looks like this:

![Screenshot from 2023-10-24 18-00-40](https://github.com/openSUSE/open-build-service/assets/24919/581326b6-60e0-4154-9b88-497b41263ea0)


**NOTES:**

- This PR covers the web channel only. The email channel will be introduced in another PR.
- There is no need to subscribe everyone to the new type of event (`Event::WorkflowRunFail`). We'll use the blog post to encourage people to subscribe so we don't overload their Notifications page.
- At the moment, only the token creator (a.k.a. executor) will receive notifications. The people the owner shared the token with won't receive notifications yet. 