### PR TITLE
Prevent RuboCop Ruby gem from being auto required

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -192,7 +192,7 @@ group :development, :test do
   # for rspec style checks
   gem 'rubocop-rspec', require: false
   # for performance checks
-  gem 'rubocop-performance'
+  gem 'rubocop-performance', require: false
   # integrates with RuboCop to analyse HAML files
   gem 'haml_lint', require: false
   # to generate random long strings

--- a/src/api/spec/lib/rubocop/cop/view_component/avoid_global_state_spec.rb
+++ b/src/api/spec/lib/rubocop/cop/view_component/avoid_global_state_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'support/rubocop'
 require './lib/rubocop/cop/view_component/avoid_global_state'
 
 RSpec.describe RuboCop::Cop::ViewComponent::AvoidGlobalState, :config do

--- a/src/api/spec/lib/rubocop/cop/view_component/class_name_spec.rb
+++ b/src/api/spec/lib/rubocop/cop/view_component/class_name_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'support/rubocop'
 require './lib/rubocop/cop/view_component/class_name'
 
 RSpec.describe RuboCop::Cop::ViewComponent::ClassName, :config do

--- a/src/api/spec/lib/rubocop/cop/view_component/file_name_spec.rb
+++ b/src/api/spec/lib/rubocop/cop/view_component/file_name_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'support/rubocop'
 require './lib/rubocop/cop/view_component/file_name'
 
 RSpec.describe RuboCop::Cop::ViewComponent::FileName, :config do

--- a/src/api/spec/lib/rubocop/cop/view_component/missing_preview_file_spec.rb
+++ b/src/api/spec/lib/rubocop/cop/view_component/missing_preview_file_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'support/rubocop'
 require './lib/rubocop/cop/view_component/missing_preview_file'
 
 RSpec.describe RuboCop::Cop::ViewComponent::MissingPreviewFile, :config do

--- a/src/api/spec/rails_helper.rb
+++ b/src/api/spec/rails_helper.rb
@@ -80,9 +80,6 @@ require 'support/thinking_sphinx'
 # support beta
 require 'support/beta'
 
-# custom matchers to test RuboCop custom cops
-require 'support/rubocop'
-
 # support time helpers
 require 'support/time_helpers'
 

--- a/src/api/spec/support/rubocop.rb
+++ b/src/api/spec/support/rubocop.rb
@@ -1,3 +1,4 @@
+require 'rubocop'
 require 'rubocop/rspec/support'
 
 RSpec.configure do |config|


### PR DESCRIPTION
Related to #15140.