### PR TITLE
Adapt Bootstrap classes to make it easier introducing color modes

### DIFF
--- a/src/api/app/assets/javascripts/webui/monitor.js
+++ b/src/api/app/assets/javascripts/webui/monitor.js
@@ -114,14 +114,14 @@ function processProgressBar(id, item)
     el_text.attr("href", url);
 
     if (delta <= 50) {
-      ctrl.addClass("bg-success");
+      ctrl.addClass("text-bg-success");
       ctrl.removeClass('bg-warning bg-danger');
     } else if (delta >= 50 && delta < 80) {
       ctrl.addClass("bg-warning");
-      ctrl.removeClass('bg-success bg-danger');
+      ctrl.removeClass('text-bg-success bg-danger');
     } else {
       ctrl.addClass("bg-danger");
-      ctrl.removeClass('bg-success bg-warning');
+      ctrl.removeClass('text-bg-success bg-warning');
     }
   }
   else {

--- a/src/api/app/assets/javascripts/webui/monitor.js
+++ b/src/api/app/assets/javascripts/webui/monitor.js
@@ -115,12 +115,12 @@ function processProgressBar(id, item)
 
     if (delta <= 50) {
       ctrl.addClass("text-bg-success");
-      ctrl.removeClass('text-bg-warning bg-danger');
+      ctrl.removeClass('text-bg-warning text-bg-danger');
     } else if (delta >= 50 && delta < 80) {
       ctrl.addClass("text-bg-warning");
-      ctrl.removeClass('text-bg-success bg-danger');
+      ctrl.removeClass('text-bg-success text-bg-danger');
     } else {
-      ctrl.addClass("bg-danger");
+      ctrl.addClass("text-bg-danger");
       ctrl.removeClass('text-bg-success text-bg-warning');
     }
   }

--- a/src/api/app/assets/javascripts/webui/monitor.js
+++ b/src/api/app/assets/javascripts/webui/monitor.js
@@ -115,13 +115,13 @@ function processProgressBar(id, item)
 
     if (delta <= 50) {
       ctrl.addClass("text-bg-success");
-      ctrl.removeClass('bg-warning bg-danger');
+      ctrl.removeClass('text-bg-warning bg-danger');
     } else if (delta >= 50 && delta < 80) {
-      ctrl.addClass("bg-warning");
+      ctrl.addClass("text-bg-warning");
       ctrl.removeClass('text-bg-success bg-danger');
     } else {
       ctrl.addClass("bg-danger");
-      ctrl.removeClass('text-bg-success bg-warning');
+      ctrl.removeClass('text-bg-success text-bg-warning');
     }
   }
   else {

--- a/src/api/app/assets/stylesheets/webui/colors.scss
+++ b/src/api/app/assets/stylesheets/webui/colors.scss
@@ -2,6 +2,7 @@
   background-color: $gray-800;
 }
 
-.bg-dismissed {
+.text-bg-dismissed {
+  color: $white;
   background-color: $gray-500;
 }

--- a/src/api/app/assets/stylesheets/webui/patchinfo.scss
+++ b/src/api/app/assets/stylesheets/webui/patchinfo.scss
@@ -24,12 +24,12 @@
     &.badge-category {
       @extend .text-bg-secondary;
 
-      &.recommended { @extend .bg-success; }
+      &.recommended { @extend .text-bg-success; }
       &.security { @extend .bg-danger; }
       &.optional { @extend .bg-info; }
     }
     &.badge-rating {
-      &.low { @extend .bg-success; }
+      &.low { @extend .text-bg-success; }
       &.moderate { @extend .bg-warning; }
       &.important { @extend .bg-danger; }
       &.critical { @extend .bg-dark; }

--- a/src/api/app/assets/stylesheets/webui/patchinfo.scss
+++ b/src/api/app/assets/stylesheets/webui/patchinfo.scss
@@ -30,7 +30,7 @@
     }
     &.badge-rating {
       &.low { @extend .text-bg-success; }
-      &.moderate { @extend .bg-warning; }
+      &.moderate { @extend .text-bg-warning; }
       &.important { @extend .bg-danger; }
       &.critical { @extend .bg-dark; }
     }

--- a/src/api/app/assets/stylesheets/webui/patchinfo.scss
+++ b/src/api/app/assets/stylesheets/webui/patchinfo.scss
@@ -32,7 +32,7 @@
       &.low { @extend .text-bg-success; }
       &.moderate { @extend .text-bg-warning; }
       &.important { @extend .text-bg-danger; }
-      &.critical { @extend .bg-dark; }
+      &.critical { @extend .text-bg-dark; }
     }
     &.badge-blocked { @extend .text-bg-danger; }
   }

--- a/src/api/app/assets/stylesheets/webui/patchinfo.scss
+++ b/src/api/app/assets/stylesheets/webui/patchinfo.scss
@@ -25,16 +25,16 @@
       @extend .text-bg-secondary;
 
       &.recommended { @extend .text-bg-success; }
-      &.security { @extend .bg-danger; }
+      &.security { @extend .text-bg-danger; }
       &.optional { @extend .bg-info; }
     }
     &.badge-rating {
       &.low { @extend .text-bg-success; }
       &.moderate { @extend .text-bg-warning; }
-      &.important { @extend .bg-danger; }
+      &.important { @extend .text-bg-danger; }
       &.critical { @extend .bg-dark; }
     }
-    &.badge-blocked { @extend .bg-danger; }
+    &.badge-blocked { @extend .text-bg-danger; }
   }
   .binaries {
     @extend .h5;

--- a/src/api/app/assets/stylesheets/webui/patchinfo.scss
+++ b/src/api/app/assets/stylesheets/webui/patchinfo.scss
@@ -22,7 +22,7 @@
       @extend .align-middle;
     }
     &.badge-category {
-      @extend .bg-secondary;
+      @extend .text-bg-secondary;
 
       &.recommended { @extend .bg-success; }
       &.security { @extend .bg-danger; }

--- a/src/api/app/assets/stylesheets/webui/patchinfo.scss
+++ b/src/api/app/assets/stylesheets/webui/patchinfo.scss
@@ -26,7 +26,7 @@
 
       &.recommended { @extend .text-bg-success; }
       &.security { @extend .text-bg-danger; }
-      &.optional { @extend .bg-info; }
+      &.optional { @extend .text-bg-info; }
     }
     &.badge-rating {
       &.low { @extend .text-bg-success; }

--- a/src/api/app/assets/stylesheets/webui/staging-workflow.scss
+++ b/src/api/app/assets/stylesheets/webui/staging-workflow.scss
@@ -79,7 +79,7 @@ ul .table-list-group-item {
       }
 
       &.state-building {
-        @extend .bg-warning;
+        @extend .text-bg-warning;
 
         span {
           @extend .text-dark;

--- a/src/api/app/assets/stylesheets/webui/staging-workflow.scss
+++ b/src/api/app/assets/stylesheets/webui/staging-workflow.scss
@@ -62,7 +62,7 @@ ul .table-list-group-item {
 
     span.badge {
       &.state-unacceptable {
-        @extend .bg-dark;
+        @extend .text-bg-dark;
       }
 
       &.state-acceptable {

--- a/src/api/app/assets/stylesheets/webui/staging-workflow.scss
+++ b/src/api/app/assets/stylesheets/webui/staging-workflow.scss
@@ -75,7 +75,7 @@ ul .table-list-group-item {
       }
 
       &.state-testing {
-        @extend .bg-info;
+        @extend .text-bg-info;
       }
 
       &.state-building {

--- a/src/api/app/assets/stylesheets/webui/staging-workflow.scss
+++ b/src/api/app/assets/stylesheets/webui/staging-workflow.scss
@@ -66,7 +66,7 @@ ul .table-list-group-item {
       }
 
       &.state-acceptable {
-        @extend .bg-success;
+        @extend .text-bg-success;
       }
 
       &.state-accepting {

--- a/src/api/app/assets/stylesheets/webui/staging-workflow.scss
+++ b/src/api/app/assets/stylesheets/webui/staging-workflow.scss
@@ -91,7 +91,7 @@ ul .table-list-group-item {
       }
 
       &.state-review {
-        @extend .bg-secondary;
+        @extend .text-bg-secondary;
       }
 
       &.state-empty {

--- a/src/api/app/assets/stylesheets/webui/staging-workflow.scss
+++ b/src/api/app/assets/stylesheets/webui/staging-workflow.scss
@@ -122,7 +122,7 @@ ul .table-list-group-item {
         }
 
         img {
-          @extend .bg-white;
+          @extend .text-bg-light;
           border-radius: 50%;
           height: 20px;
           width: 20px;

--- a/src/api/app/assets/stylesheets/webui/staging-workflow.scss
+++ b/src/api/app/assets/stylesheets/webui/staging-workflow.scss
@@ -87,7 +87,7 @@ ul .table-list-group-item {
       }
 
       &.state-failed {
-        @extend .bg-danger;
+        @extend .text-bg-danger;
       }
 
       &.state-review {

--- a/src/api/app/components/bs_request_state_badge_component.rb
+++ b/src/api/app/components/bs_request_state_badge_component.rb
@@ -12,7 +12,7 @@ class BsRequestStateBadgeComponent < ApplicationComponent
     content_tag(
       :span,
       icon_state_tag.concat(state),
-      class: ['badge', "bg-#{decode_state_color}", css_class]
+      class: ['badge', "text-bg-#{decode_state_color}", css_class]
     )
   end
 

--- a/src/api/app/components/chart_component.rb
+++ b/src/api/app/components/chart_component.rb
@@ -89,7 +89,7 @@ class ChartComponent < ApplicationComponent
     build_result = Buildresult.new(status)
     return 'text-bg-success' if build_result.successful_final_status?
     return 'bg-danger text-light' if build_result.unsuccessful_final_status?
-    return 'bg-warning text-dark' if build_result.in_progress_status?
+    return 'text-bg-warning' if build_result.in_progress_status?
 
     'bg-light text-dark border border-1' if build_result.refused_status?
   end
@@ -97,7 +97,7 @@ class ChartComponent < ApplicationComponent
   def legend
     content_tag(:div, 'Published', class: 'text-bg-success ps-2 pe-2 m-1').concat(
       content_tag(:div, 'Failed', class: 'bg-danger text-light ps-2 pe-2 m-1').concat(
-        content_tag(:div, 'Building', class: 'bg-warning text-dark ps-2 pe-2 m-1').concat(
+        content_tag(:div, 'Building', class: 'text-bg-warning ps-2 pe-2 m-1').concat(
           content_tag(:div, 'Excluded', class: 'bg-light text-dark border border-1 ps-2 pe-2 m-1')
         )
       )

--- a/src/api/app/components/chart_component.rb
+++ b/src/api/app/components/chart_component.rb
@@ -87,7 +87,7 @@ class ChartComponent < ApplicationComponent
 
   def status_color(status)
     build_result = Buildresult.new(status)
-    return 'bg-success text-light' if build_result.successful_final_status?
+    return 'text-bg-success' if build_result.successful_final_status?
     return 'bg-danger text-light' if build_result.unsuccessful_final_status?
     return 'bg-warning text-dark' if build_result.in_progress_status?
 
@@ -95,7 +95,7 @@ class ChartComponent < ApplicationComponent
   end
 
   def legend
-    content_tag(:div, 'Published', class: 'bg-success text-light ps-2 pe-2 m-1').concat(
+    content_tag(:div, 'Published', class: 'text-bg-success ps-2 pe-2 m-1').concat(
       content_tag(:div, 'Failed', class: 'bg-danger text-light ps-2 pe-2 m-1').concat(
         content_tag(:div, 'Building', class: 'bg-warning text-dark ps-2 pe-2 m-1').concat(
           content_tag(:div, 'Excluded', class: 'bg-light text-dark border border-1 ps-2 pe-2 m-1')

--- a/src/api/app/components/chart_component.rb
+++ b/src/api/app/components/chart_component.rb
@@ -88,7 +88,7 @@ class ChartComponent < ApplicationComponent
   def status_color(status)
     build_result = Buildresult.new(status)
     return 'text-bg-success' if build_result.successful_final_status?
-    return 'bg-danger text-light' if build_result.unsuccessful_final_status?
+    return 'text-bg-danger' if build_result.unsuccessful_final_status?
     return 'text-bg-warning' if build_result.in_progress_status?
 
     'bg-light text-dark border border-1' if build_result.refused_status?
@@ -96,7 +96,7 @@ class ChartComponent < ApplicationComponent
 
   def legend
     content_tag(:div, 'Published', class: 'text-bg-success ps-2 pe-2 m-1').concat(
-      content_tag(:div, 'Failed', class: 'bg-danger text-light ps-2 pe-2 m-1').concat(
+      content_tag(:div, 'Failed', class: 'text-bg-danger ps-2 pe-2 m-1').concat(
         content_tag(:div, 'Building', class: 'text-bg-warning ps-2 pe-2 m-1').concat(
           content_tag(:div, 'Excluded', class: 'bg-light text-dark border border-1 ps-2 pe-2 m-1')
         )

--- a/src/api/app/components/workflow_run_header_component.html.haml
+++ b/src/api/app/components/workflow_run_header_component.html.haml
@@ -2,7 +2,7 @@
   #{hook_event.humanize} event
 %p
   - if hook_action
-    %span.badge.bg-primary= hook_action.humanize
+    %span.badge.text-bg-primary= hook_action.humanize
   %span.badge{ class: status_class }= status.humanize
 %p Repository: #{link_to(repository_name, repository_url)}
 - case hook_event

--- a/src/api/app/components/workflow_run_header_component.rb
+++ b/src/api/app/components/workflow_run_header_component.rb
@@ -10,7 +10,7 @@ class WorkflowRunHeaderComponent < WorkflowRunRowComponent
     when 'fail'
       'bg-danger'
     when 'success'
-      'bg-primary'
+      'text-bg-primary'
     else
       'bg-warning'
     end

--- a/src/api/app/components/workflow_run_header_component.rb
+++ b/src/api/app/components/workflow_run_header_component.rb
@@ -8,7 +8,7 @@ class WorkflowRunHeaderComponent < WorkflowRunRowComponent
   def status_class
     case status
     when 'fail'
-      'bg-danger'
+      'text-bg-danger'
     when 'success'
       'text-bg-primary'
     else

--- a/src/api/app/components/workflow_run_header_component.rb
+++ b/src/api/app/components/workflow_run_header_component.rb
@@ -12,7 +12,7 @@ class WorkflowRunHeaderComponent < WorkflowRunRowComponent
     when 'success'
       'text-bg-primary'
     else
-      'bg-warning'
+      'text-bg-warning'
     end
   end
 end

--- a/src/api/app/components/workflow_run_row_component.html.haml
+++ b/src/api/app/components/workflow_run_row_component.html.haml
@@ -3,7 +3,7 @@
 .col.text-start
   = link_to "#{hook_event.humanize} event", token_workflow_run_path(workflow_run.token, workflow_run)
   - if hook_action
-    %span.ms-2.badge.bg-primary= hook_action.humanize
+    %span.ms-2.badge.text-bg-primary= hook_action.humanize
 .col.text-start
   = link_to_if repository_url, repository_name, repository_url
   - if event_source_name

--- a/src/api/app/components/workflow_run_status_badge_component.rb
+++ b/src/api/app/components/workflow_run_status_badge_component.rb
@@ -10,7 +10,7 @@ class WorkflowRunStatusBadgeComponent < ApplicationComponent
     content_tag(
       :span,
       tag.i(class: "fas fa-#{decode_status_icon} me-1").concat(@status),
-      class: ['badge', "bg-#{decode_status_color}", @css_class]
+      class: ['badge', "text-bg-#{decode_status_color}", @css_class]
     )
   end
 

--- a/src/api/app/datatables/package_datatable.rb
+++ b/src/api/app/datatables/package_datatable.rb
@@ -39,7 +39,7 @@ class PackageDatatable < Datatable
   def name_with_link(record)
     name = []
     name << link_to(record.name, package_show_path(package: record, project: @project))
-    name << tag.span('Link', class: 'badge bg-info') if record.is_link?
+    name << tag.span('Link', class: 'badge text-bg-info') if record.is_link?
     safe_join(name, ' ')
   end
 end

--- a/src/api/app/helpers/webui/projects/category_helper.rb
+++ b/src/api/app/helpers/webui/projects/category_helper.rb
@@ -4,7 +4,7 @@ module Webui::Projects::CategoryHelper
 
     badge_type = case category
                  when 'Stable'
-                   'bg-success'
+                   'text-bg-success'
                  when 'Testing'
                    'bg-warning'
                  when 'Development'

--- a/src/api/app/helpers/webui/projects/category_helper.rb
+++ b/src/api/app/helpers/webui/projects/category_helper.rb
@@ -10,7 +10,7 @@ module Webui::Projects::CategoryHelper
                  when 'Development'
                    'text-bg-info'
                  else
-                   'bg-dark'
+                   'text-bg-dark'
                  end
     tag.span(category, class: "quality-category badge ms-1 #{badge_type}")
   end

--- a/src/api/app/helpers/webui/projects/category_helper.rb
+++ b/src/api/app/helpers/webui/projects/category_helper.rb
@@ -6,7 +6,7 @@ module Webui::Projects::CategoryHelper
                  when 'Stable'
                    'text-bg-success'
                  when 'Testing'
-                   'bg-warning'
+                   'text-bg-warning'
                  when 'Development'
                    'bg-info'
                  else

--- a/src/api/app/helpers/webui/projects/category_helper.rb
+++ b/src/api/app/helpers/webui/projects/category_helper.rb
@@ -8,7 +8,7 @@ module Webui::Projects::CategoryHelper
                  when 'Testing'
                    'text-bg-warning'
                  when 'Development'
-                   'bg-info'
+                   'text-bg-info'
                  else
                    'bg-dark'
                  end

--- a/src/api/app/models/scm_status_report.rb
+++ b/src/api/app/models/scm_status_report.rb
@@ -22,7 +22,7 @@ class SCMStatusReport < ApplicationRecord
 
   def status_class
     if success?
-      'bg-primary'
+      'text-bg-primary'
     else
       'bg-danger'
     end

--- a/src/api/app/models/scm_status_report.rb
+++ b/src/api/app/models/scm_status_report.rb
@@ -24,7 +24,7 @@ class SCMStatusReport < ApplicationRecord
     if success?
       'text-bg-primary'
     else
-      'bg-danger'
+      'text-bg-danger'
     end
   end
 end

--- a/src/api/app/views/layouts/webui/_places.html.haml
+++ b/src/api/app/views/layouts/webui/_places.html.haml
@@ -14,7 +14,7 @@
         %i.fas.fa-tasks.fa-lg.me-2
         %span.nav-item-name Tasks
         - unless tasks.zero?
-          %span.badge.bg-primary.align-text-top= tasks
+          %span.badge.text-bg-primary.align-text-top= tasks
     %li.nav-item
       - if User.session!.home_project
         = link_to(project_show_path(User.session!.home_project), class: 'nav-link', title: 'Your Home Project') do

--- a/src/api/app/views/layouts/webui/_unread_notifications_counter.html.haml
+++ b/src/api/app/views/layouts/webui/_unread_notifications_counter.html.haml
@@ -1,5 +1,5 @@
 .notifications-counter
   %i.fas.fa-bell
   - unless User.session.unread_notifications.zero?
-    %span.badge.bg-primary.align-text-top= User.session.unread_notifications
+    %span.badge.text-bg-primary.align-text-top= User.session.unread_notifications
   %span.d-block Notifications

--- a/src/api/app/views/webui/groups/show.html.haml
+++ b/src/api/app/views/webui/groups/show.html.haml
@@ -7,24 +7,24 @@
         %a.nav-link.text-nowrap#group-members-tab{ aria: { controls: 'group-members' },
           data: { 'bs-toggle': 'tab' }, href: '#group-members', role: 'tab' }
           Group Members
-          %span.badge.bg-primary
+          %span.badge.text-bg-primary
             = @group.users.size
       %li.nav-item
         %a.nav-link.text-nowrap#reviews-in-tab{ aria: { controls: 'reviews-in', selected: 'true' },
         data: { 'bs-toggle': 'tab' }, href: '#reviews-in', role: 'tab' }
           Incoming Reviews
-          %span.badge.bg-primary
+          %span.badge.text-bg-primary
             = @group.involved_reviews.size
       %li.nav-item
         %a.nav-link.text-nowrap#requests-in-tab{ aria: { controls: 'requests-in' }, data: { 'bs-toggle': 'tab' }, href: '#requests-in', role: 'tab' }
           Incoming Requests
-          %span.badge.bg-primary
+          %span.badge.text-bg-primary
             = @group.incoming_requests.size
       %li.nav-item
         %a.nav-link.text-nowrap#all-requests-tab{ aria: { controls: 'all-requests' }, data: { 'bs-toggle': 'tab' }, href: '#all-requests',
                                                   role: 'tab' }
           All Requests
-          %span.badge.bg-primary
+          %span.badge.text-bg-primary
             = @group.all_requests_count
       %li.nav-item.dropdown
         %a.nav-link.dropdown-toggle{ href: '#', 'data-bs-toggle': 'dropdown', role: 'button', 'aria-expanded': 'false', 'aria-haspopup': 'true' }

--- a/src/api/app/views/webui/package/show.html.haml
+++ b/src/api/app/views/webui/package/show.html.haml
@@ -81,7 +81,7 @@
     .card#comments-list
       %h5.card-header.text-word-break-all
         Comments
-        %span.badge.bg-primary{ id: "comment-counter-package-#{@package.id}" }
+        %span.badge.text-bg-primary{ id: "comment-counter-package-#{@package.id}" }
           = @comments.length
       .card-body#comments
         = render partial: 'webui/comment/show', locals: { commentable: @package,

--- a/src/api/app/views/webui/patchinfo/show.html.haml
+++ b/src/api/app/views/webui/patchinfo/show.html.haml
@@ -49,6 +49,6 @@
       %h5.card-header Selected Binaries
       .card-body.binaries
         - @patchinfo.binaries.each do |binary|
-          %span.badge.bg-warning
+          %span.badge.text-bg-warning
             %i.me-1.fa.fa-archive
             = binary

--- a/src/api/app/views/webui/project/show.html.haml
+++ b/src/api/app/views/webui/project/show.html.haml
@@ -50,14 +50,14 @@
           %a.nav-link#packages-tab{ href: '#packages', role: 'tab', data: { 'bs-toggle': 'tab' },
           aria: { controls: 'packages', selected: 'false' } }
             Packages
-            %span.badge.bg-primary
+            %span.badge.text-bg-primary
               = @packages.length
         - if @inherited_packages.present?
           %li.nav-item
             %a.nav-link#inherited-packages-tab{ href: '#inherited-packages', role: 'tab', data: { 'bs-toggle': 'tab' },
             aria: { controls: 'inherited-packages', selected: 'false' } }
               Inherited Packages
-              %span.badge.bg-primary
+              %span.badge.text-bg-primary
                 = @inherited_packages.length
       .tab-content#packages-tabs-content
         .tab-pane.fade#packages{ role: 'tabpanel', aria: { labelledby: 'packages-tab' } }
@@ -68,7 +68,7 @@
     .card#comments-list
       %h5.card-header.text-word-break-all
         Comments
-        %span.badge.bg-primary{ id: "comment-counter-project-#{@project.id}" }
+        %span.badge.text-bg-primary{ id: "comment-counter-project-#{@project.id}" }
           = @comments.length
       .card-body#comments
         = render partial: 'webui/comment/show', locals: { commentable: @project,

--- a/src/api/app/views/webui/projects/maintenance_incidents/index.html.haml
+++ b/src/api/app/views/webui/projects/maintenance_incidents/index.html.haml
@@ -5,7 +5,7 @@
   .card-body
     %h3
       Maintenance incidents
-      %span.badge.bg-primary
+      %span.badge.text-bg-primary
         = @incidents.count
     -# haml-lint:disable MultilinePipe
     %table.w-100.responsive.table.table-sm.table-bordered.table-hover#incident-table{ data: { |

--- a/src/api/app/views/webui/repositories/_repository_entry.html.haml
+++ b/src/api/app/views/webui/repositories/_repository_entry.html.haml
@@ -51,4 +51,4 @@
       %i No architecture selected
     - else
       - repository.architectures.pluck(:name).each do |architecture|
-        %span.badge.bg-primary= architecture
+        %span.badge.text-bg-primary= architecture

--- a/src/api/app/views/webui/request/_request_comments.html.haml
+++ b/src/api/app/views/webui/request/_request_comments.html.haml
@@ -3,7 +3,7 @@
     %li.nav-item
       = link_to('#comments', class: 'nav-link text-nowrap active', data: { 'bs-toggle': 'tab' }, role: 'tab') do
         Comments for request #{bs_request.number}
-        %span.badge.bg-primary{ id: "comment-counter-request-#{bs_request.number}" }
+        %span.badge.text-bg-primary{ id: "comment-counter-request-#{bs_request.number}" }
           = comments.size
     - superseded_requests.each do |superseded|
       - if superseded.comments.any?
@@ -11,7 +11,7 @@
           = link_to("#superseded-#{superseded.number}", title: "This request was superseded by request #{superseded.superseded_by}",
             class: 'nav-link text-nowrap', data: { 'bs-toggle': 'tab' }, role: 'tab') do
             Comments for request #{superseded.number}
-            %span.badge.bg-primary{ id: "comment-counter-request-#{superseded.number}" }
+            %span.badge.text-bg-primary{ id: "comment-counter-request-#{superseded.number}" }
               = superseded.comments.size
 .card-body
   .tab-content

--- a/src/api/app/views/webui/request/_request_header.html.haml
+++ b/src/api/app/views/webui/request/_request_header.html.haml
@@ -27,7 +27,7 @@
     -# superseded
     - if bs_request.superseded_by.present?
       %li
-        %mark.text-nowrap.text-light{ class: "bg-#{badge_state.decode_state_color}" } Superseded
+        %mark.text-nowrap{ class: "text-bg-#{badge_state.decode_state_color}" } Superseded
         by
         = link_to "##{bs_request.superseded_by}", number: bs_request.superseded_by
     -# superseding statement

--- a/src/api/app/views/webui/request/_request_tabs.html.haml
+++ b/src/api/app/views/webui/request/_request_tabs.html.haml
@@ -20,4 +20,4 @@
         = link_to(request_mentioned_issues_path(bs_request.number, actions_count > 1 ? active_action : nil),
                   class: "nav-link text-nowrap #{active_tab == 'mentioned_issues' ? 'active' : ''}") do
           Mentioned Issues
-          %span.badge.bg-primary.align-text-top= issues.size
+          %span.badge.text-bg-primary.align-text-top= issues.size

--- a/src/api/app/views/webui/user/_basic_info.html.haml
+++ b/src/api/app/views/webui/user/_basic_info.html.haml
@@ -39,7 +39,7 @@
         = user.login
 
   - role_titles.each do |title|
-    %span.badge.bg-secondary
+    %span.badge.text-bg-secondary
       = title.upcase
   %p= render_as_markdown(user.biography)
 

--- a/src/api/app/views/webui/user/_edit_account_form.html.haml
+++ b/src/api/app/views/webui/user/_edit_account_form.html.haml
@@ -10,7 +10,7 @@
     = f.text_field(:login, readonly: true, class: 'form-control')
   .mb-3
     - role_titles.each do |title|
-      %span.badge.bg-secondary
+      %span.badge.text-bg-secondary
         = title.upcase
   .mb-3
     = f.text_area(:biography, rows: 6, placeholder: 'Biography', maxlength: User::MAX_BIOGRAPHY_LENGTH_ALLOWED, class: 'form-control')

--- a/src/api/app/views/webui/user/_info.html.haml
+++ b/src/api/app/views/webui/user/_info.html.haml
@@ -19,5 +19,5 @@
         - groups.each do |group|
           %li.list-group-item.d-flex.justify-content-between.align-items-center.p-2
             = link_to(group.title, group_path(group))
-            %span.badge.bg-primary
+            %span.badge.text-bg-primary
               #{group.tasks} #{'task'.pluralize(group.tasks)}

--- a/src/api/app/views/webui/user/_involvement.html.haml
+++ b/src/api/app/views/webui/user/_involvement.html.haml
@@ -75,10 +75,10 @@
                   - else
                     = link_to(involved_item, project_show_path(involved_item), class: 'pe-2')
                 - if owner_root_project_exists && involved_items_as_owner.include?(involved_item)
-                  %span.badge.bg-info Owner
+                  %span.badge.text-bg-info Owner
                 - roles.each do |role|
                   - if involved_item.user_has_role?(displayed_user, role)
-                    %span.badge.bg-info= role.title.capitalize
+                    %span.badge.text-bg-info= role.title.capitalize
             .row.mt-1
               .col
                 #involvement-description= render partial: 'webui/shared/collapsible_text', locals: { text: involved_item.description }

--- a/src/api/app/views/webui/user/_involvement.html.haml
+++ b/src/api/app/views/webui/user/_involvement.html.haml
@@ -23,7 +23,7 @@
             %span.caret
             Projects / Packages
             - if projects_packages_selected.positive?
-              %span.badge.bg-secondary.ms-2= projects_packages_selected
+              %span.badge.text-bg-secondary.ms-2= projects_packages_selected
           .dropdown-menu.keep-open
             - projects_packages.each do |project_or_package|
               - involved_html_id = "involved_#{project_or_package}"
@@ -37,7 +37,7 @@
             %span.caret
             Role
             - if roles_selected.positive?
-              %span.badge.bg-secondary.ms-2= roles_selected
+              %span.badge.text-bg-secondary.ms-2= roles_selected
           .dropdown-menu.keep-open
             - if owner_root_project_exists
               .dropdown-item

--- a/src/api/app/views/webui/user/_tabs_profile.html.haml
+++ b/src/api/app/views/webui/user/_tabs_profile.html.haml
@@ -3,17 +3,17 @@
     = link_to('#involved-packages', id: 'involved-packages-tab', class: 'scrollable-tab-link active', role: 'tab', aria: { selected: true,
                controls: 'involved-packages' }, data: { 'bs-toggle': 'tab' }) do
       Involved Packages
-      %span.badge.bg-primary
+      %span.badge.text-bg-primary
         = involved_packages.size
     = link_to('#involved-projects', id: 'involved-projects-tab', class: 'scrollable-tab-link', role: 'tab', aria: { selected: false,
                controls: 'involved-projects' }, data: { 'bs-toggle': 'tab' }) do
       Involved Projects
-      %span.badge.bg-primary
+      %span.badge.text-bg-primary
         = involved_projects.size
     = link_to('#owned', id: 'owned-tab', class: 'scrollable-tab-link', role: 'tab', aria: { selected: false,
               controls: 'owned' }, data: { 'bs-toggle': 'tab' }) do
       Owned Projects/Packages
-      %span.badge.bg-primary
+      %span.badge.text-bg-primary
         = owned.size
 
 - content_for :ready_function do

--- a/src/api/app/views/webui/users/tasks/index.html.haml
+++ b/src/api/app/views/webui/users/tasks/index.html.haml
@@ -6,7 +6,7 @@
       - cache "#{User.session!.cache_key_with_version}-reviews-in" do
         %a.nav-link.text-nowrap.active{ href: '#reviews-in', title: "Requests that #{User.session!} has to review" }
           Incoming Reviews
-          %span.badge.bg-primary
+          %span.badge.text-bg-primary
             = User.session!.involved_reviews.count
 
   .card-body
@@ -21,25 +21,25 @@
         %a.nav-link.text-nowrap#requests-in-tab{ href: '#requests-in', title: "Requests that #{User.session!} has to merge",
          'data-bs-toggle': 'tab', 'aria-controls': 'requests-in-tab', 'aria-selected': 'false', role: 'tab' }
           Incoming Requests
-          %span.badge.bg-primary
+          %span.badge.text-bg-primary
             = User.session!.incoming_requests.count
     %li.nav-item
       %a.nav-link.text-nowrap#requests-out-tab{ href: '#requests-out', title: "Requests that #{User.session!} has sent",
         'data-bs-toggle': 'tab', 'aria-controls': 'requests-out-tab', 'aria-selected': 'false', role: 'tab' }
         Outgoing Requests
-        %span.badge.bg-primary
+        %span.badge.text-bg-primary
           = User.session!.outgoing_requests.count
     %li.nav-item
       %a.nav-link.text-nowrap#requests-declined-tab{ href: '#requests-declined', title: "Requests from #{User.session!} that are declined",
         'data-bs-toggle': 'tab', 'aria-controls': 'requests-declined-tab', 'aria-selected': 'false', role: 'tab' }
         Declined Requests
-        %span.badge.bg-primary
+        %span.badge.text-bg-primary
           = User.session!.declined_requests.count
     %li.nav-item
       %a.nav-link.text-nowrap#all-requests-tab{ href: '#all-requests', title: "All Requests from #{User.session!}",
         'data-bs-toggle': 'tab', 'aria-controls': 'all-requests-tab', 'aria-selected': 'false', role: 'tab' }
         All Requests
-        %span.badge.bg-primary
+        %span.badge.text-bg-primary
           = User.session!.requests.count
     %li.nav-item.dropdown
       %a.nav-link.dropdown-toggle{ href: '#', 'data-bs-toggle': 'dropdown', role: 'button', 'aria-expanded': 'false', 'aria-haspopup': 'true' }
@@ -66,7 +66,7 @@
       %li.nav-item
         %a.nav-link.text-nowrap.active{ href: '#patchinfos-in', title: "Requests that #{User.session!} has to merge" }
           Maintenance Requests
-          %span.badge.bg-primary
+          %span.badge.text-bg-primary
             = number_of_involved_patchinfos
     .card-body
       .tab-content#patchinfos-in

--- a/src/api/spec/components/previews/card_component_preview.rb
+++ b/src/api/spec/components/previews/card_component_preview.rb
@@ -3,13 +3,13 @@ class CardComponentPreview < ViewComponent::Preview
     render(CardComponent.new) do |component|
       component.with_header do
         tag.a('openSUSE_Factory', href: '#').concat(
-          tag.span('tag-1', class: 'badge bg-primary ms-1')
+          tag.span('tag-1', class: 'badge text-bg-primary ms-1')
         ).concat(
-          tag.span('tag-2', class: 'badge bg-primary ms-1')
+          tag.span('tag-2', class: 'badge text-bg-primary ms-1')
         ).concat(
-          tag.span('tag-3', class: 'badge bg-primary ms-1')
+          tag.span('tag-3', class: 'badge text-bg-primary ms-1')
         ).concat(
-          tag.span('tag-4', class: 'badge bg-primary ms-1')
+          tag.span('tag-4', class: 'badge text-bg-primary ms-1')
         )
       end
       tag.strong('Repository paths:').concat(

--- a/src/api/spec/features/webui/requests_spec.rb
+++ b/src/api/spec/features/webui/requests_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe 'Requests', :js, :vcr do
         click_button 'Accept'
 
         expect(page).to have_text("Request #{bs_request.number}")
-        expect(find('span.badge.bg-success')).to have_text('accepted')
+        expect(find('span.badge.text-bg-success')).to have_text('accepted')
         expect(page).to have_text('In state accepted')
       end
     end
@@ -123,7 +123,7 @@ RSpec.describe 'Requests', :js, :vcr do
         click_button 'Accept'
 
         expect(page).to have_text("Request #{bs_request.number}")
-        expect(find('span.badge.bg-success')).to have_text('accepted')
+        expect(find('span.badge.text-bg-success')).to have_text('accepted')
         expect(page).to have_text('In state accepted')
       end
     end
@@ -155,7 +155,7 @@ RSpec.describe 'Requests', :js, :vcr do
         click_button 'Accept'
 
         expect(page).to have_text("Request #{bs_request.number}")
-        expect(find('span.badge.bg-success')).to have_text('accepted')
+        expect(find('span.badge.text-bg-success')).to have_text('accepted')
         expect(page).to have_text('In state accepted')
       end
     end
@@ -189,7 +189,7 @@ RSpec.describe 'Requests', :js, :vcr do
         click_button 'Accept'
 
         expect(page).to have_text("Request #{bs_request.number}")
-        expect(find('span.badge.bg-success')).to have_text('accepted')
+        expect(find('span.badge.text-bg-success')).to have_text('accepted')
         expect(page).to have_text('In state accepted')
       end
     end

--- a/src/api/spec/features/webui/requests_spec.rb
+++ b/src/api/spec/features/webui/requests_spec.rb
@@ -209,7 +209,7 @@ RSpec.describe 'Requests', :js, :vcr do
         click_button('Accept')
         expect(page).to have_text(/Open review for\s+#{reviewer.login}/)
         expect(page).to have_text('Request 1')
-        expect(find('span.badge.bg-secondary')).to have_text('review')
+        expect(find('span.badge.text-bg-secondary')).to have_text('review')
         expect(page).to have_text('In state review')
         expect(Review.count).to eq(1)
         logout

--- a/src/api/vendor/assets/stylesheets/tokenfield.scss
+++ b/src/api/vendor/assets/stylesheets/tokenfield.scss
@@ -56,12 +56,11 @@
     display: block;
     max-width: 100%;
     word-wrap: break-word;
-    color: #fff;
     padding: 10px 30px 10px 10px;
     margin: 0 5px 5px 0;
     font-size: inherit;
     @extend .badge;
-    @extend .bg-secondary;
+    @extend .text-bg-secondary;
 
     .tag-remove {
       position: absolute;


### PR DESCRIPTION
Move `bg-*` classes to `text-bg-*` classes.

### Done in this pull request

- [x] bg-primary
- [x] bg-secondary
- [x] bg-success
- [x] bg-warning
- [x] bg-danger
- [x] bg-info
- [x] bg-dark
- [x] bg-white

### To be done in next pull requests

- bg-light
- bg-gray-*
- ...

### References

From the Bootstrap 5.3 migration guide, since Bootstrap 5.2.0:

_Added new .text-bg-{color} helpers. Instead of setting individual .text-* and .bg-* utilities, you can now use [the .text-bg-* helpers](https://getbootstrap.com/docs/5.3/helpers/color-background/) to set a background-color with contrasting foreground color._

See: https://getbootstrap.com/docs/5.3/migration/#additional-changes