### PR TITLE
Fix broken YAML multi-line documentation strings

### DIFF
--- a/src/api/public/apidocs/paths/architectures.yaml
+++ b/src/api/public/apidocs/paths/architectures.yaml
@@ -1,6 +1,6 @@
 get:
   summary: List all known architectures.
-  description: >
+  description: |
     Get a list of all known architectures known to OBS in general.
     This is not the list of architectures provided by this instance. Check the
     schedulers element from the `/configuration` route for this.

--- a/src/api/public/apidocs/paths/build_project_name_repository_name_architecture_name_builddepinfo.yaml
+++ b/src/api/public/apidocs/paths/build_project_name_repository_name_architecture_name_builddepinfo.yaml
@@ -1,6 +1,6 @@
 get:
   summary: Show the build dependencies of packages that are part of the project.
-  description: >
+  description: |
     Show the build dependencies of packages that are part of the project,
     for a given repository and architecture.
   security:

--- a/src/api/public/apidocs/paths/build_project_name_repository_name_architecture_name_package_name_jobstatus.yaml
+++ b/src/api/public/apidocs/paths/build_project_name_repository_name_architecture_name_package_name_jobstatus.yaml
@@ -1,6 +1,6 @@
 get:
   summary: Show the build status of a currently running build job.
-  description: >
+  description: |
     Show the build status of a currently running build job. Shows an empty
     result if no build job is running.
   security:

--- a/src/api/public/apidocs/paths/build_project_name_repository_name_architecture_name_repository.yaml
+++ b/src/api/public/apidocs/paths/build_project_name_repository_name_architecture_name_repository.yaml
@@ -1,6 +1,6 @@
 get:
   summary: List all binaries (produced by all packages of the given project).
-  description: >
+  description: |
     List all binaries (produced by all packages of the given project) for the specified
     repository and architecture.
   security:

--- a/src/api/public/apidocs/paths/build_project_name_repository_name_buildconfig.yaml
+++ b/src/api/public/apidocs/paths/build_project_name_repository_name_buildconfig.yaml
@@ -1,6 +1,6 @@
 get:
   summary: Show the build configuration for the specified repository.
-  description: >
+  description: |
     Show the build configuration for the specified repository. Includes all base package
     requirements, mappings and macros.
   security:

--- a/src/api/public/apidocs/paths/configuration.yaml
+++ b/src/api/public/apidocs/paths/configuration.yaml
@@ -6,7 +6,7 @@ get:
     - basic_authentication: []
   responses:
     '200':
-      description: >
+      description: |
         OK. The request has succeeded.
       content:
         application/xml; charset=utf-8:
@@ -33,7 +33,7 @@ put:
           $ref: '../components/schemas/configuration.yaml'
   responses:
     '200':
-      description: >
+      description: |
         OK. The request has succeeded.
       content:
         application/xml; charset=utf-8:

--- a/src/api/public/apidocs/paths/person.yaml
+++ b/src/api/public/apidocs/paths/person.yaml
@@ -1,6 +1,6 @@
 get:
   summary: List all people.
-  description: >
+  description: |
     List all people.
   security:
     - basic_authentication: []
@@ -22,7 +22,7 @@ get:
 
   responses:
     '200':
-      description: >
+      description: |
         OK. The request has succeeded.
 
         XML Schema used for body validation: [directory.xsd](../schema/directory.xsd)

--- a/src/api/public/apidocs/paths/person_login.yaml
+++ b/src/api/public/apidocs/paths/person_login.yaml
@@ -6,7 +6,7 @@ get:
     - $ref: '../components/parameters/login.yaml'
   responses:
     '200':
-      description: >
+      description: |
         OK. The request has succeeded.
 
         XML Schema used for body validation: [user.rng](../schema/user.rng)
@@ -59,7 +59,7 @@ post:
           type: string
   responses:
     '200':
-      description: >
+      description: |
         OK. The request has succeeded.
 
         XML Schema used for body validation: [api_response.xsd](../schema/api_response.xsd)

--- a/src/api/public/apidocs/paths/person_login_group.yaml
+++ b/src/api/public/apidocs/paths/person_login_group.yaml
@@ -7,7 +7,7 @@ get:
     - $ref: '../components/parameters/login.yaml'
   responses:
     '200':
-      description: >
+      description: |
         OK. The request has succeeded.
 
         XML Schema used for body validation: [directory.xsd](../schema/directory.xsd)

--- a/src/api/public/apidocs/paths/published.yaml
+++ b/src/api/public/apidocs/paths/published.yaml
@@ -1,6 +1,6 @@
 get:
   summary: List all the published projects.
-  description: >
+  description: |
     Get a list of all the projects, all of them are considered published.
   security:
     - basic_authentication: []

--- a/src/api/public/apidocs/paths/published_project_name.yaml
+++ b/src/api/public/apidocs/paths/published_project_name.yaml
@@ -1,6 +1,6 @@
 get:
   summary: List the repositories of a project with published binaries
-  description: >
+  description: |
     Get a list of the repositories of the project that already have published binaries.
   security:
     - basic_authentication: []

--- a/src/api/public/apidocs/paths/published_project_name_repository_name.yaml
+++ b/src/api/public/apidocs/paths/published_project_name_repository_name.yaml
@@ -1,6 +1,6 @@
 get:
   summary: List the content of the directory tree where the binaries are published at the level project/repository.
-  description: >
+  description: |
     Get a list of architectures' directories and other files (.repo, .ymp, etc.) present at the level
     project/repository of the directory tree where the published binaries are stored.
   security:

--- a/src/api/public/apidocs/paths/published_project_name_repository_name_architecture_name.yaml
+++ b/src/api/public/apidocs/paths/published_project_name_repository_name_architecture_name.yaml
@@ -1,6 +1,6 @@
 get:
   summary: List the content of the directory tree where the binaries are published at the level project/repository/architecture.
-  description: >
+  description: |
     Get a list of binaries and other files present at the level project/repository/architecture of the directory
     tree as a result of successful building and publishing processes.
   security:

--- a/src/api/public/apidocs/paths/published_project_name_repository_name_architecture_name_binary_filename.yaml
+++ b/src/api/public/apidocs/paths/published_project_name_repository_name_architecture_name_binary_filename.yaml
@@ -1,6 +1,6 @@
 get:
   summary: Return the binary file itself.
-  description: >
+  description: |
     Allow to download the binary file that was published and stored under the directory
     given by project/repository/architecture/.
 

--- a/src/api/public/apidocs/paths/published_project_name_repository_name_architecture_name_binary_filename_view_ymp.yaml
+++ b/src/api/public/apidocs/paths/published_project_name_repository_name_architecture_name_binary_filename_view_ymp.yaml
@@ -1,6 +1,6 @@
 get:
   summary: Generate a ymp pattern that includes the needed repositories to install the given binary.
-  description: >
+  description: |
     Generate a ymp pattern, which contains the list of packages needed for intalling certain software without having to
     create dependencies between them.
 

--- a/src/api/public/apidocs/paths/published_project_name_repository_name_view_status.yaml
+++ b/src/api/public/apidocs/paths/published_project_name_repository_name_view_status.yaml
@@ -1,6 +1,6 @@
 get:
   summary: Present information about the last publication of the pair project and repository.
-  description: >
+  description: |
     Get information about the build process (build id, start time, etc.) for the pair project and repository.
   security:
     - basic_authentication: []


### PR DESCRIPTION
The current OpenAPI schema (https://api.opensuse.org/apidocs/OBS-v2.10.50.yaml) doesn't contain valid YAML on multi-line description strings. 
This PR changes the `>` to `|` which results in valid YAML multi-line strings when building the documentation.

## Before
```yaml
...
  "/architectures":
    get:
      summary: List all known architectures.
      description: 'Get a list of all known architectures known to OBS in general.
        This is not the list of architectures provided by this instance. Check the
        schedulers element from the `/configuration` route for this.

'
      security:
      - basic_authentication: []
...
```
## After
```yaml
...
  "/architectures":
    get:
      summary: List all known architectures.
      description: |
        Get a list of all known architectures known to OBS in general.
        This is not the list of architectures provided by this instance. Check the
        schedulers element from the `/configuration` route for this.
      security:
      - basic_authentication: []
...
```