### PR TITLE
Unify actions texts

### DIFF
--- a/src/api/app/views/webui/user/index_actions/_change_notifications.haml
+++ b/src/api/app/views/webui/user/index_actions/_change_notifications.haml
@@ -1,4 +1,4 @@
 %li.nav-item
-  = link_to(my_subscriptions_path, class: 'nav-link', title: 'Change Your Notifications') do
+  = link_to(my_subscriptions_path, class: 'nav-link', title: 'Manage Your Notifications') do
     %i.fas.fa-lg.me-2.fa-bell
-    %span.nav-item-name Change Your Notifications
+    %span.nav-item-name Manage Your Notifications

--- a/src/api/app/views/webui/users/notifications/_index_actions.html.haml
+++ b/src/api/app/views/webui/users/notifications/_index_actions.html.haml
@@ -1,5 +1,5 @@
 - content_for :actions do
   %li.nav-item
-    = link_to(my_subscriptions_path, class: 'nav-link', title: 'Change Your Notifications') do
+    = link_to(my_subscriptions_path, class: 'nav-link', title: 'Manage Your Notifications') do
       %i.fas.fa-edit.fa-lg.me-2
-      %span.nav-item-name Change Your Notifications
+      %span.nav-item-name Manage Your Notifications


### PR DESCRIPTION
Having actions like "Manage Your Tokens" and "Manage Beta Features", it makes sense to have "Manage Your Notifications" instead of "Change Your Notifications".

Now:

![profile_page](https://github.com/openSUSE/open-build-service/assets/2581944/1be4cc63-fb7d-4ae1-8889-b83e1c73195e)

![notifications_page](https://github.com/openSUSE/open-build-service/assets/2581944/cf30f539-ad76-410b-aefa-d209caa1030c)
