### PR TITLE
Add missing notifications rss feed views

### DIFF
--- a/src/api/app/views/notifications/build_fail.text.erb
+++ b/src/api/app/views/notifications/build_fail.text.erb
@@ -1,0 +1,12 @@
+<% event = notification.event.expanded_payload %>
+Visit <%= url_for(controller: 'webui/packages/build_log', action: :live_build_log, project: event['project'], package: event['package'], repository: event['repository'], arch: event['arch'], only_path: false, host: @host) %>
+
+Package <%= event['project'] %>/<%= event['package']%> failed to build in <%= event['repository']%>/<%= event['arch']%>
+
+Check out the package for editing:
+  osc checkout <%= event['project']%> <%= event['package']%>
+<% if event['faillog'] -%>
+
+Last lines of build log:
+<%= event['faillog'] %>
+<% end %>

--- a/src/api/app/views/notifications/relationship_create.text.erb
+++ b/src/api/app/views/notifications/relationship_create.text.erb
@@ -1,0 +1,11 @@
+<% event = notification.event.expanded_payload %>
+<% target_object, url = if event['package']
+  ["#{event['project']}/#{event['package']}",
+   url_for(controller: 'webui/package', action: :users, project: event['project'], package: event['package'], only_path: false, host: @host)]
+else
+  [event['project'],
+   url_for(controller: 'webui/project', action: :users, project: event['project'], only_path: false, host: @host)]
+end
+-%>
+<%= "#{event['who']} made #{event.fetch('group', 'you')} #{event['role']} of #{target_object}" %>
+Visit <%= url %>.

--- a/src/api/spec/cassettes/Webui_FeedsController/GET_notifications/when_fetching_build_failed_notifications/1_3_3_1.yml
+++ b/src/api/spec/cassettes/Webui_FeedsController/GET_notifications/when_fetching_build_failed_notifications/1_3_3_1.yml
@@ -1,0 +1,37 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/build/project/repo/arch/package/_log?view=entry
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: project 'project' does not exist
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '142'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>project 'project' does not exist</summary>
+          <details>404 project 'project' does not exist</details>
+        </status>
+  recorded_at: Wed, 13 Dec 2023 16:16:23 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
closes #15354

After checking production logs we found there are two missing views `build_fail` and `relationship_create`. This PR adds these two missing views 