### PR TITLE
[backend] change default back to gz for create/modifyrepo

### DIFF
--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -637,6 +637,13 @@ sub createrepo_rpmmd {
       last;
     }
   }
+  # createrepo_c 1.0.0 changed the default to zstd. In order to preserve
+  # compatibility with SLE12 and SLE15 GA we need to set gz
+  if ($options{'compression-zstd'}) {
+    push @legacyargs, '--compress-type=zst';
+  } else {
+    push @legacyargs, '--compress-type=gz';
+  }
   my @updateargs;
   # createrepo 0.9.9 defaults to creating the sqlite database.
   # We do disable it since it is time and space consuming.


### PR DESCRIPTION
createrepo 1.0.0 switched the default to zstd, however we need to preserve the backward compatibility with old clients so need to hardcode gz unless a zstd option is set.