### PR TITLE
[backend] use formurlencode when sending commands

### DIFF
--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -4451,6 +4451,7 @@ sub docommand {
   my $param = {
     'uri' => "$reposerver/_command",
     'request' => 'POST',
+    'formurlencode' => 1,
   };
   $res = BSWatcher::rpc($param, undef, @args);
   return $res;


### PR DESCRIPTION
Some internal commands can expand to very long parameter lists (e.g. a project with many packages).  While there is no request size limit in the RFC, this can make the query string exceed common limits of many webservers and proxies. [1]
Those limits are actually very valid. To avoid exceeding those limits we move the data into the request body for the POST requests.


[1]: https://stackoverflow.com/questions/686217/maximum-on-http-header-values