### PR TITLE
Fix expression to exclude dev rake tasks from codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,9 +5,8 @@ coverage:
         target: auto
         base: auto
         threshold: 1
-        paths:
-        - !src/api/lib/tasks/dev/
-
+ignore:
+  - "src/api/lib/tasks/dev/"
 comment:
   layout: "reach, diff, flags"
   require_changes: true


### PR DESCRIPTION
Fixes the previous PR https://github.com/openSUSE/open-build-service/pull/15124

According to the [documentation](https://docs.codecov.com/docs/ignoring-paths), the key is `ignore:`.