### PR TITLE
Email for Appeal

### DIFF
--- a/src/api/app/models/appeal.rb
+++ b/src/api/app/models/appeal.rb
@@ -14,7 +14,8 @@ class Appeal < ApplicationRecord
   end
 
   def event_parameters
-    { id: id, appellant_id: appellant.id, decision_id: decision.id, reason: reason }
+    { id: id, appellant_id: appellant.id, decision_id: decision.id, reason: reason,
+      report_last_id: decision.reports.last.id, reportable_type: decision.reports.first.reportable.class.name }
   end
 end
 

--- a/src/api/app/models/event/appeal_created.rb
+++ b/src/api/app/models/event/appeal_created.rb
@@ -4,7 +4,12 @@ module Event
 
     self.description = 'A user has appealed the decision of a moderator'
 
-    payload_keys :id, :appellant_id, :decision_id, :reason
+    payload_keys :id, :appellant_id, :decision_id, :reason, :report_last_id, :reportable_type
+
+    def subject
+      appeal = Appeal.find(payload['id'])
+      "Appeal to #{appeal.decision.reports.first.reportable&.class&.name} decision".squish
+    end
   end
 end
 

--- a/src/api/app/models/event_subscription/for_channel_form.rb
+++ b/src/api/app/models/event_subscription/for_channel_form.rb
@@ -6,7 +6,6 @@ class EventSubscription
                               'Event::ReportForRequest',
                               'Event::WorkflowRunFail', 'Event::AppealCreated',
                               'Event::FavoredDecision', 'Event::ClearedDecision'].freeze
-    DISABLE_EMAIL_FOR_EVENTS = ['Event::AppealCreated'].freeze
 
     attr_reader :name, :subscription
 
@@ -25,8 +24,7 @@ class EventSubscription
 
     def disabled_checkbox?
       (DISABLE_FOR_EVENTS.include?(@event.to_s) && (name == 'web' || name == 'rss')) ||
-        (DISABLE_RSS_FOR_EVENTS.include?(@event.to_s) && name == 'rss') ||
-        (DISABLE_EMAIL_FOR_EVENTS.include?(@event.to_s) && name == 'instant_email')
+        (DISABLE_RSS_FOR_EVENTS.include?(@event.to_s) && name == 'rss')
     end
 
     private

--- a/src/api/app/views/event_mailer/appeal_created.html.haml
+++ b/src/api/app/views/event_mailer/appeal_created.html.haml
@@ -1,0 +1,7 @@
+%p
+  - appellant = User.find(event['appellant_id'])
+  - decision = Decision.find(event['decision_id'])
+  '#{appellant}' decided to appeal to the decision '#{decision.reason}'. This is the reason:
+  = event['reason']
+%p
+  = link_to_reportables(report_id: event['report_last_id'], reportable_type: event['reportable_type'], host: @host)

--- a/src/api/app/views/event_mailer/appeal_created.text.erb
+++ b/src/api/app/views/event_mailer/appeal_created.text.erb
@@ -1,0 +1,6 @@
+<%- appellant = User.find(event['appellant_id']) %>
+<%- decision = Decision.find(event['decision_id']) %>
+'<%= appellant %>' decided to appeal to the decision '<%= decision.reason %>'. This is the reason:
+<%= event['reason'] %>
+
+<%= link_to_reportables(report_id: event['report_last_id'], reportable_type: event['reportable_type'], host: @host) %>

--- a/src/api/spec/factories/event_subscriptions.rb
+++ b/src/api/spec/factories/event_subscriptions.rb
@@ -135,6 +135,14 @@ FactoryBot.define do
       group { nil }
     end
 
+    factory :event_subscription_appeal_created do
+      eventtype { 'Event::AppealCreated' }
+      receiver_role { 'moderator' }
+      channel { :instant_email }
+      user
+      group { nil }
+    end
+
     factory :event_subscription_workflow_run_fail do
       eventtype { 'Event::WorkflowRunFail' }
       receiver_role { 'token_executor' }


### PR DESCRIPTION
When a user _appeal_ to a _decision_ taken over a _report_, an `AppealCreated` event is generated. At the moment the email notification is disabled because it is missing for this.
This PR send an email to the _moderator_ who took the _decision_ over a _report_ 