### PR TITLE
Add email subscriptions for decision related events

### DIFF
--- a/src/api/db/data/20231201205533_create_email_subscriptions_for_decision_related_events.rb
+++ b/src/api/db/data/20231201205533_create_email_subscriptions_for_decision_related_events.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class CreateEmailSubscriptionsForDecisionRelatedEvents < ActiveRecord::Migration[7.0]
+  def up
+    # This automatically subscribes everyone to the cleared and favored decision events
+    EventSubscription.create(eventtype: Event::ClearedDecision.name, channel: :instant_email, receiver_role: :reporter, enabled: true)
+    EventSubscription.create(eventtype: Event::FavoredDecision.name, channel: :instant_email, receiver_role: :reporter, enabled: true)
+    EventSubscription.create(eventtype: Event::FavoredDecision.name, channel: :instant_email, receiver_role: :offender, enabled: true)
+  end
+
+  def down
+    EventSubscription.where(eventtype: Event::ClearedDecision.name, channel: :instant_email, receiver_role: :reporter, enabled: true).destroy_all
+    EventSubscription.where(eventtype: Event::FavoredDecision.name, channel: :instant_email, receiver_role: :reporter, enabled: true).destroy_all
+    EventSubscription.where(eventtype: Event::FavoredDecision.name, channel: :instant_email, receiver_role: :offender, enabled: true).destroy_all
+  end
+end

--- a/src/api/db/data_schema.rb
+++ b/src/api/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20231120191210)
+DataMigrate::Data.define(version: 20231201205533)


### PR DESCRIPTION
Use a data migration to do so as all the users involved should be notified.

Follow-up #15308