### PR TITLE
Fix absolute URL's in link_to_reportables helper

### DIFF
--- a/src/api/app/helpers/webui/reportables_helper.rb
+++ b/src/api/app/helpers/webui/reportables_helper.rb
@@ -8,28 +8,28 @@ module Webui::ReportablesHelper
     when 'Comment'
       link_to_commentables_on_reportables(commentable: reportable.commentable, host: host)
     when 'Package'
-      link_to("#{reportable.name}", Rails.application.routes.url_helpers.package_show_path(package: reportable, project: reportable.project,
-                                                                                           anchor: 'comments-list', only_path: false, host: host))
+      link_to("#{reportable.name}", Rails.application.routes.url_helpers.package_show_url(package: reportable, project: reportable.project,
+                                                                                          anchor: 'comments-list', only_path: false, host: host))
     when 'Project'
-      link_to("#{reportable.name}", Rails.application.routes.url_helpers.project_show_path(reportable, anchor: 'comments-list', only_path: false, host: host))
+      link_to("#{reportable.name}", Rails.application.routes.url_helpers.project_show_url(reportable, anchor: 'comments-list', only_path: false, host: host))
     when 'User'
-      link_to("#{reportable.login}", Rails.application.routes.url_helpers.user_path(reportable, only_path: false, host: host))
+      link_to("#{reportable.login}", Rails.application.routes.url_helpers.user_url(reportable, only_path: false, host: host))
     end
   end
 
   def link_to_commentables_on_reportables(commentable:, host:)
     case commentable
     when BsRequest
-      link_to("Request #{commentable.number}", Rails.application.routes.url_helpers.request_show_path(commentable.number, anchor: 'comments-list', only_path: false, host: host))
+      link_to("Request #{commentable.number}", Rails.application.routes.url_helpers.request_show_url(commentable.number, anchor: 'comments-list', only_path: false, host: host))
     when BsRequestAction
-      link_to("Request #{commentable.bs_request.number}", Rails.application.routes.url_helpers.request_show_path(number: commentable.bs_request.number,
-                                                                                                                 request_action_id: commentable.id,
-                                                                                                                 anchor: 'tab-pane-changes', only_path: false, host: host))
+      link_to("Request #{commentable.bs_request.number}", Rails.application.routes.url_helpers.request_show_url(number: commentable.bs_request.number,
+                                                                                                                request_action_id: commentable.id,
+                                                                                                                anchor: 'tab-pane-changes', only_path: false, host: host))
     when Package
-      link_to("#{commentable.name}", Rails.application.routes.url_helpers.package_show_path(package: commentable, project: commentable.project,
-                                                                                            anchor: 'comments-list', only_path: false, host: host))
+      link_to("#{commentable.name}", Rails.application.routes.url_helpers.package_show_url(package: commentable, project: commentable.project,
+                                                                                           anchor: 'comments-list', only_path: false, host: host))
     when Project
-      link_to("#{commentable.name}", Rails.application.routes.url_helpers.project_show_path(commentable, anchor: 'comments-list', only_path: false, host: host))
+      link_to("#{commentable.name}", Rails.application.routes.url_helpers.project_show_url(commentable, anchor: 'comments-list', only_path: false, host: host))
     end
   end
 end

--- a/src/api/spec/mailers/event_mailer_spec.rb
+++ b/src/api/spec/mailers/event_mailer_spec.rb
@@ -252,10 +252,11 @@ RSpec.describe EventMailer, :vcr do
     context 'for an event of type Event::CreateReport' do
       let(:admin) { create(:admin_user) }
       let!(:subscription) { create(:event_subscription_create_report, user: admin) }
+      let(:report) { create(:report, reason: 'Because reasons') }
+      let(:package) { report.reportable.commentable }
       let(:mail) { EventMailer.with(subscribers: Event::CreateReport.last.subscribers, event: Event::CreateReport.last).notification_email.deliver_now }
 
       before do
-        report = create(:report, reason: 'Because reasons')
         Event::CreateReport.create({ id: report.id, user_id: report.user_id, reportable_id: report.reportable_id,
                                      reportable_type: report.reportable_type, reason: report.reason })
       end
@@ -269,8 +270,8 @@ RSpec.describe EventMailer, :vcr do
         expect(mail.body.encoded).to include('Because reasons')
       end
 
-      it 'renders link to the users page' do
-        expect(mail.body.encoded).to include('<a href="https://build.example.com/">https://build.example.com/</a>')
+      it 'renders link to the page of the comment' do
+        expect(mail.body.encoded).to include("<a href=\"https://build.example.com/package/show/#{package.project}/#{package}#comments-list\">#{package}</a>")
       end
     end
 


### PR DESCRIPTION
Use `*_url` helpers instead of `*_path` helpers. `*_path` helpers don't recognize the `host` parameter to make URL's absolute.