### PR TITLE
[dist] disable obsapidelayed in %preun on update

### DIFF
--- a/dist/functions.setup-appliance.sh
+++ b/dist/functions.setup-appliance.sh
@@ -155,7 +155,8 @@ function get_hostname {
     done
     if [ -z "$FQHOSTNAME" -o "$FQHOSTNAME" = "localhost" ] && [ -x "$(command -v hostnamectl)" ];then
       FQHOSTNAME=`hostnamectl --static 2>/dev/null`
-    elif [ -s /etc/hostname ];then
+    fi
+    if [ -z "$FQHOSTNAME" -o "$FQHOSTNAME" = "localhost" -a -s /etc/hostname ];then
       FQHOSTNAME=`cat /etc/hostname`
     fi
   fi

--- a/dist/functions.setup-appliance.sh
+++ b/dist/functions.setup-appliance.sh
@@ -159,7 +159,7 @@ function get_hostname {
       FQHOSTNAME=`cat /etc/hostname`
     fi
   fi
-
+  echo "FQHOSTNAME : $FQHOSTNAME"
   if type -p ec2-public-hostname; then
     FQHOSTNAME=`ec2-public-hostname`
   fi

--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -780,10 +780,14 @@ if [ "$1" == 2 ]; then
 
   # skip checking because "systemctl is-active" will always return 
   # true if running in chroot,
-  systemd-detect-virt --chroot ||\
-    systemctl is-active obsapidelayed.service &&\
-      touch %{_rundir}/enable_obs-api-support.target
-
+  S=0
+  systemd-detect-virt --chroot || S=$?
+  if [ $S -gt 0 ]
+  then
+    systemctl is-active obsapidelayed.service && touch %{_rundir}/enable_obs-api-support.target
+  else
+    echo "Running in chroot - skipping check for obsapidelayed.service"
+  fi
   # Try to remove obsapidelayed, but do not fail if it no longer exists.
   /usr/lib/systemd/systemd-update-helper remove-system-units obsapidelayed || :
 fi

--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -774,6 +774,7 @@ rmdir %{obs_backend_data_dir} 2> /dev/null || :
 
 # On upgrade keep the values for the %post script
 if [ "$1" == 2 ]; then
+  set -x
   [ -e /etc/init.d/rc3.d/S50obsapidelayed ] && \
     touch %{_rundir}/enable_obs-api-support.target
 
@@ -825,6 +826,7 @@ touch %{__obs_api_prefix}/last_deploy || true
 # Upgrading from SysV obsapidelayed.service to systemd obs-api-support.target
 # This must be done after %%service_add_post. Otherwise the distribution preset is
 # taken, which is disabled in case of obs-api-support.target
+set -x
 if [ -e %{_rundir}/enable_obs-api-support.target ];then
   systemctl enable --now obs-api-support.target
   rm %{_rundir}/enable_obs-api-support.target

--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -700,6 +700,7 @@ exit 0
 %preun -n obs-api
 %service_del_preun %{obs_api_support_scripts}
 
+
 %post
 %service_add_post obsscheduler.service
 %service_add_post obssrcserver.service
@@ -780,16 +781,14 @@ if [ "$1" == 2 ]; then
   if [ -e /etc/init.d/rc3.d/S50obsapidelayed ];then
     touch %{_rundir}/enable_obs-api-support.target
   fi
-  if systemctl --quiet is-active obsapidelayed.service; then
+
+  active=`systemctl is-active obsapidelayed.service`
+  rc=$?
+  if [ $rc -eq 0 ]; then
     touch %{_rundir}/start_obs-api-support.target
-    systemctl stop    obsapidelayed.service
-    if systemd-detect-virt --chroot; then
-      # If we are in a chroot, we don't know if the service runs or even exists. In that case ignore if disabling fails.
-      systemctl disable obsapidelayed.service || :
-    else
-      systemctl disable obsapidelayed.service
-    fi
   fi
+  # Try to remove obsapidelayed, but do not fail if it no longer exists.
+  /usr/lib/systemd/systemd-update-helper remove-system-units obsapidelayed || :
 fi
 
 %post -n obs-common

--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -777,8 +777,11 @@ if [ "$1" == 2 ]; then
   [ -e /etc/init.d/rc3.d/S50obsapidelayed ] && \
     touch %{_rundir}/enable_obs-api-support.target
 
-  systemctl is-active obsapidelayed.service &&
-    touch %{_rundir}/enable_obs-api-support.target
+  # skip checking because "systemctl is-active" will always return 
+  # true if running in chroot,
+  systemd-detect-virt --chroot ||\
+    systemctl is-active obsapidelayed.service &&\
+      touch %{_rundir}/enable_obs-api-support.target
 
   # Try to remove obsapidelayed, but do not fail if it no longer exists.
   /usr/lib/systemd/systemd-update-helper remove-system-units obsapidelayed || :


### PR DESCRIPTION
obsapidelayed needs to be called exclusivly because it is no longer part of obs_api_support_scripts.

Without this patch installation fails in %pre with this error message:

```
[  103s] ... testing for pre/postinstall scripts that are not idempotent 
[  103s] Running in chroot, ignoring command 'is-active' 
[  103s] Running in chroot, ignoring command 'stop' 
[  103s] Failed to disable unit, unit obsapidelayed.service does not exist. 
[  103s] preinstall script of obs-api-......noarch.rpm failed 
```

Note: This only happens in Factory/15.6 (ATM)
