### PR TITLE
Revert "Bump actions/labeler from 4 to 5"

### DIFF
--- a/.github/workflows/pull_request_labeler.yml
+++ b/.github/workflows/pull_request_labeler.yml
@@ -12,6 +12,6 @@ jobs:
       pull-requests: write  # for actions/labeler to add labels to PRs
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v5
+    - uses: actions/labeler@v4
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This reverts commit 3c4d983e300c9d89a8e0e96be9317d879d1caebd.

See upstream issue: https://github.com/actions/labeler/issues/712