### PR TITLE
Enforce the presence of a reportable on a report's creation

### DIFF
--- a/src/api/app/models/report.rb
+++ b/src/api/app/models/report.rb
@@ -2,6 +2,7 @@
 class Report < ApplicationRecord
   validates :reason, length: { maximum: 65_535 }
   validates :reportable_type, length: { maximum: 255 }
+  validates :reportable, presence: true, on: :create
 
   belongs_to :user, optional: false
   belongs_to :reportable, polymorphic: true, optional: true

--- a/src/api/spec/policies/appeal_policy_spec.rb
+++ b/src/api/spec/policies/appeal_policy_spec.rb
@@ -56,10 +56,14 @@ RSpec.describe AppealPolicy do
     end
 
     context 'when the decision is on reports for a now-deleted reportable' do
-      let(:report) { create(:report, reportable: nil) }
+      let(:report) { create(:report) }
       let(:reporter) { report.user }
       let(:decision) { create(:decision, kind: 'favor', reports: [report]) }
       let(:appeal) { create(:appeal, decision: decision, appellant: reporter) }
+
+      before do
+        report.update!(reportable: nil)
+      end
 
       permissions :create? do
         it { is_expected.not_to permit(anonymous_user, appeal) }


### PR DESCRIPTION
Creating a report without a reportable is pointless since what would even be reported in this case? Nothing!

However after its creation, a report doesn't necessarily have a reportable if this reportable is deleted. This is why the validation is only on creation.