### PR TITLE
Fix documentation. Add missing authentication flag

### DIFF
--- a/src/api/public/apidocs/paths/person_login_token_id.yaml
+++ b/src/api/public/apidocs/paths/person_login_token_id.yaml
@@ -1,6 +1,8 @@
 delete:
   summary: Delete a token of a person.
   description: Delete a token of the specified person.
+  security:
+    - basic_authentication: []
   parameters:
     - $ref: '../components/parameters/login.yaml'
     - in: path

--- a/src/api/public/apidocs/paths/source.yaml
+++ b/src/api/public/apidocs/paths/source.yaml
@@ -1,6 +1,8 @@
 get:
   summary: List all the projects.
   description: Get the list of all projects.
+  security:
+    - basic_authentication: []
   parameters:
     - name: deleted
       in: query

--- a/src/api/public/apidocs/paths/source_orderkiwirepos.yaml
+++ b/src/api/public/apidocs/paths/source_orderkiwirepos.yaml
@@ -1,6 +1,8 @@
 post:
   summary: Sort the repositories inside of a kiwi file according to path relationships.
   description: This API takes kiwi XML file in the request body and sort the repositories based on priority.
+  security:
+    - basic_authentication: []
   requestBody:
     required: true
     content:

--- a/src/api/public/apidocs/paths/source_project_name.yaml
+++ b/src/api/public/apidocs/paths/source_project_name.yaml
@@ -146,6 +146,8 @@ get:
 delete:
   summary: Delete a specified project.
   description: Deletes a specified project and all the packages of this project.
+  security:
+    - basic_authentication: []
   parameters:
     - $ref: '../components/parameters/project_name.yaml'
     - name: force


### PR DESCRIPTION
All these API endpoints require authentication. We have an authenticated API. This was missing in the documentation.