### PR TITLE
Disable RSpec/RepeatedExample cop for spec/policies

### DIFF
--- a/src/api/.rubocop.yml
+++ b/src/api/.rubocop.yml
@@ -535,6 +535,11 @@ RSpec/Rails/AvoidSetupHook:
   Exclude:
     # Don't parse minitests for RSpec cops
     - 'test/**/*'
+RSpec/RepeatedExample:
+  Exclude:
+    # This cop is currently not recognizing the pundit rspec helpers.
+    # https://github.com/varvet/pundit#rspec
+    - 'spec/policies/**/*'
 
 ##################### Bundler ##################################
 

--- a/src/api/spec/policies/comment_policy_spec.rb
+++ b/src/api/spec/policies/comment_policy_spec.rb
@@ -16,8 +16,6 @@ RSpec.describe CommentPolicy do
 
   subject { CommentPolicy }
 
-  # rubocop:disable RSpec/RepeatedExample
-  # This cop is currently not recognizing the permissions block as separate test
   permissions :destroy? do
     it 'Not logged users cannot destroy comments' do
       expect(subject).not_to permit(nil, comment)
@@ -46,7 +44,6 @@ RSpec.describe CommentPolicy do
     it 'User cannot destroy comments of other user' do
       expect(subject).not_to permit(user, comment)
     end
-    # rubocop:enable RSpec/RepeatedExample
 
     context 'with a comment of a Package' do
       before do
@@ -79,8 +76,6 @@ RSpec.describe CommentPolicy do
     end
   end
 
-  # rubocop:disable RSpec/RepeatedExample
-  # This cop is currently not recognizing the permissions block as separate test
   permissions :update? do
     it 'an anonymous user cannot update comments' do
       expect(subject).not_to permit(nil, comment)
@@ -112,10 +107,7 @@ RSpec.describe CommentPolicy do
       end
     end
   end
-  # rubocop:enable RSpec/RepeatedExample
 
-  # rubocop:disable RSpec/RepeatedExample
-  # This cop is currently not recognizing the permissions block as separate test
   permissions :reply? do
     it 'an anonymous user cannot reply to comments' do
       expect(subject).not_to permit(nil, comment)
@@ -143,9 +135,7 @@ RSpec.describe CommentPolicy do
       end
     end
   end
-  # rubocop:enable RSpec/RepeatedExample
 
-  # rubocop:disable RSpec/RepeatedExample
   permissions :moderate? do
     it 'a not logged-in user cannot moderate comments' do
       expect(subject).not_to permit(nil, comment)
@@ -185,5 +175,4 @@ RSpec.describe CommentPolicy do
       end
     end
   end
-  # rubocop:enable RSpec/RepeatedExample
 end

--- a/src/api/spec/policies/group_policy_spec.rb
+++ b/src/api/spec/policies/group_policy_spec.rb
@@ -10,8 +10,6 @@ RSpec.describe GroupPolicy do
 
   subject { GroupPolicy }
 
-  # rubocop:disable RSpec/RepeatedExample
-  # This cop is currently not recognizing the permissions block as separate test
   permissions :create?, :index? do
     it { is_expected.not_to permit(user, group) }
     it { is_expected.not_to permit(group_member, group) }
@@ -33,5 +31,4 @@ RSpec.describe GroupPolicy do
     it { is_expected.to permit(group_maintainer, group) }
     it { is_expected.to permit(admin, group) }
   end
-  # rubocop:enable RSpec/RepeatedExample
 end

--- a/src/api/spec/policies/status_message_policy_spec.rb
+++ b/src/api/spec/policies/status_message_policy_spec.rb
@@ -9,8 +9,6 @@ RSpec.describe StatusMessagePolicy do
 
   subject { StatusMessagePolicy }
 
-  # rubocop:disable RSpec/RepeatedExample
-  # This cop is currently not recognizing the permissions block as separate test
   permissions :index?, :show? do
     it { is_expected.to permit(anonymous_user, status_message) }
     it { is_expected.to permit(user, status_message) }
@@ -24,5 +22,4 @@ RSpec.describe StatusMessagePolicy do
     it { is_expected.to permit(staff_user, status_message) }
     it { is_expected.to permit(admin_user, status_message) }
   end
-  # rubocop:enable RSpec/RepeatedExample
 end

--- a/src/api/spec/policies/webui/status_message_policy_spec.rb
+++ b/src/api/spec/policies/webui/status_message_policy_spec.rb
@@ -9,8 +9,6 @@ RSpec.describe Webui::StatusMessagePolicy do
 
   subject { described_class }
 
-  # rubocop:disable RSpec/RepeatedExample
-  # This cop is currently not recognizing the permissions block as separate test
   permissions :acknowledge? do
     it { is_expected.to permit(user, status_message) }
     it { is_expected.to permit(staff_user, status_message) }
@@ -22,7 +20,6 @@ RSpec.describe Webui::StatusMessagePolicy do
     it { is_expected.to permit(staff_user, status_message) }
     it { is_expected.to permit(admin_user, status_message) }
   end
-  # rubocop:enable RSpec/RepeatedExample
 
   it "doesn't permit anonymous user" do
     expect { described_class.new(user_nobody, status_message) }


### PR DESCRIPTION
This cop is currently not recognizing the pundit rspec helpers.