### PR TITLE
Make the token naming consistent

### DIFF
--- a/src/api/app/views/person/token/index.xml.builder
+++ b/src/api/app/views/person/token/index.xml.builder
@@ -1,6 +1,7 @@
 xml.directory(count: @list.length) do |dir|
   @list.each do |token|
-    p = { id: token.id, string: token.string, kind: token.token_name, description: token.description, triggered_at: token.triggered_at }
+    token_name = token.token_name.sub('service', 'runservice') # To make token naming consistent: we create the token as runservice
+    p = { id: token.id, string: token.string, kind: token_name, description: token.description, triggered_at: token.triggered_at }
     if token.package
       p[:project] = token.package.project.name
       p[:package] = token.package.name


### PR DESCRIPTION
Because when we create the token, we have to tell the token is of type=runservice, but when we ask about the tokens a user has, we get that same token as kind=service instead.

Fixes https://github.com/openSUSE/open-build-service/issues/15078