### PR TITLE
change how to set params type to new token in set_package

### DIFF
--- a/src/api/app/controllers/webui/users/tokens_controller.rb
+++ b/src/api/app/controllers/webui/users/tokens_controller.rb
@@ -102,7 +102,8 @@ class Webui::Users::TokensController < Webui::WebuiController
     # Prevent setting a package for a workflow token
     return if @params[:type] == 'workflow'
 
-    @token = Token.token_type(@params[:type]).new(description: @params[:description])
+    @token = Token.new(description: @params[:description])
+    @token.write_attribute(:type, @params[:type])
 
     # Check if only project_name or only package_name are present
     if @extra_params[:project_name].present? ^ @extra_params[:package_name].present?

--- a/src/api/app/views/webui/users/tokens/new.html.haml
+++ b/src/api/app/views/webui/users/tokens/new.html.haml
@@ -15,7 +15,8 @@
                 = f.label(:type, 'Type:', class: 'col-form-label me-2')
                 .w-100.d-sm-none
                 = f.collection_radio_buttons(:type, type_options, :to_s, :to_s,
-                                             checked: 'service', class: 'form-check-input', include_hidden: false, required: true) do |radio|
+                                             checked: f.object.type.nil? ? 'service' : f.object.type,
+                                             class: 'form-check-input', include_hidden: false, required: true) do |radio|
                   .form-check.custom-control-inline
                     = radio.radio_button(class: 'form-check-input')
                     = radio.label(class: 'form-check-label')


### PR DESCRIPTION
Hey Friends (yikes! like the CONTRIBUTING.md :) )
actually fixed this one #15403; 

What's wrong with the old code? 
Using the method `Token.token_type`, the class itself changes and the `form_with(@token)` use the new form class to name the params, so the `require(:token)` will throw an error.
But the problems is not always available. You need to make a wrong search on project name or package name.

So setting the type with the `write_attribute(:type)` and removing the `token_type` allow to set the :type back and render correctly the :new partial.
The fix correlated regards the default value for the `:type` in the `radio_buttons`, was hard typed with `service`.