### PR TITLE
Fix event to validate and adapt textarea comment

### DIFF
--- a/src/api/app/assets/javascripts/webui/comment.js
+++ b/src/api/app/assets/javascripts/webui/comment.js
@@ -19,11 +19,8 @@ function validateForm(e) {
 
 $(document).ready(function(){
   // Disable submit button if textarea is empty and enable otherwise
-  $('.comments-list,.comment_new,.timeline,.diff').on('keyup', '.comment-field', function(e) {
+  $('.comments-list,.comment_new,.timeline,.diff').on('input', '.comment-field', function(e) {
     validateForm(e);
-  });
-
-  $('.comments-list,.comment_new,.timeline,.diff').on('keyup click', '.comment-field', function() {
     resizeTextarea(this);
   });
 


### PR DESCRIPTION
Fixes #15166

_The **input** event fires when the value of an [`<input>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input), [`<select>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select), or [`<textarea>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea) element has been changed as a direct result of a user action....._ (https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event)

In the issue the problem is that _on paste_ the button is not enabled, because the event was listening only on `keyup`. Now the event listen on the value: if it changes it validates the form and enable the submit button accordingly.


## How to test
- go to https://obs-reviewlab.opensuse.org/ncounter-bugfix-enable-button-on-change/request/show/15
- check that the `Add comment` button is disabled
- copy some text from anywhere
- paste the text in the new comment box with the middle-mouse-button click or the right-click and paste, **do not use CTRL+V** otherwise this PR change will not be tested
- make sure the `Add comment` button is now enabled