### PR TITLE
Fix for code snippet disappearance issue for CRUD operations on comment 

### DIFF
--- a/src/api/app/assets/javascripts/webui/comment.js
+++ b/src/api/app/assets/javascripts/webui/comment.js
@@ -17,12 +17,16 @@ function validateForm(e) {
   submitButton.prop('disabled', !$(e.target).val());
 }
 
-$(document).ready(function(){
+function commentFieldToggle(){
   // Disable submit button if textarea is empty and enable otherwise
   $('.comments-list,.comment_new,.timeline,.diff').on('input', '.comment-field', function(e) {
     validateForm(e);
     resizeTextarea(this);
   });
+}
+
+$(document).ready(function(){
+  commentFieldToggle();
 
   // This is being used by the legacy request view comment form to capture the rendered template
   // from the controller and replace the whole .comments-list with it

--- a/src/api/app/assets/javascripts/webui/delete_confirmation_dialog.js
+++ b/src/api/app/assets/javascripts/webui/delete_confirmation_dialog.js
@@ -36,5 +36,9 @@ function setValuesOnDeleteConfirmationDialog(modalId) {
     if (typeof(link.data('remote')) !== 'undefined') {
       modal.find('form').attr('action', link.data('remote'));
     }
+
+    if (typeof(link.data('file-name')) !== 'undefined') {
+      modal.find('#file_name').val(link.data('file-name'));
+    }
   });
 }

--- a/src/api/app/components/bs_request_comment_component.html.haml
+++ b/src/api/app/components/bs_request_comment_component.html.haml
@@ -15,7 +15,8 @@
             - if Flipper.enabled?(:content_moderation, User.session)
               - if policy(comment).moderate?
                 = button_to(comment.moderated? ? 'Permit' : 'Moderate', moderate_comment_path(comment),
-                            class: 'dropdown-item', remote: true, form_class: 'moderate-form', params: { moderation_state: !comment.moderated? })
+                            class: 'dropdown-item', remote: true, form_class: 'moderate-form', params: { moderation_state: !comment.moderated?,
+                            file_name: file_name })
             - if policy(comment).destroy?
               = link_to('#', data: { 'bs-toggle': 'modal',
                                     'bs-target': '#delete-comment-modal',
@@ -45,7 +46,7 @@
       - if policy(comment).update?
         .collapse.start-0{ id: "edit_form_of_#{comment.id}" }
           = render(partial: 'webui/comment/comment_field', locals: { form_method: :put,
-          comment: comment, commentable: commentable, element_suffix: "edit_#{comment.id}", has_cancel: true })
+          comment: comment, commentable: commentable, element_suffix: "edit_#{comment.id}", has_cancel: true, file_name: file_name })
 
     -# This should be refactored to avoid relying on global state
     - if policy(comment).reply?
@@ -61,15 +62,15 @@
         = link_to("#reply_form_of_#{comment.id}", id: "reply_button_of_#{comment.id}", 'data-bs-toggle': 'collapse',
                   class: 'fst-italic small collapsed') do
           Reply
-
       .collapse.ms-4.mb-4{ id: "reply_form_of_#{comment.id}" }
         = render(partial: 'webui/comment/comment_field', locals: { form_method: :post,
-          comment: comment.children.new, commentable: commentable, element_suffix: "reply_for_#{comment.id}", has_cancel: true })
+          comment: comment.children.new, commentable: commentable, element_suffix: "reply_for_#{comment.id}", has_cancel: true,
+          file_name: file_name })
 
     - if level <= 3
       - comment.children.includes(:user).each do |children|
-        = render BsRequestCommentComponent.new(comment: children, level: level + 1, commentable: commentable)
+        = render BsRequestCommentComponent.new(comment: children, level: level + 1, commentable: commentable, file_name: file_name)
 
 - if level > 3
   - comment.children.includes(:user).each do |children|
-    = render BsRequestCommentComponent.new(comment: children, level: level + 1, commentable: commentable)
+    = render BsRequestCommentComponent.new(comment: children, level: level + 1, commentable: commentable, file_name: file_name)

--- a/src/api/app/components/bs_request_comment_component.html.haml
+++ b/src/api/app/components/bs_request_comment_component.html.haml
@@ -43,7 +43,7 @@
         = helpers.render_as_markdown(comment)
 
       - if policy(comment).update?
-        .collapse{ id: "edit_form_of_#{comment.id}" }
+        .collapse.start-0{ id: "edit_form_of_#{comment.id}" }
           = render(partial: 'webui/comment/comment_field', locals: { form_method: :put,
           comment: comment, commentable: commentable, element_suffix: "edit_#{comment.id}", has_cancel: true })
 

--- a/src/api/app/components/bs_request_comment_component.html.haml
+++ b/src/api/app/components/bs_request_comment_component.html.haml
@@ -21,6 +21,7 @@
               = link_to('#', data: { 'bs-toggle': 'modal',
                                     'bs-target': '#delete-comment-modal',
                                     confirmation_text: 'Please confirm deletion of comment',
+                                    file_name: file_name,
                                     action: comment_path(comment) },
                             class: 'dropdown-item delete_link', title: 'Delete comment') do
                 Delete

--- a/src/api/app/components/bs_request_comment_component.rb
+++ b/src/api/app/components/bs_request_comment_component.rb
@@ -3,15 +3,16 @@
 # It is used in the beta view of the request show page, under the Overview tab,
 # merged with the BsRequestHistoryElementComponent.
 class BsRequestCommentComponent < ApplicationComponent
-  attr_reader :comment, :commentable, :level, :diff
+  attr_reader :comment, :commentable, :level, :diff, :file_name
 
-  def initialize(comment:, commentable:, level:, diff: nil)
+  def initialize(comment:, commentable:, level:, diff: nil, file_name: nil)
     super
 
     @comment = comment
     @commentable = commentable
     @level = level
     @diff = diff
+    @file_name = file_name
   end
 
   def range

--- a/src/api/app/components/delete_confirmation_dialog_component.html.haml
+++ b/src/api/app/components/delete_confirmation_dialog_component.html.haml
@@ -6,6 +6,7 @@
       .modal-body
         %p.wrap-text.confirmation-text= confirmation_text
         = form_tag(action, method: method, remote: remote) do
+          = hidden_field_tag('file_name')
           - if text_area?
             = text_area
           .modal-footer

--- a/src/api/app/components/diff_component.html.haml
+++ b/src/api/app/components/diff_component.html.haml
@@ -43,12 +43,12 @@
             - if commented_lines.include?(id)
               - commentable.comments.where(diff_ref: id).each do |comment|
                 .comments-thread.p-3
-                  = render BsRequestCommentComponent.new(comment: comment, level: 1, commentable: commentable)
+                  = render BsRequestCommentComponent.new(comment: comment, level: 1, commentable: commentable, file_name: file_name)
             - else
               .diff-comments
                 -# rubocop:disable ViewComponent/AvoidGlobalState
                 - if User.session
-                  = link_to(request_inline_comment_path(commentable.bs_request, request_action_id: commentable, line: id),
+                  = link_to(request_inline_comment_path(commentable.bs_request, request_action_id: commentable, line: id, file_name: file_name),
                             class: 'btn btn-sm btn-primary line-new-comment', remote: true, title: 'Add comment') do
                     %i.fas.fa-comment-medical
                     .visually-hidden

--- a/src/api/app/components/diff_component.rb
+++ b/src/api/app/components/diff_component.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 class DiffComponent < ApplicationComponent
-  attr_reader :diff, :file_index, :commentable, :commented_lines, :range, :source_file, :target_file
+  attr_reader :diff, :file_index, :commentable, :commented_lines, :range, :source_file, :target_file, :file_name
 
-  def initialize(diff:, file_index: nil, commentable: nil, commented_lines: [], range: (0..), source_file: nil, target_file: nil)
+  def initialize(diff:, file_index: nil, commentable: nil, commented_lines: [], range: (0..), source_file: nil, target_file: nil, file_name: nil)
     super
     @diff = parse_diff(diff)
     @file_index = file_index
@@ -12,6 +12,7 @@ class DiffComponent < ApplicationComponent
     @range = range
     @source_file = source_file
     @target_file = target_file
+    @file_name = file_name
   end
 
   def render?

--- a/src/api/app/components/diff_list_component.html.haml
+++ b/src/api/app/components/diff_list_component.html.haml
@@ -13,4 +13,4 @@
           = render(DiffSubjectComponent.new(state:, old_filename:, new_filename: name))
       .accordion-collapse.collapse{ class: expanded ? 'show' : '', id: "diff-item-#{name.parameterize}", 'data-object': view_id }
         = render(DiffComponent.new(diff: file_info.dig('diff', '_content'), file_index:, commentable:, commented_lines:,
-                                   source_file: source_file(old_filename), target_file: target_file(name)))
+                                   source_file: source_file(old_filename), target_file: target_file(name), file_name: name))

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -284,6 +284,7 @@ class Webui::RequestController < Webui::WebuiController
 
   def inline_comment
     @line = params[:line]
+    @file_name = params[:file_name]
     respond_to do |format|
       format.js
     end

--- a/src/api/app/views/webui/comment/_comment_field.html.haml
+++ b/src/api/app/views/webui/comment/_comment_field.html.haml
@@ -1,11 +1,16 @@
-- entity_type = commentable.class.name == 'BsRequest' ? 'request' : commentable.class.name.downcase
-- modal_id = "lock-#{entity_type}-#{commentable.id}-#{element_suffix}"
+:ruby
+  entity_type = commentable.class.name == 'BsRequest' ? 'request' : commentable.class.name.downcase
+  modal_id = "lock-#{entity_type}-#{commentable.id}-#{element_suffix}"
+  remote = true if remote != false
+  file_name ||= nil
 
-= form_for(comment, method: form_method, remote: true, html: { id: "#{element_suffix}_form",
+= form_for(comment, method: form_method, remote: remote, html: { id: "#{element_suffix}_form",
 class: "#{form_method}-comment-form write-and-preview" },
 data: { preview_message_url: preview_comments_path, message_body_param: 'comment[body]' }) do |f|
   = hidden_field_tag :commentable_type, commentable.class.name, { id: "#{element_suffix}_commentable_type" }
   = hidden_field_tag :commentable_id, commentable.id, { id: "#{element_suffix}_commentable_id" }
+  - if file_name.present?
+    = hidden_field_tag :file_name, file_name
   - if defined?(line)
     = f.hidden_field :diff_ref, value: line, id: "#{element_suffix}_diff_ref"
   = f.hidden_field :parent_id, value: comment.parent_id, id: "#{element_suffix}_parent_id"

--- a/src/api/app/views/webui/comment/_comment_list.html.haml
+++ b/src/api/app/views/webui/comment/_comment_list.html.haml
@@ -5,7 +5,7 @@
   = render partial: 'webui/comment/content', locals: { comment: comment, commentable: commentable, level: 1 }
 
 .comment_new.mt-3
-  = render partial: 'webui/comment/new', locals: { commentable: commentable }
+  = render partial: 'webui/comment/new', locals: { commentable: commentable, file_name: nil, remote: nil }
 
 :javascript
   $(document).ready(function() {

--- a/src/api/app/views/webui/comment/_new.html.haml
+++ b/src/api/app/views/webui/comment/_new.html.haml
@@ -10,7 +10,8 @@
         = link_to('bug tracker', bugzilla_url(commentable.bugowner_emails, "#{commentable_name}: Bug"))
   - if policy(Comment.new(commentable:)).create?
     = render(partial: 'webui/comment/comment_field',
-      locals: { form_method: :post, comment: Comment.new, commentable: commentable, element_suffix: 'new_comment', has_cancel: false })
+      locals: { form_method: :post, comment: Comment.new, commentable: commentable, element_suffix: 'new_comment', has_cancel: false,
+                file_name: file_name, remote: remote })
 - else
   .alert.alert-warning{ role: 'alert' }
     Login required, please

--- a/src/api/app/views/webui/comment/_render_timeline.js.erb
+++ b/src/api/app/views/webui/comment/_render_timeline.js.erb
@@ -1,1 +1,9 @@
-$('#comments-thread').html("<%= escape_javascript(render(BsRequestActivityTimelineComponent.new(bs_request: bs_request, request_reviews_for_non_staging_projects: request_reviews))) %>");
+<% if file_name %>
+  $("#diff-item-<%= file_name.parameterize %>").html("<%= escape_javascript(render(DiffComponent.new(diff: diff,
+                                              file_index: file_index, commentable: commentable,
+                                              commented_lines: commented_lines, file_name: file_name))) %>");
+  collectDeleteConfirmationModalsAndSetValues();
+<% else %>
+  $('#comments-thread').html("<%= escape_javascript(render(BsRequestActivityTimelineComponent.new(bs_request: bs_request, request_reviews_for_non_staging_projects: request_reviews))) %>");
+<% end %>
+commentFieldToggle();

--- a/src/api/app/views/webui/comment/_render_timeline.js.erb
+++ b/src/api/app/views/webui/comment/_render_timeline.js.erb
@@ -2,8 +2,9 @@
   $("#diff-item-<%= file_name.parameterize %>").html("<%= escape_javascript(render(DiffComponent.new(diff: diff,
                                               file_index: file_index, commentable: commentable,
                                               commented_lines: commented_lines, file_name: file_name))) %>");
-  collectDeleteConfirmationModalsAndSetValues();
 <% else %>
   $('#comments-thread').html("<%= escape_javascript(render(BsRequestActivityTimelineComponent.new(bs_request: bs_request, request_reviews_for_non_staging_projects: request_reviews))) %>");
 <% end %>
+
 commentFieldToggle();
+collectDeleteConfirmationModalsAndSetValues();

--- a/src/api/app/views/webui/comment/_render_timeline.js.erb
+++ b/src/api/app/views/webui/comment/_render_timeline.js.erb
@@ -1,0 +1,1 @@
+$('#comments-thread').html("<%= escape_javascript(render(BsRequestActivityTimelineComponent.new(bs_request: bs_request, request_reviews_for_non_staging_projects: request_reviews))) %>");

--- a/src/api/app/views/webui/comment/beta/_comments_thread.html.haml
+++ b/src/api/app/views/webui/comment/beta/_comments_thread.html.haml
@@ -1,1 +1,0 @@
-= render(BsRequestCommentComponent.new(comment: comment.root, level: 1, commentable: commentable))

--- a/src/api/app/views/webui/request/_add_inline_comment.html.haml
+++ b/src/api/app/views/webui/request/_add_inline_comment.html.haml
@@ -1,5 +1,5 @@
 - if User.session
-  = link_to(request_inline_comment_path(commentable.bs_request, request_action_id: commentable, line: diff_ref),
+  = link_to(request_inline_comment_path(commentable.bs_request, request_action_id: commentable, line: diff_ref, file_name: file_name),
             class: 'btn btn-sm btn-primary line-new-comment', remote: true, title: 'Add comment') do
     %i.fas.fa-comment-medical
     .visually-hidden

--- a/src/api/app/views/webui/request/_inline_comment.html.haml
+++ b/src/api/app/views/webui/request/_inline_comment.html.haml
@@ -1,8 +1,8 @@
 .comments-list
   - commentable.comments.where(diff_ref:).each do |comment|
     .comments-thread
-      = render BsRequestCommentComponent.new(comment: comment, level: 1, commentable: commentable)
+      = render BsRequestCommentComponent.new(comment: comment, level: 1, commentable: commentable, file_name: file_name)
   .comments-thread
     = render(partial: 'webui/comment/comment_field',
     locals: { form_method: :post, comment: Comment.new, commentable: commentable,
-              line: diff_ref, element_suffix: "new_comment_#{diff_ref}", has_cancel: true })
+              line: diff_ref, element_suffix: "new_comment_#{diff_ref}", has_cancel: true, file_name: file_name })

--- a/src/api/app/views/webui/request/beta_show.html.haml
+++ b/src/api/app/views/webui/request/beta_show.html.haml
@@ -85,7 +85,7 @@
                                                                 request_reviews_for_non_staging_projects: @request_reviews)
 
               .comment_new
-                = render partial: 'webui/comment/new', locals: { commentable: @bs_request }
+                = render partial: 'webui/comment/new', locals: { commentable: @bs_request, file_name: nil, remote: false }
               %hr
 
               - if @bs_request.accept_at.present?

--- a/src/api/app/views/webui/request/beta_show.html.haml
+++ b/src/api/app/views/webui/request/beta_show.html.haml
@@ -80,7 +80,8 @@
                     = render BsRequestActivityTimelineComponent.new(bs_request: superseding_request,
                                                                     request_reviews_for_non_staging_projects: @request_reviews)
 
-                = render BsRequestActivityTimelineComponent.new(bs_request: @bs_request,
+                #comments-thread
+                  = render BsRequestActivityTimelineComponent.new(bs_request: @bs_request,
                                                                 request_reviews_for_non_staging_projects: @request_reviews)
 
               .comment_new

--- a/src/api/app/views/webui/request/inline_comment.js.erb
+++ b/src/api/app/views/webui/request/inline_comment.js.erb
@@ -1,6 +1,6 @@
 $('#flash').empty();
-$('#comment<%= @line %> .diff-comments').html("<%= escape_javascript(render(partial: 'webui/request/inline_comment', locals: { comment: @comment, commentable: @active_action, diff_ref: @line })) %>");
+$('#comment<%= @line %> .diff-comments').html("<%= escape_javascript(render(partial: 'webui/request/inline_comment', locals: { comment: @comment, commentable: @active_action, diff_ref: @line, file_name: @file_name })) %>");
 $("#comment<%= @line %> .diff-comments textarea").focus();
 $("#comment<%= @line %>").on('click', '.cancel-comment', function (e) {
-  $('#comment<%= @line %> .diff-comments').html("<%= escape_javascript(render(partial: 'webui/request/add_inline_comment', locals: { commentable: @active_action, diff_ref: @line })) %>");
+  $('#comment<%= @line %> .diff-comments').html("<%= escape_javascript(render(partial: 'webui/request/add_inline_comment', locals: { commentable: @active_action, diff_ref: @line, file_name: @file_name })) %>");
 });

--- a/src/api/spec/controllers/webui/comments_controller_spec.rb
+++ b/src/api/spec/controllers/webui/comments_controller_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe Webui::CommentsController do
 
     context 'can destroy own comments' do
       before do
-        delete :destroy, params: { id: comment.id }
+        delete :destroy, params: { id: comment.id }, format: :js
       end
 
       it { expect(flash[:success]).to eq('Comment deleted successfully.') }
@@ -129,7 +129,7 @@ RSpec.describe Webui::CommentsController do
 
     context 'cannot destroy comment of somebody else' do
       before do
-        delete :destroy, params: { id: other_comment.id }
+        delete :destroy, params: { id: other_comment.id }, format: :js
       end
 
       it { expect(flash[:success]).to be_nil }
@@ -139,7 +139,7 @@ RSpec.describe Webui::CommentsController do
     context 'admin can destroy comments not owned by him' do
       before do
         login admin
-        delete :destroy, params: { id: other_comment.id }
+        delete :destroy, params: { id: other_comment.id }, format: :js
       end
 
       it { expect(flash[:success]).to eq('Comment deleted successfully.') }
@@ -157,11 +157,11 @@ RSpec.describe Webui::CommentsController do
         context 'with no replies' do
           before do
             login admin
-            delete :destroy, params: { id: root_comment.id }
+            delete :destroy, params: { id: root_comment.id }, format: :js
           end
 
           it 'removes the comment thread from the view' do
-            expect(response.body).to be_empty
+            expect(response).to have_http_status(:ok)
           end
         end
 
@@ -171,7 +171,7 @@ RSpec.describe Webui::CommentsController do
 
           before do
             login admin
-            delete :destroy, params: { id: root_comment.id }
+            delete :destroy, params: { id: root_comment.id }, format: :js
           end
 
           it 'renders This comment has been deleted' do
@@ -191,7 +191,7 @@ RSpec.describe Webui::CommentsController do
 
           before do
             login admin
-            delete :destroy, params: { id: leaf.id }
+            delete :destroy, params: { id: leaf.id }, format: :js
           end
 
           it 'renders the updated thread without the reply' do
@@ -209,7 +209,7 @@ RSpec.describe Webui::CommentsController do
 
           before do
             login admin
-            delete :destroy, params: { id: reply.id }
+            delete :destroy, params: { id: reply.id }, format: :js
           end
 
           it 'renders the updated thread back' do
@@ -232,7 +232,7 @@ RSpec.describe Webui::CommentsController do
             root_comment.blank_or_destroy
 
             login admin
-            delete :destroy, params: { id: leaf.id }
+            delete :destroy, params: { id: leaf.id }, format: :js
           end
 
           it 'removes the leaf' do
@@ -254,7 +254,7 @@ RSpec.describe Webui::CommentsController do
             reply.blank_or_destroy
 
             login admin
-            delete :destroy, params: { id: leaf.id }
+            delete :destroy, params: { id: leaf.id }, format: :js
           end
 
           it 'removes the root comment' do


### PR DESCRIPTION
Fixes #15241

In addition to the issue mentioned above, there is the same behavior in the changes tab and they both are directly related to the same piece of code.  One can not be fixed without another. This PR covers:
- [x] Fix CRUD operations on comments on the comments timeline
- [x] Fix CRUD operations on comments in the changes tab

Notes for test:
1. Test all the comments features(CRUD and also report/moderation) on timeline. If there is a comment on a line of code, it should not disappear.
2. Test everything mentioned in 1 for the changes tab. Previously there has been a blank line when you Delete or update a comment. Now, it should be fixed. There was a [separate card](https://trello.com/c/gHn4spEf/116-handle-deleting-comments-in-changes-tab-better-m) for this but this PR also fixed that issue.
3. Test comments on projects/packages 