### PR TITLE
Move Reply and Report links to the right on the redesigned request UI

### DIFF
--- a/src/api/app/components/bs_request_comment_component.html.haml
+++ b/src/api/app/components/bs_request_comment_component.html.haml
@@ -49,21 +49,22 @@
 
   -# This should be refactored to avoid relying on global state
   - if policy(comment).reply?
-    .mb-2
-      = link_to("#reply_form_of_#{comment.id}", id: "reply_button_of_#{comment.id}", 'data-bs-toggle': 'collapse',
-                class: 'font-italic small collapsed') do
-        Reply
-      .collapse{ id: "reply_form_of_#{comment.id}" }
-        = render(partial: 'webui/comment/comment_field', locals: { form_method: :post,
-         comment: comment.children.new, commentable: commentable, element_suffix: "reply_for_#{comment.id}", has_cancel: true })
+    .mb-2.d-flex.justify-content-end.me-2
       - if policy(Report.new(reportable: comment)).create?
-        = link_to('#', class: 'font-italic small collapsed ps-2', id: "js-comment-#{comment.id}",
+        = link_to('#', class: 'font-italic small collapsed me-2', id: "js-comment-#{comment.id}",
               data: { 'bs-toggle': 'modal',
                       'bs-target': '#report-modal',
                       'modal-title': "Report comment from #{comment.user}",
                       'reportable-type': comment.class.name,
                       'reportable-id': comment.id }) do
           Report
+      = link_to("#reply_form_of_#{comment.id}", id: "reply_button_of_#{comment.id}", 'data-bs-toggle': 'collapse',
+                class: 'font-italic small collapsed') do
+        Reply
+
+    .collapse.ms-4{ id: "reply_form_of_#{comment.id}" }
+      = render(partial: 'webui/comment/comment_field', locals: { form_method: :post,
+        comment: comment.children.new, commentable: commentable, element_suffix: "reply_for_#{comment.id}", has_cancel: true })
 
   - if level <= 3
     - comment.children.includes(:user).each do |children|


### PR DESCRIPTION
Before, when we uncollapsed the reply form, the Report link went out of place:

![report_reply_links](https://github.com/openSUSE/open-build-service/assets/2581944/f887aa7b-ebc8-4e17-89b2-0c289d7beb26)

Now the links stay in the same place and the form opens below them:

![Screenshot 2023-11-16 at 17-24-19 Open Build Service](https://github.com/openSUSE/open-build-service/assets/2581944/3c0ec879-bc00-4549-a3fd-0652e54aafa8)

I decided to move links to the right side to minimize the visual noise on the left, where many other elements like lines, icons and avatars are present. The right side is also a good position as it is the place where the reader's eyes usually end up when they finish reading.

## Testing Tips

- Make sure your user is in beta.
- This is  a good request to test with: https://obs-reviewlab.opensuse.org/saraycp-adjust_reply_and_report_position/request/show/15