### PR TITLE
Simplify Project.find_package

### DIFF
--- a/src/api/app/models/linked_project.rb
+++ b/src/api/app/models/linked_project.rb
@@ -4,6 +4,8 @@ class LinkedProject < ApplicationRecord
 
   validate :validate_duplicates
 
+  scope :local, -> { where.not(linked_db_project: nil) }
+
   protected
 
   def validate_duplicates

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -276,6 +276,10 @@ class Package < ApplicationRecord
     true
   end
 
+  def check_access?
+    Project.check_access?(project)
+  end
+
   def check_source_access!
     return if check_source_access?
     # TODO: Use pundit for authorization instead


### PR DESCRIPTION
- LinkedProject scope to be able ignore remote project links
- Introduces update_project to explicitly avoid the update_instance_or_self trap
- Introduces check_access? instance method, the class method is doing things
   we've already done while instantiating
