### PR TITLE
Handle statistics result returning nil

### DIFF
--- a/src/api/app/models/local_build_statistic/for_package.rb
+++ b/src/api/app/models/local_build_statistic/for_package.rb
@@ -15,7 +15,7 @@ module LocalBuildStatistic
 
     def statistic
       result = backend_statistics
-      return if result.empty?
+      return if result.blank?
 
       disk = result.dig('disk', 'usage')
       memory = result.dig('memory', 'usage')


### PR DESCRIPTION
The backend statistics return no results (nil) in some corner cases. We better use `blank?` than `empty?` to cover both empty array and nil.

Fixes: #15404

Apart from this, we have to figure out if returning nil is ok or a regression.