### PR TITLE
Distinguish HistoryElement::ReviewAccepted for staging workflows from others

### DIFF
--- a/src/api/app/models/history_element/review_accepted.rb
+++ b/src/api/app/models/history_element/review_accepted.rb
@@ -5,6 +5,10 @@ module HistoryElement
     end
 
     def user_action
+      # We check if the accepted review was created when the request was staged in a staging workflow. In this case, the review
+      # will also be for the managers group of that staging workflow.
+      return 'staged request' if review.for_group? && request.staged_request? && review.by_group == request.staging_project.staging_workflow.managers_group.title
+
       'accepted review'
     end
   end


### PR DESCRIPTION
This isn't efficient at all, but right now, we don't have another way to achieve this result. It would involve a major refactor in the creation of history elements related to staging workflows.

~~This PR depends on #15495, so rebase once it has been merged.~~

Before:
![before](https://github.com/openSUSE/open-build-service/assets/1102934/6836c82f-af1c-4c26-95f3-0fc8002bd98d)

Now:
![now](https://github.com/openSUSE/open-build-service/assets/1102934/6ace730c-292f-4152-97ba-e165d776f16f)