### PR TITLE
Include more information for notifications about deleted comments

### DIFF
--- a/src/api/app/components/notification_action_description_component.rb
+++ b/src/api/app/components/notification_action_description_component.rb
@@ -45,8 +45,10 @@ class NotificationActionDescriptionComponent < ApplicationComponent
     when 'Event::BuildFail'
       "Build was triggered because of #{@notification.event_payload['reason']}"
     # TODO: Remove `Event::CreateReport` after all existing records are migrated to the new STI classes
-    when 'Event::CreateReport', 'Event::ReportForProject', 'Event::ReportForPackage', 'Event::ReportForComment', 'Event::ReportForUser'
+    when 'Event::CreateReport', 'Event::ReportForProject', 'Event::ReportForPackage', 'Event::ReportForUser'
       "'#{@notification.notifiable.user.login}' created a report for a #{@notification.event_payload['reportable_type'].downcase}. This is the reason:"
+    when 'Event::ReportForComment'
+      "'#{@notification.notifiable.user.login}' created a report for a comment from #{@notification.event_payload['commenter']}. This is the reason:"
     when 'Event::ClearedDecision'
       "'#{@notification.notifiable.moderator.login}' decided to clear the report. This is the reason:"
     when 'Event::FavoredDecision'

--- a/src/api/app/models/event/report_for_comment.rb
+++ b/src/api/app/models/event/report_for_comment.rb
@@ -2,7 +2,7 @@ module Event
   class ReportForComment < Report
     self.description = 'Report for a comment has been created'
     payload_keys :commentable_type, :bs_request_number, :bs_request_action_id,
-                 :project_name, :package_name
+                 :project_name, :package_name, :commenter
   end
 end
 

--- a/src/api/app/models/report.rb
+++ b/src/api/app/models/report.rb
@@ -34,7 +34,7 @@ class Report < ApplicationRecord
   def create_event
     case reportable_type
     when 'Comment'
-      Event::ReportForComment.create(event_parameters_for_comment(commentable: reportable.commentable))
+      Event::ReportForComment.create(event_parameters_for_comment(commentable: reportable.commentable).merge(commenter: reportable.user.login))
     when 'Package'
       Event::ReportForPackage.create(event_parameters.merge(package_name: reportable.name,
                                                             project_name: reportable.project.name))


### PR DESCRIPTION
For deleted comments, we don't link to the project/package/request since the comment is gone. It also clearly states that the notification is for a deleted comment.

For all comments, we show in the notification's details who wrote the comment with the `from ABC` text.

![example](https://github.com/openSUSE/open-build-service/assets/1102934/be8cfe7f-baa3-4146-9de2-9adfc48c211f)
