### PR TITLE
Make room for the comment-bubble top-left corner

### DIFF
--- a/src/api/app/components/bs_request_comment_component.html.haml
+++ b/src/api/app/components/bs_request_comment_component.html.haml
@@ -1,8 +1,8 @@
 .d-flex.mt-3.align-items-start
   %i{ title: 'Comment', class: "fas fa-lg fa-comment text-dark #{ level > 1 ? 'd-none' : '' }" }
   = render(AvatarComponent.new(name: comment.user.name, email: comment.user.email, size: 35, shape: :circle, custom_css: 'avatars-counter'))
-  .timeline-item-comment.ms-2.flex-fill.overflow-auto
-    .comment-bubble
+  .timeline-item-comment.ms-0.flex-fill.overflow-auto
+    .comment-bubble.ms-3
       - if policy(comment).update? || policy(comment).destroy?
         .dropdown.dropleft.float-end.mt-3.mx-3
           = link_to('#', role: 'button', 'data-bs-toggle': 'dropdown', 'aria-expanded': 'false', class: 'text-dark') do


### PR DESCRIPTION
In the middle of some refactoring/reshaping/redesign, the top-left corner of the comment-bubble got broken (actually disappeared) because of the spacing not set on the proper element to let the corner be visible. This PR fixes that issue.

## Before
![image](https://github.com/openSUSE/open-build-service/assets/7080830/819ad773-af24-4e93-8bfb-d450dcf7affe)


## After
![image](https://github.com/openSUSE/open-build-service/assets/7080830/efc7c739-642e-466e-8b1b-5cdb9caf8c9a)
