### PR TITLE
Add missing model annotation for Event::ReportForRequest

### DIFF
--- a/src/api/app/models/event/report_for_request.rb
+++ b/src/api/app/models/event/report_for_request.rb
@@ -4,3 +4,22 @@ module Event
     payload_keys :bs_request_number
   end
 end
+
+# == Schema Information
+#
+# Table name: events
+#
+#  id          :bigint           not null, primary key
+#  eventtype   :string(255)      not null, indexed
+#  mails_sent  :boolean          default(FALSE), indexed
+#  payload     :text(65535)
+#  undone_jobs :integer          default(0)
+#  created_at  :datetime         indexed
+#  updated_at  :datetime
+#
+# Indexes
+#
+#  index_events_on_created_at  (created_at)
+#  index_events_on_eventtype   (eventtype)
+#  index_events_on_mails_sent  (mails_sent)
+#


### PR DESCRIPTION
This was generated while running `bundle exec rake db:migrate` on master.