### PR TITLE
Support request report event

### DIFF
--- a/src/api/app/components/notification_action_description_component.rb
+++ b/src/api/app/components/notification_action_description_component.rb
@@ -47,6 +47,8 @@ class NotificationActionDescriptionComponent < ApplicationComponent
     # TODO: Remove `Event::CreateReport` after all existing records are migrated to the new STI classes
     when 'Event::CreateReport', 'Event::ReportForProject', 'Event::ReportForPackage', 'Event::ReportForUser'
       "'#{@notification.notifiable.user.login}' created a report for a #{@notification.event_payload['reportable_type'].downcase}. This is the reason:"
+    when 'Event::ReportForRequest'
+      "'#{@notification.notifiable.user.login}' created a report for a request. This is the reason:"
     when 'Event::ReportForComment'
       "'#{@notification.notifiable.user.login}' created a report for a comment from #{@notification.event_payload['commenter']}. This is the reason:"
     when 'Event::ClearedDecision'

--- a/src/api/app/components/notification_notifiable_link_component.rb
+++ b/src/api/app/components/notification_notifiable_link_component.rb
@@ -57,6 +57,8 @@ class NotificationNotifiableLinkComponent < ApplicationComponent
       end
     when 'Event::ReportForProject', 'Event::ReportForPackage'
       @notification.event_type.constantize.notification_link_text(@notification.event_payload)
+    when 'Event::ReportForRequest'
+      "Report for Request ##{@notification.notifiable.reportable.number}"
     when 'Event::ClearedDecision'
       # All reports should point to the same reportable. We will take care of that here:
       # https://trello.com/c/xrjOZGa7/45-ensure-all-reports-of-a-decision-point-to-the-same-reportable
@@ -122,6 +124,14 @@ class NotificationNotifiableLinkComponent < ApplicationComponent
       @notification.event_type.constantize.notification_link_path(@notification)
     when 'Event::ReportForUser'
       Rails.application.routes.url_helpers.user_path(@notification.event_payload['user_login'])
+    when 'Event::ReportForRequest'
+      anchor = if @notification.notifiable.reportable.is_a?(BsRequestAction)
+                 'tab-pane-changes'
+               else
+                 'comments-list'
+               end
+      bs_request = @notification.notifiable.reportable
+      Rails.application.routes.url_helpers.request_show_path(bs_request.number, notification_id: @notification.id, anchor: anchor)
     when 'Event::ClearedDecision', 'Event::FavoredDecision'
       reportable = @notification.notifiable.reports.first.reportable
       link_for_reportables(reportable)

--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -83,6 +83,7 @@ class BsRequest < ApplicationRecord
   has_many :not_accepted_reviews, -> { where.not(state: :accepted) }, class_name: 'Review'
   has_many :notifications, as: :notifiable, dependent: :delete_all
   has_many :watched_items, as: :watchable, dependent: :destroy
+  has_many :reports, as: :reportable, dependent: :nullify
 
   validates :state, inclusion: { in: VALID_REQUEST_STATES }
   validates :creator, presence: true

--- a/src/api/app/models/event/base.rb
+++ b/src/api/app/models/event/base.rb
@@ -22,6 +22,7 @@ module Event
       'Event::ReportForPackage' => 'Receive notifications for reported packages.',
       'Event::ReportForProject' => 'Receive notifications for reported projects.',
       'Event::ReportForUser' => 'Receive notifications for reported users.',
+      'Event::ReportForRequest' => 'Receive notifications for reported requests',
       'Event::ClearedDecision' => 'Receive notifications for cleared report decisions.',
       'Event::FavoredDecision' => 'Receive notifications for favored report decisions.',
       'Event::WorkflowRunFail' => 'Receive notifications for failed workflow runs on SCM/CI integration.'
@@ -41,7 +42,7 @@ module Event
          'Event::RequestStatechange', 'Event::CommentForProject', 'Event::CommentForPackage',
          'Event::CommentForRequest',
          'Event::RelationshipCreate', 'Event::RelationshipDelete',
-         'Event::ReportForComment', 'Event::ReportForPackage', 'Event::ReportForProject', 'Event::ReportForUser',
+         'Event::ReportForComment', 'Event::ReportForPackage', 'Event::ReportForProject', 'Event::ReportForUser', 'Event::ReportForRequest',
          'Event::WorkflowRunFail'].map(&:constantize)
       end
 

--- a/src/api/app/models/event/report_for_request.rb
+++ b/src/api/app/models/event/report_for_request.rb
@@ -1,0 +1,6 @@
+module Event
+  class ReportForRequest < Report
+    self.description = 'Report for a request has been created'
+    payload_keys :bs_request_number
+  end
+end

--- a/src/api/app/models/report.rb
+++ b/src/api/app/models/report.rb
@@ -42,6 +42,8 @@ class Report < ApplicationRecord
       Event::ReportForProject.create(event_parameters.merge(project_name: reportable.name))
     when 'User'
       Event::ReportForUser.create(event_parameters.merge(user_login: reportable.login))
+    when 'BsRequest'
+      Event::ReportForRequest.create(event_parameters.merge(bs_request_number: reportable.number))
     end
   end
 

--- a/src/api/app/policies/bs_request_policy.rb
+++ b/src/api/app/policies/bs_request_policy.rb
@@ -23,6 +23,11 @@ class BsRequestPolicy < ApplicationPolicy
     author? && record.state.in?([:new, :review, :declined])
   end
 
+  ## TODO: define who can report a request
+  def update?
+    false unless user
+  end
+
   private
 
   def author?

--- a/src/api/app/policies/report_policy.rb
+++ b/src/api/app/policies/report_policy.rb
@@ -6,6 +6,7 @@ class ReportPolicy < ApplicationPolicy
     CommentPolicy.new(user, record.reportable).maintainer? if record.reportable_type == 'Comment'
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def create?
     return false unless Flipper.enabled?(:content_moderation, user)
 
@@ -22,8 +23,11 @@ class ReportPolicy < ApplicationPolicy
       !CommentPolicy.new(user, record.reportable).update?
     when 'User'
       !UserPolicy.new(user, record.reportable).update?
+    when 'BsRequest'
+      !BsRequestPolicy.new(user, record.reportable).update?
     end
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   def notify?
     return false unless Flipper.enabled?(:content_moderation, user)

--- a/src/api/app/queries/notifications_finder.rb
+++ b/src/api/app/queries/notifications_finder.rb
@@ -51,7 +51,7 @@ class NotificationsFinder
   def for_reports
     # TODO: Remove `Event::CreateReport` after all existing records are migrated to the new STI classes
     @relation.where(event_type: ['Event::CreateReport', 'Event::ReportForProject', 'Event::ReportForPackage',
-                                 'Event::ReportForComment', 'Event::ReportForUser',
+                                 'Event::ReportForComment', 'Event::ReportForUser', 'Event::ReportForRequest',
                                  'Event::ClearedDecision', 'Event::FavoredDecision'], delivered: false)
   end
 

--- a/src/api/app/services/notification_service/notifier.rb
+++ b/src/api/app/services/notification_service/notifier.rb
@@ -15,6 +15,7 @@ module NotificationService
                         'Event::ReportForPackage',
                         'Event::ReportForComment',
                         'Event::ReportForUser',
+                        'Event::ReportForRequest',
                         'Event::ClearedDecision',
                         'Event::FavoredDecision',
                         'Event::WorkflowRunFail',
@@ -40,6 +41,7 @@ module NotificationService
                         'Event::ReportForPackage',
                         'Event::ReportForComment',
                         'Event::ReportForUser',
+                        'Event::ReportForRequest',
                         'Event::ClearedDecision',
                         'Event::FavoredDecision',
                         'Event::WorkflowRunFail'].freeze

--- a/src/api/app/views/webui/request/_report_request.html.haml
+++ b/src/api/app/views/webui/request/_report_request.html.haml
@@ -1,0 +1,9 @@
+%li.nav-item
+  = link_to('#', class: 'nav-link', id: "js-request-#{bs_request.number}",
+        data: { 'bs-toggle': 'modal',
+                'bs-target': '#report-modal',
+                'modal-title': "Report #{bs_request.number}",
+                'reportable-type': bs_request.class.name,
+                'reportable-id': bs_request.number }) do
+    %i.fas.fa-regular.fa-flag.fa-lg.me-2
+    %span.nav-item-name Report Request

--- a/src/api/app/views/webui/request/_show_actions.html.haml
+++ b/src/api/app/views/webui/request/_show_actions.html.haml
@@ -1,0 +1,3 @@
+- content_for :actions do
+  - if policy(Report.new(reportable: bs_request)).create?
+    = render partial: 'webui/request/report_request', locals: { bs_request: bs_request }

--- a/src/api/app/views/webui/request/beta_show.html.haml
+++ b/src/api/app/views/webui/request/beta_show.html.haml
@@ -2,6 +2,7 @@
 :ruby
   @pagetitle = "Request #{@bs_request.number}"
   @pagetitle += ": #{@action[:name]}"
+  render partial: 'webui/request/show_actions', locals: { bs_request: @bs_request }
 
 = render partial: 'beta_alert', locals: { bs_request: @bs_request, action: @action }
 

--- a/src/api/app/views/webui/request/show.html.haml
+++ b/src/api/app/views/webui/request/show.html.haml
@@ -4,6 +4,7 @@
   content_for(:meta_image, gravatar_url(User.find_by_login(@bs_request.creator).email))
   @pagetitle = "Request #{@bs_request.number}"
   @pagetitle += ": #{@actions.first[:name]}" if @actions.count == 1
+  render partial: 'webui/request/show_actions', locals: { bs_request: @bs_request }
 
 - if @not_full_diff && User.session
   = render partial: 'webui/shared/truncated_diff_hint', locals: { path: request_show_path(number: @bs_request.number, full_diff: true) }

--- a/src/api/lib/tasks/dev/reports.rake
+++ b/src/api/lib/tasks/dev/reports.rake
@@ -14,9 +14,16 @@ namespace :dev do
         factory.comments.create!(user: admin, body: 'This project is crap!'),
         create(:package_with_files, name: 'crappy_package', project: factory),
         create(:project, name: 'some_crappy_project_name', commit_user: admin),
-        create(:confirmed_user, login: 'crapboy')
+        create(:confirmed_user, login: 'crapboy'),
       ].each do |reportable|
         Report.create!(reportable: reportable, user: iggy, reason: 'Watch your language, please')
+      end
+
+      user_1 = User.find_by(login: 'user_1')
+      [
+        create(:bs_request_with_submit_action, creator: user_1, description: 'Hey! Visit my new site $$$!')
+      ].each do |reportable|
+        Report.create!(reportable: reportable, user: user_1, reason: 'This is a scam')
       end
     end
 


### PR DESCRIPTION
This PR adds the support for the event to detect a reported Request, enables the subscription of the event and the notification of that event.

This is how it looks like in the notifications page:

![image](https://github.com/openSUSE/open-build-service/assets/2650/e7b5527f-3c5c-4514-a91a-b6f1b9174ddf)

Depends on #15370 
