### PR TITLE
Patchinfo component fix

### DIFF
--- a/src/api/app/components/patchinfo_component.html.haml
+++ b/src/api/app/components/patchinfo_component.html.haml
@@ -36,16 +36,16 @@
     - if @patchinfo['releasetarget'].present?
       %h6 Targeted for release in the following projects
       %ul
-        - release_targets.each do |releasetarget|
+        - release_targets.each do |release_target|
           %li
-            - if (project = Project.find_by_name(releasetarget['project']))
+            - if (project = Project.find_by_name(release_target['project']))
               = link_to(project_show_path(project)) do
-                = releasetarget['project']
+                = release_target['project']
             - else
-              = releasetarget['project']
-            - if releasetarget.key?('repository')
+              = release_target['project']
+            - if release_target.key?('repository')
               Repository:
-              = releasetarget['repository']
+              = release_target['repository']
 
     - if @patchinfo['binary'].present?
       %h6 Affected binaries

--- a/src/api/app/components/patchinfo_component.html.haml
+++ b/src/api/app/components/patchinfo_component.html.haml
@@ -36,7 +36,7 @@
     - if @patchinfo['releasetarget'].present?
       %h6 Targeted for release in the following projects
       %ul
-        - @patchinfo['releasetarget'].each do |releasetarget|
+        - release_targets.each do |releasetarget|
           %li
             - if (project = Project.find_by_name(releasetarget['project']))
               = link_to(project_show_path(project)) do
@@ -50,19 +50,19 @@
     - if @patchinfo['binary'].present?
       %h6 Affected binaries
       %ul
-        - @patchinfo['binary'].each do |binary|
+        - binaries.each do |binary|
           %li= binary
 
     - if @patchinfo['package'].present?
       %h6 Affected packages
       %ul
-        - @patchinfo['package'].each do |package|
+        - packages.each do |package|
           %li= package
 
     - if @patchinfo['issue'].present?
       %h6 Issues related to the patch
       %ul
-        - @patchinfo['issue'].each do |issue_hash|
+        - issues.each do |issue_hash|
           - if (issue = Issue.find_or_create_by_name_and_tracker(issue_hash['id'], issue_hash['tracker']))
             %li
               = link_to(issue.url) do

--- a/src/api/app/components/patchinfo_component.rb
+++ b/src/api/app/components/patchinfo_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class PatchinfoComponent < ApplicationComponent
-  attr_reader :patchinfo, :path
+  attr_reader :patchinfo, :path, :release_targets, :binaries, :packages, :issues
 
   CATEGORY_COLOR = { ptf: 'text-bg-danger',
                      security: 'text-bg-warning',
@@ -18,6 +18,11 @@ class PatchinfoComponent < ApplicationComponent
     super
     @patchinfo = Xmlhash.parse(patchinfo)
     @path = path
+
+    @release_targets = [@patchinfo['releasetarget']].flatten
+    @binaries = [@patchinfo['binary']].flatten
+    @packages = [@patchinfo['package']].flatten
+    @issues = [@patchinfo['issue']].flatten
   end
 
   def category

--- a/src/api/spec/components/patchinfo_component_spec.rb
+++ b/src/api/spec/components/patchinfo_component_spec.rb
@@ -1,0 +1,149 @@
+require 'rails_helper'
+
+RSpec.describe PatchinfoComponent, type: :component do
+  let!(:user) { create(:user, :with_home, login: 'tom') }
+
+  context 'with one tag per type' do
+    let(:patchinfo_text) do
+      '<patchinfo>
+        <category>recommended</category>
+        <rating>low</rating>
+        <packager>tom</packager>
+        <summary/>
+        <description/>
+        <binary>binary_001</binary>
+        <package>package_a</package>
+        <issue tracker="cve" id="2023-1111"/>
+        <releasetarget project="openSUSE:Factory" repository="15.4" />
+      </patchinfo>'
+    end
+
+    before do
+      render_inline(described_class.new(patchinfo_text, 'path-to-request-changes'))
+    end
+
+    it do
+      expect(rendered_content).to have_text('Affected binaries')
+    end
+
+    it do
+      expect(rendered_content).to have_css('li', text: 'binary_001')
+    end
+
+    it do
+      expect(rendered_content).to have_text('2023-1111')
+    end
+
+    it do
+      expect(rendered_content).to have_text('Affected packages')
+    end
+
+    it do
+      expect(rendered_content).to have_text('package_a')
+    end
+
+    it do
+      expect(rendered_content).to have_text('Targeted for release in the following projects')
+    end
+
+    it do
+      expect(rendered_content).to have_text('openSUSE:Factory')
+    end
+
+    it do
+      expect(rendered_content).to have_text('15.4')
+    end
+  end
+
+  context 'with multiple tags per type' do
+    let(:patchinfo_text) do
+      '<patchinfo>
+        <category>recommended</category>
+        <rating>low</rating>
+        <packager>tom</packager>
+        <summary/>
+        <description/>
+        <package>package_a</package>
+        <package>package_b</package>
+        <binary>binary_001</binary>
+        <binary>binary_002</binary>
+        <issue tracker="cve" id="2023-1111"/>
+        <issue tracker="cve" id="2023-2222"/>
+        <releasetarget project="openSUSE:Factory" repository="15.4" />
+        <releasetarget project="openSUSE:Factory" repository="15.5" />
+      </patchinfo>'
+    end
+
+    before do
+      render_inline(described_class.new(patchinfo_text, 'path-to-request-changes'))
+    end
+
+    it do
+      expect(rendered_content).to have_text('Affected binaries')
+    end
+
+    it do
+      expect(rendered_content).to have_text('binary_001').and(have_text('binary_002'))
+    end
+
+    it do
+      expect(rendered_content).to have_text('Issues related to the patch')
+    end
+
+    it do
+      expect(rendered_content).to have_text('2023-1111').and(have_text('2023-2222'))
+    end
+
+    it do
+      expect(rendered_content).to have_text('Affected packages')
+    end
+
+    it do
+      expect(rendered_content).to have_text('package_a').and(have_text('package_b'))
+    end
+
+    it do
+      expect(rendered_content).to have_text('Targeted for release in the following projects')
+    end
+
+    it do
+      expect(rendered_content).to have_text('openSUSE:Factory')
+    end
+
+    it do
+      expect(rendered_content).to have_text('15.4').and(have_text('15.5'))
+    end
+  end
+
+  context 'with missing tags' do
+    let(:patchinfo_text) do
+      '<patchinfo>
+        <category>recommended</category>
+        <rating>low</rating>
+        <packager>tom</packager>
+        <summary/>
+        <description/>
+      </patchinfo>'
+    end
+
+    before do
+      render_inline(described_class.new(patchinfo_text, 'path-to-request-changes'))
+    end
+
+    it do
+      expect(rendered_content).not_to have_text('Affected binaries')
+    end
+
+    it do
+      expect(rendered_content).not_to have_text('Affected packages')
+    end
+
+    it do
+      expect(rendered_content).not_to have_text('Issues related to the patch')
+    end
+
+    it do
+      expect(rendered_content).not_to have_text('Targeted for release in the following projects')
+    end
+  end
+end


### PR DESCRIPTION
Handle patchinfo tags as arrays. Otherwise, the loop crashes when there is only one element (not an array).
Include component specs.

Follow up https://github.com/openSUSE/open-build-service/pull/15257