### PR TITLE
Move check_access into instantiation callback

### DIFF
--- a/src/api/app/jobs/create_project_log_entry_job.rb
+++ b/src/api/app/jobs/create_project_log_entry_job.rb
@@ -2,6 +2,8 @@ class CreateProjectLogEntryJob < ApplicationJob
   queue_as :project_log_rotate
 
   def perform(payload, created_at, event_model_name)
-    ProjectLogEntry.create_from(payload, created_at, event_model_name)
+    admin = CONFIG['default_admin'] || 'Admin'
+    admin = User.find_by(login: admin)
+    admin&.run_as { ProjectLogEntry.create_from(payload, created_at, event_model_name) }
   end
 end

--- a/src/api/app/models/bs_request_action.rb
+++ b/src/api/app/models/bs_request_action.rb
@@ -111,7 +111,7 @@ class BsRequestAction < ApplicationRecord
   end
 
   def is_from_remote?
-    Project.unscoped.is_remote_project?(source_project, true)
+    Project.is_remote_project?(source_project)
   end
 
   def store_from_xml(hash)

--- a/src/api/app/models/concerns/project_maintenance.rb
+++ b/src/api/app/models/concerns/project_maintenance.rb
@@ -22,7 +22,7 @@ module ProjectMaintenance
       at ||= AttribType.find_by_namespace_and_name!('OBS', 'MaintenanceProject')
       maintenance_project = Project.find_by_attribute_type(at).first
 
-      return unless maintenance_project && check_access?(maintenance_project)
+      return unless maintenance_project
 
       maintenance_project
     end

--- a/src/api/app/models/event/request.rb
+++ b/src/api/app/models/event/request.rb
@@ -170,7 +170,7 @@ module Event
     end
 
     def source_from_remote?
-      payload['actions'].any? { |action| Project.unscoped.is_remote_project?(action['sourceproject'], true) }
+      payload['actions'].any? { |action| Project.is_remote_project?(action['sourceproject']) }
     end
 
     def payload_without_target_project?

--- a/src/api/app/models/owner_search/assignee.rb
+++ b/src/api/app/models/owner_search/assignee.rb
@@ -37,7 +37,7 @@ module OwnerSearch
     end
 
     def extract_maintainer(package)
-      return unless package && Package.check_access?(package)
+      return unless package
 
       owner = create_owner(package)
       # no filter defined, so do not check for roles and just return container

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -113,13 +113,6 @@ class Package < ApplicationRecord
 
   has_many :tokens, class_name: 'Token::Service', dependent: :destroy, inverse_of: :package
 
-  def self.check_access?(package)
-    return false if package.nil?
-    return false unless package.instance_of?(Package)
-
-    Project.check_access?(package.project)
-  end
-
   def self.check_cache(project, package, opts)
     @key = { 'get_by_project_and_name' => 1, :package => package, :opts => opts }
 
@@ -219,7 +212,6 @@ class Package < ApplicationRecord
     end
 
     raise UnknownObjectError, "Package not found: #{project.name}/#{package_name}" unless package
-    raise ReadAccessError, "#{project.name}/#{package.name}" unless check_access?(package)
 
     package.check_source_access! if opts[:use_source]
 
@@ -273,10 +265,6 @@ class Package < ApplicationRecord
     return false if (disabled_for?('sourceaccess', nil, nil) || project.disabled_for?('sourceaccess', nil, nil)) && !User.possibly_nobody.can_source_access?(self)
 
     true
-  end
-
-  def check_access?
-    Project.check_access?(project)
   end
 
   def check_source_access!

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -261,7 +261,7 @@ class User < ApplicationRecord
   def self.get_default_admin
     admin = CONFIG['default_admin'] || 'Admin'
     user = User.find_by!(login: admin)
-    raise NotFoundError, "Admin not found, user #{admin} has not admin permissions" unless user.is_admin?
+    raise NotFoundError, "Admin not found, user #{admin} has no admin permissions" unless user.is_admin?
 
     user
   end

--- a/src/api/app/queries/packages_finder.rb
+++ b/src/api/app/queries/packages_finder.rb
@@ -42,7 +42,7 @@ class PackagesFinder
   private
 
   def find_package(args)
-    Package.find_by_sql(args).keep_if { |p| Package.check_access?(p) }
+    Package.find_by_sql(args)
   end
 
   def base_query


### PR DESCRIPTION
We already have a default_scope to check for the access Flag hack while finding Projects. And then we had Project.check_access? all over the app where we maybe instantiate a Project through some other means (associations, arel etc.)

Instead let's do this in a after_initialize callback.