### PR TITLE
Remove warning comments about using VCR

### DIFF
--- a/src/api/spec/controllers/webui/packages/job_history_controller_spec.rb
+++ b/src/api/spec/controllers/webui/packages/job_history_controller_spec.rb
@@ -1,9 +1,5 @@
 require 'rails_helper'
 require 'webmock/rspec'
-# WARNING: If you change owner tests make sure you uncomment this line
-# and start a test backend. Some of the Owner methods
-# require real backend answers for projects/packages.
-# CONFIG['global_write_through'] = true
 
 RSpec.describe Webui::Packages::JobHistoryController, :vcr do
   describe 'GET #index' do

--- a/src/api/spec/controllers/webui/patchinfo_controller_spec.rb
+++ b/src/api/spec/controllers/webui/patchinfo_controller_spec.rb
@@ -1,8 +1,4 @@
 require 'rails_helper'
-# WARNING: If you change tests make sure you uncomment this line
-# and start a test backend. Some of the Patchinfo methods
-# require real backend answers for projects/packages.
-# CONFIG['global_write_through'] = true
 
 RSpec.describe Webui::PatchinfoController, :vcr do
   let(:user) { create(:user, :with_home, login: 'macario') }

--- a/src/api/spec/controllers/webui/project_controller_spec.rb
+++ b/src/api/spec/controllers/webui/project_controller_spec.rb
@@ -1,9 +1,6 @@
 require 'rails_helper'
 require 'webmock/rspec'
-# WARNING: If you change owner tests make sure you uncomment this line
-# and start a test backend. Some of the Owner methods
-# require real backend answers for projects/packages.
-# CONFIG['global_write_through'] = true
+
 RSpec.describe Webui::ProjectController, :vcr do
   let(:user) { create(:confirmed_user, :with_home, login: 'tom') }
   let(:admin_user) { create(:admin_user, login: 'admin') }

--- a/src/api/spec/controllers/webui/request_controller_spec.rb
+++ b/src/api/spec/controllers/webui/request_controller_spec.rb
@@ -1,8 +1,4 @@
 require 'rails_helper'
-# WARNING: If you change changerequest tests make sure you uncomment this line
-# and start a test backend. Some of the methods require real backend answers
-# for projects/packages.
-# CONFIG['global_write_through'] = true
 
 RSpec.describe Webui::RequestController, :vcr do
   let(:submitter_with_group) { create(:user_with_groups, :with_home, login: 'fluffyrabbit') }

--- a/src/api/spec/controllers/webui/search_controller_spec.rb
+++ b/src/api/spec/controllers/webui/search_controller_spec.rb
@@ -1,8 +1,4 @@
 require 'rails_helper'
-# WARNING: If you change owner tests make sure you uncomment this line
-# and start a test backend. Some of the Owner methods
-# require real backend answers for projects/packages.
-# CONFIG['global_write_through'] = true
 
 RSpec.describe Webui::SearchController, :vcr do
   let!(:user) { create(:confirmed_user, :with_home, login: 'Iggy') }

--- a/src/api/spec/jobs/bs_request_action_webui_infos_job_spec.rb
+++ b/src/api/spec/jobs/bs_request_action_webui_infos_job_spec.rb
@@ -1,8 +1,5 @@
 require 'rails_helper'
 require 'webmock/rspec'
-# WARNING: If you change #file_exists or #has_file test make sure
-# you uncomment the next line and start a test backend.
-# CONFIG['global_write_through'] = true
 
 RSpec.describe BsRequestActionWebuiInfosJob, :vcr do
   include ActiveJob::TestHelper

--- a/src/api/spec/jobs/configuration_write_to_backend_job_spec.rb
+++ b/src/api/spec/jobs/configuration_write_to_backend_job_spec.rb
@@ -1,10 +1,5 @@
 require 'rails_helper'
 
-# WARNING: If you change tests make sure you uncomment this line
-# and start a test backend. Some of the actions
-# require real backend answers for projects/packages.
-# CONFIG['global_write_through'] = true
-
 RSpec.describe ConfigurationWriteToBackendJob, :vcr do
   include ActiveJob::TestHelper
 

--- a/src/api/spec/jobs/issue_tracker_fetch_issues_job_spec.rb
+++ b/src/api/spec/jobs/issue_tracker_fetch_issues_job_spec.rb
@@ -1,11 +1,6 @@
 require 'rails_helper'
 require 'webmock/rspec'
 
-# WARNING: If you change tests make sure you uncomment this line
-# and start a test backend. Some of the actions
-# require real backend answers for projects/packages.
-# CONFIG['global_write_through'] = true
-
 RSpec.describe IssueTrackerFetchIssuesJob, :vcr do
   include ActiveJob::TestHelper
 

--- a/src/api/spec/jobs/package_update_if_dirty_job_spec.rb
+++ b/src/api/spec/jobs/package_update_if_dirty_job_spec.rb
@@ -1,10 +1,5 @@
 require 'rails_helper'
 
-# WARNING: If you change tests make sure you uncomment this line
-# and start a test backend. Some of the actions
-# require real backend answers for projects/packages.
-# CONFIG['global_write_through'] = true
-
 RSpec.describe PackageUpdateIfDirtyJob, :vcr do
   include ActiveJob::TestHelper
 

--- a/src/api/spec/jobs/update_package_meta_job_spec.rb
+++ b/src/api/spec/jobs/update_package_meta_job_spec.rb
@@ -1,10 +1,5 @@
 require 'rails_helper'
 
-# WARNING: If you change tests make sure you uncomment this line
-# and start a test backend. Some of the actions
-# require real backend answers for projects/packages.
-# CONFIG['global_write_through'] = true
-
 RSpec.describe UpdatePackageMetaJob, :vcr do
   include ActiveJob::TestHelper
 

--- a/src/api/spec/jobs/update_packages_if_dirty_job_spec.rb
+++ b/src/api/spec/jobs/update_packages_if_dirty_job_spec.rb
@@ -1,10 +1,5 @@
 require 'rails_helper'
 
-# WARNING: If you change tests make sure you uncomment this line
-# and start a test backend. Some of the actions
-# require real backend answers for projects/packages.
-# CONFIG['global_write_through'] = true
-
 RSpec.describe UpdatePackagesIfDirtyJob, :vcr do
   include ActiveJob::TestHelper
 

--- a/src/api/spec/jobs/update_released_binaries_job_spec.rb
+++ b/src/api/spec/jobs/update_released_binaries_job_spec.rb
@@ -1,7 +1,4 @@
 require 'rails_helper'
-# WARNING: If you change #file_exists or #has_file test make sure
-# you uncomment the next line and start a test backend.
-# CONFIG['global_write_through'] = true
 
 RSpec.describe UpdateReleasedBinariesJob, :vcr do
   describe '#perform' do

--- a/src/api/spec/mailers/event_mailer_spec.rb
+++ b/src/api/spec/mailers/event_mailer_spec.rb
@@ -1,8 +1,4 @@
 require 'rails_helper'
-# WARNING: If you change tests make sure you uncomment this line
-# and start a test backend. Some of the actions
-# require real backend answers for projects/packages.
-# CONFIG['global_write_through'] = true
 
 RSpec.describe EventMailer, :vcr do
   # Needed for X-OBS-URL

--- a/src/api/spec/models/backend/file_spec.rb
+++ b/src/api/spec/models/backend/file_spec.rb
@@ -1,7 +1,4 @@
 require 'rails_helper'
-# WARNING: If you change #file_exists or #has_file test make sure
-# you uncomment the next line and start a test backend.
-# CONFIG['global_write_through'] = true
 
 RSpec.describe Backend::File, :vcr do
   let(:user) { create(:user, :with_home, login: 'user') }

--- a/src/api/spec/models/backend_package_spec.rb
+++ b/src/api/spec/models/backend_package_spec.rb
@@ -1,10 +1,5 @@
 require 'rails_helper'
 
-# WARNING: If you change tests make sure you uncomment this line
-# and start a test backend. Some of the actions
-# require real backend answers for projects/packages.
-# CONFIG['global_write_through'] = true
-
 RSpec.describe BackendPackage, :vcr do
   describe '.refresh_dirty' do
     let!(:project) { create(:project, name: 'apache') }

--- a/src/api/spec/models/bs_request_action_delete_spec.rb
+++ b/src/api/spec/models/bs_request_action_delete_spec.rb
@@ -1,8 +1,4 @@
 require 'rails_helper'
-# WARNING: If you change tests make sure you uncomment this line
-# and start a test backend. Some of the BsRequestAction methods
-# require real backend answers for projects/packages.
-# CONFIG['global_write_through'] = true
 
 RSpec.describe BsRequestActionDelete, :vcr do
   let(:receiver) { create(:confirmed_user, :with_home, login: 'titan') }

--- a/src/api/spec/models/buildresult_spec.rb
+++ b/src/api/spec/models/buildresult_spec.rb
@@ -1,8 +1,5 @@
 require 'rails_helper'
 require 'webmock/rspec'
-# WARNING: If you change #file_exists or #has_file test make sure
-# you uncomment the next line and start a test backend.
-# CONFIG['global_write_through'] = true
 
 RSpec.describe Buildresult, :vcr do
   describe '#status_description' do

--- a/src/api/spec/models/issue_spec.rb
+++ b/src/api/spec/models/issue_spec.rb
@@ -1,10 +1,5 @@
 require 'rails_helper'
 
-# WARNING: If you change tests make sure you uncomment this line
-# and start a test backend. Some of the actions
-# require real backend answers for projects/packages.
-# CONFIG['global_write_through'] = true
-
 RSpec.describe Issue do
   describe '#fetch_issues' do
     let!(:issue_tracker) { create(:issue_tracker) }

--- a/src/api/spec/models/package_spec.rb
+++ b/src/api/spec/models/package_spec.rb
@@ -1,9 +1,7 @@
 require 'rails_helper'
 require 'webmock/rspec'
 require 'rantly/rspec_extensions'
-# WARNING: If you change #file_exists or #has_file test make sure
-# you uncomment the next line and start a test backend.
-# CONFIG['global_write_through'] = true
+
 RSpec.describe Package, :vcr do
   let(:user) { create(:confirmed_user, :with_home, login: 'tom') }
   let(:home_project) { user.home_project }

--- a/src/api/spec/models/project/staging_project_spec.rb
+++ b/src/api/spec/models/project/staging_project_spec.rb
@@ -1,7 +1,5 @@
 require 'rails_helper'
 require 'rantly/rspec_extensions'
-# WARNING: If you need to make a Backend call uncomment the following line
-# CONFIG['global_write_through'] = true
 
 RSpec.describe Project, :vcr do
   describe 'Staging Project' do

--- a/src/api/spec/models/project_spec.rb
+++ b/src/api/spec/models/project_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 require 'rantly/rspec_extensions'
-# WARNING: If you need to make a Backend call uncomment the following line
-# CONFIG['global_write_through'] = true
+
 RSpec.describe Project, :vcr do
   let!(:project) { create(:project, name: 'openSUSE_41') }
   let(:remote_project) { create(:remote_project, name: 'openSUSE.org') }


### PR DESCRIPTION
We already know how to develop using VCR. No need to include a warning comment on every test which uses VCR. Some of these comments could be also outdated.

See our wiki documentation: https://github.com/openSUSE/open-build-service/wiki/Testing-with-VCR

See related PR #12788.