### PR TITLE
Prevent some Ruby gems from being auto required

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -182,9 +182,9 @@ group :development, :test do
   # for mocking the backend
   gem 'vcr'
   # as alternative to the standard IRB shell
-  gem 'pry'
+  gem 'pry', require: false
   # add step-by-step debugging and stack navigation capabilities to pry
-  gem 'pry-byebug'
+  gem 'pry-byebug', require: false
   # for style checks
   gem 'rubocop', require: false
   # for rails style checks
@@ -194,7 +194,7 @@ group :development, :test do
   # for performance checks
   gem 'rubocop-performance'
   # integrates with RuboCop to analyse HAML files
-  gem 'haml_lint'
+  gem 'haml_lint', require: false
   # to generate random long strings
   gem 'faker'
   # to launch browser in test
@@ -204,7 +204,7 @@ group :development, :test do
   # to find n+1 queries
   gem 'bullet'
   # Use Puma as the app server
-  gem 'puma'
+  gem 'puma', require: false
   # to drive headless chrome
   gem 'selenium-webdriver'
 end


### PR DESCRIPTION
We don't want to load them into every process.

For example, when running a spec, we don't need the `puma` gem to be loaded.

They are currently loaded here: https://github.com/openSUSE/open-build-service/blob/fea862b7704583bfaf1262a33a3409280d9bc36b/src/api/config/application.rb#L24-L30