### PR TITLE
Fix small cluttering

### DIFF
--- a/src/api/app/views/webui/request/beta_show_tabs/_build_status.html.haml
+++ b/src/api/app/views/webui/request/beta_show_tabs/_build_status.html.haml
@@ -1,5 +1,5 @@
 - unless buildresults.excluded_counter.zero? && !buildresults.show_all
-  .mt-3.form-check
+  .mt-3.mb-3.form-check
     = check_box_tag('show_all', true, buildresults.show_all, class: 'form-check-input d-none',
                     onchange: 'updateBuildResultBeta()')
     - label_message = buildresults.excluded_counter.zero? ? 'Hide' : "Show #{buildresults.excluded_counter}"


### PR DESCRIPTION
When there are excluded results, the text appears too close to the actual results. This PR adds a bit of spacing between those elements.

_Before_
![Screenshot from 2024-01-18 10-24-58](https://github.com/openSUSE/open-build-service/assets/2650/c317ac86-53d1-49c0-89ad-0ba8621049b1)

_After_
![2024-01-18_10-38](https://github.com/openSUSE/open-build-service/assets/2650/2cdbf377-a65f-4e37-9a93-46a592d3f813)
