### PR TITLE
Allow commenting on the same line after a comment was deleted from it

### DIFF
--- a/src/api/app/assets/stylesheets/webui/diff.scss
+++ b/src/api/app/assets/stylesheets/webui/diff.scss
@@ -10,8 +10,13 @@
   z-index: 4;
 }
 
+.line-new-comment {
+  display: none;
+}
+
 .pre.scroll {
   --line-index-digits: 6ch;
+  --additional-padding: 0px;
   @for $i from 1 through 10 {
     .digits-#{$i} {
       --line-index-digits: #{$i}ch;
@@ -28,12 +33,15 @@
       .line-new-comment {
         display: none;
       }
+      .comments-thread .line-new-comment {
+        --additional-padding: 1rem;
+      }
       &:hover .line-new-comment {
         display: block;
         position: absolute;
         z-index: 1000;
-        margin-left: calc(2 * (var(--line-index-digits) + 2rem + var(--bs-border-width)) + 0.5rem + var(--bs-border-width));
-        margin-top: -1.75rem;
+        margin-left: calc(2 * (var(--line-index-digits) + 2rem + var(--bs-border-width)) + 0.5rem + var(--bs-border-width) - var(--additional-padding));
+        margin-top: -1.75rem !important;
       }
       .line-comment .fa-comment {
         display: none;
@@ -43,12 +51,10 @@
       }
       .line-comment .comments-thread {
         &:first-child {
-          @extend .border-top;
-          > :first-child { @extend .mt-3; }
+          > :first-child { margin-top: 1rem; }
         }
         &:last-child {
-          @extend .border-bottom;
-          > :last-child { @extend .mb-3; }
+          > :last-child { margin-bottom: 1rem; }
         }
         @extend .px-3;
       }

--- a/src/api/app/controllers/webui/comments_controller.rb
+++ b/src/api/app/controllers/webui/comments_controller.rb
@@ -77,6 +77,11 @@ class Webui::CommentsController < Webui::WebuiController
              end
 
     if Flipper.enabled?(:request_show_redesign, User.session) && ['BsRequest', 'BsRequestAction'].include?(@comment.commentable_type)
+      if @comment.commentable_type == 'BsRequestAction' && Comment.where(commentable: @comment.commentable, diff_ref: @comment.root.diff_ref).count.zero?
+        return render(partial: 'webui/request/add_inline_comment',
+                      locals: { commentable: @comment.root.commentable, diff_ref: @comment.root.diff_ref },
+                      status: status)
+      end
       # if we're a root comment with no replies there is no need to re-render anything
       return head(:ok) if @comment.root? && @comment.leaf?
 

--- a/src/api/app/views/webui/comment/beta/_comments_thread.html.haml
+++ b/src/api/app/views/webui/comment/beta/_comments_thread.html.haml
@@ -1,1 +1,4 @@
 = render(BsRequestCommentComponent.new(comment: comment.root, level: 1, commentable: commentable, diff: defined?(diff) ? diff : nil ))
+
+:javascript
+  collectDeleteConfirmationModalsAndSetValues();


### PR DESCRIPTION
Depends on #15501 

After deleting a comment in the changes tab, there was no way to add a comment to the same line without reloading. This aims to fix the issue