### PR TITLE
Remove not needed `try` for no longer existing RSS group subscribers

### DIFF
--- a/src/api/app/services/notification_service/notifier.rb
+++ b/src/api/app/services/notification_service/notifier.rb
@@ -67,7 +67,7 @@ module NotificationService
     end
 
     def create_notification?(subscriber, channel)
-      return false if subscriber.nil? || subscriber.away? || (channel == :rss && subscriber.try(:rss_secret).blank?)
+      return false if subscriber.nil? || subscriber.away? || (channel == :rss && subscriber.rss_secret.blank?)
       return false unless notifiable_exists?
       return false unless create_report_notification?(event: @event, subscriber: subscriber)
 


### PR DESCRIPTION
This is a follow up to #15290.

Now that subscription of groups to RSSs are prevented, we can now safely rely on the fact that when we deal with RSS channels, the receiver will always be a user.
