### PR TITLE
Always show subscription form for report events in the admin interface

### DIFF
--- a/src/api/app/models/event_subscription/form.rb
+++ b/src/api/app/models/event_subscription/form.rb
@@ -45,8 +45,11 @@ class EventSubscription
 
     def show_form_for_create_report_event?(event_class:, subscriber:)
       if event_class.name.in?(['Event::ReportForProject', 'Event::ReportForPackage', 'Event::ReportForComment', 'Event::ReportForUser'])
-        # There is no subscriber for the global subscription configuration
-        return false if subscriber.blank?
+        # There is no subscriber associated to "global" event subscriptions
+        # which are set through the admin configuration interface.
+        # Admin user should be able to configure all event subscription types,
+        # even if they are not participating in the corresponding beta program
+        return true if subscriber.blank?
         return false unless ReportPolicy.new(subscriber, Report).notify?
       end
 


### PR DESCRIPTION
Admin user should be able to configure all event subscription types, even if they are not participating in the corresponding beta program or do not have the moderator role themself.

How to test this (in your dev env):

1. Login as Admin user
2. Make sure you are not part of the `content_moderation` beta program (http://localhost:3000/my/beta_features)
3. The subscription form should still appear in the admin interface (http://localhost:3000/notifications)

NOTE: I might change the code that checks subscriptions for events that are associated with the content moderation beta program in another PR. I wanted to keep the scope of this PR low. So I didn't wanted to change the naming of things etc. here since there are more events (Decisions, Appeals...) that have to be handled.