### PR TITLE
Add decision events to subscription configuration form 

### DIFF
--- a/src/api/app/models/event/base.rb
+++ b/src/api/app/models/event/base.rb
@@ -43,7 +43,7 @@ module Event
          'Event::CommentForRequest',
          'Event::RelationshipCreate', 'Event::RelationshipDelete',
          'Event::ReportForComment', 'Event::ReportForPackage', 'Event::ReportForProject', 'Event::ReportForUser',
-         'Event::WorkflowRunFail', 'Event::AppealCreated'].map(&:constantize)
+         'Event::WorkflowRunFail', 'Event::AppealCreated', 'Event::ClearedDecision', 'Event::FavoredDecision'].map(&:constantize)
       end
 
       def classnames

--- a/src/api/app/models/event_subscription.rb
+++ b/src/api/app/models/event_subscription.rb
@@ -18,7 +18,9 @@ class EventSubscription < ApplicationRecord
     target_package_watcher: 'Watching the target package',
     request_watcher: 'Watching the request',
     moderator: 'User with moderator role',
-    token_executor: 'User who runs the workflow'
+    token_executor: 'User who runs the workflow',
+    reporter: 'Reporter',
+    offender: 'Offender'
   }.freeze
 
   enum channel: {

--- a/src/api/app/models/event_subscription/for_channel_form.rb
+++ b/src/api/app/models/event_subscription/for_channel_form.rb
@@ -3,7 +3,8 @@ class EventSubscription
     DISABLE_FOR_EVENTS = ['Event::ServiceFail'].freeze
     DISABLE_RSS_FOR_EVENTS = ['Event::ReportForProject', 'Event::ReportForPackage',
                               'Event::ReportForComment', 'Event::ReportForUser',
-                              'Event::WorkflowRunFail', 'Event::AppealCreated'].freeze
+                              'Event::WorkflowRunFail', 'Event::AppealCreated',
+                              'Event::FavoredDecision', 'Event::ClearedDecision'].freeze
     DISABLE_EMAIL_FOR_EVENTS = ['Event::AppealCreated'].freeze
 
     attr_reader :name, :subscription

--- a/src/api/app/models/event_subscription/form.rb
+++ b/src/api/app/models/event_subscription/form.rb
@@ -3,6 +3,7 @@ class EventSubscription
     EVENTS_FOR_CONTENT_MODERATORS = ['Event::ReportForProject', 'Event::ReportForPackage',
                                      'Event::ReportForComment', 'Event::ReportForUser',
                                      'Event::AppealCreated'].freeze
+    EVENTS_IN_CONTENT_MODERATION_BETA = ['Event::FavoredDecision', 'Event::ClearedDecision'].freeze
 
     attr_reader :subscriber
 
@@ -53,8 +54,8 @@ class EventSubscription
       # Admin user should be able to configure all event subscription types,
       # even if they are not participating in the corresponding beta program
       return true if subscriber.blank?
-
       return false if EVENTS_FOR_CONTENT_MODERATORS.include?(event_class.name) && !ReportPolicy.new(subscriber, Report).notify?
+      return false if EVENTS_IN_CONTENT_MODERATION_BETA.include?(event_class.name) && !Flipper.enabled?(:content_moderation, subscriber)
 
       true
     end


### PR DESCRIPTION
Users that are participating in the content_moderation beta
program should be able to configure those subscriptions.
Admin should always be able to configure them for the defaults.

![image](https://github.com/openSUSE/open-build-service/assets/22001671/f8ea6c04-9648-45f5-8ab0-624ad069d9f6)
