### PR TITLE
Remove the WorkflowRuns with unsupported events

### DIFF
--- a/src/api/db/data/20231023110428_remove_unsupported_hook_events.rb
+++ b/src/api/db/data/20231023110428_remove_unsupported_hook_events.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class RemoveUnsupportedHookEvents < ActiveRecord::Migration[7.0]
+  def up
+    WorkflowRun.where.not(hook_event: [*SCMWebhookEventValidator::ALLOWED_GITHUB_AND_GITEA_EVENTS, *SCMWebhookEventValidator::ALLOWED_GITLAB_EVENTS]).destroy_all
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/src/api/db/data_schema.rb
+++ b/src/api/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20231016113740)
+DataMigrate::Data.define(version: 20231023110428)


### PR DESCRIPTION
This removes all of the WorkflowRuns with unsupported events from both GitHub/Gitea and Gitlab.

In order to test:
1. Make sure you have any unsupported event in WorkflowRuns (for example with `WorkflowRun.where.not(hook_event: [*SCMWebhookEventValidator::ALLOWED_GITHUB_AND_GITEA_EVENTS, *SCMWebhookEventValidator::ALLOWED_GITLAB_EVENTS])`)
2. Run the data migration
3. Check the unsupported events again

This should be merged after #15087 