### PR TITLE
Include more information in notifications for deleted reportables

### DIFF
--- a/src/api/app/components/notification_notifiable_link_component.rb
+++ b/src/api/app/components/notification_notifiable_link_component.rb
@@ -7,7 +7,9 @@ class NotificationNotifiableLinkComponent < ApplicationComponent
   end
 
   def call
-    link_to(notifiable_link_text, notifiable_link_path, class: 'mx-1')
+    return link_to(notifiable_link_text, notifiable_link_path, class: 'mx-1') if notifiable_link_path.present?
+
+    tag.span(notifiable_link_text, class: 'fst-italic mx-1')
   end
 
   private
@@ -106,14 +108,8 @@ class NotificationNotifiableLinkComponent < ApplicationComponent
       link_for_reportables(reportable)
     when 'Event::ReportForComment'
       path_to_commentables_on_reports(event_payload: @notification.event_payload, notification_id: @notification.id)
-    when 'Event::ReportForPackage'
-      Rails.application.routes.url_helpers.package_show_path(package: @notification.event_payload['package_name'],
-                                                             project: @notification.event_payload['project_name'],
-                                                             notification_id: @notification.id,
-                                                             anchor: 'comments-list')
-    when 'Event::ReportForProject'
-      Rails.application.routes.url_helpers.project_show_path(@notification.event_payload['project_name'],
-                                                             notification_id: @notification.id)
+    when 'Event::ReportForProject', 'Event::ReportForPackage'
+      @notification.event_type.constantize.notification_link_path(@notification)
     when 'Event::ReportForUser'
       Rails.application.routes.url_helpers.user_path(@notification.event_payload['user_login'])
     when 'Event::ClearedDecision', 'Event::FavoredDecision'

--- a/src/api/app/components/notification_notifiable_link_component.rb
+++ b/src/api/app/components/notification_notifiable_link_component.rb
@@ -48,9 +48,12 @@ class NotificationNotifiableLinkComponent < ApplicationComponent
     when 'Event::CreateReport', 'Event::ReportForComment', 'Event::ReportForUser'
       "Report for a #{@notification.event_payload['reportable_type']}"
     when 'Event::ReportForProject'
-      "Report for Project #{@notification.event_payload['project_name']}"
+      deleted_message = ' (already deleted)' unless Project.exists_by_name(@notification.event_payload['project_name'])
+      "Report for Project #{@notification.event_payload['project_name']}#{deleted_message}"
     when 'Event::ReportForPackage'
-      "Report for Package #{@notification.event_payload['project_name']} / #{@notification.event_payload['package_name']}"
+      deleted_message = ' (already deleted)' unless Package.exists_by_project_and_name(@notification.event_payload['project_name'],
+                                                                                       @notification.event_payload['package_name'])
+      "Report for Package #{@notification.event_payload['project_name']} / #{@notification.event_payload['package_name']}#{deleted_message}"
     when 'Event::ClearedDecision'
       # All reports should point to the same reportable. We will take care of that here:
       # https://trello.com/c/xrjOZGa7/45-ensure-all-reports-of-a-decision-point-to-the-same-reportable

--- a/src/api/app/components/notification_notifiable_link_component.rb
+++ b/src/api/app/components/notification_notifiable_link_component.rb
@@ -47,13 +47,8 @@ class NotificationNotifiableLinkComponent < ApplicationComponent
     # TODO: Remove `Event::CreateReport` after all existing records are migrated to the new STI classes
     when 'Event::CreateReport', 'Event::ReportForComment', 'Event::ReportForUser'
       "Report for a #{@notification.event_payload['reportable_type']}"
-    when 'Event::ReportForProject'
-      deleted_message = ' (already deleted)' unless Project.exists_by_name(@notification.event_payload['project_name'])
-      "Report for Project #{@notification.event_payload['project_name']}#{deleted_message}"
-    when 'Event::ReportForPackage'
-      deleted_message = ' (already deleted)' unless Package.exists_by_project_and_name(@notification.event_payload['project_name'],
-                                                                                       @notification.event_payload['package_name'])
-      "Report for Package #{@notification.event_payload['project_name']} / #{@notification.event_payload['package_name']}#{deleted_message}"
+    when 'Event::ReportForProject', 'Event::ReportForPackage'
+      @notification.event_type.constantize.notification_link_text(@notification.event_payload)
     when 'Event::ClearedDecision'
       # All reports should point to the same reportable. We will take care of that here:
       # https://trello.com/c/xrjOZGa7/45-ensure-all-reports-of-a-decision-point-to-the-same-reportable

--- a/src/api/app/components/notification_notifiable_link_component.rb
+++ b/src/api/app/components/notification_notifiable_link_component.rb
@@ -45,8 +45,12 @@ class NotificationNotifiableLinkComponent < ApplicationComponent
       arch = @notification.event_payload['arch']
       "Package #{package} on #{project} project failed to build against #{repository} / #{arch}"
     # TODO: Remove `Event::CreateReport` after all existing records are migrated to the new STI classes
-    when 'Event::CreateReport', 'Event::ReportForProject', 'Event::ReportForPackage', 'Event::ReportForComment', 'Event::ReportForUser'
+    when 'Event::CreateReport', 'Event::ReportForComment', 'Event::ReportForUser'
       "Report for a #{@notification.event_payload['reportable_type']}"
+    when 'Event::ReportForProject'
+      "Report for Project #{@notification.event_payload['project_name']}"
+    when 'Event::ReportForPackage'
+      "Report for Package #{@notification.event_payload['project_name']} / #{@notification.event_payload['package_name']}"
     when 'Event::ClearedDecision'
       # All reports should point to the same reportable. We will take care of that here:
       # https://trello.com/c/xrjOZGa7/45-ensure-all-reports-of-a-decision-point-to-the-same-reportable

--- a/src/api/app/models/event/report_for_package.rb
+++ b/src/api/app/models/event/report_for_package.rb
@@ -8,8 +8,7 @@ module Event
 
       Rails.application.routes.url_helpers.package_show_path(package: notification.event_payload['package_name'],
                                                              project: notification.event_payload['project_name'],
-                                                             notification_id: notification.id,
-                                                             anchor: 'comments-list')
+                                                             notification_id: notification.id)
     end
 
     def self.notification_link_text(payload)

--- a/src/api/app/models/event/report_for_package.rb
+++ b/src/api/app/models/event/report_for_package.rb
@@ -3,6 +3,15 @@ module Event
     self.description = 'Report for a package has been created'
     payload_keys :package_name, :project_name
 
+    def self.notification_link_path(notification)
+      return unless Package.exists_by_project_and_name(notification.event_payload['project_name'], notification.event_payload['package_name'])
+
+      Rails.application.routes.url_helpers.package_show_path(package: notification.event_payload['package_name'],
+                                                             project: notification.event_payload['project_name'],
+                                                             notification_id: notification.id,
+                                                             anchor: 'comments-list')
+    end
+
     def self.notification_link_text(payload)
       deleted_message = ' (already deleted)' unless Package.exists_by_project_and_name(payload['project_name'], payload['package_name'])
       "Report for Package #{payload['project_name']} / #{payload['package_name']}#{deleted_message}"

--- a/src/api/app/models/event/report_for_package.rb
+++ b/src/api/app/models/event/report_for_package.rb
@@ -2,6 +2,11 @@ module Event
   class ReportForPackage < Report
     self.description = 'Report for a package has been created'
     payload_keys :package_name, :project_name
+
+    def self.notification_link_text(payload)
+      deleted_message = ' (already deleted)' unless Package.exists_by_project_and_name(payload['project_name'], payload['package_name'])
+      "Report for Package #{payload['project_name']} / #{payload['package_name']}#{deleted_message}"
+    end
   end
 end
 

--- a/src/api/app/models/event/report_for_project.rb
+++ b/src/api/app/models/event/report_for_project.rb
@@ -2,6 +2,11 @@ module Event
   class ReportForProject < Report
     self.description = 'Report for a project has been created'
     payload_keys :project_name
+
+    def self.notification_link_text(payload)
+      deleted_message = ' (already deleted)' unless Project.exists_by_name(payload['project_name'])
+      "Report for Project #{payload['project_name']}#{deleted_message}"
+    end
   end
 end
 

--- a/src/api/app/models/event/report_for_project.rb
+++ b/src/api/app/models/event/report_for_project.rb
@@ -3,6 +3,10 @@ module Event
     self.description = 'Report for a project has been created'
     payload_keys :project_name
 
+    def self.notification_link_path(notification)
+      Rails.application.routes.url_helpers.project_show_path(notification.event_payload['project_name'], notification_id: notification.id) if Project.exists_by_name(notification.event_payload['project_name'])
+    end
+
     def self.notification_link_text(payload)
       deleted_message = ' (already deleted)' unless Project.exists_by_name(payload['project_name'])
       "Report for Project #{payload['project_name']}#{deleted_message}"


### PR DESCRIPTION
Include more information in notifications for deleted projects and packages.

## Before

![Screenshot from 2023-12-01 13-51-09](https://github.com/openSUSE/open-build-service/assets/24919/b4793c80-8f99-4682-9db5-5da403a85d0f)

## After

![Screenshot from 2023-12-06 13-55-18](https://github.com/openSUSE/open-build-service/assets/24919/4120f5a8-349e-4065-b45a-9d3bef2bb0f6)

