### PR TITLE
Deprecate `POST /person/register` API endpoint

### DIFF
--- a/src/api/public/apidocs/paths/person_register.yaml
+++ b/src/api/public/apidocs/paths/person_register.yaml
@@ -1,5 +1,7 @@
 post:
   summary: Registers a new person
+  deprecated: true
+  description: This endpoint is exactly the same as `POST /person?cmd=register`, please use that one.
   requestBody:
     description: Data for the person to register.
     required: true


### PR DESCRIPTION
Prevent from using a [polluted namespace](https://github.com/openSUSE/open-build-service/blob/e8901089a2eb15bc9907b257562eddda94fdf503/src/api/config/routes/api_routes.rb#L20-L22). A person "register" could exist. It is the same API endpoint as `POST /person`.

See the deprecated API endpoint in the [review-app](https://obs-reviewlab.opensuse.org/eduardoj-documentationdeprecate_person_register/apidocs/index#/Person/post_person_register).