### PR TITLE
Display the build results as a table on larger viewports

### DIFF
--- a/src/api/app/assets/stylesheets/webui/build-results.scss
+++ b/src/api/app/assets/stylesheets/webui/build-results.scss
@@ -225,32 +225,27 @@
 
   @include media-breakpoint-up(xl) {
     display: grid;
-    grid-auto-flow: row;
-    row-gap: 1px;
-    background-color: var(--bs-border-color);
+    grid-template-columns: 1fr repeat(20, auto);
 
     .build-result-architectures, .build-result-row, .build-result-legend {
       display: contents;
     }
-  
-    @for $i from 1 to 20 {
-      &.build-result-table-#{$i} {
-        grid-template-columns: [name] 10fr repeat(#{$i}, [arch] 1fr);
-      }
-    }
 
     .build-result-name {
-      grid-column-start: name;
+      grid-column-start: 1;
       padding: 0.25rem 1rem;
-      background-color: var(--bs-body-bg);
     }
 
     .build-result-architecture {
-      grid-column-start: [arch];
       padding: 0.25rem 1rem;
-      background-color: var(--bs-body-bg);
       text-align: end;
       .architecture { display: none }
+    }
+
+    .build-result-row {
+      .build-result-name, .build-result-architecture {
+        border-top: var(--bs-border-width) solid var(--bs-border-color);
+      }
     }
   }
 }

--- a/src/api/app/assets/stylesheets/webui/build-results.scss
+++ b/src/api/app/assets/stylesheets/webui/build-results.scss
@@ -195,3 +195,62 @@
     &.left { left: .5rem; }
   }
 }
+
+.build-result-table {
+  .build-result-legend {
+    display: none;
+  }
+
+  .build-result-row {
+    display: flex;
+    justify-content: space-between;
+    padding: 0.25rem 1rem;
+    flex-wrap: wrap;
+  }
+
+  .build-result-architectures {
+    display: flex;
+    margin-left: auto;
+    flex-wrap: wrap;
+    justify-content: end;
+  }
+
+  .build-result-architectures .badge {
+    margin-left: 0.25rem;
+  }
+
+  .build-result-row:not(:last-of-type) {
+    border-bottom: var(--bs-border-width) solid var(--bs-border-color);
+  }
+
+  @include media-breakpoint-up(xl) {
+    display: grid;
+    grid-auto-flow: row;
+    row-gap: 1px;
+    background-color: var(--bs-border-color);
+
+    .build-result-architectures, .build-result-row, .build-result-legend {
+      display: contents;
+    }
+  
+    @for $i from 1 to 20 {
+      &.build-result-table-#{$i} {
+        grid-template-columns: [name] 10fr repeat(#{$i}, [arch] 1fr);
+      }
+    }
+
+    .build-result-name {
+      grid-column-start: name;
+      padding: 0.25rem 1rem;
+      background-color: var(--bs-body-bg);
+    }
+
+    .build-result-architecture {
+      grid-column-start: [arch];
+      padding: 0.25rem 1rem;
+      background-color: var(--bs-body-bg);
+      text-align: end;
+      .architecture { display: none }
+    }
+  }
+}

--- a/src/api/app/components/build_results_monitor_component.html.haml
+++ b/src/api/app/components/build_results_monitor_component.html.haml
@@ -23,7 +23,7 @@
                 = render partial: 'webui/shared/build_status_count_badge', locals: { category: key, count: value.to_s }
 
       .accordion-collapse.collapse{ id: "collapse-#{package_name.gsub(':', '_')}", class: show }
-        .rounded-bottom.build-result-table{ class: "build-result-table-#{filtered_architecture_names.length}" }
+        .build-result-table
           .build-result-legend
             .build-result-name
             - filtered_architecture_names.each do |architecture_name|

--- a/src/api/app/components/build_results_monitor_component.html.haml
+++ b/src/api/app/components/build_results_monitor_component.html.haml
@@ -23,20 +23,28 @@
                 = render partial: 'webui/shared/build_status_count_badge', locals: { category: key, count: value.to_s }
 
       .accordion-collapse.collapse{ id: "collapse-#{package_name.gsub(':', '_')}", class: show }
-        .list-group.list-group-flush.rounded-bottom
+        .rounded-bottom.build-result-table{ class: "build-result-table-#{filtered_architecture_names.length}" }
+          .build-result-legend
+            .build-result-name
+            - filtered_architecture_names.each do |architecture_name|
+              .build-result-architecture
+                = architecture_name
           - filtered_repository_names.each do |repository_name|
-            .list-group-item.d-flex.justify-content-between
+            .build-result-row
               = link_to(helpers.word_break(repository_name, 22),
                         project_package_repository_binaries_path(project_name: project_name,
                                                                  package_name: package_name,
                                                                  repository_name: repository_name),
-                        title: "Binaries for #{repository_name}")
-              %span.text-end
-                - results_per_package_and_repository(package_name, repository_name).each do |result|
-                  = render partial: 'webui/shared/build_status_badge', locals: { status: result[:status],
-                                                                                 text: "#{result[:architecture]} : #{repository_status(result)}" ,
-                                                                                 url: live_build_log_url(result[:status],
-                                                                                                         project_name,
-                                                                                                         package_name,
-                                                                                                         repository_name,
-                                                                                                         result[:architecture]) }
+                        title: "Binaries for #{repository_name}", class: 'build-result-name text-break')
+              .build-result-architectures
+                - filtered_architecture_names.each do |architecture_name|
+                  .build-result-architecture
+                    - results_per_package_repository_and_architecture(package_name, repository_name, architecture_name).each do |result|
+                      = render partial: 'webui/shared/build_status_badge', locals: { status: result[:status],
+                                                                                     text: repository_status(result) ,
+                                                                                     architecture: result[:architecture],
+                                                                                     url: live_build_log_url(result[:status],
+                                                                                                             project_name,
+                                                                                                             package_name,
+                                                                                                             repository_name,
+                                                                                                             result[:architecture]) }

--- a/src/api/app/components/build_results_monitor_component.rb
+++ b/src/api/app/components/build_results_monitor_component.rb
@@ -36,6 +36,10 @@ class BuildResultsMonitorComponent < ApplicationComponent
     raw_data.pluck(:architecture).uniq
   end
 
+  def filtered_architecture_names
+    @filtered_data.pluck(:architecture).uniq
+  end
+
   def status_names
     raw_data.pluck(:status).uniq
   end
@@ -57,6 +61,10 @@ class BuildResultsMonitorComponent < ApplicationComponent
 
   def results_per_package_and_repository(package, repository)
     results_per_package(package).select { |result| result[:repository] == repository }
+  end
+
+  def results_per_package_repository_and_architecture(package, repository, architecture)
+    results_per_package_and_repository(package, repository).select { |result| result[:architecture] == architecture }
   end
 
   def live_build_log_url(status, project, package, repository, architecture)

--- a/src/api/app/views/webui/shared/_build_status_badge.html.haml
+++ b/src/api/app/views/webui/shared/_build_status_badge.html.haml
@@ -1,8 +1,10 @@
 - if url
   = link_to url, class: "badge #{build_status_category_color(status)} clickable", title: 'Live build log' do
     %i.fa.me-2{ class: build_status_icon(status), title: status.humanize }
+    %span.architecture #{architecture} :
     = text
 - else
   %span.badge{ class: build_status_category_color(status) }
     %i.fa.me-2{ class: build_status_icon(status), title: status.humanize }
+    %span.architecture #{architecture} :
     = text


### PR DESCRIPTION
This displays the build results as a table on larger viewports, so the architectures align in columns
[Screencast from 2024-01-23 11-15-18.webm](https://github.com/openSUSE/open-build-service/assets/114928900/33decba1-b30e-42cf-8a90-ef997915cfcd)
