### PR TITLE
Remove call to update Configuration in database cleaner

### DIFF
--- a/src/api/spec/factories/users.rb
+++ b/src/api/spec/factories/users.rb
@@ -23,14 +23,14 @@ FactoryBot.define do
 
     to_create do |user, evaluator|
       if evaluator.create_home_project
+        user.save!
+      else
         # rubocop:disable Rails/SkipsModelValidations
         # Avoid triggering the callbacks to propagate the change to the backend
-        Configuration.update_column(:allow_user_to_create_home_project, true)
-        user.save!
         Configuration.update_column(:allow_user_to_create_home_project, false)
-        # rubocop:enable Rails/SkipsModelValidations
-      else
         user.save!
+        Configuration.update_column(:allow_user_to_create_home_project, true)
+        # rubocop:enable Rails/SkipsModelValidations
       end
     end
 

--- a/src/api/spec/lib/statistics_calculations_spec.rb
+++ b/src/api/spec/lib/statistics_calculations_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe StatisticsCalculations do
     let!(:project_without_package) { travel_to(59.seconds.ago) { create(:project) } }
 
     before do
-      Configuration.update(allow_user_to_create_home_project: false)
       User.session = user
     end
 

--- a/src/api/spec/support/database_cleaner.rb
+++ b/src/api/spec/support/database_cleaner.rb
@@ -25,7 +25,6 @@ RSpec.configure do |config|
                                  :transaction
                                end
     DatabaseCleaner.start
-    Configuration.first_or_create(name: 'private', title: 'Open Build Service').update(allow_user_to_create_home_project: false)
   end
 
   config.after do


### PR DESCRIPTION
The `first_or_create` call will never create a record because the `description` field is validated from being present.

We don't need to update the `allow_user_to_create_home_project` field to `false`  on every rspec example.

See:
- 79b5e04cb78e2feceb51779b7c8ffff08f7f53d9
- f87366b9287fdc001122c284406c21c0bdc6c429