### PR TITLE
Scroll towards the current request action

### DIFF
--- a/src/api/app/assets/javascripts/webui/request_show_redesign/bs_request_actions.js
+++ b/src/api/app/assets/javascripts/webui/request_show_redesign/bs_request_actions.js
@@ -1,2 +1,9 @@
 // JavaScript code for the new view under request_show_redesign
 
+$(document).ready(function() {
+  $('#request-actions').on('shown.bs.dropdown', function () {
+    // Scrolls towards the current request action
+    var currentAction = $('a.dropdown-item.active');
+    currentAction[0].scrollIntoView({behavior: "smooth", block: "center"});
+  });
+});


### PR DESCRIPTION
The dropdown can contain a long list of actions. Once it is opened, it scrolls towards the active/selected one.

We had this functionality before, it was removed by mistake in commit [a14e43e](https://github.com/openSUSE/open-build-service/pull/14164/commits/a14e43e442e8e87618c2e521ce51a1acc38d0268).