### PR TITLE
Exclude dev rake tasks from code coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,6 +5,9 @@ coverage:
         target: auto
         base: auto
         threshold: 1
+        paths:
+        - !src/api/lib/tasks/dev/
+
 comment:
   layout: "reach, diff, flags"
   require_changes: true


### PR DESCRIPTION
It doesn't make much sense to track code coverage of rake tasks used only for development purposes. We don't plan to create tests for them.

See this comment: https://github.com/openSUSE/open-build-service/pull/15094#issuecomment-1782787726