### PR TITLE
Implement an event to detect request reporting

### DIFF
--- a/src/api/app/models/event/report_for_request.rb
+++ b/src/api/app/models/event/report_for_request.rb
@@ -1,0 +1,6 @@
+module Event
+  class ReportForRequest < Report
+    self.description = 'Report for a request has been created'
+    payload_keys :bs_request_number
+  end
+end

--- a/src/api/app/models/report.rb
+++ b/src/api/app/models/report.rb
@@ -43,6 +43,8 @@ class Report < ApplicationRecord
       Event::ReportForProject.create(event_parameters.merge(project_name: reportable.name))
     when 'User'
       Event::ReportForUser.create(event_parameters.merge(user_login: reportable.login))
+    when 'BsRequest'
+      Event::ReportForRequest.create(event_parameters.merge(bs_request_number: reportable.number))
     end
   end
 

--- a/src/api/lib/tasks/dev/reports.rake
+++ b/src/api/lib/tasks/dev/reports.rake
@@ -18,6 +18,13 @@ namespace :dev do
       ].each do |reportable|
         Report.create!(reportable: reportable, user: iggy, reason: 'Watch your language, please')
       end
+
+      user1 = User.find_by(login: 'user_1')
+      [
+        create(:bs_request_with_submit_action, creator: user1, description: 'Hey! Visit my new site $$$!')
+      ].each do |reportable|
+        Report.create!(reportable: reportable, user: user1, reason: 'This is a scam')
+      end
     end
 
     # Run `rake dev:reports:decisions` (always after running `rake dev:reports:data`)


### PR DESCRIPTION
When a request is reported, we now get an event called `Event::ReportForRequest`.

## How can I test this?

1. Open up a development instance
2. Go into some request
3. Click on the "Report Request" link on the left.
4. Run a rails console and run this:

`Event::ReportForRequest.last`

This should get you an event:
- pointing to the reported request 
- reported by the user you were logged in before

Depends on #15370 
