### PR TITLE
[backend] Checker: free all caches when we finished checking a prp

### DIFF
--- a/src/backend/BSSched/Checker.pm
+++ b/src/backend/BSSched/Checker.pm
@@ -633,6 +633,13 @@ sub unpreparepool {
   delete $ctx->{'pool_local'};
 }
 
+sub free_caches {
+  my ($ctx) = @_;
+  delete $ctx->{'gbininfo_cache'};
+  delete $ctx->{'alien_repo_cache'};
+  delete $ctx->{'packstatus_cache'};
+}
+
 # emulate depsort2 with depsort. This is not very fast,
 # please update perl-BSSolv to get depsort2.
 sub emulate_depsort2 {

--- a/src/backend/bs_getbinariesproxy
+++ b/src/backend/bs_getbinariesproxy
@@ -440,21 +440,32 @@ sub getpreinstallimage {
   manage_cache($cachesize - $cgi->{'sizek'} * 1024) if $cgi->{'sizek'};
   my $tmpfilename = "$cachetmpdir/$$".'_preinstallimage';
   unlink($tmpfilename);
-  my $res = BSRPC::rpc({
-    'uri' => "$cgi->{'server'}/build/$prpa/$cgi->{'path'}",
-    'timeout' => $gettimeout,
-    'receiver' => \&BSHTTP::file_receiver,
-    'filename' => $tmpfilename,
-  });  
-  my $fd = gensym;
-  open($fd, '<', $tmpfilename) || die("$tmpfilename: $!\n");
-  my @s = stat($tmpfilename);
-  die("stat: $!\n") unless @s;
-  writestr("$tmpfilename.meta", undef, "$hdrmd5  :preinstallimage\n");
-  manage_cache($cachesize, undef, [ [$cacheid, $s[7], $tmpfilename] ]);
-  unlink("$tmpfilename.meta");
-  unlink($tmpfilename);
-  printstats(0, 0, 1, int($s[7] / 1024), 'preinstallimage', $prpa);
+  my $kmiss = 0;
+  my $res;
+  my $fd;
+  eval {
+    $res = BSRPC::rpc({
+      'uri' => "$cgi->{'server'}/build/$prpa/$cgi->{'path'}",
+      'timeout' => $gettimeout,
+      'receiver' => \&BSHTTP::file_receiver,
+      'filename' => $tmpfilename,
+    });  
+    $fd = gensym;
+    open($fd, '<', $tmpfilename) || die("$tmpfilename: $!\n");
+    my @s = stat($tmpfilename);
+    die("stat: $!\n") unless @s;
+    $kmiss = int($s[7] / 1024);
+    writestr("$tmpfilename.meta", undef, "$hdrmd5  :preinstallimage\n");
+    manage_cache($cachesize, undef, [ [$cacheid, $s[7], $tmpfilename] ]);
+    unlink("$tmpfilename.meta");
+    unlink($tmpfilename);
+  };
+  if ($@) {
+    unlink("$tmpfilename.meta");
+    unlink($tmpfilename);
+    die($@);
+  }
+  printstats(0, 0, 1, $kmiss, 'preinstallimage', $prpa);
   BSServer::reply_file($fd, "Content-Type: application/octet-stream");
   return undef;
 }
@@ -625,5 +636,6 @@ my $conf = {
 $conf->{'maxchild'} = $BSConfig::getbinariesproxyserver_maxchild if $BSConfig::getbinariesproxyserver_maxchild;
 %$conf = (%$conf, %{$BSConfig::getbinariesproxyserver_extraconf}) if $BSConfig::getbinariesproxyserver_extraconf;
 
+BSRPC::set_clientcert(BSConfiguration::get_clientcert('getbinariesproxy'));
 BSStdServer::server('getbinariesproxy', \@ARGV, $conf);
 

--- a/src/backend/bs_sched
+++ b/src/backend/bs_sched
@@ -1152,6 +1152,7 @@ eval {
     # free memory
     Build::forgetdeps($bconf);
     $ctx->unpreparepool();
+    $ctx->free_caches();
 
     my $wasfinished = $gctx->{'prpfinished'}->{$prp};
 


### PR DESCRIPTION
This is needed because the checker does not go out of scope when we do async rpcs, thus we need to release as much memory as possible.