### PR TITLE
[backend] bs_worker: delete obsolete symlink creation code

### DIFF
--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -4036,11 +4036,6 @@ sub dobuild {
       print "final rename failed: $!\n";
       return 1;
     }
-    # XXX: extracted cpio is flat but code below expects those directories...
-    symlink('.', "$buildroot/.build.packages/SRPMS");
-    symlink('.', "$buildroot/.build.packages/DEBS");
-    symlink('.', "$buildroot/.build.packages/KIWI");
-    symlink('.', "$buildroot/.build.packages/PRODUCT");
     # convert build statistics into xml
     my $statsfile = "$buildroot/.build.packages/OTHER/_statistics";
     updatestatsfromfile($stats, $statsfile) if -e $statsfile;


### PR DESCRIPTION
The build script does not extract flat files since 2009