### PR TITLE
Fix `create` action of Webui::GroupsController

### DIFF
--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -723,12 +723,6 @@ RSpec/IndexedLet:
     - 'spec/support/shared_contexts/a_user_and_subscriptions.rb'
     - 'spec/support/shared_contexts/a_user_and_subscriptions_with_defaults.rb'
 
-# Offense count: 42
-# Configuration parameters: AssignmentOnly.
-RSpec/InstanceVariable:
-  Exclude:
-    - 'spec/models/group_spec.rb'
-
 # Offense count: 1
 RSpec/IteratedExpectation:
   Exclude:

--- a/src/api/app/models/group.rb
+++ b/src/api/app/models/group.rb
@@ -98,15 +98,14 @@ class Group < ApplicationRecord
   end
 
   def replace_members(members)
-    Group.transaction do
-      users.delete_all
-      members.split(',').each do |m|
-        users << User.find_by_login!(m)
-      end
-      save!
+    new_members = []
+    members.split(',').each do |m|
+      new_members << User.find_by_login!(m)
     end
+    users.replace(new_members)
   rescue ActiveRecord::RecordInvalid, NotFoundError => e
     errors.add(:base, e.message)
+    false
   end
 
   def remove_user(user)

--- a/src/api/spec/models/group_spec.rb
+++ b/src/api/spec/models/group_spec.rb
@@ -11,43 +11,61 @@ RSpec.describe Group do
   end
 
   describe '#replace_members' do
-    context 'with valid user input' do
-      it 'adds one user successfully' do
-        group.replace_members([user.login])
-        expect(group.users).to eq([user])
+    subject! { group.replace_members(members) }
+
+    context 'no previous group users' do
+      context 'adding one valid user' do
+        let(:members) { user.login }
+
+        it 'adds one user successfully' do
+          expect(subject).to be_truthy
+          expect(group.users).to eq([user])
+        end
       end
 
-      it 'adds more than one user successfully' do
-        group.replace_members([user.login, another_user.login])
-        expect(group.users).to eq([user])
+      context 'adding two valid users' do
+        let(:members) { "#{user.login},#{another_user.login}" }
+
+        it 'adds more than one user successfully' do
+          expect(subject).to be_truthy
+          expect(group.users).to eq([user, another_user])
+        end
+      end
+
+      context 'with user _nobody_' do
+        let(:members) { create(:user_nobody).login }
+
+        it 'does not add the user' do
+          expect(subject).to be_falsey
+          expect(group.users).to eq([])
+          expect(group.errors.full_messages).to eq(["Validation failed: Couldn't find user _nobody_"])
+        end
       end
     end
 
-    context 'with user _nobody_' do
-      let(:nobody) { create(:user_nobody) }
-
-      it 'does not add the user' do
-        group.replace_members([nobody.login])
-        expect(group.errors.full_messages).to eq(["Validation failed: Couldn't find user _nobody_"])
-      end
-    end
-
-    context 'with invalid user input' do
+    context 'one previous group user' do
       before do
         group.users << user
-        @before = group.users
       end
 
-      it 'does not change users' do
-        group.replace_members('Foobar')
-        expect(group.users).to eq(@before)
-        expect(group.errors.full_messages).to eq(["Couldn't find User with login = Foobar"])
+      context 'with an invalid user' do
+        let(:members) { 'Foobar' }
+
+        it 'errors and does not change users' do
+          expect(subject).to be_falsey
+          expect(group.users).to eq([user])
+          expect(group.errors.full_messages).to eq(["Couldn't find User with login = Foobar"])
+        end
       end
 
-      it 'does not change users when one user is valid' do
-        group.replace_members("#{user.login},Foobar")
-        expect(group.users).to eq(@before)
-        expect(group.errors.full_messages).to eq(["Couldn't find User with login = Foobar"])
+      context 'with two users, one of them invalid' do
+        let(:members) { "#{another_user.login},Foobar" }
+
+        it 'errors and does not change users' do
+          expect(subject).to be_falsey
+          expect(group.users).to eq([user])
+          expect(group.errors.full_messages).to eq(["Couldn't find User with login = Foobar"])
+        end
       end
     end
   end


### PR DESCRIPTION
Fix the `replace_members` Group model method and its specs: prevent removal of previous groups users when for, at least one user of the new members to replace, there are validation failures or the user is not found.

Create a transaction when saving group details and group users in the `create` action of the Webui::GroupsController. This helps to guarantee not creating a group when there are group details validation failures, or new users validation failures or not found new users.

Adapt specs of `create` action of the Webui::GroupsController.

The fixed code was introduced in #1574.

Found while trying to address a RuboCop offense in #15186.