### PR TITLE
Fix API documentation related to `/source/{project_name}...` endpoints

### DIFF
--- a/src/api/public/apidocs/paths/source_project_name.yaml
+++ b/src/api/public/apidocs/paths/source_project_name.yaml
@@ -9,7 +9,7 @@ get:
       in: query
       schema:
         type: string
-      description: Set to `1` to list the deleted packages of a project.
+      description: Set to `1` to list the packages of a deleted project.
       example: 1
     - in: query
       name: expand

--- a/src/api/public/apidocs/paths/source_project_name_project_file.yaml
+++ b/src/api/public/apidocs/paths/source_project_name_project_file.yaml
@@ -7,12 +7,18 @@ get:
   parameters:
     - $ref: '../components/parameters/project_name.yaml'
     - $ref: '../components/parameters/file_name.yaml'
+    - name: deleted
+      in: query
+      schema:
+        type: string
+      description: Set to `1` to read a file of a deleted project.
+      example: 1
     - in: query
       name: meta
       required: false
       schema:
         type: integer
-      description: Set to 1 to include _meta files
+      description: Set to `1` to include _meta files
       example: 1
     - in: query
       name: rev


### PR DESCRIPTION
## For reviewers

### Check the changes in the review-app

- [GET /source/{project_name}](https://obs-reviewlab.opensuse.org/eduardoj-documentationfix_source_project/apidocs/index#/Sources%20-%20Packages/get_source__project_name_)
- [GET /source/{project_name}/_project/{file_name}](https://obs-reviewlab.opensuse.org/eduardoj-documentationfix_source_project/apidocs/index#/Sources%20-%20Projects/get_source__project_name___project__file_name_)

### Use your development environment
- Create a project. For example: `home:user1:project1`
- Create a package inside the previous project: For example: `home:user1:project1/package1`
- Delete the project

For the first commit, the following API request returns the list of packages of a deleted project:
```
$ curl -u user1:$PASSWORD -H 'accept: application/xml; charset=utf-8' "http://localhost:3000/home:user1:project1?deleted=1"
<directory>
  <entry name="package1"/>
</directory>
```

For the second commit, the following API request returns the content of the _history file:
```
$ curl -u user1:$PASSWORD -H 'accept: application/xml; charset=utf-8' "http://localhost:3000/home:user1:project1/_project/_history?deleted=1"
<revisionlist>
  <revision rev="1" vrev="">
    <srcmd5>d41d8cd98f00b204e9800998ecf8427e</srcmd5>
    <version></version>
    <time>1703087418</time>
    <user>user1</user>
    <comment>project was deleted</comment>
  </revision>
</revisionlist>
```
