### PR TITLE
Separate comments buttons properly

### DIFF
--- a/src/api/app/views/webui/comment/_comment_field.html.haml
+++ b/src/api/app/views/webui/comment/_comment_field.html.haml
@@ -29,7 +29,7 @@ data: { preview_message_url: preview_comments_path, message_body_param: 'comment
         - when :post
           = f.submit 'Add comment', class: 'btn btn-primary me-2', data: { disable_with: 'Creating comment...' }, disabled: true
           - if !comment.parent_id && CommentLockPolicy.new(User.session, commentable).create?
-            = button_tag(type: 'button', class: 'btn btn-warning', data: { 'bs-toggle': 'modal', 'bs-target': "##{modal_id}-modal" }) do
+            = button_tag(type: 'button', class: 'btn btn-warning me-2', data: { 'bs-toggle': 'modal', 'bs-target': "##{modal_id}-modal" }) do
               - if commentable.comment_lock.blank?
                 %i.fa.fa-lock
                 Lock comments


### PR DESCRIPTION
Before:

![Screenshot 2023-11-16 at 18-18-40 Open Build Service](https://github.com/openSUSE/open-build-service/assets/2581944/498e1577-524b-4119-ac93-667df3a1de24)


After:

![Screenshot 2023-11-16 at 18-23-37 Open Build Service](https://github.com/openSUSE/open-build-service/assets/2581944/49c17090-252f-4e7e-b83d-f451d384422a)
