### PR TITLE
Move the build result accordion content into the accordion-item

### DIFF
--- a/src/api/app/assets/stylesheets/webui/build-results.scss
+++ b/src/api/app/assets/stylesheets/webui/build-results.scss
@@ -177,8 +177,7 @@
 
 #build-results-monitor {
   .accordion-button:not(.collapsed) {
-    @extend .text-bg-selected;
-    color: var(--bs-accordion-active-color);
+    --bs-accordion-active-bg: var(--bs-secondary-bg);
   }
 
   .accordion-button:hover {

--- a/src/api/app/components/build_results_monitor_component.html.haml
+++ b/src/api/app/components/build_results_monitor_component.html.haml
@@ -21,21 +21,21 @@
               - results_count_per_package_and_category(package_name).each do |key, value|
                 = render partial: 'webui/shared/build_status_count_badge', locals: { category: key, count: value.to_s }
 
-    .accordion-collapse.border.p-4.pt-1.collapse{ id: "collapse-#{package_name.gsub(':', '_')}", class: show }
-      .list-group.list-group-flush
-        - filtered_repository_names.each do |repository_name|
-          .list-group-item.d-flex.justify-content-between
-            = link_to(helpers.word_break(repository_name, 22),
-                      project_package_repository_binaries_path(project_name: project_name,
-                                                               package_name: package_name,
-                                                               repository_name: repository_name),
-                      title: "Binaries for #{repository_name}")
-            %span.text-end
-              - results_per_package_and_repository(package_name, repository_name).each do |result|
-                = render partial: 'webui/shared/build_status_badge', locals: { status: result[:status],
-                                                                               text: "#{result[:architecture]} : #{repository_status(result)}" ,
-                                                                               url: live_build_log_url(result[:status],
-                                                                                                       project_name,
-                                                                                                       package_name,
-                                                                                                       repository_name,
-                                                                                                       result[:architecture]) }
+      .accordion-collapse.collapse{ id: "collapse-#{package_name.gsub(':', '_')}", class: show }
+        .list-group.list-group-flush.rounded-bottom
+          - filtered_repository_names.each do |repository_name|
+            .list-group-item.d-flex.justify-content-between
+              = link_to(helpers.word_break(repository_name, 22),
+                        project_package_repository_binaries_path(project_name: project_name,
+                                                                 package_name: package_name,
+                                                                 repository_name: repository_name),
+                        title: "Binaries for #{repository_name}")
+              %span.text-end
+                - results_per_package_and_repository(package_name, repository_name).each do |result|
+                  = render partial: 'webui/shared/build_status_badge', locals: { status: result[:status],
+                                                                                 text: "#{result[:architecture]} : #{repository_status(result)}" ,
+                                                                                 url: live_build_log_url(result[:status],
+                                                                                                         project_name,
+                                                                                                         package_name,
+                                                                                                         repository_name,
+                                                                                                         result[:architecture]) }


### PR DESCRIPTION
This reduces the need to do custom classes to display it nicely. I also included some css tweaks to make this work nicer with dark theme.
![Screenshot from 2024-01-22 18-34-00](https://github.com/openSUSE/open-build-service/assets/114928900/7d07f5c6-ff36-488e-bd14-f7961d4598e5)
