### PR TITLE
Fix the use of the appeal policy

### DIFF
--- a/src/api/app/controllers/webui/appeals_controller.rb
+++ b/src/api/app/controllers/webui/appeals_controller.rb
@@ -9,7 +9,7 @@ class Webui::AppealsController < Webui::WebuiController
 
   def new
     @decision = Decision.find(decision_params)
-    @appeal = Appeal.new(decision: @decision)
+    @appeal = Appeal.new(decision: @decision, appellant: User.session)
 
     authorize @appeal
   end
@@ -18,7 +18,7 @@ class Webui::AppealsController < Webui::WebuiController
     @decision = Decision.find(decision_params)
     @appeal = Appeal.new(appeal_params)
     @appeal.decision = @decision
-    @appeal.appellant = User.session!
+    @appeal.appellant = User.session
 
     authorize @appeal
 


### PR DESCRIPTION
While writing the feature specs the policy use for the
AppealsController#new action was not allowing the creation of the
appeals because it was missing the appellant.