### PR TITLE
Add subscription form for `Event::AppealCreated` for moderators and admins

### DIFF
--- a/src/api/app/models/event/appeal_created.rb
+++ b/src/api/app/models/event/appeal_created.rb
@@ -2,7 +2,7 @@ module Event
   class AppealCreated < Base
     receiver_roles :moderator
 
-    self.description = 'A reported user has appealed the decision'
+    self.description = 'A user has appealed the decision of a moderator'
 
     payload_keys :id, :appellant_id, :decision_id, :reason
   end

--- a/src/api/app/models/event/base.rb
+++ b/src/api/app/models/event/base.rb
@@ -24,7 +24,8 @@ module Event
       'Event::ReportForUser' => 'Receive notifications for reported users.',
       'Event::ClearedDecision' => 'Receive notifications for cleared report decisions.',
       'Event::FavoredDecision' => 'Receive notifications for favored report decisions.',
-      'Event::WorkflowRunFail' => 'Receive notifications for failed workflow runs on SCM/CI integration.'
+      'Event::WorkflowRunFail' => 'Receive notifications for failed workflow runs on SCM/CI integration.',
+      'Event::AppealCreated' => 'Receive notifications when a user appeals against a decision of a moderator.'
     }.freeze
 
     class << self
@@ -42,7 +43,7 @@ module Event
          'Event::CommentForRequest',
          'Event::RelationshipCreate', 'Event::RelationshipDelete',
          'Event::ReportForComment', 'Event::ReportForPackage', 'Event::ReportForProject', 'Event::ReportForUser',
-         'Event::WorkflowRunFail'].map(&:constantize)
+         'Event::WorkflowRunFail', 'Event::AppealCreated'].map(&:constantize)
       end
 
       def classnames

--- a/src/api/app/models/event_subscription/for_channel_form.rb
+++ b/src/api/app/models/event_subscription/for_channel_form.rb
@@ -3,7 +3,8 @@ class EventSubscription
     DISABLE_FOR_EVENTS = ['Event::ServiceFail'].freeze
     DISABLE_RSS_FOR_EVENTS = ['Event::ReportForProject', 'Event::ReportForPackage',
                               'Event::ReportForComment', 'Event::ReportForUser',
-                              'Event::WorkflowRunFail'].freeze
+                              'Event::WorkflowRunFail', 'Event::AppealCreated'].freeze
+    DISABLE_EMAIL_FOR_EVENTS = ['Event::AppealCreated'].freeze
 
     attr_reader :name, :subscription
 
@@ -22,7 +23,8 @@ class EventSubscription
 
     def disabled_checkbox?
       (DISABLE_FOR_EVENTS.include?(@event.to_s) && (name == 'web' || name == 'rss')) ||
-        (DISABLE_RSS_FOR_EVENTS.include?(@event.to_s) && name == 'rss')
+        (DISABLE_RSS_FOR_EVENTS.include?(@event.to_s) && name == 'rss') ||
+        (DISABLE_EMAIL_FOR_EVENTS.include?(@event.to_s) && name == 'instant_email')
     end
 
     private


### PR DESCRIPTION
Allow user (with moderator role and in the beta program) and admin (for default subscriptions) to configure subscriptions for the `Event::AppealCreated` through the webUI.

How to test this:

- Test as a regular user:
  1. Login as a regular user
  2. Go to the subscription configuration page (http://localhost:3000/my/subscriptions)
  3. The form for the `Event::AppealCreated` should not appear (even if the user is part of the beta program)

- Test as a user with moderator role:
  1. Login as a user with moderator role
  2. Go to the subscription configuration page (http://localhost:3000/my/subscriptions)
  3. The form for the `Event::AppealCreated` should appear (if the moderator is in the beta program)

- Test as admin user for default subscriptions:
   1. Login as user with admin role
   2. Go to the default subscription configuration page (http://localhost:3000/notifications)
   3. The form for the `Event::AppealCreated` should appear (even if the Admin is not in beta)