### PR TITLE
Do not process workflow tokens in the runservice endpoint

### DIFF
--- a/src/api/app/controllers/trigger_controller.rb
+++ b/src/api/app/controllers/trigger_controller.rb
@@ -14,6 +14,7 @@ class TriggerController < ApplicationController
 
   before_action :validate_gitlab_event, if: :gitlab_webhook?
   before_action :set_token
+  before_action :check_token_class
   before_action :set_project_name
   before_action :set_package_name
   # From Triggerable
@@ -41,6 +42,11 @@ class TriggerController < ApplicationController
   end
 
   private
+
+  def check_token_class
+    # It make no sense to process Token::Workflows on a runservice request
+    raise ActiveRecord::RecordNotFound, 'Token not found' if @token.instance_of?(Token::Workflow)
+  end
 
   def gitlab_webhook?
     request.env['HTTP_X_GITLAB_EVENT'].present?

--- a/src/api/app/controllers/trigger_workflow_controller.rb
+++ b/src/api/app/controllers/trigger_workflow_controller.rb
@@ -3,7 +3,7 @@ class TriggerWorkflowController < TriggerController
   include ScmWebhookPayloadDataExtractor
 
   # We don't need to validate that the body of the request is XML. We receive JSON
-  skip_before_action :validate_xml_request, :set_project_name, :set_package_name, :set_project, :set_package, :set_object_to_authorize, :set_multibuild_flavor
+  skip_before_action :validate_xml_request, :set_project_name, :set_package_name, :set_project, :set_package, :set_object_to_authorize, :set_multibuild_flavor, :check_token_class
 
   before_action :set_scm_event
   before_action :set_scm_extractor

--- a/src/api/public/apidocs/paths/trigger_operation.yaml
+++ b/src/api/public/apidocs/paths/trigger_operation.yaml
@@ -286,6 +286,11 @@ post:
               value:
                 code: unknown_package
                 details: 'Package not found: home:Admin/foo'
+            unknown_token:
+              summary: Not found (Token)
+              value:
+                code: not_found
+                details: 'Token not found'
             non_existent_workflows_file:
               summary: Non existent workflows file
               value:

--- a/src/api/spec/controllers/trigger_controller_spec.rb
+++ b/src/api/spec/controllers/trigger_controller_spec.rb
@@ -189,6 +189,25 @@ RSpec.describe TriggerController, :vcr do
         it { expect(response.body).to include(expected_response_body) }
       end
     end
+
+    context 'when the token is of type workflow' do
+      let(:token) { create(:workflow_token, executor: user) }
+      let(:package) { create(:package_with_service, name: 'package_with_service', project: project) }
+      let(:expected_response_body) do
+        <<~XML
+          <status code="not_found">
+            <summary>Token not found</summary>
+          </status>
+        XML
+      end
+
+      before do
+        post :create, params: { format: :xml, project: project, package: package }
+      end
+
+      it { expect(response).to have_http_status(:not_found) }
+      it { expect(response.body).to include(expected_response_body) }
+    end
   end
 
   describe '#create' do


### PR DESCRIPTION
It makes no sense to process Workflow Tokens in the `/trigger/runservice` endpoint, so we just 404 when a request like that comes in.

Fixes #13849 

## How to Test It

Having a Workflow Token with an id of 1, a `home:Admin` project and a `hello_world` package:

```
osc api -X POST "http://localhost:3000/trigger/runservice?id=1&project=home:Admin&package=hello_world" -a X-Obs-Signature <secret>
```
or

Using the `/apidocs/index.html#/Trigger/post_trigger__operation_`