### PR TITLE
Distinguish conversation from other history elements

### DIFF
--- a/src/api/app/assets/stylesheets/webui/comments.scss
+++ b/src/api/app/assets/stylesheets/webui/comments.scss
@@ -23,7 +23,7 @@
 .comment-bubble {
   $comment-bubble-outline: rgba($gray-400, 0.5);
   $comment-bubble-background: $gray-100;
-  @extend .rounded;
+  @extend .rounded-4;
   @extend .mb-2;
   border: 1px solid $comment-bubble-outline;
   position: relative;
@@ -35,9 +35,9 @@
   }
 
   // Arrow on the top left of the comment bubble
-  $comment-bubble-arrow-top-position: 0;
-  $comment-bubble-arrow-left-position: 14px;
-  $comment-bubble-arrow-size: 16px;
+  $comment-bubble-arrow-top-position: 12px;
+  $comment-bubble-arrow-left-position: 0;
+  $comment-bubble-arrow-size: 14px;
   // This creates two triangles.
   // `::before` creates a triangle which matches the color of the comment bubble's outline.
   //
@@ -53,17 +53,17 @@
     width: 0;
     height: 0;
     border: $comment-bubble-arrow-size solid transparent;
-    border-bottom-color: $comment-bubble-outline;
+    border-right-color: $comment-bubble-outline;
     border-top: 0;
     border-left: 0;
-    margin-left: -($comment-bubble-arrow-size / 2);
-    margin-top: -$comment-bubble-arrow-size;
+    margin-top: -($comment-bubble-arrow-size / 4);
+    margin-left: -$comment-bubble-arrow-size;
   }
   &::after {
-    top: $comment-bubble-arrow-top-position + 2px;
-    left: $comment-bubble-arrow-left-position + 1px;
+    top: $comment-bubble-arrow-top-position + 1px;
+    left: $comment-bubble-arrow-left-position + 2px;
     z-index: 1;
-    border-bottom-color: $comment-bubble-background;
+    border-right-color: $comment-bubble-background;
   }
 
   .dropdown {

--- a/src/api/app/assets/stylesheets/webui/timeline.scss
+++ b/src/api/app/assets/stylesheets/webui/timeline.scss
@@ -11,12 +11,18 @@
         position: relative;
         left: $timeline-offset; // The avatars of users involved in timeline items will be displayed on the timeline border
 
-        .d-inline-flex i:first-child {
-            padding-top: $timeline-item-avatar-height / 2;
-            height: $timeline-item-avatar-height;
-            width: $timeline-item-avatar-width;
-            text-align: center;
-            background-color: var(--timeline-bg);
+        .d-inline-flex {
+            i:first-child {
+                padding-top: $timeline-item-avatar-height / 2;
+                height: $timeline-item-avatar-height;
+                width: $timeline-item-avatar-width;
+                text-align: center;
+                background-color: var(--timeline-bg);
+            }
+
+            a > i:first-child{
+                background: none;
+            }
         }
 
         $timeline-item-avatar-margin: 0.5rem;

--- a/src/api/app/assets/stylesheets/webui/timeline.scss
+++ b/src/api/app/assets/stylesheets/webui/timeline.scss
@@ -11,7 +11,7 @@
         position: relative;
         left: $timeline-offset; // The avatars of users involved in timeline items will be displayed on the timeline border
 
-        .d-inline-flex {
+        .d-flex {
             i:first-child {
                 padding-top: $timeline-item-avatar-height / 2;
                 height: $timeline-item-avatar-height;

--- a/src/api/app/components/bs_request_activity_timeline_component.html.haml
+++ b/src/api/app/components/bs_request_activity_timeline_component.html.haml
@@ -1,5 +1,5 @@
 - timeline.each do |comment_or_history_element|
-  .timeline-item
+  .timeline-item.mb-3
     - if comment_or_history_element.is_a?(Comment)
       .comments-thread
         = render BsRequestCommentComponent.new(comment: comment_or_history_element, level: 1, commentable: comment_or_history_element.commentable,

--- a/src/api/app/components/bs_request_comment_component.html.haml
+++ b/src/api/app/components/bs_request_comment_component.html.haml
@@ -25,7 +25,7 @@
                 Delete
       .px-3.py-2.border-bottom
         = link_to(helpers.realname_with_login(comment.user), user_path(comment.user))
-        wrote
+        \-
         = link_to("#comment-#{comment.id}", title: l(comment.created_at.utc), name: "comment-#{comment.id}") do
           = render TimeComponent.new(time: comment.created_at)
         = render CommentHistoryComponent.new(comment)

--- a/src/api/app/components/bs_request_comment_component.html.haml
+++ b/src/api/app/components/bs_request_comment_component.html.haml
@@ -1,4 +1,4 @@
-.d-flex
+.d-flex.mt-3
   %i{ title: 'Comment', class: "fas fa-lg fa-comment lh-1 text-dark #{ level > 1 ? 'd-none' : '' }" }
   = render(AvatarComponent.new(name: comment.user.name, email: comment.user.email, size: 35, shape: :circle, custom_css: 'avatars-counter'))
   .timeline-item-comment.ms-2.flex-fill
@@ -49,7 +49,7 @@
 
     -# This should be refactored to avoid relying on global state
     - if policy(comment).reply?
-      .d-flex.justify-content-end.mb-3.me-2
+      .d-flex.justify-content-end.me-2
         - if policy(Report.new(reportable: comment)).create?
           = link_to('#', class: 'font-italic small collapsed me-2', id: "js-comment-#{comment.id}",
                 data: { 'bs-toggle': 'modal',

--- a/src/api/app/components/bs_request_comment_component.html.haml
+++ b/src/api/app/components/bs_request_comment_component.html.haml
@@ -1,74 +1,74 @@
-.d-inline-flex.mb-3
+.d-flex
   %i{ title: 'Comment', class: "fas fa-lg fa-comment text-dark #{ level > 1 ? 'd-none' : '' }" }
   = render(AvatarComponent.new(name: comment.user.name, email: comment.user.email, size: 35, shape: :circle, custom_css: 'avatars-counter'))
-.timeline-item-comment.mb-4
-  .comment-bubble
-    - if policy(comment).update? || policy(comment).destroy?
-      .dropdown.dropleft.float-end.mt-3.mx-3
-        = link_to('#', role: 'button', 'data-bs-toggle': 'dropdown', 'aria-expanded': 'false', class: 'text-dark') do
-          %i.fas.fa-ellipsis
-        .dropdown-menu
-          - if policy(comment).update?
-            = link_to("#edit_form_of_#{comment.id}", id: "edit_button_of_#{comment.id}", 'data-bs-toggle': 'collapse',
-                      class: 'dropdown-item collapsed') do
-              Edit
-          - if Flipper.enabled?(:content_moderation, User.session)
-            - if policy(comment).moderate?
-              = button_to(comment.moderated? ? 'Permit' : 'Moderate', moderate_comment_path(comment),
-                          class: 'dropdown-item', remote: true, form_class: 'moderate-form', params: { moderation_state: !comment.moderated? })
-          - if policy(comment).destroy?
-            = link_to('#', data: { 'bs-toggle': 'modal',
-                                   'bs-target': '#delete-comment-modal',
-                                   confirmation_text: 'Please confirm deletion of comment',
-                                   action: comment_path(comment) },
-                           class: 'dropdown-item delete_link', title: 'Delete comment') do
-              Delete
-    .px-3.py-2.border-bottom
-      = link_to(helpers.realname_with_login(comment.user), user_path(comment.user))
-      wrote
-      = link_to("#comment-#{comment.id}", title: l(comment.created_at.utc), name: "comment-#{comment.id}") do
-        = render TimeComponent.new(time: comment.created_at)
-      = render CommentHistoryComponent.new(comment)
-    - if comment.diff_ref && diff
-      - action = comment.commentable
-      .px-3.pt-3.pb-2
-        = link_to request_show_path(number: action.bs_request, request_action_id: action) do
-          = action.uniq_key
-        >
-        = link_to request_changes_path(number: action.bs_request, request_action_id: action, anchor: comment.diff_ref) do
-          = render(DiffSubjectComponent.new(state: diff['state'], old_filename: diff.dig('old', 'name'), new_filename: diff.dig('new', 'name')))
-      = render(DiffComponent.new(diff: diff.dig('diff', '_content'), range:))
-    .comment-bubble-content
-      = render ReportsNoticeComponent.new(reportable: comment, user: User.session)
-      = helpers.render_as_markdown(comment)
+  .timeline-item-comment.ms-2.flex-fill
+    .comment-bubble
+      - if policy(comment).update? || policy(comment).destroy?
+        .dropdown.dropleft.float-end.mt-3.mx-3
+          = link_to('#', role: 'button', 'data-bs-toggle': 'dropdown', 'aria-expanded': 'false', class: 'text-dark') do
+            %i.fas.fa-ellipsis
+          .dropdown-menu
+            - if policy(comment).update?
+              = link_to("#edit_form_of_#{comment.id}", id: "edit_button_of_#{comment.id}", 'data-bs-toggle': 'collapse',
+                        class: 'dropdown-item collapsed') do
+                Edit
+            - if Flipper.enabled?(:content_moderation, User.session)
+              - if policy(comment).moderate?
+                = button_to(comment.moderated? ? 'Permit' : 'Moderate', moderate_comment_path(comment),
+                            class: 'dropdown-item', remote: true, form_class: 'moderate-form', params: { moderation_state: !comment.moderated? })
+            - if policy(comment).destroy?
+              = link_to('#', data: { 'bs-toggle': 'modal',
+                                    'bs-target': '#delete-comment-modal',
+                                    confirmation_text: 'Please confirm deletion of comment',
+                                    action: comment_path(comment) },
+                            class: 'dropdown-item delete_link', title: 'Delete comment') do
+                Delete
+      .px-3.py-2.border-bottom
+        = link_to(helpers.realname_with_login(comment.user), user_path(comment.user))
+        wrote
+        = link_to("#comment-#{comment.id}", title: l(comment.created_at.utc), name: "comment-#{comment.id}") do
+          = render TimeComponent.new(time: comment.created_at)
+        = render CommentHistoryComponent.new(comment)
+      - if comment.diff_ref && diff
+        - action = comment.commentable
+        .px-3.pt-3.pb-2
+          = link_to request_show_path(number: action.bs_request, request_action_id: action) do
+            = action.uniq_key
+          >
+          = link_to request_changes_path(number: action.bs_request, request_action_id: action, anchor: comment.diff_ref) do
+            = render(DiffSubjectComponent.new(state: diff['state'], old_filename: diff.dig('old', 'name'), new_filename: diff.dig('new', 'name')))
+        = render(DiffComponent.new(diff: diff.dig('diff', '_content'), range:))
+      .comment-bubble-content
+        = render ReportsNoticeComponent.new(reportable: comment, user: User.session)
+        = helpers.render_as_markdown(comment)
 
-    - if policy(comment).update?
-      .collapse{ id: "edit_form_of_#{comment.id}" }
-        = render(partial: 'webui/comment/comment_field', locals: { form_method: :put,
-         comment: comment, commentable: commentable, element_suffix: "edit_#{comment.id}", has_cancel: true })
+      - if policy(comment).update?
+        .collapse{ id: "edit_form_of_#{comment.id}" }
+          = render(partial: 'webui/comment/comment_field', locals: { form_method: :put,
+          comment: comment, commentable: commentable, element_suffix: "edit_#{comment.id}", has_cancel: true })
 
-  -# This should be refactored to avoid relying on global state
-  - if policy(comment).reply?
-    .mb-2.d-flex.justify-content-end.me-2
-      - if policy(Report.new(reportable: comment)).create?
-        = link_to('#', class: 'font-italic small collapsed me-2', id: "js-comment-#{comment.id}",
-              data: { 'bs-toggle': 'modal',
-                      'bs-target': '#report-modal',
-                      'modal-title': "Report comment from #{comment.user}",
-                      'reportable-type': comment.class.name,
-                      'reportable-id': comment.id }) do
-          Report
-      = link_to("#reply_form_of_#{comment.id}", id: "reply_button_of_#{comment.id}", 'data-bs-toggle': 'collapse',
-                class: 'font-italic small collapsed') do
-        Reply
+    -# This should be refactored to avoid relying on global state
+    - if policy(comment).reply?
+      .d-flex.justify-content-end.mb-3.me-2
+        - if policy(Report.new(reportable: comment)).create?
+          = link_to('#', class: 'font-italic small collapsed me-2', id: "js-comment-#{comment.id}",
+                data: { 'bs-toggle': 'modal',
+                        'bs-target': '#report-modal',
+                        'modal-title': "Report comment from #{comment.user}",
+                        'reportable-type': comment.class.name,
+                        'reportable-id': comment.id }) do
+            Report
+        = link_to("#reply_form_of_#{comment.id}", id: "reply_button_of_#{comment.id}", 'data-bs-toggle': 'collapse',
+                  class: 'font-italic small collapsed') do
+          Reply
 
-    .collapse.ms-4{ id: "reply_form_of_#{comment.id}" }
-      = render(partial: 'webui/comment/comment_field', locals: { form_method: :post,
-        comment: comment.children.new, commentable: commentable, element_suffix: "reply_for_#{comment.id}", has_cancel: true })
+      .collapse.ms-4.mb-4{ id: "reply_form_of_#{comment.id}" }
+        = render(partial: 'webui/comment/comment_field', locals: { form_method: :post,
+          comment: comment.children.new, commentable: commentable, element_suffix: "reply_for_#{comment.id}", has_cancel: true })
 
-  - if level <= 3
-    - comment.children.includes(:user).each do |children|
-      = render BsRequestCommentComponent.new(comment: children, level: level + 1, commentable: commentable)
+    - if level <= 3
+      - comment.children.includes(:user).each do |children|
+        = render BsRequestCommentComponent.new(comment: children, level: level + 1, commentable: commentable)
 
 - if level > 3
   - comment.children.includes(:user).each do |children|

--- a/src/api/app/components/bs_request_comment_component.html.haml
+++ b/src/api/app/components/bs_request_comment_component.html.haml
@@ -1,5 +1,5 @@
 .d-flex
-  %i{ title: 'Comment', class: "fas fa-lg fa-comment text-dark #{ level > 1 ? 'd-none' : '' }" }
+  %i{ title: 'Comment', class: "fas fa-lg fa-comment lh-1 text-dark #{ level > 1 ? 'd-none' : '' }" }
   = render(AvatarComponent.new(name: comment.user.name, email: comment.user.email, size: 35, shape: :circle, custom_css: 'avatars-counter'))
   .timeline-item-comment.ms-2.flex-fill
     .comment-bubble

--- a/src/api/app/components/bs_request_comment_component.html.haml
+++ b/src/api/app/components/bs_request_comment_component.html.haml
@@ -1,5 +1,5 @@
 .d-inline-flex.mb-3
-  %i.fas.fa-lg.fa-comment.text-dark{ title: 'Comment' }
+  %i{ title: 'Comment', class: "fas fa-lg fa-comment text-dark #{ level > 1 ? 'd-none' : '' }" }
   = render(AvatarComponent.new(name: comment.user.name, email: comment.user.email, size: 35, shape: :circle, custom_css: 'avatars-counter'))
 .timeline-item-comment.mb-4
   .comment-bubble

--- a/src/api/app/components/bs_request_comment_component.html.haml
+++ b/src/api/app/components/bs_request_comment_component.html.haml
@@ -1,12 +1,6 @@
-.d-inline-flex
+.d-inline-flex.mb-3
   %i.fas.fa-lg.fa-comment.text-dark{ title: 'Comment' }
   = render(AvatarComponent.new(name: comment.user.name, email: comment.user.email, size: 35, shape: :circle, custom_css: 'avatars-counter'))
-  .mb-3
-    = link_to(helpers.realname_with_login(comment.user), user_path(comment.user))
-    wrote
-    = link_to("#comment-#{comment.id}", title: l(comment.created_at.utc), name: "comment-#{comment.id}") do
-      = render TimeComponent.new(time: comment.created_at)
-    = render CommentHistoryComponent.new(comment)
 .timeline-item-comment.mb-4
   .comment-bubble
     - if policy(comment).update? || policy(comment).destroy?
@@ -29,9 +23,15 @@
                                    action: comment_path(comment) },
                            class: 'dropdown-item delete_link', title: 'Delete comment') do
               Delete
+    .px-3.py-2.border-bottom
+      = link_to(helpers.realname_with_login(comment.user), user_path(comment.user))
+      wrote
+      = link_to("#comment-#{comment.id}", title: l(comment.created_at.utc), name: "comment-#{comment.id}") do
+        = render TimeComponent.new(time: comment.created_at)
+      = render CommentHistoryComponent.new(comment)
     - if comment.diff_ref && diff
       - action = comment.commentable
-      .px-3.py-2
+      .px-3.pt-3.pb-2
         = link_to request_show_path(number: action.bs_request, request_action_id: action) do
           = action.uniq_key
         >

--- a/src/api/app/components/bs_request_comment_component.html.haml
+++ b/src/api/app/components/bs_request_comment_component.html.haml
@@ -1,5 +1,5 @@
-.d-flex.mt-3
-  %i{ title: 'Comment', class: "fas fa-lg fa-comment lh-1 text-dark #{ level > 1 ? 'd-none' : '' }" }
+.d-flex.mt-3.align-items-start
+  %i{ title: 'Comment', class: "fas fa-lg fa-comment text-dark #{ level > 1 ? 'd-none' : '' }" }
   = render(AvatarComponent.new(name: comment.user.name, email: comment.user.email, size: 35, shape: :circle, custom_css: 'avatars-counter'))
   .timeline-item-comment.ms-2.flex-fill
     .comment-bubble

--- a/src/api/app/components/bs_request_history_element_component.html.haml
+++ b/src/api/app/components/bs_request_history_element_component.html.haml
@@ -1,27 +1,28 @@
-.d-inline-flex
+.d-flex.align-items-start
   = icon
-  %p.ms-2.small
-    = link_to(helpers.realname_with_login(element.user), user_path(element.user))
-    - if element.instance_of?(HistoryElement::RequestSuperseded)
-      superseded this request with
-      = link_to("request ##{element.description_extension}", request_show_path(element.description_extension))
-    - elsif element.instance_of?(HistoryElement::RequestReviewAdded) && element.review
-      = element.user_action_prefix
-      %strong
-        = element.action_target
-      = element.user_action_suffix
-    - elsif element.instance_of?(HistoryElement::RequestAccepted) && pending_reviews?
-      #{element.user_action} and dismissed pending reviews
-    - else
-      = element.user_action
-    = link_to("#status-history-#{element.id}", title: l(element.created_at.utc), name: "status-history-#{element.id}") do
-      = render TimeComponent.new(time: element.created_at)
-    - if element.comment.present?
-      = link_to("#collapse-history-element-comment-#{element.id}",
-                  data: { 'bs-toggle': 'collapse' },
-                  aria: { expanded: false, controls: "collapse-history-element-comment" }) do
-        %i.fas.fa-chevron-right.expander.py-0{ title: 'Show details' }>
-        %i.fas.fa-chevron-down.collapser.py-0{ title: 'Hide details' }>
+  .ms-2
+    %span.small
+      = link_to(helpers.realname_with_login(element.user), user_path(element.user))
+      - if element.instance_of?(HistoryElement::RequestSuperseded)
+        superseded this request with
+        = link_to("request ##{element.description_extension}", request_show_path(element.description_extension))
+      - elsif element.instance_of?(HistoryElement::RequestReviewAdded) && element.review
+        = element.user_action_prefix
+        %strong
+          = element.action_target
+        = element.user_action_suffix
+      - elsif element.instance_of?(HistoryElement::RequestAccepted) && pending_reviews?
+        #{element.user_action} and dismissed pending reviews
+      - else
+        = element.user_action
+      = link_to("#status-history-#{element.id}", title: l(element.created_at.utc), name: "status-history-#{element.id}") do
+        = render TimeComponent.new(time: element.created_at)
+      - if element.comment.present?
+        = link_to("#collapse-history-element-comment-#{element.id}",
+                    data: { 'bs-toggle': 'collapse' },
+                    aria: { expanded: false, controls: "collapse-history-element-comment" }) do
+          %i.fas.fa-sm.fa-chevron-right.expander.py-0{ title: 'Show details' }>
+          %i.fas.fa-sm.fa-chevron-down.collapser.py-0{ title: 'Hide details' }>
 - if element.comment.present?
   .timeline-item-comment.collapse{ id: "collapse-history-element-comment-#{element.id}" }
     %p.m-2.mb-4= element.comment

--- a/src/api/app/components/bs_request_history_element_component.html.haml
+++ b/src/api/app/components/bs_request_history_element_component.html.haml
@@ -1,6 +1,6 @@
 .d-inline-flex
   = icon
-  %p.ms-2
+  %p.ms-2.small
     = link_to(helpers.realname_with_login(element.user), user_path(element.user))
     - if element.instance_of?(HistoryElement::RequestSuperseded)
       superseded this request with

--- a/src/api/app/components/bs_request_history_element_component.html.haml
+++ b/src/api/app/components/bs_request_history_element_component.html.haml
@@ -1,7 +1,6 @@
 .d-inline-flex
   = icon
-  = render(AvatarComponent.new(name: element.user.name, email: element.user.email, size: 36, shape: :circle, custom_css: 'avatars-counter'))
-  %p
+  %p.ms-2
     = link_to(helpers.realname_with_login(element.user), user_path(element.user))
     - if element.instance_of?(HistoryElement::RequestSuperseded)
       superseded this request with

--- a/src/api/app/components/bs_request_history_element_component.html.haml
+++ b/src/api/app/components/bs_request_history_element_component.html.haml
@@ -16,6 +16,12 @@
       = element.user_action
     = link_to("#status-history-#{element.id}", title: l(element.created_at.utc), name: "status-history-#{element.id}") do
       = render TimeComponent.new(time: element.created_at)
-
-.timeline-item-comment.mb-4
-  = render partial: 'webui/shared/collapsible_text', locals: { text: element.comment, extra_css_classes: css_for_comment }
+    - if element.comment.present?
+      = link_to("#collapse-history-element-comment-#{element.id}",
+                  data: { 'bs-toggle': 'collapse' },
+                  aria: { expanded: false, controls: "collapse-history-element-comment" }) do
+        %i.fas.fa-chevron-right.expander.py-0{ title: 'Show details' }>
+        %i.fas.fa-chevron-down.collapser.py-0{ title: 'Hide details' }>
+- if element.comment.present?
+  .timeline-item-comment.collapse{ id: "collapse-history-element-comment-#{element.id}" }
+    %p.m-2.mb-4= element.comment

--- a/src/api/app/components/bs_request_history_element_component.rb
+++ b/src/api/app/components/bs_request_history_element_component.rb
@@ -27,15 +27,6 @@ class BsRequestHistoryElementComponent < ApplicationComponent
     end
   end
 
-  # While all history elements possibly have a comment, not all of them are from an actual human...
-  def element_with_comment_from_human?
-    ['RequestReviewAdded', 'ReviewAccepted', 'ReviewDeclined', 'RequestAccepted', 'RequestDeclined'].include?(@element.type.demodulize)
-  end
-
-  def css_for_comment
-    element_with_comment_from_human? ? 'border-start border-3 ps-3 ms-1' : ''
-  end
-
   def pending_reviews?
     request_reviews_for_non_staging_projects.any?(&:new?)
   end

--- a/src/api/app/components/bs_request_history_element_component.rb
+++ b/src/api/app/components/bs_request_history_element_component.rb
@@ -33,7 +33,7 @@ class BsRequestHistoryElementComponent < ApplicationComponent
   end
 
   def css_for_comment
-    element_with_comment_from_human? ? 'border-start border-3 ps-3 ms-4' : ''
+    element_with_comment_from_human? ? 'border-start border-3 ps-3 ms-1' : ''
   end
 
   def pending_reviews?

--- a/src/api/app/components/bs_request_history_element_component.rb
+++ b/src/api/app/components/bs_request_history_element_component.rb
@@ -33,7 +33,7 @@ class BsRequestHistoryElementComponent < ApplicationComponent
   end
 
   def css_for_comment
-    element_with_comment_from_human? ? 'comment-bubble comment-bubble-content' : ''
+    element_with_comment_from_human? ? 'border-start border-3 ps-3 ms-4' : ''
   end
 
   def pending_reviews?

--- a/src/api/app/views/webui/request/beta_show.html.haml
+++ b/src/api/app/views/webui/request/beta_show.html.haml
@@ -38,19 +38,20 @@
             #comments-list
               .timeline.pb-2.ms-3{ data: { comment_counter: local_assigns[:comment_counter_id] } }
                 %h4.list-group.mb-4.ms-3.pt-3 Comments & History
-                .timeline-item
-                  .d-inline-flex
+                .timeline-item.mb-3
+                  .d-flex.align-items-start
                     %i.fas.fa-lg.fa-code-commit.text-dark
-                    %p.ms-2.small
-                      - creator = User.find_by_login(@bs_request.creator) || User.nobody
-                      = link_to(realname_with_login(creator), user_path(creator))
-                      created this request
-                      = link_to('#request-creation', title: I18n.l(@bs_request.created_at.utc), name: 'request-creation') do
-                        = render TimeComponent.new(time: @bs_request.created_at)
-                      - if @bs_request.superseding.any?
-                        superseding
-                        - @bs_request.superseding.each do |superseded_request|
-                          = link_to("request ##{superseded_request.number}", request_show_path(superseded_request.number, anchor: 'overview'))
+                    .ms-2
+                      %span.small
+                        - creator = User.find_by_login(@bs_request.creator) || User.nobody
+                        = link_to(realname_with_login(creator), user_path(creator))
+                        created this request
+                        = link_to('#request-creation', title: I18n.l(@bs_request.created_at.utc), name: 'request-creation') do
+                          = render TimeComponent.new(time: @bs_request.created_at)
+                        - if @bs_request.superseding.any?
+                          superseding
+                          - @bs_request.superseding.each do |superseded_request|
+                            = link_to("request ##{superseded_request.number}", request_show_path(superseded_request.number, anchor: 'overview'))
 
                 - @bs_request.superseding.each do |superseding_request|
                   .timeline-item.pb-4

--- a/src/api/app/views/webui/request/beta_show.html.haml
+++ b/src/api/app/views/webui/request/beta_show.html.haml
@@ -41,9 +41,8 @@
                 .timeline-item
                   .d-inline-flex
                     %i.fas.fa-lg.fa-code-commit.text-dark
-                    - creator = User.find_by_login(@bs_request.creator) || User.nobody
-                    = image_tag_for(creator, size: 35, custom_class: 'rounded-circle bg-light border border-gray-400 avatars-counter')
-                    %p
+                    %p.ms-2
+                      - creator = User.find_by_login(@bs_request.creator) || User.nobody
                       = link_to(realname_with_login(creator), user_path(creator))
                       created this request
                       = link_to('#request-creation', title: I18n.l(@bs_request.created_at.utc), name: 'request-creation') do

--- a/src/api/app/views/webui/request/beta_show.html.haml
+++ b/src/api/app/views/webui/request/beta_show.html.haml
@@ -41,7 +41,7 @@
                 .timeline-item
                   .d-inline-flex
                     %i.fas.fa-lg.fa-code-commit.text-dark
-                    %p.ms-2
+                    %p.ms-2.small
                       - creator = User.find_by_login(@bs_request.creator) || User.nobody
                       = link_to(realname_with_login(creator), user_path(creator))
                       created this request

--- a/src/api/spec/components/bs_request_activity_timeline_component_spec.rb
+++ b/src/api/spec/components/bs_request_activity_timeline_component_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe BsRequestActivityTimelineComponent, type: :component do
   let!(:comment) { travel_to(1.day.ago) { create(:comment_request, commentable: bs_request) } }
 
   it 'shows the comment first, as it is an older timeline item' do
-    expect(render_inline(described_class.new(bs_request: bs_request))).to have_css('.timeline-item:first-child', text: 'wrote')
+    expect(render_inline(described_class.new(bs_request: bs_request))).to have_css('.timeline-item:first-child', text: comment.user.login)
     expect(render_inline(described_class.new(bs_request: bs_request))).to have_css('.timeline-item:first-child', text: '1 day ago')
   end
 

--- a/src/api/spec/components/bs_request_comment_component_spec.rb
+++ b/src/api/spec/components/bs_request_comment_component_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe BsRequestCommentComponent, type: :component do
   end
 
   it 'displays who wrote the comment' do
-    expect(rendered_content).to have_text("#{comment_a.user.realname} (#{comment_a.user.login})\nwrote")
+    expect(rendered_content).to have_text("#{comment_a.user.realname} (#{comment_a.user.login})\n-")
   end
 
   it 'displays the time when the comment happened in words' do
@@ -73,8 +73,8 @@ RSpec.describe BsRequestCommentComponent, type: :component do
   end
 
   context 'when rendering a comment thread' do
-    let(:comment_b) { create(:comment_request, commentable: commentable, body: 'Comment B', parent: comment_a) }
-    let!(:comment_c) { create(:comment_request, commentable: commentable, body: 'Comment C', parent: comment_b) }
+    let!(:comment_b) { create(:comment_request, commentable: commentable, body: 'Comment B', parent: comment_a) } # level 1 => 2 nested .timeline-item-comment
+    let(:comment_c) { create(:comment_request, commentable: commentable, body: 'Comment C', parent: comment_b) }
     let(:comment_d) { create(:comment_request, commentable: commentable, body: 'Comment D', parent: comment_c) }
     let!(:comment_e) { create(:comment_request, commentable: commentable, body: 'Comment E', parent: comment_d) }
 
@@ -83,23 +83,21 @@ RSpec.describe BsRequestCommentComponent, type: :component do
     end
 
     it 'displays the parent comment' do
-      expect(rendered_content).to have_text("(#{comment_a.user.login})\nwrote")
+      expect(rendered_content).to have_text("(#{comment_a.user.login})\n-")
       expect(rendered_content).to have_text('Comment A')
     end
 
-    it 'displays the comments on level 2 in the 2nd level' do
-      expect(rendered_content).to have_css('.timeline-item-comment > .timeline-item-comment', text: "(#{comment_c.user.login})\nwrote")
-      expect(rendered_content).to have_css('.timeline-item-comment > .timeline-item-comment  > .timeline-item-comment', text: 'Comment C')
+    it 'displays the third child comment on the third children level' do
+      expect(rendered_content).to have_css("#{(['.d-flex > .timeline-item-comment'] * 4).join(' > ')} > .comment-bubble", text: "(#{comment_d.user.login})\n-")
+      expect(rendered_content).to have_css("#{(['.d-flex > .timeline-item-comment'] * 4).join(' > ')} > .comment-bubble", text: 'Comment D')
     end
 
-    it 'does not display the comments on level 4 in the 4th one' do
-      expect(rendered_content).not_to have_selector((['.timeline-item-comment'] * 4).join(' > '), text: "(#{comment_e.user.login})\nwrote")
-      expect(rendered_content).not_to have_selector((['.timeline-item-comment'] * 5).join(' > '), text: "(#{comment_e.user.login})\nwrote")
+    it 'does not display the fourth child comment on the fourth children level' do
+      expect(rendered_content).not_to have_selector("#{(['.d-flex > .timeline-item-comment'] * 5).join(' > ')} > .comment-bubble", text: 'Comment E')
     end
 
-    it 'displays the comments on level 4 in the 3rd level' do
-      expect(rendered_content).to have_selector((['.timeline-item-comment'] * 3).join(' > '), text: "(#{comment_e.user.login})\nwrote")
-      expect(rendered_content).to have_selector((['.timeline-item-comment'] * 4).join(' > '), text: 'Comment E')
+    it 'does not display the fourth child comment on the third children level' do
+      expect(rendered_content).to have_selector("#{(['.d-flex > .timeline-item-comment'] * 4).join(' > ')} > .comment-bubble", text: 'Comment E')
     end
   end
 end

--- a/src/api/spec/components/bs_request_history_element_component_spec.rb
+++ b/src/api/spec/components/bs_request_history_element_component_spec.rb
@@ -11,20 +11,12 @@ RSpec.describe BsRequestHistoryElementComponent, type: :component do
   context 'for any kind of history elements' do
     let(:element) { travel_to(1.day.ago) { create(:history_element_request_accepted, user: user) } }
 
-    it 'displays an avatar' do
-      expect(rendered_content).to have_selector("img[title='#{user.realname}']", count: 1)
-    end
-
     it 'displays the name of the user involved' do
       expect(rendered_content).to have_text("#{user.realname} (#{user.login})")
     end
 
     it 'displays the time in words' do
       expect(rendered_content).to have_text('1 day ago')
-    end
-
-    it 'displays the element comment' do
-      expect(rendered_content).to have_css('.timeline-item-comment', text: element.comment)
     end
   end
 


### PR DESCRIPTION
These are the changes so far:

- Nested comments don't show the comment icon. It's displayed only once per comment thread on top of the timeline.
- The name of the commenter and the date are moved inside the comment bubble.
- The comment bubble is moved to the right side of the avatar.
- The comment bubble is more rounded and its arrow is moved to the left.
- The Report and Reply links are moved to the right side, but this comes from PR #15218.
- Any comment/message which is not part of a conversation i.e. the message sent when asking someone to review.
  - doesn't have an avatar
  - uses a smaller font size
  -  is not displayed but can be read when hovering the file icon next to the date.
- Having `wrote` everywhere is redundant now, so it's replaced by a dash.

Please compare the following images. Look as the second one is more compacted.

**Before:**

![before](https://github.com/openSUSE/open-build-service/assets/2581944/066d07ca-3770-42c4-8288-d07f56ca2263)

**After:**

![Screenshot 2023-11-21 at 17-32-17 Open Build Service](https://github.com/openSUSE/open-build-service/assets/2581944/5c3a4388-98a5-49d1-b3be-92d56c37f450)



**TODO:**
- [x] Align the comment icon and the first avatar in the comment thread properly
- [x] Collapse/hide non-conversation comments (from HistoryElement#comment).

**NOTE:** I tried to add one commit per change, so it'll be easy to remove/modify any of them independently
