### PR TITLE
Add migration after flipper rubygem update

### DIFF
--- a/src/api/db/migrate/20231218151408_change_flipper_gates_value_to_text.rb
+++ b/src/api/db/migrate/20231218151408_change_flipper_gates_value_to_text.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class ChangeFlipperGatesValueToText < ActiveRecord::Migration[7.0]
+  def up
+    # Ensure this incremental update migration is idempotent
+    return unless connection.column_exists? :flipper_gates, :value, :string
+
+    remove_index :flipper_gates, [:feature_key, :key, :value] if index_exists? :flipper_gates, [:feature_key, :key, :value]
+    safety_assured { change_column :flipper_gates, :value, :text }
+    add_index :flipper_gates, [:feature_key, :key, :value], unique: true, length: { value: 255 }
+  end
+
+  def down
+    safety_assured { change_column :flipper_gates, :value, :string }
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_11_120635) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_18_151408) do
   create_table "appeals", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.text "reason", null: false
     t.integer "appellant_id", null: false
@@ -512,10 +512,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_11_120635) do
   create_table "flipper_gates", id: :integer, charset: "utf8mb4", collation: "utf8mb4_bin", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "feature_key", null: false
     t.string "key", null: false
-    t.string "value"
+    t.text "value"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
-    t.index ["feature_key", "key", "value"], name: "index_flipper_gates_on_feature_key_and_key_and_value", unique: true
+    t.index ["feature_key", "key", "value"], name: "index_flipper_gates_on_feature_key_and_key_and_value", unique: true, length: { value: 255 }
   end
 
   create_table "group_maintainers", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|


### PR DESCRIPTION
Upgrading the flipper rubygem to 1.1.2 version, requires running a migration (see #15364). This migration can be created through the following command:

`rails generate flipper:update`

Add this migration, as a result of running the command above, instead of requiring a manual intervention of OBS administrators.

I modified the migration:
1. adding `safety_assured` clauses, and
1. fixing one RuboCop offense.

Giving the number of database records of the table being modified (`flipper_gates`, less than 5 database records) I consider that it is safe to change the type of the column. This will block writes while the table is rewritten, but this shouldn't be a problem.