### PR TITLE
Don't ignore notifying ActionView::MissingTemplate

### DIFF
--- a/src/api/config/initializers/airbrake.rb
+++ b/src/api/config/initializers/airbrake.rb
@@ -102,7 +102,7 @@ end
 def ignore_by_class?(notice)
   exceptions_to_ignore = ['ActiveRecord::RecordNotFound', 'ActionController::InvalidAuthenticityToken',
                           'CGI::Session::CookieStore::TamperedWithCookie', 'ActionController::UnknownAction',
-                          'AbstractController::ActionNotFound', 'ActionView::MissingTemplate', 'Bunny::TCPConnectionFailedForAllHosts',
+                          'AbstractController::ActionNotFound', 'Bunny::TCPConnectionFailedForAllHosts',
                           'Timeout::Error', 'Net::HTTPBadResponse', 'Errno::ECONNRESET', 'Interrupt',
                           'RoutesHelper::WebuiMatcher::InvalidRequestFormat', 'ActionDispatch::Http::MimeNegotiation::InvalidType',
                           'ActionController::UnknownFormat', 'Backend::NotFoundError', 'AMQ::Protocol::EmptyResponseError']


### PR DESCRIPTION
When we return an ActionView::MissingTemplate exception, we developers want to be notified. This way we can fix the exception.

Related to #15354.