### PR TITLE
Require pry-bybug by default

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -184,7 +184,7 @@ group :development, :test do
   # as alternative to the standard IRB shell
   gem 'pry', require: false
   # add step-by-step debugging and stack navigation capabilities to pry
-  gem 'pry-byebug', require: false
+  gem 'pry-byebug'
   # for style checks
   gem 'rubocop', require: false
   # for rails style checks


### PR DESCRIPTION
On PR https://github.com/openSUSE/open-build-service/pull/15140 we stopped requiring `pry-byebug` by default.

Since then, when you run docker to debug some code, as explained [here](https://github.com/openSUSE/open-build-service/wiki/Development-Environment-Tips-&-Tricks#debugging), and try to use `next`, `step`, etc. you get errors like this:

```
> next     
(eval):2: Can't escape from eval with next
```

You can require `pry-byebug` every time you debug, but I prefer to require it by default and make it straightforward.