### PR TITLE
Collect artifacts for set flag step

### DIFF
--- a/src/api/app/services/workflows/artifacts_collector.rb
+++ b/src/api/app/services/workflows/artifacts_collector.rb
@@ -14,7 +14,7 @@ module Workflows
                       target_project: @step.target_project_name,
                       target_package: @step.target_package_name
                     }
-                  when 'Workflow::Step::RebuildPackage', 'Workflow::Step::TriggerServices'
+                  when 'Workflow::Step::RebuildPackage', 'Workflow::Step::TriggerServices', 'Workflow::Step::SetFlags'
                     @step.step_instructions
                   when 'Workflow::Step::ConfigureRepositories'
                     {

--- a/src/api/lib/tasks/dev/workflows.rake
+++ b/src/api/lib/tasks/dev/workflows.rake
@@ -40,6 +40,7 @@ namespace :dev do
         create(:workflow_artifacts_per_step_link_package, workflow_run: workflow_run, source_project_name: source_project_name, target_project_name: target_project_name)
         create(:workflow_artifacts_per_step_rebuild_package, workflow_run: workflow_run, source_project_name: source_project_name, target_project_name: target_project_name)
         create(:workflow_artifacts_per_step_config_repositories, workflow_run: workflow_run, source_project_name: source_project_name, target_project_name: target_project_name)
+        create(:workflow_artifacts_per_step_set_flags, workflow_run: workflow_run, source_project_name: source_project_name, target_project_name: target_project_name)
       end
     end
 

--- a/src/api/spec/factories/workflow_artifacts_per_step.rb
+++ b/src/api/spec/factories/workflow_artifacts_per_step.rb
@@ -69,5 +69,20 @@ FactoryBot.define do
         }.to_json
       end
     end
+    factory :workflow_artifacts_per_step_set_flags do
+      step { 'Workflow::Step::SetFlags' }
+      before(:create) do |workflow_artifacts_per_step, evaluator|
+        workflow_artifacts_per_step.artifacts = {
+          flags: [
+            type: 'build',
+            status: 'enable',
+            project: evaluator.source_project_name,
+            package: evaluator.source_package_name,
+            repository: 'openSUSE_Tumbleweed',
+            architecture: 'x86_64'
+          ]
+        }.to_json
+      end
+    end
   end
 end


### PR DESCRIPTION
Prior to this PR, we were not collecting artifacts for the `set_flag` steps. This PR collects these missing artifacts.

![image](https://github.com/openSUSE/open-build-service/assets/12820609/8af96110-a3cb-4d69-b082-fd12df018981)

