### PR TITLE
Prevent dealing with RSS subscriptions for groups

### DIFF
--- a/src/api/app/models/event_subscription/find_for_event.rb
+++ b/src/api/app/models/event_subscription/find_for_event.rb
@@ -82,6 +82,9 @@ class EventSubscription
     end
 
     def expand_receivers_for_groups(receiver, channel)
+      # RSS subscriptions for groups are not supported
+      return [] if channel == :rss
+
       # We don't split events which come through the web channel, for a group subscriber.
       # They are split in the NotificationService::WebChannel service, if needed.
       return [receiver] if channel == :web || receiver.email.present?


### PR DESCRIPTION
Follow up #15276.

The code crashed with the following combination:
- There is a default subscription to RSS (user or group not specified)
- There are no specific subscriptions of that group with RSS (obviously, it's not possible).
- There is an event whose receiver is a group
- That group has an email

At some point, the code returned the default subscription for RSS as a valid subscription for that receiver. That's wrong because RSS + group is not a valid combination.


## Testing Tips

You can reproduce the error by adding this test around line 201 of the notifier_spec.rb. It makes little sense to test if "something is not created because it shouldn't", that's why the test is not included in the PR. The specs for FindForEvent#subscriptions are extended to cover this corner case instead.

```
        context 'test' do
          let(:group) { create(:group_with_user) }
          let(:user) { group.users.first }
          let(:event) { Event::RelationshipCreate.create!(who: owner.login, group: group.title, project: project.name, notifiable_id: project.id) }

          let!(:default_subscription) do
            create(
              :event_subscription,
              eventtype: 'Event::RelationshipCreate',
              receiver_role: 'any_role',
              user: nil,
              group: nil,
              channel: :rss
            )
          end

          it 'creates a new notification for the subscribed group members' do
            expect { NotificationService::Notifier.new(event).call }.not_to raise_error
          end
        end
```