### PR TITLE
Organize the simplified chart_build_result_summary UI

### DIFF
--- a/src/api/app/components/chart_component.html.haml
+++ b/src/api/app/components/chart_component.html.haml
@@ -5,7 +5,7 @@
         Refresh
         %i.fas.fa-sync-alt{ id: 'chart-build-reload' }
       %h4
-        Build results summary
+        Build Results Summary
     - if distinct_repositories.size > ChartComponent::MINIMUM_DISTINCT_BUILD_REPOSITORIES || raw_data.size > ChartComponent::MINIMUM_BUILD_RESULTS
       = column_chart( chart_data,
                       width: '100%',

--- a/src/api/app/components/chart_component.html.haml
+++ b/src/api/app/components/chart_component.html.haml
@@ -1,10 +1,11 @@
 - if raw_data.size.positive?
   .m-4
-    .btn.btn-outline-primary.float-end{ onclick: 'updateChartBuildResults()', accesskey: 'r', title: 'Refresh Chart Build Results' }
-      Refresh
-      %i.fas.fa-sync-alt{ id: 'chart-build-reload' }
-    %h4
-      Build results summary
+    .mb-4
+      .btn.btn-outline-primary.float-end{ onclick: 'updateChartBuildResults()', accesskey: 'r', title: 'Refresh Chart Build Results' }
+        Refresh
+        %i.fas.fa-sync-alt{ id: 'chart-build-reload' }
+      %h4
+        Build results summary
     - if distinct_repositories.size > ChartComponent::MINIMUM_DISTINCT_BUILD_REPOSITORIES || raw_data.size > ChartComponent::MINIMUM_BUILD_RESULTS
       = column_chart( chart_data,
                       width: '100%',
@@ -15,14 +16,18 @@
                       library: { scales: { y: { ticks: { stepSize: 1 }}}},
                     )
     - else
-      .ms-2.me-2
-        .row.mb-4.small
-          %b.text-center Legend
+      %div
+        .row.align-items-center.mb-2
           .col-12.d-flex.justify-content-center
-            = legend
+            .border.d-flex.flex-wrap.gap-1.p-2.small
+              %b.me-2= 'Build status legend:'
+              = legend
+        .row.p-2.ps-1
+          %b.col-3= Repository
+          %b.col-9= Architecture
         - distinct_repositories.each do |repo|
-          .row.mt-2
-            %b.col-3
+          .row.p-1.align-items-center
+            .col-3
               = repo
             .col-9.d-flex.flex-wrap.gap-1.justify-content-start
               - raw_data.each do |result|

--- a/src/api/app/components/chart_component.rb
+++ b/src/api/app/components/chart_component.rb
@@ -57,10 +57,10 @@ class ChartComponent < ApplicationComponent
   end
 
   def legend
-    content_tag(:div, 'Published', class: 'text-bg-success ps-2 pe-2 m-1').concat(
-      content_tag(:div, 'Failed', class: 'text-bg-danger ps-2 pe-2 m-1').concat(
-        content_tag(:div, 'Building', class: 'text-bg-warning ps-2 pe-2 m-1').concat(
-          content_tag(:div, 'Excluded', class: 'bg-light text-dark border border-1 ps-2 pe-2 m-1')
+    content_tag(:div, 'Published', class: 'text-bg-success ps-2 pe-2').concat(
+      content_tag(:div, 'Failed', class: 'text-bg-danger ps-2 pe-2').concat(
+        content_tag(:div, 'Building', class: 'text-bg-warning ps-2 pe-2').concat(
+          content_tag(:div, 'Excluded', class: 'bg-light text-dark border border-1 ps-2 pe-2')
         )
       )
     )


### PR DESCRIPTION
# Before
![image](https://github.com/openSUSE/open-build-service/assets/7080830/ff37334d-337c-40f1-8e19-08ce288be1e9)


# After
![image](https://github.com/openSUSE/open-build-service/assets/7080830/e57e36bd-6ba6-4087-bd4b-c12049ced75c)
