### PR TITLE
Fix three-dots superseded history timeline alignment

### DIFF
--- a/src/api/app/assets/stylesheets/webui/timeline.scss
+++ b/src/api/app/assets/stylesheets/webui/timeline.scss
@@ -36,11 +36,10 @@
         }
 
         i.timeline-break, i.timeline-offset {
-            @extend .py-2;
+            @extend .py-1;
             @extend .me-2;
             @extend .fas;
             @extend .fa-ellipsis-vertical;
-            margin-left: 0.66rem;
         }
         i.timeline-break {
             background-color: var(--timeline-bg);
@@ -51,6 +50,7 @@
         }
         i.timeline-offset {
             color: transparent;
+            @extend .ms-3;
         }
     }
 


### PR DESCRIPTION
## Before
![image](https://github.com/openSUSE/open-build-service/assets/7080830/d51933e4-0a00-48a5-9218-56289a142f48)


## After
![image](https://github.com/openSUSE/open-build-service/assets/7080830/ec7d2873-e419-4fab-be27-3018be479222)
