### PR TITLE
Catch OpenSSL::SSL::SSLError exceptions when reporting back to the SCM/CI

### DIFF
--- a/src/api/app/services/gitlab_status_reporter.rb
+++ b/src/api/app/services/gitlab_status_reporter.rb
@@ -21,7 +21,7 @@ class GitlabStatusReporter < SCMExceptionHandler
       @workflow_run.save_scm_report_success(request_context)
       RabbitmqBus.send_to_bus('metrics', "scm_status_report,status=success,scm=#{@event_subscription_payload[:scm]} value=1")
     end
-  rescue Gitlab::Error::Error => e
+  rescue Gitlab::Error::Error, OpenSSL::SSL::SSLError => e
     rescue_with_handler(e) || raise(e)
     RabbitmqBus.send_to_bus('metrics', "scm_status_report,status=fail,scm=#{@event_subscription_payload[:scm]},exception=#{e.class} value=1") if @workflow_run.present?
   end

--- a/src/api/app/services/scm_exception_handler.rb
+++ b/src/api/app/services/scm_exception_handler.rb
@@ -30,6 +30,7 @@ class SCMExceptionHandler
   end
 
   rescue_from Gitlab::Error::BadGateway,
+              Gitlab::Error::BadRequest,
               Gitlab::Error::Conflict,
               Gitlab::Error::Forbidden,
               Gitlab::Error::InternalServerError,
@@ -38,7 +39,7 @@ class SCMExceptionHandler
               Gitlab::Error::ServiceUnavailable,
               Gitlab::Error::TooManyRequests,
               Gitlab::Error::Unauthorized,
-              Gitlab::Error::BadRequest do |exception|
+              OpenSSL::SSL::SSLError do |exception|
     log_to_workflow_run(exception, 'GitLab') if @workflow_run.present?
   end
 


### PR DESCRIPTION
This exception is thrown by httparty, the rubygem used by the Gitlab rubygem. Therefore, we catch this exception only when trying to connect to a Gitlab instance.