### PR TITLE
Make sure that Mail::Address is available in the patchinfo component

### DIFF
--- a/src/api/app/components/patchinfo_component.rb
+++ b/src/api/app/components/patchinfo_component.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'mail'
+
 class PatchinfoComponent < ApplicationComponent
   attr_reader :patchinfo, :path
 


### PR DESCRIPTION
This doesn't seem to be included by rails by default, so let's include it so that it's available