### PR TITLE
Use `revoke_request` policy in `request_decision_component`

### DIFF
--- a/src/api/app/components/request_decision_component.html.haml
+++ b/src/api/app/components/request_decision_component.html.haml
@@ -15,7 +15,7 @@
           %label.form-check-label{ for: "forward-#{index}" }
             Forward submit request to
             #{helpers.project_or_package_link(project: forward[:project], package: forward[:package], short: true)}
-    - if can_revoke_request?
+    - if policy(@bs_request).revoke_request?
       = submit_tag 'Revoke request', name: 'revoked', class: 'btn btn-danger me-2'
     - if can_reopen_request?
       = submit_tag 'Reopen request', name: 'new', class: 'btn btn-warning me-2'

--- a/src/api/app/components/request_decision_component.rb
+++ b/src/api/app/components/request_decision_component.rb
@@ -29,10 +29,6 @@ class RequestDecisionComponent < ApplicationComponent
   end
 
   # TODO: Move all those "can_*" checks to a pundit policy
-  def can_revoke_request?
-    @is_author && @bs_request.state.in?([:new, :review, :declined])
-  end
-
   def can_accept_request?
     @bs_request.state.in?([:new, :review]) && @is_target_maintainer
   end


### PR DESCRIPTION
Meanwhile we created a policy for the authorization logic, let's use it in the view component and remove duplicates.

Moved out of https://github.com/openSUSE/open-build-service/pull/14318 (outdated and only parts of it still apply).
Part of cleaning up the request controller, I only plan to do this for the request workflow redesign beta endpoints.