### PR TITLE
Don't query the database for configuration fixed fields

### DIFF
--- a/src/api/app/models/configuration.rb
+++ b/src/api/app/models/configuration.rb
@@ -62,7 +62,7 @@ class Configuration < ApplicationRecord
     # the data from the first instance
     def method_missing(method_name, *args, &)
       Configuration.create(name: 'private', title: 'Open Build Service', description: 'Private OBS Instance') unless first
-      if first.respond_to?(method_name)
+      if Configuration.instance_methods.include?(method_name)
         first.send(method_name, *args, &)
       else
         super


### PR DESCRIPTION
Make use of `Configuration.instance_methods` to prevent from performing a query to the database every time a  configuration parameter is accessed.

### Before

```
[1] pry(main)> Configuration.gravatar
  Configuration Load (0.6ms)  SELECT `configurations`.* FROM `configurations` ORDER BY `configurations`.`id` ASC LIMIT 1
  Configuration Load (0.7ms)  SELECT `configurations`.* FROM `configurations` ORDER BY `configurations`.`id` ASC LIMIT 1
  Configuration Load (0.5ms)  SELECT `configurations`.* FROM `configurations` ORDER BY `configurations`.`id` ASC LIMIT 1
=> true
[2] pry(main)>
```

### After

```
[1] pry(main)> Configuration.gravatar
  Configuration Load (0.7ms)  SELECT `configurations`.* FROM `configurations` ORDER BY `configurations`.`id` ASC LIMIT 1
  Configuration Load (0.5ms)  SELECT `configurations`.* FROM `configurations` ORDER BY `configurations`.`id` ASC LIMIT 1
=> true
[2] pry(main)>
```
