### PR TITLE
Ignore errors early, to avoid creating extra WorkflowRuns

### DIFF
--- a/src/api/app/controllers/concerns/rescue_handler.rb
+++ b/src/api/app/controllers/concerns/rescue_handler.rb
@@ -30,6 +30,10 @@ module RescueHandler
       render_error status: 403, errorcode: 'invalid_token', message: exception.message
     end
 
+    rescue_from Trigger::Errors::MissingExtractor do |exception|
+      render_error status: 400, errorcode: 'bad_request', message: exception.message
+    end
+
     rescue_from Project::WritePermissionError do |exception|
       render_error status: 403, errorcode: 'modify_project_no_permission', message: exception.message
     end

--- a/src/api/app/controllers/concerns/scm_webhook_headers_data_extractor.rb
+++ b/src/api/app/controllers/concerns/scm_webhook_headers_data_extractor.rb
@@ -23,6 +23,15 @@ module ScmWebhookHeadersDataExtractor
     @github_event || @gitlab_event || @gitea_event
   end
 
+  def ignored_event?
+    case scm_vendor
+    when 'github', 'gitea'
+      SCMWebhookEventValidator::ALLOWED_GITHUB_AND_GITEA_EVENTS.exclude?(hook_event)
+    when 'gitlab'
+      SCMWebhookEventValidator::ALLOWED_GITLAB_EVENTS.exclude?(hook_event)
+    end
+  end
+
   def extract_generic_event_type
     # We only have filters for push, tag_push, and pull_request
     if hook_event == 'Push Hook' || payload.fetch('ref', '').match('refs/heads')

--- a/src/api/app/controllers/trigger/errors.rb
+++ b/src/api/app/controllers/trigger/errors.rb
@@ -5,6 +5,10 @@ module Trigger::Errors
           'No valid token found'
   end
 
+  class MissingExtractor < APIError
+    setup 'bad_request', 400, 'Extractor could not be created.'
+  end
+
   class BadSCMPayload < APIError
     setup 'bad_request',
           400,

--- a/src/api/spec/controllers/trigger_workflow_controller_spec.rb
+++ b/src/api/spec/controllers/trigger_workflow_controller_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe TriggerWorkflowController do
       end
 
       it { expect(response).to have_http_status(:bad_request) }
-      it { expect(WorkflowRun.count).to eq(1) }
+      it { expect(WorkflowRun.count).to eq(0) }
 
       it 'returns an error message in the response body' do
         expect(response.body).to eql("<status code=\"bad_request\">\n  <summary>This SCM event is not supported</summary>\n</status>\n")


### PR DESCRIPTION
This makes sure to weed out the events and actions that shouldn't have WorkflowRuns created for them.

To test this:
1. Create a token and create a webhook on the scm side associated with it
2. Trigger an action that falls outside of the accepted events and actions
3. See it return a status 200 with a note about the event and/or action not being supported

Additionally, the extractor error can be triggered earlier, because it indicates missing headers for events, which needs to be detected before we can ok the action