### PR TITLE
Switch allow_remote_projects default

### DIFF
--- a/src/api/app/models/concerns/project_links.rb
+++ b/src/api/app/models/concerns/project_links.rb
@@ -31,10 +31,10 @@ module ProjectLinks
   end
 
   def expand_linking_to
-    expand_all_projects(allow_remote_projects: false).map(&:id)
+    expand_all_projects.map(&:id)
   end
 
-  def expand_all_projects(project_map: {}, allow_remote_projects: true)
+  def expand_all_projects(project_map: {}, allow_remote_projects: false)
     # cycle check
     return [] if project_map[self]
 

--- a/src/api/app/models/concerns/project_maintenance.rb
+++ b/src/api/app/models/concerns/project_maintenance.rb
@@ -51,7 +51,7 @@ module ProjectMaintenance
   end
 
   def expand_maintained_projects
-    maintained_projects.collect { |mp| mp.project.expand_all_projects(allow_remote_projects: false) }.flatten
+    maintained_projects.collect { |mp| mp.project.expand_all_projects }.flatten
   end
 
   def is_maintenance_release?

--- a/src/api/app/models/owner_search/assignee.rb
+++ b/src/api/app/models/owner_search/assignee.rb
@@ -71,7 +71,7 @@ module OwnerSearch
       return package_owner if package_owner
 
       # no match, loop about projects below with this package container name
-      package.project.expand_all_projects(allow_remote_projects: false).each do |project|
+      package.project.expand_all_projects.each do |project|
         project_package = project.packages.find_by_name(package.name)
         next if project_package.nil? || @already_checked[project_package.id]
 
@@ -114,7 +114,7 @@ module OwnerSearch
     end
 
     def find_assignees(binary_name)
-      projects = @rootproject.expand_all_projects(allow_remote_projects: false)
+      projects = @rootproject.expand_all_projects
 
       # binary search via all projects
       data = Xmlhash.parse(Backend::Api::Search.binary(projects.map(&:name), binary_name))

--- a/src/api/app/models/owner_search/missing.rb
+++ b/src/api/app/models/owner_search/missing.rb
@@ -7,7 +7,7 @@ module OwnerSearch
       owners = []
       # search in each marked project
       projects_to_look_at.each do |project|
-        @projects = project.expand_all_projects(allow_remote_projects: false)
+        @projects = project.expand_all_projects
         @roles = filter(project).map { |f| Role.find_by_title!(f) }
 
         (all_packages - defined_packages).each do |p|

--- a/src/api/app/models/owner_search/owned.rb
+++ b/src/api/app/models/owner_search/owned.rb
@@ -6,7 +6,7 @@ module OwnerSearch
       # search in each marked project
       projects_to_look_at.map do |project|
         @roles = filter(project).map { |f| Role.find_by_title!(f) }
-        @projects = project.expand_all_projects(allow_remote_projects: false)
+        @projects = project.expand_all_projects
         find_projects(project, owner)
         find_packages(project, owner)
       end

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -213,7 +213,7 @@ class Package < ApplicationRecord
     if pkg.nil? && opts[:follow_project_links]
       # in case we link to a remote project we need to assume that the
       # backend may be able to find it even when we don't have the package local
-      prj.expand_all_projects.each do |p|
+      prj.expand_all_projects(allow_remote_projects: true).each do |p|
         return nil unless p.is_a?(Project)
       end
     end


### PR DESCRIPTION
There is only one place in the app where we look at remote project links. All the others turned it off, let's make this the default.