### PR TITLE
Workflow_configuration: show the file content

### DIFF
--- a/src/api/app/components/workflow_run_detail_component.rb
+++ b/src/api/app/components/workflow_run_detail_component.rb
@@ -28,10 +28,18 @@ class WorkflowRunDetailComponent < ApplicationComponent
   def workflow_configuration_data
     return content_tag(:p, 'This information is not available.') unless workflow_run.configuration_source
 
-    content_tag(:h5, "Workflow Configuration File #{workflow_run.workflow_configuration_url.present? ? 'URL' : 'Path'}").concat(
-      content_tag(:pre,
-                  workflow_run.configuration_source,
-                  class: 'border p-2')
+    output = content_tag(:h5, "Workflow Configuration File #{workflow_run.workflow_configuration_url.present? ? 'URL' : 'Path'}").concat(
+      content_tag(:pre, workflow_run.configuration_source, class: 'border p-2')
     )
+
+    if workflow_run.workflow_configuration
+      output.concat(
+        content_tag(:h5, 'Workflow Configuration').concat(
+          content_tag(:pre, workflow_run.workflow_configuration, class: 'border p-2')
+        )
+      )
+    end
+
+    output
   end
 end

--- a/src/api/lib/tasks/dev/workflows.rake
+++ b/src/api/lib/tasks/dev/workflows.rake
@@ -24,6 +24,8 @@ namespace :dev do
       create(:workflow_run, :succeeded, :tag_push, token: workflow_token)
       create(:workflow_run, :succeeded, token: workflow_token)
       create(:workflow_run, :succeeded, :pull_request_closed, token: workflow_token)
+      create(:workflow_run, :with_url, token: workflow_token)
+      create(:workflow_run, :without_configuration_data, token: workflow_token)
 
       # GitLab
       create(:workflow_run_gitlab, token: workflow_token)

--- a/src/api/spec/components/workflow_run_detail_component_spec.rb
+++ b/src/api/spec/components/workflow_run_detail_component_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe WorkflowRunDetailComponent, type: :component do
+  context 'with a workflow run with configuration data path' do
+    let(:workflow_run_with_path) { create(:workflow_run) }
+
+    before do
+      render_inline(described_class.new(workflow_run: workflow_run_with_path))
+    end
+
+    it { expect(rendered_content).to have_text('Workflow Configuration File Path') }
+    it { expect(rendered_content).to have_text('Workflow Configuration') }
+  end
+
+  context 'with a workflow run with configuration data URL' do
+    let(:workflow_run_with_url) { create(:workflow_run, :with_url) }
+
+    before do
+      render_inline(described_class.new(workflow_run: workflow_run_with_url))
+    end
+
+    it { expect(rendered_content).to have_text('Workflow Configuration File URL') }
+    it { expect(rendered_content).to have_text('Workflow Configuration') }
+  end
+
+  context 'with a workflow run without configuration data' do
+    let(:workflow_run_without_data) { create(:workflow_run, :without_configuration_data) }
+
+    before do
+      render_inline(described_class.new(workflow_run: workflow_run_without_data))
+    end
+
+    it { expect(rendered_content).not_to have_text('Workflow Configuration File Path') }
+    it { expect(rendered_content).not_to have_text('Workflow Configuration File URL') }
+    it { expect(rendered_content).to have_text('This information is not available.') }
+  end
+end

--- a/src/api/spec/factories/workflow_runs.rb
+++ b/src/api/spec/factories/workflow_runs.rb
@@ -10,6 +10,8 @@ FactoryBot.define do
     repository_name { Faker::Lorem.word }
     repository_owner { Faker::Team.creature }
     response_url { 'https://api.github.com' }
+    workflow_configuration_path { '.obs/workflows.yml' }
+    workflow_configuration_url { nil }
     request_headers do
       <<~END_OF_HEADERS
         HTTP_X_GITHUB_EVENT: pull_request
@@ -20,13 +22,20 @@ FactoryBot.define do
     request_payload do
       File.read('spec/support/files/request_payload_github_pull_request_opened.json')
     end
-
-    trait 'with_configuration_path' do
-      workflow_configuration_path { '.obs/workflows.yml' }
+    workflow_configuration do
+      File.read('spec/support/files/workflows.yml')
     end
 
-    trait 'with_configuration_url' do
+    trait :with_url do
+      workflow_configuration_path { nil }
       workflow_configuration_url { 'http://example.com/workflows.yml' }
+    end
+
+    # Emulating the old workflow runs, before we started to store them
+    trait :without_configuration_data do
+      workflow_configuration_path { nil }
+      workflow_configuration_url { nil }
+      workflow_configuration { nil }
     end
 
     trait :pull_request_closed do


### PR DESCRIPTION
Show all the information available about the `Workflows Configuration File` for a `workflow_run`.
**Existing information**
- Path
- URL

**Additional information**
- File Content

If the workflow configuration file was ~received, parsed and stored by the scm service~ downloadable, it renders now the content of the file in the dedicated workflow run configuration sub-tab.

## Before
![image](https://github.com/openSUSE/open-build-service/assets/7080830/b90afc78-3321-4602-adfa-89c596b1f3df)

## After

![Screenshot 2023-10-26 at 18-15-43 Open Build Service](https://github.com/openSUSE/open-build-service/assets/2581944/68c24ba7-f6cd-4afb-9e5b-95ec8fc6c243)


## Testing tips

- Go to review-app or run `rake dev:test_data:create` in dev. env.
- Open any workflow run to see the content of the _Workflow Configuration_ tab (Profile > Manage Tokens > Workflow runs > click on one of the workflow runs)
- [Workflow run with ID 7](https://obs-reviewlab.opensuse.org/ncounter-workflow-config-ui/my/tokens/1/workflow_runs/7#tab-pane-workflow-configuration-tab-content7) has URL and configuration content stored.
- [Workflow run with ID 8](https://obs-reviewlab.opensuse.org/ncounter-workflow-config-ui/my/tokens/1/workflow_runs/8#tab-pane-workflow-configuration-tab-content8) doesn't have URL, PATH or configuration content stored. Emulates the old workflow runs.
- [The rest of the workflow runs](https://obs-reviewlab.opensuse.org/ncounter-workflow-config-ui/my/tokens/1/workflow_runs/1#tab-pane-workflow-configuration-tab-content1) have PATH and configuration content stored.