### PR TITLE
Move logic to fetch open reviews to a finder class

### DIFF
--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -525,8 +525,7 @@ class Webui::RequestController < Webui::WebuiController
   def prepare_request_data
     @is_author = @bs_request.creator == User.possibly_nobody.login
     @is_target_maintainer = @bs_request.is_target_maintainer?(User.session)
-    reviews = @bs_request.reviews.where(state: 'new')
-    @my_open_reviews = reviews.select { |review| review.matches_user?(User.session) }
+    @my_open_reviews = ReviewsFinder.new(@bs_request.reviews).open_reviews_for_user(User.session)
 
     @diff_limit = params[:full_diff] ? 0 : nil
     @diff_to_superseded_id = params[:diff_to_superseded]

--- a/src/api/app/queries/reviews_finder.rb
+++ b/src/api/app/queries/reviews_finder.rb
@@ -9,4 +9,8 @@ class ReviewsFinder
       state: [:accepted, :declined]
     )
   end
+
+  def open_reviews_for_user(user)
+    @relation.where(state: 'new').select { |review| review.matches_user?(user) }
+  end
 end


### PR DESCRIPTION
Moved out of https://github.com/openSUSE/open-build-service/pull/14318 (outdated and only parts of it still apply).
Part of cleaning up the request controller, I only plan to do this for the request workflow redesign beta endpoints.