### PR TITLE
Add missing preview for write_and_preview_component

### DIFF
--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -1383,7 +1383,6 @@ ViewComponent/MissingPreviewFile:
     - 'app/components/workflow_run_request_action_filter_component.rb'
     - 'app/components/workflow_run_row_component.rb'
     - 'app/components/workflow_run_status_badge_component.rb'
-    - 'app/components/write_and_preview_component.rb'
 
 # Offense count: 2760
 # This cop supports safe autocorrection (--autocorrect).

--- a/src/api/spec/components/previews/write_and_preview_component_preview.rb
+++ b/src/api/spec/components/previews/write_and_preview_component_preview.rb
@@ -1,0 +1,9 @@
+class WriteAndPreviewComponentPreview < ViewComponent::Preview
+  def for_message_editing
+    view = ActionView::Base.new('', {}, nil)
+    status_message = StatusMessage.new(message: 'Message text', severity: 'announcement', communication_scope: 'in_rollout_users')
+    form = ActionView::Helpers::FormBuilder.new(:status_message, status_message, view, {})
+    url = '/news_items/preview'
+    render(WriteAndPreviewComponent.new(form, url))
+  end
+end


### PR DESCRIPTION
To test please visit `/rails/view_components/write_and_preview_component/for_message_editing` on your localhost