### PR TITLE
Fix `GET /configuration` to show default_tracker

### DIFF
--- a/src/api/app/models/configuration.rb
+++ b/src/api/app/models/configuration.rb
@@ -42,7 +42,8 @@ class Configuration < ApplicationRecord
     unlisted_projects_filter: nil,
     unlisted_projects_filter_description: nil,
     tos_url: nil,
-    code_of_conduct: nil
+    code_of_conduct: nil,
+    default_tracker: nil
   }
   # rubocop:enable Style/MutableConstant
 

--- a/src/api/public/apidocs/components/schemas/configuration.yaml
+++ b/src/api/public/apidocs/components/schemas/configuration.yaml
@@ -60,6 +60,9 @@ properties:
   unlisted_projects_filter_description:
     type: string
     example: home projects
+  default_tracker:
+    type: string
+    example: bnc
   code_of_conduct:
     type: string
     example: |


### PR DESCRIPTION
The default_tracker configuration parameter is not shown. It must be shown.

### Before

```bash
> osc -A http://localhost:3000 api '/configuration' | grep default_tracker
>
```

### After

```bash
> osc -A http://localhost:3000 api '/configuration' | grep default_tracker
  <default_tracker>bnc</default_tracker>
>
```