### PR TITLE
Allow users to subscribe to reported requests events

### DIFF
--- a/src/api/app/models/event/base.rb
+++ b/src/api/app/models/event/base.rb
@@ -22,6 +22,7 @@ module Event
       'Event::ReportForPackage' => 'Receive notifications for reported packages.',
       'Event::ReportForProject' => 'Receive notifications for reported projects.',
       'Event::ReportForUser' => 'Receive notifications for reported users.',
+      'Event::ReportForRequest' => 'Receive notifications for reported requests',
       'Event::ClearedDecision' => 'Receive notifications for cleared report decisions.',
       'Event::FavoredDecision' => 'Receive notifications for favored report decisions.',
       'Event::WorkflowRunFail' => 'Receive notifications for failed workflow runs on SCM/CI integration.',
@@ -42,7 +43,7 @@ module Event
          'Event::RequestStatechange', 'Event::CommentForProject', 'Event::CommentForPackage',
          'Event::CommentForRequest',
          'Event::RelationshipCreate', 'Event::RelationshipDelete',
-         'Event::ReportForComment', 'Event::ReportForPackage', 'Event::ReportForProject', 'Event::ReportForUser',
+         'Event::ReportForComment', 'Event::ReportForPackage', 'Event::ReportForProject', 'Event::ReportForUser', 'Event::ReportForRequest',
          'Event::WorkflowRunFail', 'Event::AppealCreated', 'Event::ClearedDecision', 'Event::FavoredDecision'].map(&:constantize)
       end
 

--- a/src/api/app/models/event_subscription/for_channel_form.rb
+++ b/src/api/app/models/event_subscription/for_channel_form.rb
@@ -3,6 +3,7 @@ class EventSubscription
     DISABLE_FOR_EVENTS = ['Event::ServiceFail'].freeze
     DISABLE_RSS_FOR_EVENTS = ['Event::ReportForProject', 'Event::ReportForPackage',
                               'Event::ReportForComment', 'Event::ReportForUser',
+                              'Event::ReportForRequest',
                               'Event::WorkflowRunFail', 'Event::AppealCreated',
                               'Event::FavoredDecision', 'Event::ClearedDecision'].freeze
     DISABLE_EMAIL_FOR_EVENTS = ['Event::AppealCreated'].freeze

--- a/src/api/app/models/event_subscription/form.rb
+++ b/src/api/app/models/event_subscription/form.rb
@@ -2,6 +2,7 @@ class EventSubscription
   class Form
     EVENTS_FOR_CONTENT_MODERATORS = ['Event::ReportForProject', 'Event::ReportForPackage',
                                      'Event::ReportForComment', 'Event::ReportForUser',
+                                     'Event::ReportForRequest',
                                      'Event::AppealCreated'].freeze
     EVENTS_IN_CONTENT_MODERATION_BETA = ['Event::FavoredDecision', 'Event::ClearedDecision'].freeze
 


### PR DESCRIPTION
You can now go into [your subscriptions](https://build.opensuse.org/my/subscriptions) page and add yourself to receive events for reported requests. 

You have to be a moderator to be able to subscribe yourself, though.

This is how it looks like:
![image](https://github.com/openSUSE/open-build-service/assets/2650/6673314a-5237-476a-8d18-187d78623550)

## How Can I Test This?

1. Ensure your user has a "moderator" role.
2. Ensure your user is enrolled into the [beta program](http://localhost:3000/my/beta_features).
3. You can see it in the [review app instance](https://obs-reviewlab.opensuse.org/danidoni-allow-users-to-subscribe-to-reported-requests-events/my/subscriptions)


Depends on #15375