### PR TITLE
Add missing attribute types to `db/seeds.rb`

### DIFF
--- a/.github/workflows/isolated_migrations.yml
+++ b/.github/workflows/isolated_migrations.yml
@@ -34,6 +34,8 @@ jobs:
               - '!src/api/db/schema.rb'
               - '!src/api/db/data/**'
               - '!src/api/db/data_schema.rb'
+              - '!src/api/db/attribute_descriptions.rb'
+              - '!src/api/db/seeds.rb'
               - '!.github/workflows/isolated_migrations.yml'
               - '!src/api/.rubocop*.yml'
             schema_migrations:

--- a/src/api/db/attribute_descriptions.rb
+++ b/src/api/db/attribute_descriptions.rb
@@ -17,7 +17,7 @@ def update_all_attrib_type_descriptions
     'InitializeDevelPackage' => 'Accepting a new package via a submit request to this project will set the devel project of the new package to the source of the request.',
     'BranchTarget' => 'Branches from this project will not follow any project links for the target link.',
     'BranchRepositoriesFromProject' => 'Use repository definitions from the specified project when creating a branch.',
-    'BranchSkipRepositories' => 'Skip the listed repositories when branching from this projet.',
+    'BranchSkipRepositories' => 'Skip the listed repositories when branching from this project.',
     'AutoCleanup' => 'The object will recieve a delete request at specified time (YYYY-MM-DD HH:MM:SS) in the value',
     'Issues' => 'Use this attribute to reference issues this object has',
     'QualityCategory' => 'Use this attribute to classify the usability of a project. This gets used by the user package search for instance.',

--- a/src/api/db/data/20231106165306_add_branch_skip_repositories_to_attrib_types.rb
+++ b/src/api/db/data/20231106165306_add_branch_skip_repositories_to_attrib_types.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class AddBranchSkipRepositoriesToAttribTypes < ActiveRecord::Migration[7.0]
+  def up
+    ans = AttribNamespace.find_by(name: 'OBS')
+    at = ans.attrib_types.create_with(
+      description: 'Skip the listed repositories when branching from this project.'
+    ).find_or_create_by(name: 'BranchSkipRepositories')
+
+    maintainer_role = Role.find_by(title: 'maintainer')
+    at.attrib_type_modifiable_bies.find_or_create_by(role_id: maintainer_role.id)
+  end
+
+  def down
+    ans = AttribNamespace.find_by(name: 'OBS')
+    ans.attrib_types.find_by(name: 'BranchSkipRepositories').destroy
+  end
+end

--- a/src/api/db/data/20231107095249_add_planned_release_date_to_attrib_types.rb
+++ b/src/api/db/data/20231107095249_add_planned_release_date_to_attrib_types.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class AddPlannedReleaseDateToAttribTypes < ActiveRecord::Migration[7.0]
+  def up
+    ans = AttribNamespace.find_by(name: 'OBS')
+    at = ans.attrib_types.create_with(
+      description: 'A timestamp for the planned release date of an incident.',
+      value_count: 1
+    ).find_or_create_by(name: 'PlannedReleaseDate')
+
+    maintainer_role = Role.find_by(title: 'maintainer')
+    at.attrib_type_modifiable_bies.find_or_create_by(role_id: maintainer_role.id)
+  end
+
+  def down
+    ans = AttribNamespace.find_by(name: 'OBS')
+    ans.attrib_types.find_by(name: 'PlannedReleaseDate').destroy
+  end
+end

--- a/src/api/db/data/20231107100650_add_enforce_revisions_in_requests_to_attrib_types.rb
+++ b/src/api/db/data/20231107100650_add_enforce_revisions_in_requests_to_attrib_types.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class AddEnforceRevisionsInRequestsToAttribTypes < ActiveRecord::Migration[7.0]
+  def up
+    ans = AttribNamespace.find_by(name: 'OBS')
+    at = ans.attrib_types.create_with(
+      description: 'Enforce revisions in request actions'
+    ).find_or_create_by(name: 'EnforceRevisionsInRequests')
+
+    maintainer_role = Role.find_by(title: 'maintainer')
+    at.attrib_type_modifiable_bies.find_or_create_by(role_id: maintainer_role.id)
+  end
+
+  def down
+    ans = AttribNamespace.find_by(name: 'OBS')
+    ans.attrib_types.find_by(name: 'EnforceRevisionsInRequests').destroy
+  end
+end

--- a/src/api/db/data_schema.rb
+++ b/src/api/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20231107095249)
+DataMigrate::Data.define(version: 20231107100650)

--- a/src/api/db/data_schema.rb
+++ b/src/api/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20231023110428)
+DataMigrate::Data.define(version: 20231106165306)

--- a/src/api/db/data_schema.rb
+++ b/src/api/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20231106165306)
+DataMigrate::Data.define(version: 20231107095249)

--- a/src/api/db/seeds.rb
+++ b/src/api/db/seeds.rb
@@ -166,6 +166,9 @@ at.allowed_values << AttribAllowedValue.new(value: 'BugownerOnly')
 at = ans.attrib_types.where(name: 'CreatorCannotAcceptOwnRequests').first_or_create(value_count: 0)
 at.attrib_type_modifiable_bies.where(user_id: admin.id).first_or_create
 
+at = ans.attrib_types.where(name: 'PlannedReleaseDate').first_or_create(value_count: 1)
+at.attrib_type_modifiable_bies.where(role_id: maintainer_role.id).first_or_create
+
 update_all_attrib_type_descriptions
 
 puts 'Seeding issue trackers ...'

--- a/src/api/db/seeds.rb
+++ b/src/api/db/seeds.rb
@@ -166,6 +166,8 @@ at.allowed_values << AttribAllowedValue.new(value: 'BugownerOnly')
 at = ans.attrib_types.where(name: 'CreatorCannotAcceptOwnRequests').first_or_create(value_count: 0)
 at.attrib_type_modifiable_bies.where(user_id: admin.id).first_or_create
 
+at = ans.attrib_types.where(name: 'EnforceRevisionsInRequests').first_or_create
+at.attrib_type_modifiable_bies.where(role_id: maintainer_role.id).first_or_create
 at = ans.attrib_types.where(name: 'PlannedReleaseDate').first_or_create(value_count: 1)
 at.attrib_type_modifiable_bies.where(role_id: maintainer_role.id).first_or_create
 

--- a/src/api/db/seeds.rb
+++ b/src/api/db/seeds.rb
@@ -126,6 +126,8 @@ at = ans.attrib_types.where(name: 'ProjectStatusPackageFailComment').first_or_cr
 at.attrib_type_modifiable_bies.where(role_id: maintainer_role.id).first_or_create
 at = ans.attrib_types.where(name: 'BranchRepositoriesFromProject').first_or_create(value_count: 1)
 at.attrib_type_modifiable_bies.where(role_id: maintainer_role.id).first_or_create
+at = ans.attrib_types.where(name: 'BranchSkipRepositories').first_or_create
+at.attrib_type_modifiable_bies.where(role_id: maintainer_role.id).first_or_create
 at = ans.attrib_types.where(name: 'AutoCleanup').first_or_create(value_count: 1)
 at.attrib_type_modifiable_bies.where(role_id: maintainer_role.id).first_or_create
 


### PR DESCRIPTION
Fixes #13931.

### TODO

- [x] `OBS:BranchSkipRepositories`
- [x] `OBS:PlannedReleaseDate`
- [x] `OBS:EnforceRevisionsInRequests`
