### PR TITLE
fix for %pre script for 15.6

### DIFF
--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -781,14 +781,8 @@ if [ "$1" == 2 ]; then
     touch %{_rundir}/enable_obs-api-support.target
   fi
   if systemctl --quiet is-active obsapidelayed.service; then
-    touch %{_rundir}/start_obs-api-support.target
-    systemctl stop    obsapidelayed.service
-    if systemd-detect-virt --chroot; then
-      # If we are in a chroot, we don't know if the service runs or even exists. In that case ignore if disabling fails.
-      systemctl disable obsapidelayed.service || :
-    else
-      systemctl disable obsapidelayed.service
-    fi
+    touch %{_rundir}/enable_obs-api-support.target
+    systemctl disable --now obsapidelayed.service || :
   fi
 fi
 
@@ -831,12 +825,16 @@ touch %{__obs_api_prefix}/last_deploy || true
 # This must be done after %%service_add_post. Otherwise the distribution preset is
 # take, which is disabled in case of obs-api-support.target
 if [ -e %{_rundir}/enable_obs-api-support.target ];then
-  systemctl enable obs-api-support.target
+  # Don't break on errors if ENV variable SYSTEMD_OFFLINE=1 is set
+  # like in obs build script
+  if [ "$SYSTEMD_OFFLINE" -gt 0 ];then
+    systemctl enable --now obs-api-support.target || true
+  else
+    # if SYSTEMD_OFFLINE=1 is not set, users should get an error
+    # reported
+    systemctl enable --now obs-api-support.target
+  fi
   rm %{_rundir}/enable_obs-api-support.target
-fi
-if [ -e %{_rundir}/start_obs-api-support.target ];then
-  systemctl start  obs-api-support.target
-  rm %{_rundir}/start_obs-api-support.target
 fi
 
 %postun -n obs-api

--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -769,8 +769,6 @@ rmdir %{obs_backend_data_dir} 2> /dev/null || :
 %service_del_postun -r obsclouduploadserver.service
 
 %pre -n obs-api
-getent passwd obsapidelayed >/dev/null || \
-  /usr/sbin/useradd -r -s /bin/bash -c "User for build service api delayed jobs" -d %{__obs_api_prefix} -g %{apache_group} obsapidelayed
 %service_add_pre %{obs_api_support_scripts}
 
 # On upgrade keep the values for the %post script


### PR DESCRIPTION
    The %pre section might fail in OBS since 15.6 if
    "systemctl disable obsapidelayed.service"
    returns non-zero exit code.
    
    This is caused by using "export SYSTEMD_OFFLINE=1" in build script.
