### PR TITLE
Fetch the review from the Review model, not HistoryElement::Review

### DIFF
--- a/src/api/app/models/history_element/review.rb
+++ b/src/api/app/models/history_element/review.rb
@@ -4,11 +4,11 @@ module HistoryElement
     self.abstract_class = true
 
     def review
-      Review.find(op_object_id)
+      ::Review.find(op_object_id)
     end
 
     def request
-      Review.find(op_object_id).bs_request
+      review.bs_request
     end
 
     def review=(review)


### PR DESCRIPTION
This is the same we do HistoryElement::RequestReviewAdded https://github.com/openSUSE/open-build-service/blob/4a20d898a4ff69db1ebe5378591cd6450960e83f/src/api/app/models/history_element/request_review_added.rb#L33

Without this change, we were previously fetching the HistoryElement::Review record which we already had.