### PR TITLE
Remove unneeded `vcr: false` assignments

### DIFF
--- a/src/api/spec/controllers/person/token_controller_spec.rb
+++ b/src/api/spec/controllers/person/token_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Person::TokenController, vcr: false do
+RSpec.describe Person::TokenController do
   let(:user) { create(:user_with_service_token, :with_home) }
   let(:other_user) { create(:confirmed_user) }
 

--- a/src/api/spec/jobs/report_to_scm_job_spec.rb
+++ b/src/api/spec/jobs/report_to_scm_job_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe ReportToSCMJob, vcr: false do
+RSpec.describe ReportToSCMJob do
   let(:user) { create(:confirmed_user, login: 'foolano') }
   let(:token) { Token::Workflow.create(executor: user, scm_token: 'fake_token') }
   let(:project) { create(:project, name: 'project_1', maintainer: user) }

--- a/src/api/spec/models/branch_package/lookup_incident_package_spec.rb
+++ b/src/api/spec/models/branch_package/lookup_incident_package_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe BranchPackage::LookupIncidentPackage, vcr: false do
+RSpec.describe BranchPackage::LookupIncidentPackage do
   let(:user) { create(:confirmed_user, :with_home, login: 'tom') }
 
   before do

--- a/src/api/spec/models/service/name_validator_spec.rb
+++ b/src/api/spec/models/service/name_validator_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 require 'webmock/rspec'
 
-RSpec.describe Service::NameValidator, vcr: false do
+RSpec.describe Service::NameValidator do
   it { expect(described_class.new('download_files')).to be_valid }
   it { expect(described_class.new('Foo::Bar')).not_to be_valid }
   it { expect(described_class.new(nil)).not_to be_valid }

--- a/src/api/spec/requests/kerberos_login_spec.rb
+++ b/src/api/spec/requests/kerberos_login_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 require 'gssapi'
 
-RSpec.describe 'Kerberos login', vcr: false do
+RSpec.describe 'Kerberos login' do
   describe 'authentication in kerberos mode' do
     let(:user) { create(:confirmed_user) }
 

--- a/src/api/spec/services/consistency_check_job_service/base_consistency_checker_spec.rb
+++ b/src/api/spec/services/consistency_check_job_service/base_consistency_checker_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe ConsistencyCheckJobService::BaseConsistencyChecker, vcr: false do
+RSpec.describe ConsistencyCheckJobService::BaseConsistencyChecker do
   let(:base_consistency_checker) { described_class.new }
 
   describe '#dir_to_array' do


### PR DESCRIPTION
The `vcr` RSpec flag is `false` by default.