### PR TITLE
Autocorrect RuboCop offenses in migrations

### DIFF
--- a/.github/workflows/isolated_migrations.yml
+++ b/.github/workflows/isolated_migrations.yml
@@ -21,10 +21,15 @@ jobs:
         uses: tj-actions/changed-files@v40
         with:
           files_yaml: |
+            linters:
+              - '.github/workflows/isolated_migrations.yml'
+              - 'src/api/.rubocop*.yml'
             migrations:
               - src/api/db/**
             not_migrations:
               - '!src/api/db/**'
+              - '!.github/workflows/isolated_migrations.yml'
+              - '!src/api/.rubocop*.yml'
             schema_migrations:
               - src/api/db/migrate/**
             data_migrations:
@@ -33,6 +38,13 @@ jobs:
               - src/api/db/schema.rb
             data_schema:
               - src/api/db/data_schema.rb
+
+      - name: List the files related to linters that this PR changes
+        if: steps.changed-files-yaml.outputs.linters_any_changed == 'true'
+        run: |
+          for file in ${{ steps.changed-files-yaml.outputs.linters_all_changed_files }}; do
+            echo "- $file"
+          done
 
       - name: List the files related to migrations that this PR changes
         if: steps.changed-files-yaml.outputs.migrations_any_changed == 'true'
@@ -55,13 +67,13 @@ jobs:
           exit 1
 
       - name: Missing schema changes
-        if: (steps.changed-files-yaml.outputs.schema_migrations_any_changed == 'true') && (steps.changed-files-yaml.outputs.schema_any_changed == 'false')
+        if: (steps.changed-files-yaml.outputs.schema_migrations_any_changed == 'true') && (steps.changed-files-yaml.outputs.linters_any_changed == 'false') && (steps.changed-files-yaml.outputs.schema_any_changed == 'false')
         run: |
           echo "You introduced some schema migration, please introduce the schema.rb changes as well"
           exit 1
 
       - name: Missing data schema changes
-        if: (steps.changed-files-yaml.outputs.data_schema_migrations_any_changed == 'true') && (steps.changed-files-yaml.outputs.data_schema_any_changed == 'false')
+        if: (steps.changed-files-yaml.outputs.data_schema_migrations_any_changed == 'true') && (steps.changed-files-yaml.outputs.linters_any_changed == 'false') && (steps.changed-files-yaml.outputs.data_schema_any_changed == 'false')
         run: |
           echo "You introduced some data migrations, please introduce the data_schema.rb changes as well"
           exit 1

--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -47,7 +47,6 @@ Layout/LineContinuationLeadingSpace:
   Exclude:
     - 'app/models/bs_request_action_maintenance_incident.rb'
     - 'app/models/project.rb'
-    - 'db/migrate/20180516074538_explicitly_set_charset.rb'
     - 'spec/controllers/webui/project_controller_spec.rb'
     - 'test/functional/source_controller_test.rb'
 

--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -484,7 +484,6 @@ Naming/BlockForwarding:
   Exclude:
     - 'app/lib/suse/permission.rb'
     - 'app/models/configuration.rb'
-    - 'db/data/20170831143534_convert_notifications_event_payload_to_json.rb'
 
 # Offense count: 19
 # Configuration parameters: ForbiddenDelimiters.

--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -105,7 +105,6 @@ Lint/NonLocalExitFromIterator:
 Lint/RedundantCopDisableDirective:
   Exclude:
     - 'app/models/issue_tracker.rb'
-    - 'db/migrate/20210511201658_add_data_migrations_table.rb'
     - 'spec/jobs/consistency_check_job_spec.rb'
 
 # Offense count: 3

--- a/src/api/db/data/20170831143534_convert_notifications_event_payload_to_json.rb
+++ b/src/api/db/data/20170831143534_convert_notifications_event_payload_to_json.rb
@@ -34,19 +34,19 @@ end
 # Hash extension is used to run force_encoding against each string value in the hash
 # in data migration to convert yaml to json serialisation for event payloads
 class Hash
-  def traverse(&block)
-    traverse_value(self, &block)
+  def traverse(&)
+    traverse_value(self, &)
   end
 
   private
 
-  def traverse_value(value, &block)
+  def traverse_value(value, &)
     case value
     when Hash
-      value.each { |key, sub_value| value[key] = traverse_value(sub_value, &block) }
+      value.each { |key, sub_value| value[key] = traverse_value(sub_value, &) }
 
     when Array
-      value.map { |element| traverse_value(element, &block) }
+      value.map { |element| traverse_value(element, &) }
 
     else
       yield(value)

--- a/src/api/db/migrate/20180516074538_explicitly_set_charset.rb
+++ b/src/api/db/migrate/20180516074538_explicitly_set_charset.rb
@@ -21,8 +21,8 @@ class ExplicitlySetCharset < ActiveRecord::Migration[5.1]
 
     change_column(:flags, :status, "ENUM('enable','disable') CHARACTER SET utf8 NOT NULL")
     change_column(:flags, :repo, 'varchar(255) CHARACTER SET utf8 DEFAULT NULL')
-    change_column(:flags, :flag, "ENUM('useforbuild','sourceaccess','binarydownload','debuginfo','build','publish','access','lock')" \
-                                 ' CHARACTER SET utf8 NOT NULL')
+    change_column(:flags, :flag, "ENUM('useforbuild','sourceaccess','binarydownload','debuginfo','build','publish','access','lock') " \
+                                 'CHARACTER SET utf8 NOT NULL')
   end
 
   def down

--- a/src/api/db/migrate/20210511201658_add_data_migrations_table.rb
+++ b/src/api/db/migrate/20210511201658_add_data_migrations_table.rb
@@ -1,9 +1,7 @@
 class AddDataMigrationsTable < ActiveRecord::Migration[6.0]
   def change
-    # rubocop:disable Rails/CreateTableWithTimestamps
     create_table :data_migrations, primary_key: 'version', id: false, if_not_exists: true do |t|
       t.string :version
     end
-    # rubocop:enable Rails/CreateTableWithTimestamps
   end
 end


### PR DESCRIPTION
I grouped the fixes for RuboCop offenses for migrations and data migrations.

The "Isolated Migrations" GitHub action was adapted to not complain when there are also changes in the linters configuration.