### PR TITLE
Send email notifications for failed workflow runs

### DIFF
--- a/src/api/app/models/event/workflow_run_fail.rb
+++ b/src/api/app/models/event/workflow_run_fail.rb
@@ -2,9 +2,15 @@ module Event
   class WorkflowRunFail < Base
     self.message_bus_routing_key = 'workflow_run.fail'
     self.description = 'Workflow run has failed'
-    payload_keys :id, :token_id
+    payload_keys :id, :token_id, :hook_event, :summary, :repository_full_name
 
     receiver_roles :token_executor
+
+    # Example of subject:
+    #   Workflow run failed on Merge request hook
+    def subject
+      "Workflow run failed on #{payload['hook_event']}"
+    end
 
     def token_executors
       [Token.find_by(id: payload['token_id'], type: 'Token::Workflow')&.executor].compact

--- a/src/api/app/models/event_subscription/for_channel_form.rb
+++ b/src/api/app/models/event_subscription/for_channel_form.rb
@@ -22,8 +22,7 @@ class EventSubscription
 
     def disabled_checkbox?
       (DISABLE_FOR_EVENTS.include?(@event.to_s) && (name == 'web' || name == 'rss')) ||
-        (DISABLE_RSS_FOR_EVENTS.include?(@event.to_s) && name == 'rss') ||
-        (@event.to_s == 'Event::WorkflowRunFail' && name == 'instant_email') # TODO: remove as soon as the email channel is implemented
+        (DISABLE_RSS_FOR_EVENTS.include?(@event.to_s) && name == 'rss')
     end
 
     private

--- a/src/api/app/models/workflow_run.rb
+++ b/src/api/app/models/workflow_run.rb
@@ -122,7 +122,7 @@ class WorkflowRun < ApplicationRecord
   private
 
   def event_parameters
-    { id: id, token_id: token_id }
+    { id: id, token_id: token_id, hook_event: (hook_event&.humanize || 'unknown'), summary: summary, repository_full_name: repository_full_name }
   end
 
   def create_event

--- a/src/api/app/views/event_mailer/workflow_run_fail.html.haml
+++ b/src/api/app/views/event_mailer/workflow_run_fail.html.haml
@@ -1,0 +1,8 @@
+%p
+  A workflow run failed for #{ event['summary'] }
+  = succeed '.' do
+    - if event['repository_full_name']
+      on repository #{ event['repository_full_name'] }
+
+%p
+  Check the details about this #{link_to('Workflow Run', token_workflow_run_url(event['token_id'], event['id'], only_path: false, host: @host)) }.

--- a/src/api/app/views/event_mailer/workflow_run_fail.text.erb
+++ b/src/api/app/views/event_mailer/workflow_run_fail.text.erb
@@ -1,0 +1,7 @@
+A workflow run failed for <%= event['summary'] %>
+<% if event['repository_full_name'] %>
+on repository <%= event['repository_full_name'] -%>
+<% end -%>
+.
+
+Check the details about this <%= link_to('Workflow Run', token_workflow_run_url(event['token_id'], event['id'], only_path: false, host: @host)) %>.

--- a/src/api/spec/factories/event_subscriptions.rb
+++ b/src/api/spec/factories/event_subscriptions.rb
@@ -118,5 +118,13 @@ FactoryBot.define do
       user
       group { nil }
     end
+
+    factory :event_subscription_workflow_run_fail do
+      eventtype { 'Event::WorkflowRunFail' }
+      receiver_role { 'token_executor' }
+      channel { :instant_email }
+      user
+      group { nil }
+    end
   end
 end


### PR DESCRIPTION
Enables the email channel and sets up everything to allow users to receive email notifications regarding failed workflow runs.