### PR TITLE
Add missing annotation from DB schema changes

### DIFF
--- a/src/api/app/models/event/report.rb
+++ b/src/api/app/models/event/report.rb
@@ -10,3 +10,22 @@ module Event
     end
   end
 end
+
+# == Schema Information
+#
+# Table name: events
+#
+#  id          :bigint           not null, primary key
+#  eventtype   :string(255)      not null, indexed
+#  mails_sent  :boolean          default(FALSE), indexed
+#  payload     :text(65535)
+#  undone_jobs :integer          default(0)
+#  created_at  :datetime         indexed
+#  updated_at  :datetime
+#
+# Indexes
+#
+#  index_events_on_created_at  (created_at)
+#  index_events_on_eventtype   (eventtype)
+#  index_events_on_mails_sent  (mails_sent)
+#

--- a/src/api/app/models/event/report_for_comment.rb
+++ b/src/api/app/models/event/report_for_comment.rb
@@ -5,3 +5,22 @@ module Event
                  :project_name, :package_name
   end
 end
+
+# == Schema Information
+#
+# Table name: events
+#
+#  id          :bigint           not null, primary key
+#  eventtype   :string(255)      not null, indexed
+#  mails_sent  :boolean          default(FALSE), indexed
+#  payload     :text(65535)
+#  undone_jobs :integer          default(0)
+#  created_at  :datetime         indexed
+#  updated_at  :datetime
+#
+# Indexes
+#
+#  index_events_on_created_at  (created_at)
+#  index_events_on_eventtype   (eventtype)
+#  index_events_on_mails_sent  (mails_sent)
+#

--- a/src/api/app/models/event/report_for_package.rb
+++ b/src/api/app/models/event/report_for_package.rb
@@ -4,3 +4,22 @@ module Event
     payload_keys :package_name, :project_name
   end
 end
+
+# == Schema Information
+#
+# Table name: events
+#
+#  id          :bigint           not null, primary key
+#  eventtype   :string(255)      not null, indexed
+#  mails_sent  :boolean          default(FALSE), indexed
+#  payload     :text(65535)
+#  undone_jobs :integer          default(0)
+#  created_at  :datetime         indexed
+#  updated_at  :datetime
+#
+# Indexes
+#
+#  index_events_on_created_at  (created_at)
+#  index_events_on_eventtype   (eventtype)
+#  index_events_on_mails_sent  (mails_sent)
+#

--- a/src/api/app/models/event/report_for_project.rb
+++ b/src/api/app/models/event/report_for_project.rb
@@ -4,3 +4,22 @@ module Event
     payload_keys :project_name
   end
 end
+
+# == Schema Information
+#
+# Table name: events
+#
+#  id          :bigint           not null, primary key
+#  eventtype   :string(255)      not null, indexed
+#  mails_sent  :boolean          default(FALSE), indexed
+#  payload     :text(65535)
+#  undone_jobs :integer          default(0)
+#  created_at  :datetime         indexed
+#  updated_at  :datetime
+#
+# Indexes
+#
+#  index_events_on_created_at  (created_at)
+#  index_events_on_eventtype   (eventtype)
+#  index_events_on_mails_sent  (mails_sent)
+#

--- a/src/api/app/models/event/report_for_user.rb
+++ b/src/api/app/models/event/report_for_user.rb
@@ -4,3 +4,22 @@ module Event
     payload_keys :user_login
   end
 end
+
+# == Schema Information
+#
+# Table name: events
+#
+#  id          :bigint           not null, primary key
+#  eventtype   :string(255)      not null, indexed
+#  mails_sent  :boolean          default(FALSE), indexed
+#  payload     :text(65535)
+#  undone_jobs :integer          default(0)
+#  created_at  :datetime         indexed
+#  updated_at  :datetime
+#
+# Indexes
+#
+#  index_events_on_created_at  (created_at)
+#  index_events_on_eventtype   (eventtype)
+#  index_events_on_mails_sent  (mails_sent)
+#

--- a/src/api/app/models/event/workflow_run_fail.rb
+++ b/src/api/app/models/event/workflow_run_fail.rb
@@ -21,3 +21,22 @@ module Event
     end
   end
 end
+
+# == Schema Information
+#
+# Table name: events
+#
+#  id          :bigint           not null, primary key
+#  eventtype   :string(255)      not null, indexed
+#  mails_sent  :boolean          default(FALSE), indexed
+#  payload     :text(65535)
+#  undone_jobs :integer          default(0)
+#  created_at  :datetime         indexed
+#  updated_at  :datetime
+#
+# Indexes
+#
+#  index_events_on_created_at  (created_at)
+#  index_events_on_eventtype   (eventtype)
+#  index_events_on_mails_sent  (mails_sent)
+#

--- a/src/api/app/models/unregistered_user.rb
+++ b/src/api/app/models/unregistered_user.rb
@@ -84,7 +84,7 @@ end
 #  login_failure_count           :integer          default(0), not null
 #  password_digest               :string(255)
 #  realname                      :string(200)      default(""), not null
-#  rss_secret                    :string(255)      indexed
+#  rss_secret                    :string(200)      indexed
 #  state                         :string           default("unconfirmed")
 #  created_at                    :datetime
 #  updated_at                    :datetime

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -963,7 +963,7 @@ end
 #  login_failure_count           :integer          default(0), not null
 #  password_digest               :string(255)
 #  realname                      :string(200)      default(""), not null
-#  rss_secret                    :string(255)      indexed
+#  rss_secret                    :string(200)      indexed
 #  state                         :string           default("unconfirmed")
 #  created_at                    :datetime
 #  updated_at                    :datetime


### PR DESCRIPTION
This was generated with `bundle exec rake db:migrate`, they should have been included in the PRs which introduced the models / changes.