### PR TITLE
Rake docker:build task uses docker compose subcommand

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -219,12 +219,11 @@ Windows.
 that require an case sensitive filesystem (default in Linux, configurable in **MacOS/Windows**),
 make sure you run all this from a filesystem that supports this. Here you have [some instructions](https://github.com/openSUSE/open-build-service/wiki/Setup-an-OBS-Development-Environment-on-macOS) in case you are a MacOS user.
 
-1. Install [docker](https://www.docker.com) and [docker-compose (version >= 1.20.0)¹](https://docs.docker.com/compose/).
+1. Install [docker (version >= v2)¹](https://www.docker.com)
    There is documentation about this for [openSUSE](https://en.opensuse.org/SDB:Docker) and various
    [other operating systems](https://docs.docker.com/engine/installation/).
 
-   ¹ A version equal to or greater than _1.20.0_ is required for _docker-compose_ as we depend on the
-   `--use-aliases` flag for the command `docker-compose run` in our development environment.
+   ¹ A version greater than _v2_ is required for _docker compose_ subcommand to work.
 
 2. Install [rake](https://github.com/ruby/rake)
 
@@ -250,7 +249,7 @@ make sure you run all this from a filesystem that supports this. Here you have [
 6. Start your development environment with:
 
     ```
-    docker-compose up
+    docker compose up
     ```
 
 7. Check out your OBS frontend:
@@ -267,14 +266,14 @@ You can access the frontend at [localhost:3000](http://localhost:3000). Whatever
 9. Changed something in the frontend? Test your changes!
 
     ```
-    docker-compose run --rm frontend bundle exec rspec
-    docker-compose run --rm frontend bundle exec rake dev:lint:all
+    docker compose run --rm frontend bundle exec rspec
+    docker compose run --rm frontend bundle exec rake dev:lint:all
     ```
 
 10. Changed something in the backend? Test your changes!
 
     ```
-    docker-compose run  --rm backend make -C src/backend test
+    docker compose run  --rm backend make -C src/backend test
     ```
 
 11. You can find more details about the development environment [in our wiki](https://github.com/openSUSE/open-build-service/wiki/Development-Environment-Tips-&-Tricks).

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The OBS source code repository is hosted on [Github](https://github.com/opensuse
 ## Installation
 To run the OBS in production, we recommend using our [appliance](https://openbuildservice.org/download/) which is the whole package: A recent and stable Linux Operating System ([openSUSE](https://www.opensuse.org)) bundled and pre-configured with all the server and OBS components you need to get going.
 
-If that is not for you because you have some special needs for your setup (e.g. different partition schema, SLES as base system, etc.), you can also install our packages and run a setup wizard. The docker-compose setup is meant only for development.
+If that is not for you because you have some special needs for your setup (e.g. different partition schema, SLES as base system, etc.), you can also install our packages and run a setup wizard. The docker compose setup is meant only for development.
 
 After finishing the installation of your base system, follow these steps:
 

--- a/Rakefile
+++ b/Rakefile
@@ -31,28 +31,28 @@ services:
         CONTAINER_USERID: #{CONTAINER_USERID}
 EOF"
     # Build the frontend container and pull newer version of the image if available
-    sh 'docker-compose build --pull frontend'
+    sh 'docker compose build --pull frontend'
     # Build the minitest container on top of that
-    sh 'docker-compose -f docker-compose.yml -f docker-compose.minitest.yml -f docker-compose.minitest-user.yml build --pull minitest'
+    sh 'docker compose -f docker-compose.yml -f docker-compose.minitest.yml -f docker-compose.minitest-user.yml build --pull minitest'
     # Bootstrap the app
-    sh 'docker-compose up -d db'
-    sh 'docker-compose run --no-deps --rm frontend bundle exec rake dev:bootstrap RAILS_ENV=development'
+    sh 'docker compose up -d db'
+    sh 'docker compose run --no-deps --rm frontend bundle exec rake dev:bootstrap RAILS_ENV=development'
   ensure
-    sh 'docker-compose stop'
+    sh 'docker compose stop'
   end
 
   namespace :sre do
     desc 'Prepare the application health monitoring containers'
     task :build do
-      sh 'docker-compose -f docker-compose.sre.yml -f docker-compose.yml up -d rabbit'
+      sh 'docker compose -f docker-compose.sre.yml -f docker-compose.yml up -d rabbit'
       sh 'wget http://localhost:15672/cli/rabbitmqadmin -O contrib/rabbitmqadmin'
       sh 'chmod +x contrib/rabbitmqadmin'
       sh './contrib/rabbitmqadmin declare exchange name=pubsub type=topic durable=true auto_delete=false internal=false'
       # configure the app
-      sh 'docker-compose -f docker-compose.sre.yml -f docker-compose.yml up -d db'
-      sh 'docker-compose -f docker-compose.sre.yml -f docker-compose.yml run --no-deps --rm frontend bundle exec rake dev:sre:configure'
+      sh 'docker compose -f docker-compose.sre.yml -f docker-compose.yml up -d db'
+      sh 'docker compose -f docker-compose.sre.yml -f docker-compose.yml run --no-deps --rm frontend bundle exec rake dev:sre:configure'
     ensure
-      sh 'docker-compose -f docker-compose.sre.yml -f docker-compose.yml stop'
+      sh 'docker compose -f docker-compose.sre.yml -f docker-compose.yml stop'
     end
   end
 end

--- a/src/api/lib/tasks/dev/minitest.rake
+++ b/src/api/lib/tasks/dev/minitest.rake
@@ -4,7 +4,7 @@ namespace :dev do
       desc 'Create minitest fixtures in the database (as opposed to loading them with db:fixture:load)'
       task create: :test_environment do
         puts "\n\nMake sure you start with a fresh backend! Outside the container run..."
-        puts "docker-compose stop backend; docker-compose rm -f backend; docker-compose up -d backend\n\n"
+        puts "docker compose stop backend; docker compose rm -f backend; docker compose up -d backend\n\n"
         puts 'Please also note this will drop your current test database'
         puts "Confirm? Enter 'YES' to confirm:"
         input = $stdin.gets.chomp


### PR DESCRIPTION
On systems with more recent docker versions, docker-compose may not exist as docker has a compose subcommand now.