### PR TITLE
Fix issue when creating notification with group and RSS

### DIFF
--- a/src/api/app/services/notification_service/notifier.rb
+++ b/src/api/app/services/notification_service/notifier.rb
@@ -67,7 +67,7 @@ module NotificationService
     end
 
     def create_notification?(subscriber, channel)
-      return false if subscriber.nil? || subscriber.away? || (channel == :rss && subscriber.rss_secret.blank?)
+      return false if subscriber.nil? || subscriber.away? || (channel == :rss && subscriber.try(:rss_secret).blank?)
       return false unless notifiable_exists?
       return false unless create_report_notification?(event: @event, subscriber: subscriber)
 


### PR DESCRIPTION
Fixes: #15273

It's weird because there is no subscription for a group + RSS channel in the production database.
That kind of subscription is not even possible through the WebUI.
![Screenshot 2023-11-27 at 17-48-41 Open Build Service](https://github.com/openSUSE/open-build-service/assets/2581944/aeef6d86-a8a4-4af3-bf2a-aabd402b550f)
