### PR TITLE
Report the author of a comment as well as their comment if wanted

### DIFF
--- a/src/api/app/assets/javascripts/webui/report.js
+++ b/src/api/app/assets/javascripts/webui/report.js
@@ -27,8 +27,13 @@ function setValuesOnReportDialog(modalId) {
     }
 
     if (typeof(link.data('reportable-type')) !== 'undefined') {
-      modal.find('#report_reportable_type').val(link.data('reportable-type'));
-      modal.find('.reportable_type').text(link.data('reportable-type'));
+      var reportableType = link.data('reportable-type');
+      var reportableIsComment = reportableType === 'Comment';
+
+      modal.find('#report_reportable_type').val(reportableType);
+      modal.find('.reportable_type').text(reportableType);
+      modal.find('#report-comment-author-container').toggle(reportableIsComment);
+      modal.find('#report_comment_author').prop('disabled', !reportableIsComment);
     }
 
     modal.find('#link_id').val(link.attr('id'));

--- a/src/api/app/controllers/webui/reports_controller.rb
+++ b/src/api/app/controllers/webui/reports_controller.rb
@@ -10,7 +10,14 @@ class Webui::ReportsController < Webui::WebuiController
     @link_id = params[:link_id]
 
     if @report.save
-      flash[:success] = "#{@report.reportable_type} reported successfully"
+      if @report.reportable_type == 'Comment' && params[:report_comment_author].present?
+        @user.submitted_reports.create!(report_params.merge(reportable_id: @report.reportable.user_id,
+                                                            reportable_type: 'User',
+                                                            reason: "This user has been reported together with a comment they wrote. Report reason for the comment: #{@report.reason}"))
+        flash[:success] = 'Comment and its author both reported successfully'
+      else
+        flash[:success] = "#{@report.reportable_type} reported successfully"
+      end
     else
       flash[:error] = @report.errors.full_messages.to_sentence
     end

--- a/src/api/app/views/webui/shared/_report_modal.html.haml
+++ b/src/api/app/views/webui/shared/_report_modal.html.haml
@@ -28,6 +28,9 @@
               = form.text_area(:reason, class: 'form-control')
               .text-muted
                 Please include any additional information here.
+          .form-check#report-comment-author-container
+            = check_box_tag(:report_comment_author, '1', false, class: 'form-check-input')
+            = label_tag(:report_comment_author, 'Report the author of the comment', class: 'form-check-label')
           .modal-footer
             %a.btn.btn-sm.btn-outline-secondary.px-4{ data: { 'bs-dismiss': 'modal' } }
               Cancel

--- a/src/api/spec/cassettes/Reports/reporting_a_comment_on_a_package/for_a_user_who_is_not_the_author/is_possible_to_report_the_both_the_comment_and_its_author.yml
+++ b/src/api/spec/cassettes/Reports/reporting_a_comment_on_a_package/for_a_user_who_is_not_the_author/is_possible_to_report_the_both_the_comment_and_its_author.yml
@@ -1,0 +1,205 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/source/some_random_project/some_random_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 5e01c48b-f80a-4c97-b4c2-e1d9a0314c39
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '94'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="some_random_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Wed, 13 Dec 2023 16:05:29 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/some_random_project/some_random_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '94'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="some_random_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Wed, 13 Dec 2023 16:05:29 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/some_random_project/some_random_package/_history?deleted=0&meta=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 5e01c48b-f80a-4c97-b4c2-e1d9a0314c39
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Wed, 13 Dec 2023 16:05:29 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/some_random_project/_result?lastbuild=1&locallink=1&multibuild=1&package=some_random_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 5fd6330b-fb4c-45c4-9842-1f605aa2ddcd
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 13 Dec 2023 16:05:30 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/some_random_project/_result?lastbuild=1&locallink=1&multibuild=1&package=some_random_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - e40a8525-36b3-472c-805d-9f6e80c61a4d
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 13 Dec 2023 16:05:30 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/some_random_project/_result?package=some_random_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 9eae69e2-628f-485c-b3ef-827e03cf5984
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 13 Dec 2023 16:05:30 GMT
+recorded_with: VCR 6.2.0

--- a/src/api/spec/cassettes/Reports/reporting_a_comment_on_a_project/for_a_user_who_is_not_the_author/is_possible_to_report_both_the_comment_and_its_author.yml
+++ b/src/api/spec/cassettes/Reports/reporting_a_comment_on_a_project/for_a_user_who_is_not_the_author/is_possible_to_report_both_the_comment_and_its_author.yml
@@ -1,0 +1,71 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/build/some_random_project/_result?code=unresolvable&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - f1f83102-2291-428f-9676-98e78e03ea7c
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 13 Dec 2023 16:05:33 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/some_random_project/_result?view=summary
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 467f6daa-3cd5-4dec-8537-33dc5a6df166
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 13 Dec 2023 16:05:34 GMT
+recorded_with: VCR 6.2.0

--- a/src/api/spec/features/beta/webui/reports_spec.rb
+++ b/src/api/spec/features/beta/webui/reports_spec.rb
@@ -5,10 +5,11 @@ RSpec.describe 'Reports', :js, :vcr do
     Flipper.enable(:content_moderation)
   end
 
-  def fill_and_submit_report_form
+  def fill_and_submit_report_form(report_comment_author: false)
     within('#report-modal') do
       find_by_id('report_category_other').click
       fill_in id: 'report_reason', with: 'This is not okay!'
+      check('report_comment_author') if report_comment_author
       click_button('Submit')
     end
   end
@@ -29,6 +30,14 @@ RSpec.describe 'Reports', :js, :vcr do
         click_link('Report', id: "js-comment-#{comment.id}")
         fill_and_submit_report_form
         expect(page).to have_text('You reported this comment.')
+        within('#flash') { expect(page).to have_text('Comment reported successfully') }
+      end
+
+      it 'is possible to report both the comment and its author' do
+        click_link('Report', id: "js-comment-#{comment.id}")
+        fill_and_submit_report_form(report_comment_author: true)
+        expect(page).to have_text('You reported this comment.')
+        within('#flash') { expect(page).to have_text('Comment and its author both reported successfully') }
       end
     end
 
@@ -64,6 +73,14 @@ RSpec.describe 'Reports', :js, :vcr do
         click_link('Report', id: "js-comment-#{comment.id}")
         fill_and_submit_report_form
         expect(page).to have_text('You reported this comment.')
+        within('#flash') { expect(page).to have_text('Comment reported successfully') }
+      end
+
+      it 'is possible to report the both the comment and its author' do
+        click_link('Report', id: "js-comment-#{comment.id}")
+        fill_and_submit_report_form(report_comment_author: true)
+        expect(page).to have_text('You reported this comment.')
+        within('#flash') { expect(page).to have_text('Comment and its author both reported successfully') }
       end
     end
 
@@ -99,6 +116,14 @@ RSpec.describe 'Reports', :js, :vcr do
         click_link('Report', id: "js-comment-#{comment.id}")
         fill_and_submit_report_form
         expect(page).to have_text('You reported this comment.')
+        within('#flash') { expect(page).to have_text('Comment reported successfully') }
+      end
+
+      it 'is possible to report the both the comment and its author' do
+        click_link('Report', id: "js-comment-#{comment.id}")
+        fill_and_submit_report_form(report_comment_author: true)
+        expect(page).to have_text('You reported this comment.')
+        within('#flash') { expect(page).to have_text('Comment and its author both reported successfully') }
       end
     end
 
@@ -129,6 +154,7 @@ RSpec.describe 'Reports', :js, :vcr do
 
       it 'displays the "You reported this project." message instantly' do
         desktop? ? click_link('Report Project') : click_menu_link('Actions', 'Report Project')
+        expect(page).not_to have_text('Report the author of the comment')
         fill_and_submit_report_form
         expect(page).to have_text('You reported this project.')
       end
@@ -165,6 +191,7 @@ RSpec.describe 'Reports', :js, :vcr do
 
       it 'displays the "You reported this package." message instantly' do
         desktop? ? click_link('Report Package') : click_menu_link('Actions', 'Report Package')
+        expect(page).not_to have_text('Report the author of the comment')
         fill_and_submit_report_form
         expect(page).to have_text('You reported this package.')
       end
@@ -199,6 +226,7 @@ RSpec.describe 'Reports', :js, :vcr do
 
       it 'displays the "You reported this user." message instantly' do
         click_link('Report', id: "js-user-#{another_user.id}")
+        expect(page).not_to have_text('Report the author of the comment')
         fill_and_submit_report_form
         expect(page).to have_text('You reported this user.')
       end


### PR DESCRIPTION
This is an improvement over having to report a comment, then its author by going to their profile. It's simply quicker to do so now, all at once.