### PR TITLE
Read repository_name also when bulding the binary path

### DIFF
--- a/src/api/app/controllers/webui/packages/main_controller.rb
+++ b/src/api/app/controllers/webui/packages/main_controller.rb
@@ -17,7 +17,11 @@ module Webui
         return @architecture if @architecture
 
         flash[:error] = "Couldn't find architecture '#{params[:arch]}'."
-        redirect_to(project_package_repository_binaries_path(package_name: @package.name, project_name: @project.name, repository_name: params[:repository]))
+
+        repository_name = params[:repository] || params[:repository_name]
+        redirect_to(project_package_repository_binaries_path(package_name: @package.name,
+                                                             project_name: @project.name,
+                                                             repository_name: repository_name))
       end
     end
   end


### PR DESCRIPTION
Building the rpmlint.log binary info page (for example) crashes:

https://build.opensuse.org/projects/openSUSE:Factory/packages/telegram-desktop/repositories/standard/binaries/x86_86/rpmlint.log

That url tries to build the index action path but it's not providing the `repository_name` parameter and the Url helper fails.

Fixes #14879