### PR TITLE
Ensure all reports of a Decision point to the same reportable 

### DIFF
--- a/src/api/spec/models/report_spec.rb
+++ b/src/api/spec/models/report_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe Report do
+  describe '#reports_pointing_to_same_reportable' do
+    context 'when different reportables' do
+      let(:decision) { create(:decision) }
+      let(:report) { build(:report, decision: decision) }
+
+      before do
+        report.save
+      end
+
+      it { expect(report.valid?).to be(false) }
+      it { expect(report.errors.full_messages).to eq(['Decision has reports pointing to a different reportable. All decision reports should point to same reportable.']) }
+    end
+
+    context 'when reports are pointing to same trportable' do
+      let(:report) { create(:report) }
+      let(:decision) { create(:decision, reports: [report]) }
+      let(:new_report) { build(:report, reportable: report.reportable, decision: decision) }
+
+      it { expect(new_report.valid?).to be(true) }
+    end
+  end
+end


### PR DESCRIPTION
To test:
Try to add a report(1) to a decision that has one or more reports that point to a different reportable than report(1)