### PR TITLE
[api] fix handling of architecture filter for release command

### DIFF
--- a/docs/api/api/api.txt
+++ b/docs/api/api/api.txt
@@ -674,6 +674,7 @@ POST /source/<project>/<package>?cmd=release
 
 Parameters:
   comment: description for the history
+  arch: limit the release to the specified architecture
   repository: limit the release to the specified repository
   target_repository: specify the target repository name (together with target_project)
   target_project: overwrites the target definition from project meta


### PR DESCRIPTION
it would filter on release before, but fail if not filtered architectures are missing in target