### PR TITLE
Remove validation of token type

### DIFF
--- a/src/api/app/controllers/trigger_controller.rb
+++ b/src/api/app/controllers/trigger_controller.rb
@@ -12,7 +12,6 @@ class TriggerController < ApplicationController
 
   before_action :set_token
   before_action :validate_parameters_by_token
-  before_action :validate_token_type, only: [:rebuild, :release, :runservice]
   before_action :set_project_name
   before_action :set_package_name
   # From Triggerable
@@ -54,10 +53,6 @@ class TriggerController < ApplicationController
   end
 
   private
-
-  def validate_token_type
-    raise InvalidToken, "The token can not perform an '#{action_name}' operation" unless @token.instance_of?(Token.token_type(action_name))
-  end
 
   def validate_parameters_by_token
     case @token.type

--- a/src/api/spec/cassettes/TriggerController/_rebuild/with_project_and_package_parameter/1_1_2_1.yml
+++ b/src/api/spec/cassettes/TriggerController/_rebuild/with_project_and_package_parameter/1_1_2_1.yml
@@ -2,12 +2,12 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/project/_meta?user=user_7
+    uri: http://backend:5352/source/project/_meta?user=user_4
     body:
       encoding: UTF-8
       string: |
         <project name="project">
-          <title>The Wives of Bath</title>
+          <title>Recalled to Life</title>
           <description/>
           <person userid="foo" role="maintainer"/>
         </project>
@@ -30,27 +30,27 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '144'
+      - '143'
     body:
       encoding: UTF-8
       string: |
         <project name="project">
-          <title>The Wives of Bath</title>
+          <title>Recalled to Life</title>
           <description></description>
           <person userid="foo" role="maintainer"/>
         </project>
-  recorded_at: Thu, 23 Nov 2023 16:03:53 GMT
+  recorded_at: Wed, 03 Jan 2024 15:43:57 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/project/_meta?user=user_7
+    uri: http://backend:5352/source/project/_meta?user=user_4
     body:
       encoding: UTF-8
       string: |
         <project name="project">
-          <title>The Wives of Bath</title>
+          <title>Recalled to Life</title>
           <description/>
           <person userid="foo" role="maintainer"/>
-          <repository name="repository_5">
+          <repository name="repository_3">
             <arch>i586</arch>
           </repository>
         </project>
@@ -73,28 +73,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '217'
+      - '216'
     body:
       encoding: UTF-8
       string: |
         <project name="project">
-          <title>The Wives of Bath</title>
+          <title>Recalled to Life</title>
           <description></description>
           <person userid="foo" role="maintainer"/>
-          <repository name="repository_5">
+          <repository name="repository_3">
             <arch>i586</arch>
           </repository>
         </project>
-  recorded_at: Thu, 23 Nov 2023 16:03:53 GMT
+  recorded_at: Wed, 03 Jan 2024 15:43:57 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/project/package_with_service/_meta?user=user_8
+    uri: http://backend:5352/source/project/package_trigger/_meta?user=user_5
     body:
       encoding: UTF-8
       string: |
-        <package name="package_with_service" project="project">
-          <title>An Instant In The Wind</title>
-          <description>Consectetur voluptates commodi tempora.</description>
+        <package name="package_trigger" project="project">
+          <title>Such, Such Were the Joys</title>
+          <description>Molestias ut aut eaque.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -115,63 +115,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '176'
+      - '157'
     body:
       encoding: UTF-8
       string: |
-        <package name="package_with_service" project="project">
-          <title>An Instant In The Wind</title>
-          <description>Consectetur voluptates commodi tempora.</description>
+        <package name="package_trigger" project="project">
+          <title>Such, Such Were the Joys</title>
+          <description>Molestias ut aut eaque.</description>
         </package>
-  recorded_at: Thu, 23 Nov 2023 16:03:53 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/project/package_with_service/_service
-    body:
-      encoding: UTF-8
-      string: |
-        <services>
-          <service name="download_url">
-            <param name="host">openbuildservice.org</param>
-            <param name="protocol">https</param>
-            <param name="path">/images/obs-logo.svg</param>
-          </service>
-        </services>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '207'
-    body:
-      encoding: UTF-8
-      string: |
-        <revision rev="1" vrev="1">
-          <srcmd5>04c1aad4249eab9193c388f1eac9dbf1</srcmd5>
-          <version>unknown</version>
-          <time>1700755433</time>
-          <user>unknown</user>
-          <comment></comment>
-          <requestid/>
-        </revision>
-  recorded_at: Thu, 23 Nov 2023 16:03:53 GMT
+  recorded_at: Wed, 03 Jan 2024 15:43:57 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/project/package_with_service?cmd=runservice&user=foo
+    uri: http://backend:5352/build/project?cmd=rebuild&package=package_trigger
     body:
       encoding: UTF-8
       string: ''
@@ -202,5 +157,5 @@ http_interactions:
       string: '<status code="ok" />
 
 '
-  recorded_at: Thu, 23 Nov 2023 16:03:53 GMT
+  recorded_at: Wed, 03 Jan 2024 15:43:57 GMT
 recorded_with: VCR 6.2.0

--- a/src/api/spec/cassettes/TriggerController/_rebuild/with_project_parameter/1_1_3_1.yml
+++ b/src/api/spec/cassettes/TriggerController/_rebuild/with_project_parameter/1_1_3_1.yml
@@ -2,12 +2,12 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/project/_meta?user=user_6
+    uri: http://backend:5352/source/project/_meta?user=user_1
     body:
       encoding: UTF-8
       string: |
         <project name="project">
-          <title>As I Lay Dying</title>
+          <title>That Hideous Strength</title>
           <description/>
           <person userid="foo" role="maintainer"/>
         </project>
@@ -30,27 +30,27 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '141'
+      - '148'
     body:
       encoding: UTF-8
       string: |
         <project name="project">
-          <title>As I Lay Dying</title>
+          <title>That Hideous Strength</title>
           <description></description>
           <person userid="foo" role="maintainer"/>
         </project>
-  recorded_at: Thu, 23 Nov 2023 16:03:52 GMT
+  recorded_at: Wed, 03 Jan 2024 15:43:56 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/project/_meta?user=user_6
+    uri: http://backend:5352/source/project/_meta?user=user_1
     body:
       encoding: UTF-8
       string: |
         <project name="project">
-          <title>As I Lay Dying</title>
+          <title>That Hideous Strength</title>
           <description/>
           <person userid="foo" role="maintainer"/>
-          <repository name="repository_4">
+          <repository name="repository_1">
             <arch>i586</arch>
           </repository>
         </project>
@@ -73,17 +73,51 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '214'
+      - '221'
     body:
       encoding: UTF-8
       string: |
         <project name="project">
-          <title>As I Lay Dying</title>
+          <title>That Hideous Strength</title>
           <description></description>
           <person userid="foo" role="maintainer"/>
-          <repository name="repository_4">
+          <repository name="repository_1">
             <arch>i586</arch>
           </repository>
         </project>
-  recorded_at: Thu, 23 Nov 2023 16:03:53 GMT
+  recorded_at: Wed, 03 Jan 2024 15:43:56 GMT
+- request:
+    method: post
+    uri: http://backend:5352/build/project?cmd=rebuild
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+  recorded_at: Wed, 03 Jan 2024 15:43:56 GMT
 recorded_with: VCR 6.2.0

--- a/src/api/spec/cassettes/TriggerController/_rebuild/with_token_package/1_1_1_1.yml
+++ b/src/api/spec/cassettes/TriggerController/_rebuild/with_token_package/1_1_1_1.yml
@@ -2,12 +2,12 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/project/_meta?user=user_9
+    uri: http://backend:5352/source/project/_meta?user=user_2
     body:
       encoding: UTF-8
       string: |
         <project name="project">
-          <title>Terrible Swift Sword</title>
+          <title>Fear and Trembling</title>
           <description/>
           <person userid="foo" role="maintainer"/>
         </project>
@@ -30,27 +30,27 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '147'
+      - '145'
     body:
       encoding: UTF-8
       string: |
         <project name="project">
-          <title>Terrible Swift Sword</title>
+          <title>Fear and Trembling</title>
           <description></description>
           <person userid="foo" role="maintainer"/>
         </project>
-  recorded_at: Thu, 23 Nov 2023 16:03:53 GMT
+  recorded_at: Wed, 03 Jan 2024 15:43:57 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/project/_meta?user=user_9
+    uri: http://backend:5352/source/project/_meta?user=user_2
     body:
       encoding: UTF-8
       string: |
         <project name="project">
-          <title>Terrible Swift Sword</title>
+          <title>Fear and Trembling</title>
           <description/>
           <person userid="foo" role="maintainer"/>
-          <repository name="repository_6">
+          <repository name="repository_2">
             <arch>i586</arch>
           </repository>
         </project>
@@ -73,28 +73,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '220'
+      - '218'
     body:
       encoding: UTF-8
       string: |
         <project name="project">
-          <title>Terrible Swift Sword</title>
+          <title>Fear and Trembling</title>
           <description></description>
           <person userid="foo" role="maintainer"/>
-          <repository name="repository_6">
+          <repository name="repository_2">
             <arch>i586</arch>
           </repository>
         </project>
-  recorded_at: Thu, 23 Nov 2023 16:03:53 GMT
+  recorded_at: Wed, 03 Jan 2024 15:43:57 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/project/package_with_service/_meta?user=user_10
+    uri: http://backend:5352/source/project/package_trigger/_meta?user=user_3
     body:
       encoding: UTF-8
       string: |
-        <package name="package_with_service" project="project">
-          <title>Waiting for the Barbarians</title>
-          <description>Expedita et aut ipsum.</description>
+        <package name="package_trigger" project="project">
+          <title>The Glory and the Dream</title>
+          <description>Perferendis minus qui aut.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -115,63 +115,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '163'
+      - '159'
     body:
       encoding: UTF-8
       string: |
-        <package name="package_with_service" project="project">
-          <title>Waiting for the Barbarians</title>
-          <description>Expedita et aut ipsum.</description>
+        <package name="package_trigger" project="project">
+          <title>The Glory and the Dream</title>
+          <description>Perferendis minus qui aut.</description>
         </package>
-  recorded_at: Thu, 23 Nov 2023 16:03:53 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/project/package_with_service/_service
-    body:
-      encoding: UTF-8
-      string: |
-        <services>
-          <service name="download_url">
-            <param name="host">openbuildservice.org</param>
-            <param name="protocol">https</param>
-            <param name="path">/images/obs-logo.svg</param>
-          </service>
-        </services>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '207'
-    body:
-      encoding: UTF-8
-      string: |
-        <revision rev="3" vrev="3">
-          <srcmd5>1a148582a3ecb701c7a763b8bc69bd96</srcmd5>
-          <version>unknown</version>
-          <time>1700755433</time>
-          <user>unknown</user>
-          <comment></comment>
-          <requestid/>
-        </revision>
-  recorded_at: Thu, 23 Nov 2023 16:03:53 GMT
+  recorded_at: Wed, 03 Jan 2024 15:43:57 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/project/package_with_service?cmd=runservice&user=foo
+    uri: http://backend:5352/build/project?cmd=rebuild&package=package_trigger
     body:
       encoding: UTF-8
       string: ''
@@ -202,5 +157,5 @@ http_interactions:
       string: '<status code="ok" />
 
 '
-  recorded_at: Thu, 23 Nov 2023 16:03:53 GMT
+  recorded_at: Wed, 03 Jan 2024 15:43:57 GMT
 recorded_with: VCR 6.2.0

--- a/src/api/spec/cassettes/TriggerController/_release/with_project_and_package_parameter/1_2_2_1.yml
+++ b/src/api/spec/cassettes/TriggerController/_release/with_project_and_package_parameter/1_2_2_1.yml
@@ -2,12 +2,12 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/source_project/_meta?user=user_13
+    uri: http://backend:5352/source/source_project/_meta?user=user_14
     body:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>The Road Less Traveled</title>
+          <title>By Grand Central Station I Sat Down and Wept</title>
           <description/>
           <person userid="foo" role="maintainer"/>
         </project>
@@ -30,24 +30,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '156'
+      - '178'
     body:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>The Road Less Traveled</title>
+          <title>By Grand Central Station I Sat Down and Wept</title>
           <description></description>
           <person userid="foo" role="maintainer"/>
         </project>
-  recorded_at: Thu, 23 Nov 2023 16:03:54 GMT
+  recorded_at: Wed, 03 Jan 2024 15:43:59 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/target_project/_meta?user=user_14
+    uri: http://backend:5352/source/target_project/_meta?user=user_15
     body:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>O Jerusalem!</title>
+          <title>If Not Now, When?</title>
           <description/>
           <person userid="foo" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '146'
+      - '151'
     body:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>O Jerusalem!</title>
+          <title>If Not Now, When?</title>
           <description></description>
           <person userid="foo" role="maintainer"/>
         </project>
-  recorded_at: Thu, 23 Nov 2023 16:03:54 GMT
+  recorded_at: Wed, 03 Jan 2024 15:43:59 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/source_project/source_package/_meta?user=user_15
+    uri: http://backend:5352/source/source_project/source_package/_meta?user=user_16
     body:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>Behold the Man</title>
-          <description>Quo voluptate perspiciatis odio.</description>
+          <title>For Whom the Bell Tolls</title>
+          <description>Optio voluptas et ex.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,15 +109,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '162'
+      - '160'
     body:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>Behold the Man</title>
-          <description>Quo voluptate perspiciatis odio.</description>
+          <title>For Whom the Bell Tolls</title>
+          <description>Optio voluptas et ex.</description>
         </package>
-  recorded_at: Thu, 23 Nov 2023 16:03:54 GMT
+  recorded_at: Wed, 03 Jan 2024 15:43:59 GMT
 - request:
     method: post
     uri: http://backend:5352/build/target_project?cmd=suspendproject&comment=Releasing%20via%20trigger%20event
@@ -151,7 +151,7 @@ http_interactions:
       string: '<status code="ok" />
 
 '
-  recorded_at: Thu, 23 Nov 2023 16:03:54 GMT
+  recorded_at: Wed, 03 Jan 2024 15:43:59 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/source_package/_meta?user=foo
@@ -159,8 +159,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="source_package" project="target_project">
-          <title>Behold the Man</title>
-          <description>Quo voluptate perspiciatis odio.</description>
+          <title>For Whom the Bell Tolls</title>
+          <description>Optio voluptas et ex.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -181,15 +181,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '162'
+      - '160'
     body:
       encoding: UTF-8
       string: |
         <package name="source_package" project="target_project">
-          <title>Behold the Man</title>
-          <description>Quo voluptate perspiciatis odio.</description>
+          <title>For Whom the Bell Tolls</title>
+          <description>Optio voluptas et ex.</description>
         </package>
-  recorded_at: Thu, 23 Nov 2023 16:03:54 GMT
+  recorded_at: Wed, 03 Jan 2024 15:43:59 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/source_package/_meta?user=foo
@@ -197,8 +197,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="source_package" project="target_project">
-          <title>Behold the Man</title>
-          <description>Quo voluptate perspiciatis odio.</description>
+          <title>For Whom the Bell Tolls</title>
+          <description>Optio voluptas et ex.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -219,15 +219,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '162'
+      - '160'
     body:
       encoding: UTF-8
       string: |
         <package name="source_package" project="target_project">
-          <title>Behold the Man</title>
-          <description>Quo voluptate perspiciatis odio.</description>
+          <title>For Whom the Bell Tolls</title>
+          <description>Optio voluptas et ex.</description>
         </package>
-  recorded_at: Thu, 23 Nov 2023 16:03:54 GMT
+  recorded_at: Wed, 03 Jan 2024 15:43:59 GMT
 - request:
     method: post
     uri: http://backend:5352/source/target_project/source_package?cmd=copy&comment=Release%20from%20source_project%20/%20source_package&expand=1&noservice=1&opackage=source_package&oproject=source_project&user=foo&withacceptinfo=1&withvrev=1
@@ -255,19 +255,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '247'
+      - '249'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="1" vrev="1">
+        <revision rev="10" vrev="10">
           <srcmd5>d41d8cd98f00b204e9800998ecf8427e</srcmd5>
           <version>unknown</version>
-          <time>1700755434</time>
+          <time>1704296639</time>
           <user>foo</user>
           <comment>Release from source_project / source_package</comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 23 Nov 2023 16:03:54 GMT
+  recorded_at: Wed, 03 Jan 2024 15:43:59 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/source_package/_meta?user=foo
@@ -275,8 +275,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="source_package" project="target_project">
-          <title>Behold the Man</title>
-          <description>Quo voluptate perspiciatis odio.</description>
+          <title>For Whom the Bell Tolls</title>
+          <description>Optio voluptas et ex.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -297,15 +297,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '162'
+      - '160'
     body:
       encoding: UTF-8
       string: |
         <package name="source_package" project="target_project">
-          <title>Behold the Man</title>
-          <description>Quo voluptate perspiciatis odio.</description>
+          <title>For Whom the Bell Tolls</title>
+          <description>Optio voluptas et ex.</description>
         </package>
-  recorded_at: Thu, 23 Nov 2023 16:03:54 GMT
+  recorded_at: Wed, 03 Jan 2024 15:43:59 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/source_package
@@ -331,13 +331,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '106'
+      - '108'
     body:
       encoding: UTF-8
       string: |
-        <directory name="source_package" rev="1" vrev="1" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        <directory name="source_package" rev="10" vrev="10" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 23 Nov 2023 16:03:54 GMT
+  recorded_at: Wed, 03 Jan 2024 15:43:59 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/source_package?view=info
@@ -363,14 +363,14 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '147'
+      - '149'
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="source_package" rev="1" vrev="1" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        <sourceinfo package="source_package" rev="10" vrev="10" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
           <error>no source uploaded</error>
         </sourceinfo>
-  recorded_at: Thu, 23 Nov 2023 16:03:54 GMT
+  recorded_at: Wed, 03 Jan 2024 15:43:59 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/source_package
@@ -396,13 +396,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '106'
+      - '108'
     body:
       encoding: UTF-8
       string: |
-        <directory name="source_package" rev="1" vrev="1" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        <directory name="source_package" rev="10" vrev="10" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 23 Nov 2023 16:03:54 GMT
+  recorded_at: Wed, 03 Jan 2024 15:43:59 GMT
 - request:
     method: post
     uri: http://backend:5352/source/target_project/source_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -430,16 +430,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '295'
+      - '296'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="3f25486d141abc607c80a0cf2dade0d6">
+        <sourcediff key="c5ccffe9a2a560b76bc99b1148121c36">
           <old project="target_project" package="source_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="target_project" package="source_package" rev="1" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="target_project" package="source_package" rev="10" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files/>
         </sourcediff>
-  recorded_at: Thu, 23 Nov 2023 16:03:54 GMT
+  recorded_at: Wed, 03 Jan 2024 15:43:59 GMT
 - request:
     method: post
     uri: http://backend:5352/build/target_project?cmd=resumeproject&comment=Releasing%20via%20trigger%20event
@@ -473,5 +473,5 @@ http_interactions:
       string: '<status code="ok" />
 
 '
-  recorded_at: Thu, 23 Nov 2023 16:03:54 GMT
+  recorded_at: Wed, 03 Jan 2024 15:44:00 GMT
 recorded_with: VCR 6.2.0

--- a/src/api/spec/cassettes/TriggerController/_release/with_project_parameter/1_2_3_1.yml
+++ b/src/api/spec/cassettes/TriggerController/_release/with_project_parameter/1_2_3_1.yml
@@ -2,12 +2,12 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/source_project/_meta?user=user_16
+    uri: http://backend:5352/source/source_project/_meta?user=user_17
     body:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>Blithe Spirit</title>
+          <title>No Longer at Ease</title>
           <description/>
           <person userid="foo" role="maintainer"/>
         </project>
@@ -30,24 +30,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '147'
+      - '151'
     body:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>Blithe Spirit</title>
+          <title>No Longer at Ease</title>
           <description></description>
           <person userid="foo" role="maintainer"/>
         </project>
-  recorded_at: Thu, 23 Nov 2023 16:03:54 GMT
+  recorded_at: Wed, 03 Jan 2024 15:44:00 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/target_project/_meta?user=user_17
+    uri: http://backend:5352/source/target_project/_meta?user=user_18
     body:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>A Swiftly Tilting Planet</title>
+          <title>An Instant In The Wind</title>
           <description/>
           <person userid="foo" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '158'
+      - '156'
     body:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>A Swiftly Tilting Planet</title>
+          <title>An Instant In The Wind</title>
           <description></description>
           <person userid="foo" role="maintainer"/>
         </project>
-  recorded_at: Thu, 23 Nov 2023 16:03:54 GMT
+  recorded_at: Wed, 03 Jan 2024 15:44:00 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/source_project/source_package/_meta?user=user_18
+    uri: http://backend:5352/source/source_project/source_package/_meta?user=user_19
     body:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>If I Forget Thee Jerusalem</title>
-          <description>Eum sit tempore voluptas.</description>
+          <title>Rosemary Sutcliff</title>
+          <description>Quibusdam expedita error et.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,13 +109,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '167'
+      - '161'
     body:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>If I Forget Thee Jerusalem</title>
-          <description>Eum sit tempore voluptas.</description>
+          <title>Rosemary Sutcliff</title>
+          <description>Quibusdam expedita error et.</description>
         </package>
-  recorded_at: Thu, 23 Nov 2023 16:03:54 GMT
+  recorded_at: Wed, 03 Jan 2024 15:44:00 GMT
 recorded_with: VCR 6.2.0

--- a/src/api/spec/cassettes/TriggerController/_release/with_token_package/1_2_1_1.yml
+++ b/src/api/spec/cassettes/TriggerController/_release/with_token_package/1_2_1_1.yml
@@ -2,12 +2,12 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/source_project/_meta?user=user_19
+    uri: http://backend:5352/source/source_project/_meta?user=user_11
     body:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>Nectar in a Sieve</title>
+          <title>The Needle's Eye</title>
           <description/>
           <person userid="foo" role="maintainer"/>
         </project>
@@ -30,24 +30,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '151'
+      - '150'
     body:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>Nectar in a Sieve</title>
+          <title>The Needle's Eye</title>
           <description></description>
           <person userid="foo" role="maintainer"/>
         </project>
-  recorded_at: Thu, 23 Nov 2023 16:03:54 GMT
+  recorded_at: Wed, 03 Jan 2024 15:43:58 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/target_project/_meta?user=user_20
+    uri: http://backend:5352/source/target_project/_meta?user=user_12
     body:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>The Wealth of Nations</title>
+          <title>The Other Side of Silence</title>
           <description/>
           <person userid="foo" role="maintainer"/>
         </project>
@@ -70,25 +70,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '155'
+      - '159'
     body:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>The Wealth of Nations</title>
+          <title>The Other Side of Silence</title>
           <description></description>
           <person userid="foo" role="maintainer"/>
         </project>
-  recorded_at: Thu, 23 Nov 2023 16:03:54 GMT
+  recorded_at: Wed, 03 Jan 2024 15:43:58 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/source_project/source_package/_meta?user=user_21
+    uri: http://backend:5352/source/source_project/source_package/_meta?user=user_13
     body:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>This Lime Tree Bower</title>
-          <description>Sequi sapiente rerum tempora.</description>
+          <title>Let Us Now Praise Famous Men</title>
+          <description>Ab cupiditate at voluptatem.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -109,15 +109,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '165'
+      - '172'
     body:
       encoding: UTF-8
       string: |
         <package name="source_package" project="source_project">
-          <title>This Lime Tree Bower</title>
-          <description>Sequi sapiente rerum tempora.</description>
+          <title>Let Us Now Praise Famous Men</title>
+          <description>Ab cupiditate at voluptatem.</description>
         </package>
-  recorded_at: Thu, 23 Nov 2023 16:03:54 GMT
+  recorded_at: Wed, 03 Jan 2024 15:43:59 GMT
 - request:
     method: post
     uri: http://backend:5352/build/target_project?cmd=suspendproject&comment=Releasing%20via%20trigger%20event
@@ -151,7 +151,7 @@ http_interactions:
       string: '<status code="ok" />
 
 '
-  recorded_at: Thu, 23 Nov 2023 16:03:55 GMT
+  recorded_at: Wed, 03 Jan 2024 15:43:59 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/source_package/_meta?user=foo
@@ -159,8 +159,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="source_package" project="target_project">
-          <title>This Lime Tree Bower</title>
-          <description>Sequi sapiente rerum tempora.</description>
+          <title>Let Us Now Praise Famous Men</title>
+          <description>Ab cupiditate at voluptatem.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -181,15 +181,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '165'
+      - '172'
     body:
       encoding: UTF-8
       string: |
         <package name="source_package" project="target_project">
-          <title>This Lime Tree Bower</title>
-          <description>Sequi sapiente rerum tempora.</description>
+          <title>Let Us Now Praise Famous Men</title>
+          <description>Ab cupiditate at voluptatem.</description>
         </package>
-  recorded_at: Thu, 23 Nov 2023 16:03:55 GMT
+  recorded_at: Wed, 03 Jan 2024 15:43:59 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/source_package/_meta?user=foo
@@ -197,8 +197,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="source_package" project="target_project">
-          <title>This Lime Tree Bower</title>
-          <description>Sequi sapiente rerum tempora.</description>
+          <title>Let Us Now Praise Famous Men</title>
+          <description>Ab cupiditate at voluptatem.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -219,15 +219,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '165'
+      - '172'
     body:
       encoding: UTF-8
       string: |
         <package name="source_package" project="target_project">
-          <title>This Lime Tree Bower</title>
-          <description>Sequi sapiente rerum tempora.</description>
+          <title>Let Us Now Praise Famous Men</title>
+          <description>Ab cupiditate at voluptatem.</description>
         </package>
-  recorded_at: Thu, 23 Nov 2023 16:03:55 GMT
+  recorded_at: Wed, 03 Jan 2024 15:43:59 GMT
 - request:
     method: post
     uri: http://backend:5352/source/target_project/source_package?cmd=copy&comment=Release%20from%20source_project%20/%20source_package&expand=1&noservice=1&opackage=source_package&oproject=source_project&user=foo&withacceptinfo=1&withvrev=1
@@ -259,15 +259,15 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <revision rev="2" vrev="2">
+        <revision rev="9" vrev="9">
           <srcmd5>d41d8cd98f00b204e9800998ecf8427e</srcmd5>
           <version>unknown</version>
-          <time>1700755435</time>
+          <time>1704296639</time>
           <user>foo</user>
           <comment>Release from source_project / source_package</comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 23 Nov 2023 16:03:55 GMT
+  recorded_at: Wed, 03 Jan 2024 15:43:59 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/source_package/_meta?user=foo
@@ -275,8 +275,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         <package name="source_package" project="target_project">
-          <title>This Lime Tree Bower</title>
-          <description>Sequi sapiente rerum tempora.</description>
+          <title>Let Us Now Praise Famous Men</title>
+          <description>Ab cupiditate at voluptatem.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -297,15 +297,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '165'
+      - '172'
     body:
       encoding: UTF-8
       string: |
         <package name="source_package" project="target_project">
-          <title>This Lime Tree Bower</title>
-          <description>Sequi sapiente rerum tempora.</description>
+          <title>Let Us Now Praise Famous Men</title>
+          <description>Ab cupiditate at voluptatem.</description>
         </package>
-  recorded_at: Thu, 23 Nov 2023 16:03:55 GMT
+  recorded_at: Wed, 03 Jan 2024 15:43:59 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/source_package
@@ -335,9 +335,9 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="source_package" rev="2" vrev="2" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        <directory name="source_package" rev="9" vrev="9" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 23 Nov 2023 16:03:55 GMT
+  recorded_at: Wed, 03 Jan 2024 15:43:59 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/source_package?view=info
@@ -367,10 +367,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourceinfo package="source_package" rev="2" vrev="2" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        <sourceinfo package="source_package" rev="9" vrev="9" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
           <error>no source uploaded</error>
         </sourceinfo>
-  recorded_at: Thu, 23 Nov 2023 16:03:55 GMT
+  recorded_at: Wed, 03 Jan 2024 15:43:59 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/source_package
@@ -400,9 +400,9 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="source_package" rev="2" vrev="2" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        <directory name="source_package" rev="9" vrev="9" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
         </directory>
-  recorded_at: Thu, 23 Nov 2023 16:03:55 GMT
+  recorded_at: Wed, 03 Jan 2024 15:43:59 GMT
 - request:
     method: post
     uri: http://backend:5352/source/target_project/source_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
@@ -434,12 +434,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="6aff91aa47f1c0147e4fdc1a84a9440e">
+        <sourcediff key="78e36a4d0e76087a21d97e8c0c1ab635">
           <old project="target_project" package="source_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="target_project" package="source_package" rev="2" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="target_project" package="source_package" rev="9" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
           <files/>
         </sourcediff>
-  recorded_at: Thu, 23 Nov 2023 16:03:55 GMT
+  recorded_at: Wed, 03 Jan 2024 15:43:59 GMT
 - request:
     method: post
     uri: http://backend:5352/build/target_project?cmd=resumeproject&comment=Releasing%20via%20trigger%20event
@@ -473,5 +473,5 @@ http_interactions:
       string: '<status code="ok" />
 
 '
-  recorded_at: Thu, 23 Nov 2023 16:03:55 GMT
+  recorded_at: Wed, 03 Jan 2024 15:43:59 GMT
 recorded_with: VCR 6.2.0

--- a/src/api/spec/cassettes/TriggerController/_runservice/_verfiy_package_params/1_3_3_1.yml
+++ b/src/api/spec/cassettes/TriggerController/_runservice/_verfiy_package_params/1_3_3_1.yml
@@ -2,12 +2,12 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/project/_meta?user=user_5
+    uri: http://backend:5352/source/project/_meta?user=user_10
     body:
       encoding: UTF-8
       string: |
         <project name="project">
-          <title>Have His Carcase</title>
+          <title>The Curious Incident of the Dog in the Night-Time</title>
           <description/>
           <person userid="foo" role="maintainer"/>
         </project>
@@ -30,27 +30,27 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '143'
+      - '176'
     body:
       encoding: UTF-8
       string: |
         <project name="project">
-          <title>Have His Carcase</title>
+          <title>The Curious Incident of the Dog in the Night-Time</title>
           <description></description>
           <person userid="foo" role="maintainer"/>
         </project>
-  recorded_at: Thu, 23 Nov 2023 16:03:52 GMT
+  recorded_at: Wed, 03 Jan 2024 15:43:58 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/project/_meta?user=user_5
+    uri: http://backend:5352/source/project/_meta?user=user_10
     body:
       encoding: UTF-8
       string: |
         <project name="project">
-          <title>Have His Carcase</title>
+          <title>The Curious Incident of the Dog in the Night-Time</title>
           <description/>
           <person userid="foo" role="maintainer"/>
-          <repository name="repository_3">
+          <repository name="repository_6">
             <arch>i586</arch>
           </repository>
         </project>
@@ -73,51 +73,17 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '216'
+      - '249'
     body:
       encoding: UTF-8
       string: |
         <project name="project">
-          <title>Have His Carcase</title>
+          <title>The Curious Incident of the Dog in the Night-Time</title>
           <description></description>
           <person userid="foo" role="maintainer"/>
-          <repository name="repository_3">
+          <repository name="repository_6">
             <arch>i586</arch>
           </repository>
         </project>
-  recorded_at: Thu, 23 Nov 2023 16:03:52 GMT
-- request:
-    method: post
-    uri: http://backend:5352/build/project?cmd=rebuild
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      Content-Type:
-      - application/octet-stream
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '21'
-    body:
-      encoding: UTF-8
-      string: '<status code="ok" />
-
-'
-  recorded_at: Thu, 23 Nov 2023 16:03:52 GMT
+  recorded_at: Wed, 03 Jan 2024 15:43:58 GMT
 recorded_with: VCR 6.2.0

--- a/src/api/spec/cassettes/TriggerController/_runservice/with_project_and_package_parameter/1_3_2_1.yml
+++ b/src/api/spec/cassettes/TriggerController/_runservice/with_project_and_package_parameter/1_3_2_1.yml
@@ -2,12 +2,12 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/project/_meta?user=user_3
+    uri: http://backend:5352/source/project/_meta?user=user_6
     body:
       encoding: UTF-8
       string: |
         <project name="project">
-          <title>Wildfire at Midnight</title>
+          <title>The Little Foxes</title>
           <description/>
           <person userid="foo" role="maintainer"/>
         </project>
@@ -30,27 +30,27 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '147'
+      - '143'
     body:
       encoding: UTF-8
       string: |
         <project name="project">
-          <title>Wildfire at Midnight</title>
+          <title>The Little Foxes</title>
           <description></description>
           <person userid="foo" role="maintainer"/>
         </project>
-  recorded_at: Thu, 23 Nov 2023 16:03:52 GMT
+  recorded_at: Wed, 03 Jan 2024 15:43:57 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/project/_meta?user=user_3
+    uri: http://backend:5352/source/project/_meta?user=user_6
     body:
       encoding: UTF-8
       string: |
         <project name="project">
-          <title>Wildfire at Midnight</title>
+          <title>The Little Foxes</title>
           <description/>
           <person userid="foo" role="maintainer"/>
-          <repository name="repository_2">
+          <repository name="repository_4">
             <arch>i586</arch>
           </repository>
         </project>
@@ -73,28 +73,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '220'
+      - '216'
     body:
       encoding: UTF-8
       string: |
         <project name="project">
-          <title>Wildfire at Midnight</title>
+          <title>The Little Foxes</title>
           <description></description>
           <person userid="foo" role="maintainer"/>
-          <repository name="repository_2">
+          <repository name="repository_4">
             <arch>i586</arch>
           </repository>
         </project>
-  recorded_at: Thu, 23 Nov 2023 16:03:52 GMT
+  recorded_at: Wed, 03 Jan 2024 15:43:57 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/project/package_trigger/_meta?user=user_4
+    uri: http://backend:5352/source/project/package_with_service/_meta?user=user_7
     body:
       encoding: UTF-8
       string: |
-        <package name="package_trigger" project="project">
-          <title>Stranger in a Strange Land</title>
-          <description>Aliquid quaerat quibusdam nesciunt.</description>
+        <package name="package_with_service" project="project">
+          <title>The Wings of the Dove</title>
+          <description>Suscipit vero dolore nisi.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -115,18 +115,63 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '171'
+      - '162'
     body:
       encoding: UTF-8
       string: |
-        <package name="package_trigger" project="project">
-          <title>Stranger in a Strange Land</title>
-          <description>Aliquid quaerat quibusdam nesciunt.</description>
+        <package name="package_with_service" project="project">
+          <title>The Wings of the Dove</title>
+          <description>Suscipit vero dolore nisi.</description>
         </package>
-  recorded_at: Thu, 23 Nov 2023 16:03:52 GMT
+  recorded_at: Wed, 03 Jan 2024 15:43:57 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project/package_with_service/_service
+    body:
+      encoding: UTF-8
+      string: |
+        <services>
+          <service name="download_url">
+            <param name="host">openbuildservice.org</param>
+            <param name="protocol">https</param>
+            <param name="path">/images/obs-logo.svg</param>
+          </service>
+        </services>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="17" vrev="17">
+          <srcmd5>5485842684aa2ce4407eb0e4d20f7878</srcmd5>
+          <version>unknown</version>
+          <time>1704296637</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 03 Jan 2024 15:43:57 GMT
 - request:
     method: post
-    uri: http://backend:5352/build/project?cmd=rebuild&package=package_trigger
+    uri: http://backend:5352/source/project/package_with_service?cmd=runservice&user=foo
     body:
       encoding: UTF-8
       string: ''
@@ -157,5 +202,5 @@ http_interactions:
       string: '<status code="ok" />
 
 '
-  recorded_at: Thu, 23 Nov 2023 16:03:52 GMT
+  recorded_at: Wed, 03 Jan 2024 15:43:58 GMT
 recorded_with: VCR 6.2.0

--- a/src/api/spec/cassettes/TriggerController/_runservice/with_token_package/1_3_1_1.yml
+++ b/src/api/spec/cassettes/TriggerController/_runservice/with_token_package/1_3_1_1.yml
@@ -2,12 +2,12 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/project/_meta?user=user_1
+    uri: http://backend:5352/source/project/_meta?user=user_8
     body:
       encoding: UTF-8
       string: |
         <project name="project">
-          <title>The Wind's Twelve Quarters</title>
+          <title>All the King's Men</title>
           <description/>
           <person userid="foo" role="maintainer"/>
         </project>
@@ -30,27 +30,27 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '153'
+      - '145'
     body:
       encoding: UTF-8
       string: |
         <project name="project">
-          <title>The Wind's Twelve Quarters</title>
+          <title>All the King's Men</title>
           <description></description>
           <person userid="foo" role="maintainer"/>
         </project>
-  recorded_at: Thu, 23 Nov 2023 16:03:52 GMT
+  recorded_at: Wed, 03 Jan 2024 15:43:58 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/project/_meta?user=user_1
+    uri: http://backend:5352/source/project/_meta?user=user_8
     body:
       encoding: UTF-8
       string: |
         <project name="project">
-          <title>The Wind's Twelve Quarters</title>
+          <title>All the King's Men</title>
           <description/>
           <person userid="foo" role="maintainer"/>
-          <repository name="repository_1">
+          <repository name="repository_5">
             <arch>i586</arch>
           </repository>
         </project>
@@ -73,28 +73,28 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '226'
+      - '218'
     body:
       encoding: UTF-8
       string: |
         <project name="project">
-          <title>The Wind's Twelve Quarters</title>
+          <title>All the King's Men</title>
           <description></description>
           <person userid="foo" role="maintainer"/>
-          <repository name="repository_1">
+          <repository name="repository_5">
             <arch>i586</arch>
           </repository>
         </project>
-  recorded_at: Thu, 23 Nov 2023 16:03:52 GMT
+  recorded_at: Wed, 03 Jan 2024 15:43:58 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/project/package_trigger/_meta?user=user_2
+    uri: http://backend:5352/source/project/package_with_service/_meta?user=user_9
     body:
       encoding: UTF-8
       string: |
-        <package name="package_trigger" project="project">
-          <title>Those Barren Leaves, Thrones, Dominations</title>
-          <description>Sequi alias sed molestiae.</description>
+        <package name="package_with_service" project="project">
+          <title>Of Mice and Men</title>
+          <description>Dicta ut nisi reprehenderit.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -115,18 +115,63 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '177'
+      - '158'
     body:
       encoding: UTF-8
       string: |
-        <package name="package_trigger" project="project">
-          <title>Those Barren Leaves, Thrones, Dominations</title>
-          <description>Sequi alias sed molestiae.</description>
+        <package name="package_with_service" project="project">
+          <title>Of Mice and Men</title>
+          <description>Dicta ut nisi reprehenderit.</description>
         </package>
-  recorded_at: Thu, 23 Nov 2023 16:03:52 GMT
+  recorded_at: Wed, 03 Jan 2024 15:43:58 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project/package_with_service/_service
+    body:
+      encoding: UTF-8
+      string: |
+        <services>
+          <service name="download_url">
+            <param name="host">openbuildservice.org</param>
+            <param name="protocol">https</param>
+            <param name="path">/images/obs-logo.svg</param>
+          </service>
+        </services>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="19" vrev="19">
+          <srcmd5>122ff4262defe1764c6156f8422b6071</srcmd5>
+          <version>unknown</version>
+          <time>1704296638</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 03 Jan 2024 15:43:58 GMT
 - request:
     method: post
-    uri: http://backend:5352/build/project?cmd=rebuild&package=package_trigger
+    uri: http://backend:5352/source/project/package_with_service?cmd=runservice&user=foo
     body:
       encoding: UTF-8
       string: ''
@@ -157,5 +202,5 @@ http_interactions:
       string: '<status code="ok" />
 
 '
-  recorded_at: Thu, 23 Nov 2023 16:03:52 GMT
+  recorded_at: Wed, 03 Jan 2024 15:43:58 GMT
 recorded_with: VCR 6.2.0

--- a/src/api/spec/controllers/trigger_controller_spec.rb
+++ b/src/api/spec/controllers/trigger_controller_spec.rb
@@ -11,14 +11,6 @@ RSpec.describe TriggerController do
     allow(token_extractor).to receive(:call).and_return(token)
   end
 
-  describe '.verify_token_type' do
-    let(:token) { create(:service_token, executor: user) }
-
-    subject { post :rebuild, format: :xml }
-
-    it { expect(Xmlhash.parse(subject.body)['code']).to eq('invalid_token') }
-  end
-
   describe '#rebuild', :vcr do
     let(:token) { create(:rebuild_token, executor: user, package: nil) }
     let(:project) { create(:project_with_repository, name: 'project', maintainer: user) }


### PR DESCRIPTION
This validation made `osc` throw an exception when using `osc trigger` without the `--operation` parameter over a release token.

The reason is that `osc` calls `POST /trigger/runservice` by default when the `operation` is not passed. Even if the `Token#type` is a different one.

We want to introduce this validation, but not now. We will wait until a new version of `osc` is released, with the support of the `POST /trigger` API endpoint.

Follow up to #15414.