### PR TITLE
Don't encode rpmlint log output

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -472,7 +472,6 @@ class Webui::PackageController < Webui::WebuiController
 
   def rpmlint_log
     @log = Backend::Api::BuildResults::Binaries.rpmlint_log(params[:project], params[:package], params[:repository], params[:architecture])
-    @log.encode!(xml: :text)
     render partial: 'rpmlint_log'
   rescue Backend::NotFoundError
     render plain: 'No rpmlint log'


### PR DESCRIPTION
The backend output of the rpmlint_log call is properly encoded. We don't need to encode it again.

Before:
```
[...]
less space and be loaded faster. This is usually done automatically at
buildtime by rpm.

Check time report (&gt;1% &amp; &gt;0.1s):
Check                            Duration (in s)   Fraction (in %)  Checked files[...]
```

After:
```
[...]
less space and be loaded faster. This is usually done automatically at
buildtime by rpm.

Check time report (>1% & >0.1s):
Check                            Duration (in s)   Fraction (in %)  Checked files
[...]
```

Fixes #7760.