### PR TITLE
Remove warning comments about using VCR (II)

### DIFF
--- a/src/api/spec/controllers/source_attribute_controller_spec.rb
+++ b/src/api/spec/controllers/source_attribute_controller_spec.rb
@@ -1,5 +1,3 @@
-# CONFIG['global_write_through'] = true
-
 RSpec.describe SourceAttributeController, :vcr do
   render_views
 

--- a/src/api/spec/controllers/source_controller_spec.rb
+++ b/src/api/spec/controllers/source_controller_spec.rb
@@ -1,7 +1,3 @@
-# WARNING: Some tests require real backend answers, so make sure you uncomment
-# this line and start a test backend.
-# CONFIG['global_write_through'] = true
-
 RSpec.describe SourceController, :vcr do
   let(:user) { create(:confirmed_user, :with_home, login: 'tom') }
   let(:project) { user.home_project }

--- a/src/api/spec/controllers/source_project_config_controller_spec.rb
+++ b/src/api/spec/controllers/source_project_config_controller_spec.rb
@@ -1,5 +1,3 @@
-# CONFIG['global_write_through'] = true
-
 RSpec.describe SourceProjectConfigController, :vcr do
   let(:user) { create(:confirmed_user, :with_home, login: 'tom') }
   let(:project) { user.home_project }

--- a/src/api/spec/controllers/source_project_meta_controller_spec.rb
+++ b/src/api/spec/controllers/source_project_meta_controller_spec.rb
@@ -1,5 +1,3 @@
-# CONFIG['global_write_through'] = true
-
 RSpec.describe SourceProjectMetaController, :vcr do
   render_views
 

--- a/src/api/spec/controllers/source_project_package_meta_controller_spec.rb
+++ b/src/api/spec/controllers/source_project_package_meta_controller_spec.rb
@@ -1,5 +1,3 @@
-# CONFIG['global_write_through'] = true
-
 RSpec.describe SourceProjectPackageMetaController, :vcr do
   render_views
   let(:user) { create(:confirmed_user, login: 'tom') }

--- a/src/api/spec/controllers/webui/kiwi/images_controller_spec.rb
+++ b/src/api/spec/controllers/webui/kiwi/images_controller_spec.rb
@@ -1,7 +1,3 @@
-# WARNING: Some tests require real backend answers, so make sure you uncomment
-# this line and start a test backend.
-# CONFIG['global_write_through'] = true
-
 RSpec.describe Webui::Kiwi::ImagesController, :vcr do
   let(:project) { create(:project, name: 'fake_project') }
   let(:user) { create(:confirmed_user, :with_home, login: 'tom') }

--- a/src/api/spec/factories/packages.rb
+++ b/src/api/spec/factories/packages.rb
@@ -45,8 +45,6 @@ FactoryBot.define do
       end
 
       after(:create) do |package, evaluator|
-        # NOTE: Enable global write through when writing new VCR cassetes.
-        # ensure the backend knows the project
         if CONFIG['global_write_through']
           Backend::Connection.put("/source/#{CGI.escape(package.project.name)}/#{CGI.escape(package.name)}/_config", Faker::Lorem.paragraph)
           Backend::Connection.put(
@@ -68,8 +66,6 @@ FactoryBot.define do
       end
 
       after(:create) do |package, evaluator|
-        # NOTE: Enable global write through when writing new VCR cassetes.
-        # ensure the backend knows the project
         if CONFIG['global_write_through']
           Backend::Connection.put(
             "/source/#{CGI.escape(package.project.name)}/#{CGI.escape(package.name)}/#{evaluator.file_name}", evaluator.file_content
@@ -91,8 +87,6 @@ FactoryBot.define do
       end
 
       after(:create) do |package, evaluator|
-        # NOTE: Enable global write through when writing new VCR cassetes.
-        # ensure the backend knows the project
         if CONFIG['global_write_through']
           full_path = "/source/#{package.project.name}/#{package.name}/#{evaluator.changes_file_name}"
           Backend::Connection.put(Addressable::URI.escape(full_path), evaluator.changes_file_content)
@@ -106,9 +100,6 @@ FactoryBot.define do
       end
 
       after(:create) do |package, evaluator|
-        # NOTE: Enable global write through when writing new VCR cassetes.
-        # ensure the backend knows the project
-
         flavor_xml = evaluator.flavors.map { |flavor| "<flavor>#{flavor}</flavor>" }.join
         flavor_xml = "<multibuild>#{flavor_xml}</multibuild>"
         if CONFIG['global_write_through']
@@ -127,8 +118,6 @@ FactoryBot.define do
 
         file_content = "<link package=\"#{target_package}\" project=\"#{target_package.project}\" />"
 
-        # NOTE: Enable global write through when writing new VCR cassetes.
-        # ensure the backend knows the project
         if CONFIG['global_write_through']
           Backend::Connection.put(
             "/source/#{CGI.escape(package.project.name)}/#{CGI.escape(package.name)}/_link", file_content
@@ -147,8 +136,6 @@ FactoryBot.define do
         PackageKind.create(package_id: package.id, kind: 'link')
         file_content = "<link package=\"#{evaluator.remote_package_name}\" project=\"#{remote_project.name}\" />"
 
-        # NOTE: Enable global write through when writing new VCR cassetes.
-        # ensure the backend knows the project
         if CONFIG['global_write_through']
           Backend::Connection.put(
             "/source/#{CGI.escape(package.project.name)}/#{CGI.escape(package.name)}/_link", file_content
@@ -187,8 +174,6 @@ FactoryBot.define do
 
     factory :package_with_service do
       after(:create) do |package|
-        # NOTE: Enable global write through when writing new VCR cassetes.
-        # ensure the backend knows the project
         if CONFIG['global_write_through']
           Backend::Connection.put(Addressable::URI.escape("/source/#{package.project.name}/#{package.name}/_service"),
                                   File.read('spec/fixtures/files/download_url_service.xml'))
@@ -198,8 +183,6 @@ FactoryBot.define do
 
     factory :package_with_broken_service do
       after(:create) do |package|
-        # NOTE: Enable global write through when writing new VCR cassetes.
-        # ensure the backend knows the project
         if CONFIG['global_write_through']
           Backend::Connection.put(Addressable::URI.escape("/source/#{package.project.name}/#{package.name}/_service"),
                                   '<service>broken</service>')
@@ -227,8 +210,6 @@ FactoryBot.define do
       end
 
       after(:create) do |package, evaluator|
-        # NOTE: Enable global write through when writing new VCR cassetes.
-        # ensure the backend knows the project
         if CONFIG['global_write_through']
           full_path = "/source/#{package.project.name}/#{package.name}/#{evaluator.kiwi_file_name}"
           Backend::Connection.put(Addressable::URI.escape(full_path), evaluator.kiwi_file_content)

--- a/src/api/spec/jobs/issue_tracker_write_to_backend_job_spec.rb
+++ b/src/api/spec/jobs/issue_tracker_write_to_backend_job_spec.rb
@@ -1,7 +1,3 @@
-# WARNING: Some tests require real backend answers, so make sure you uncomment
-# this line and start a test backend.
-# CONFIG['global_write_through'] = true
-
 RSpec.describe IssueTrackerWriteToBackendJob, :vcr do
   include ActiveJob::TestHelper
 

--- a/src/api/spec/jobs/update_backend_infos_job_spec.rb
+++ b/src/api/spec/jobs/update_backend_infos_job_spec.rb
@@ -1,7 +1,3 @@
-# WARNING: Some tests require real backend answers, so make sure you uncomment
-# this line and start a test backend.
-# CONFIG['global_write_through'] = true
-
 RSpec.describe UpdateBackendInfosJob, :vcr do
   let(:project) { create(:project, name: 'apache') }
   let(:package) { create(:package, name: 'mod_ssl', project: project) }

--- a/src/api/spec/models/kiwi/image_spec.rb
+++ b/src/api/spec/models/kiwi/image_spec.rb
@@ -1,9 +1,5 @@
 require 'webmock/rspec'
 
-# WARNING: Some tests require real backend answers, so make sure you uncomment
-# this line and start a test backend.
-# CONFIG['global_write_through'] = true
-
 RSpec.describe Kiwi::Image, :vcr do
   include_context 'a kiwi image xml'
   include_context 'an invalid kiwi image xml'


### PR DESCRIPTION
We already know how to develop using VCR. No need to include a comment on tests which use VCR.

Follow up to #15316.