### PR TITLE
Reduce number of lines of `call` method

### DIFF
--- a/src/api/app/components/notification_action_description_component.rb
+++ b/src/api/app/components/notification_action_description_component.rb
@@ -12,36 +12,9 @@ class NotificationActionDescriptionComponent < ApplicationComponent
     @target_object = [project, package].compact.join(' / ')
   end
 
-  # rubocop:disable Metrics/CyclomaticComplexity
   def call
-    tag.div(class: ['smart-overflow']) do
-      case @notification.event_type
-      when 'Event::RequestStatechange', 'Event::RequestCreate', 'Event::ReviewWanted', 'Event::CommentForRequest'
-        BsRequestActionSourceAndTargetComponent.new(bs_request).call
-      when 'Event::CommentForProject'
-        "#{@notification.notifiable.commentable.name}"
-      when 'Event::CommentForPackage'
-        commentable = @notification.notifiable.commentable
-        "#{commentable.project.name} / #{commentable.name}"
-      when 'Event::RelationshipCreate'
-        "#{@user} made #{@recipient} #{@role} of #{@target_object}"
-      when 'Event::RelationshipDelete'
-        "#{@user} removed #{@recipient} as #{@role} of #{@target_object}"
-      when 'Event::BuildFail'
-        "Build was triggered because of #{@notification.event_payload['reason']}"
-      # TODO: Remove `Event::CreateReport` after all existing records are migrated to the new STI classes
-      when 'Event::CreateReport', 'Event::ReportForProject', 'Event::ReportForPackage', 'Event::ReportForComment', 'Event::ReportForUser'
-        "'#{@notification.notifiable.user.login}' created a report for a #{@notification.event_payload['reportable_type'].downcase}. This is the reason:"
-      when 'Event::ClearedDecision'
-        class_name = @notification.notifiable.reports.first.reportable.class.name.downcase
-        "'#{@notification.notifiable.moderator.login}' decided to clear the report about the #{class_name}. This is the reason:"
-      when 'Event::FavoredDecision'
-        class_name = @notification.notifiable.reports.first.reportable.class.name.downcase
-        "'#{@notification.notifiable.moderator.login}' decided to favor the report about the #{class_name}. This is the reason:"
-      end
-    end
+    tag.div(description_text, class: ['smart-overflow'])
   end
-  # rubocop:enable Metrics/CyclomaticComplexity
 
   private
 
@@ -54,4 +27,33 @@ class NotificationActionDescriptionComponent < ApplicationComponent
                       @notification.notifiable.commentable
                     end
   end
+
+  # rubocop:disable Metrics/CyclomaticComplexity
+  def description_text
+    case @notification.event_type
+    when 'Event::RequestStatechange', 'Event::RequestCreate', 'Event::ReviewWanted', 'Event::CommentForRequest'
+      BsRequestActionSourceAndTargetComponent.new(bs_request).call
+    when 'Event::CommentForProject'
+      "#{@notification.notifiable.commentable.name}"
+    when 'Event::CommentForPackage'
+      commentable = @notification.notifiable.commentable
+      "#{commentable.project.name} / #{commentable.name}"
+    when 'Event::RelationshipCreate'
+      "#{@user} made #{@recipient} #{@role} of #{@target_object}"
+    when 'Event::RelationshipDelete'
+      "#{@user} removed #{@recipient} as #{@role} of #{@target_object}"
+    when 'Event::BuildFail'
+      "Build was triggered because of #{@notification.event_payload['reason']}"
+    # TODO: Remove `Event::CreateReport` after all existing records are migrated to the new STI classes
+    when 'Event::CreateReport', 'Event::ReportForProject', 'Event::ReportForPackage', 'Event::ReportForComment', 'Event::ReportForUser'
+      "'#{@notification.notifiable.user.login}' created a report for a #{@notification.event_payload['reportable_type'].downcase}. This is the reason:"
+    when 'Event::ClearedDecision'
+      class_name = @notification.notifiable.reports.first.reportable.class.name.downcase
+      "'#{@notification.notifiable.moderator.login}' decided to clear the report about the #{class_name}. This is the reason:"
+    when 'Event::FavoredDecision'
+      class_name = @notification.notifiable.reports.first.reportable.class.name.downcase
+      "'#{@notification.notifiable.moderator.login}' decided to favor the report about the #{class_name}. This is the reason:"
+    end
+  end
+  # rubocop:enable Metrics/CyclomaticComplexity
 end


### PR DESCRIPTION
This way we comply with the requirements of codeclimate.

Related to #15084.