### PR TITLE
Don't extend the comments beyond the timeline space

### DIFF
--- a/src/api/app/components/bs_request_comment_component.html.haml
+++ b/src/api/app/components/bs_request_comment_component.html.haml
@@ -1,7 +1,7 @@
 .d-flex.mt-3.align-items-start
   %i{ title: 'Comment', class: "fas fa-lg fa-comment text-dark #{ level > 1 ? 'd-none' : '' }" }
   = render(AvatarComponent.new(name: comment.user.name, email: comment.user.email, size: 35, shape: :circle, custom_css: 'avatars-counter'))
-  .timeline-item-comment.ms-2.flex-fill
+  .timeline-item-comment.ms-2.flex-fill.overflow-auto
     .comment-bubble
       - if policy(comment).update? || policy(comment).destroy?
         .dropdown.dropleft.float-end.mt-3.mx-3


### PR DESCRIPTION
Fixes #15278

To test it:
1. Open a bs_request show
2. Create a comment like shown in https://build.opensuse.org/request/show/1129301