### PR TITLE
Fix broken single line documentation strings

### DIFF
--- a/src/api/public/apidocs/paths/build_project_name_repository_name_architecture_name_package_name_file_name.yaml
+++ b/src/api/public/apidocs/paths/build_project_name_repository_name_architecture_name_package_name_file_name.yaml
@@ -1,7 +1,6 @@
 get:
   summary: Return a specific artifact file contents
-  description: |
-    Given a project, repository, architecture and package, retrieve the given file's content.
+  description: "Given a project, repository, architecture and package, retrieve the given file's content."
   security:
     - basic_authentication: []
   parameters:
@@ -82,8 +81,7 @@ put:
     '401':
       $ref: '../components/responses/unauthorized.yaml'
     '403':
-      description: |
-        No permission to upload binaries for this project
+      description: No permission to upload binaries for this project
       content:
         application/xml; charset=utf-8:
           schema:
@@ -134,8 +132,7 @@ delete:
     '200':
       $ref: '../components/responses/succeeded.yaml'
     '400':
-      description: |
-        Operation is not allowed
+      description: Operation is not allowed
       content:
         application/xml; charset=utf-8:
           schema:
@@ -144,8 +141,7 @@ delete:
             code: 'invalid_operation'
             summary: 'Delete operation of build results is not allowed'
     '403':
-      description: |
-        No permission to delete binaries from this project
+      description: No permission to delete binaries from this project
       content:
         application/xml; charset=utf-8:
           schema:

--- a/src/api/public/apidocs/paths/build_project_name_repository_name_architecture_name_package_name_file_name_view_fileinfo.yaml
+++ b/src/api/public/apidocs/paths/build_project_name_repository_name_architecture_name_package_name_file_name_view_fileinfo.yaml
@@ -1,6 +1,6 @@
 get:
   summary: This endpoint returns details about an specific artifact
-  description: |
+  description: 
     Given a project, repository, architecture and package, retrieve the given artifact's details.
   security:
     - basic_authentication: []

--- a/src/api/public/apidocs/paths/build_project_name_repository_name_architecture_name_package_name_file_name_view_fileinfo.yaml
+++ b/src/api/public/apidocs/paths/build_project_name_repository_name_architecture_name_package_name_file_name_view_fileinfo.yaml
@@ -1,7 +1,6 @@
 get:
   summary: This endpoint returns details about an specific artifact
-  description: 
-    Given a project, repository, architecture and package, retrieve the given artifact's details.
+  description: Given a project, repository, architecture and package, retrieve the given artifact's details.
   security:
     - basic_authentication: []
   parameters:

--- a/src/api/public/apidocs/paths/build_project_name_repository_name_architecture_name_package_name_log.yaml
+++ b/src/api/public/apidocs/paths/build_project_name_repository_name_architecture_name_package_name_log.yaml
@@ -9,8 +9,7 @@ get:
     - $ref: '../components/parameters/package_name.yaml'
   responses:
     '200':
-      description: |
-        This endpoint returns the log file content
+      description: This endpoint returns the log file content
       content:
         text/plain:
           example: |

--- a/src/api/public/apidocs/paths/configuration.yaml
+++ b/src/api/public/apidocs/paths/configuration.yaml
@@ -1,13 +1,11 @@
 get:
   summary: Display the configuration of this Open Build Service instance
-  description: |
-    Display the configuration of this Open Build Service instance.
+  description: Display the configuration of this Open Build Service instance.
   security:
     - basic_authentication: []
   responses:
     '200':
-      description: |
-        OK. The request has succeeded.
+      description: OK. The request has succeeded.
       content:
         application/xml; charset=utf-8:
           schema:
@@ -33,8 +31,7 @@ put:
           $ref: '../components/schemas/configuration.yaml'
   responses:
     '200':
-      description: |
-        OK. The request has succeeded.
+      description: OK. The request has succeeded.
       content:
         application/xml; charset=utf-8:
           schema:

--- a/src/api/public/apidocs/paths/distributions_distribution_id.yaml
+++ b/src/api/public/apidocs/paths/distributions_distribution_id.yaml
@@ -1,15 +1,13 @@
 get:
   summary: Show a distribution.
-  description: |
-    Show a distribution that can be build against.
+  description: Show a distribution that can be build against.
   security:
     - basic_authentication: []
   parameters:
     - $ref: '../components/parameters/distribution_id.yaml'
   responses:
     '200':
-      description: |
-        OK. The request has succeded.
+      description: OK. The request has succeded.
       content:
         application/xml; charset=utf-8:
           schema:
@@ -73,8 +71,7 @@ delete:
     - $ref: '../components/parameters/distribution_id.yaml'
   responses:
     '200':
-      description: |
-        OK. The request has succeded.
+      description: OK. The request has succeded.
       content:
         application/xml; charset=utf-8:
           schema:

--- a/src/api/public/apidocs/paths/distributions_include_remotes.yaml
+++ b/src/api/public/apidocs/paths/distributions_include_remotes.yaml
@@ -1,7 +1,6 @@
 get:
   summary: List all distributions including remote.
-  description: |
-    List all distributions that can be build against, including the ones provided by the interconnect.
+  description: List all distributions that can be build against, including the ones provided by the interconnect.
   security:
     - basic_authentication: []
   responses:

--- a/src/api/public/apidocs/paths/my_notifications.yaml
+++ b/src/api/public/apidocs/paths/my_notifications.yaml
@@ -27,9 +27,7 @@ get:
         enum: ['requests', 'incoming_requests', 'outgoing_requests', 'read']
   responses:
     '200':
-      description: |
-        OK. The request has succeeded.
-
+      description: OK. The request has succeeded.
       content:
         application/xml; charset=utf-8:
           schema:

--- a/src/api/public/apidocs/paths/person.yaml
+++ b/src/api/public/apidocs/paths/person.yaml
@@ -1,7 +1,6 @@
 get:
   summary: List all people.
-  description: |
-    List all people.
+  description: List all people.
   security:
     - basic_authentication: []
   parameters:

--- a/src/api/public/apidocs/paths/published.yaml
+++ b/src/api/public/apidocs/paths/published.yaml
@@ -1,7 +1,6 @@
 get:
   summary: List all the published projects.
-  description: |
-    Get a list of all the projects, all of them are considered published.
+  description: Get a list of all the projects, all of them are considered published.
   security:
     - basic_authentication: []
   responses:

--- a/src/api/public/apidocs/paths/published_project_name.yaml
+++ b/src/api/public/apidocs/paths/published_project_name.yaml
@@ -1,7 +1,6 @@
 get:
   summary: List the repositories of a project with published binaries
-  description: |
-    Get a list of the repositories of the project that already have published binaries.
+  description: Get a list of the repositories of the project that already have published binaries.
   security:
     - basic_authentication: []
   parameters:

--- a/src/api/public/apidocs/paths/published_project_name_repository_name_view_status.yaml
+++ b/src/api/public/apidocs/paths/published_project_name_repository_name_view_status.yaml
@@ -1,7 +1,6 @@
 get:
   summary: Present information about the last publication of the pair project and repository.
-  description: |
-    Get information about the build process (build id, start time, etc.) for the pair project and repository.
+  description: Get information about the build process (build id, start time, etc.) for the pair project and repository.
   security:
     - basic_authentication: []
   parameters:

--- a/src/api/public/apidocs/paths/request_id_cmd_diff.yaml
+++ b/src/api/public/apidocs/paths/request_id_cmd_diff.yaml
@@ -1,7 +1,6 @@
 post:
   summary: Get the diff for all packages affected by the request.
-  description: |
-    Get the diff for all packages affected by the request.
+  description: Get the diff for all packages affected by the request.
   security:
     - basic_authentication: []
   parameters:

--- a/src/api/public/apidocs/paths/search.yaml
+++ b/src/api/public/apidocs/paths/search.yaml
@@ -1,7 +1,6 @@
 get:
   summary: Search in projects or in packages.
-  description: |
-    Get a list of projects or a list of packages that match a XPath expression, passed in the query parameter `match`.
+  description: Get a list of projects or a list of packages that match a XPath expression, passed in the query parameter `match`.
   security:
     - basic_authentication: []
   parameters:
@@ -152,7 +151,6 @@ get:
 post:
   deprecated: true
   summary: Search in projects or in packages.
-  description: |
-    This endpoint is exactly the same as `GET /search`, please use that one.
+  description: This endpoint is exactly the same as `GET /search`, please use that one.
   tags:
     - Search

--- a/src/api/public/apidocs/paths/search_channel.yaml
+++ b/src/api/public/apidocs/paths/search_channel.yaml
@@ -1,7 +1,6 @@
 get:
   summary: List channel objects that match a XPath condition.
-  description: |
-    Return a collection of channel objects with release informations that match a XPath condition.
+  description: Return a collection of channel objects with release informations that match a XPath condition.
   security:
     - basic_authentication: []
   parameters:
@@ -79,7 +78,6 @@ get:
 post:
   deprecated: true
   summary: List channel objects that match a XPath condition.
-  description: |
-    This endpoint is exactly the same as `GET /search/channel`, please use that one.
+  description: This endpoint is exactly the same as `GET /search/channel`, please use that one.
   tags:
     - Search

--- a/src/api/public/apidocs/paths/search_channel_binary.yaml
+++ b/src/api/public/apidocs/paths/search_channel_binary.yaml
@@ -84,7 +84,6 @@ get:
 post:
   deprecated: true
   summary: List channel objects that match a XPath condition.
-  description: |
-    This endpoint is exactly the same as `GET /search/channel/binary`, please use that one.
+  description: This endpoint is exactly the same as `GET /search/channel/binary`, please use that one.
   tags:
     - Search

--- a/src/api/public/apidocs/paths/search_channel_binary_id.yaml
+++ b/src/api/public/apidocs/paths/search_channel_binary_id.yaml
@@ -73,7 +73,6 @@ get:
 post:
   deprecated: true
   summary: List channel objects that match a XPath condition.
-  description: |
-    This endpoint is exactly the same as `GET /search/channel/binary/id`, please use that one.
+  description: This endpoint is exactly the same as `GET /search/channel/binary/id`, please use that one.
   tags:
     - Search

--- a/src/api/public/apidocs/paths/search_issue.yaml
+++ b/src/api/public/apidocs/paths/search_issue.yaml
@@ -84,7 +84,6 @@ get:
 post:
   deprecated: true
   summary: List issues that match a XPath condition.
-  description: |
-    This endpoint is exactly the same as `GET /search/issue`, please use that one.
+  description: This endpoint is exactly the same as `GET /search/issue`, please use that one.
   tags:
     - Search

--- a/src/api/public/apidocs/paths/search_missing_owner.yaml
+++ b/src/api/public/apidocs/paths/search_missing_owner.yaml
@@ -64,7 +64,6 @@ post:
   summary: |
     Search for packages that miss the definition for a by default
     responsible person or group.
-  description: |
-    This endpoint is exactly the same as `GET /search/missing_owner`, please use that one.
+  description: This endpoint is exactly the same as `GET /search/missing_owner`, please use that one.
   tags:
     - Search

--- a/src/api/public/apidocs/paths/search_owner.yaml
+++ b/src/api/public/apidocs/paths/search_owner.yaml
@@ -188,7 +188,6 @@ get:
 post:
   deprecated: true
   summary: Search for the users or groups who are the owners of a project or package.
-  description: |
-    This endpoint is exactly the same as `GET /search/owner`, please use that one.
+  description: This endpoint is exactly the same as `GET /search/owner`, please use that one.
   tags:
     - Search

--- a/src/api/public/apidocs/paths/search_package.yaml
+++ b/src/api/public/apidocs/paths/search_package.yaml
@@ -92,7 +92,6 @@ get:
 post:
   deprecated: true
   summary: List packages that match a XPath condition.
-  description: |
-    This endpoint is exactly the same as `GET /search/package`, please use that one.
+  description: This endpoint is exactly the same as `GET /search/package`, please use that one.
   tags:
     - Search

--- a/src/api/public/apidocs/paths/search_package__id.yaml
+++ b/src/api/public/apidocs/paths/search_package__id.yaml
@@ -1,15 +1,13 @@
 get:
   deprecated: true
   summary: List packages that match a XPath condition.
-  description: |
-    This endpoint is exactly the same as `GET /search/package/id`, please use that one.
+  description: This endpoint is exactly the same as `GET /search/package/id`, please use that one.
   tags:
     - Search
 
 post:
   deprecated: true
   summary: List packages that match a XPath condition.
-  description: |
-    This endpoint is exactly the same as `GET /search/package/id`, please use that one.
+  description: This endpoint is exactly the same as `GET /search/package/id`, please use that one.
   tags:
     - Search

--- a/src/api/public/apidocs/paths/search_package_id.yaml
+++ b/src/api/public/apidocs/paths/search_package_id.yaml
@@ -87,7 +87,6 @@ get:
 post:
   deprecated: true
   summary: List packages that match a XPath condition.
-  description: |
-    This endpoint is exactly the same as `GET /search/package/id`, please use that one.
+  description: This endpoint is exactly the same as `GET /search/package/id`, please use that one.
   tags:
     - Search

--- a/src/api/public/apidocs/paths/search_person.yaml
+++ b/src/api/public/apidocs/paths/search_person.yaml
@@ -74,7 +74,6 @@ get:
 post:
   deprecated: true
   summary: List users that match a XPath condition.
-  description: |
-    This endpoint is exactly the same as `GET /search/person`, please use that one.
+  description: This endpoint is exactly the same as `GET /search/person`, please use that one.
   tags:
     - Search

--- a/src/api/public/apidocs/paths/search_project.yaml
+++ b/src/api/public/apidocs/paths/search_project.yaml
@@ -87,7 +87,6 @@ get:
 post:
   deprecated: true
   summary: List project objects that match a XPath condition.
-  description: |
-    This endpoint is exactly the same as `GET /search/project`, please use that one.
+  description: This endpoint is exactly the same as `GET /search/project`, please use that one.
   tags:
     - Search

--- a/src/api/public/apidocs/paths/search_project__id.yaml
+++ b/src/api/public/apidocs/paths/search_project__id.yaml
@@ -1,15 +1,13 @@
 get:
   deprecated: true
   summary: List projects that match a XPath condition.
-  description: |
-    This endpoint is exactly the same as `GET /search/project/id`, please use that one.
+  description: This endpoint is exactly the same as `GET /search/project/id`, please use that one.
   tags:
     - Search
 
 post:
   deprecated: true
   summary: List projects that match a XPath condition.
-  description: |
-    This endpoint is exactly the same as `GET /search/project/id`, please use that one.
+  description: This endpoint is exactly the same as `GET /search/project/id`, please use that one.
   tags:
     - Search

--- a/src/api/public/apidocs/paths/search_project_id.yaml
+++ b/src/api/public/apidocs/paths/search_project_id.yaml
@@ -79,7 +79,6 @@ get:
 post:
   deprecated: true
   summary: List projects that match a XPath condition.
-  description: |
-    This endpoint is exactly the same as `GET /search/project/id`, please use that one.
+  description: This endpoint is exactly the same as `GET /search/project/id`, please use that one.
   tags:
     - Search

--- a/src/api/public/apidocs/paths/search_published_binary_id.yaml
+++ b/src/api/public/apidocs/paths/search_published_binary_id.yaml
@@ -45,7 +45,6 @@ get:
 post:
   deprecated: true
   summary: Search for currently available binaries in the publish area.
-  description: |
-    This endpoint is exactly the same as `GET /search/published/binary/id`, please use that one.
+  description: This endpoint is exactly the same as `GET /search/published/binary/id`, please use that one.
   tags:
     - Search

--- a/src/api/public/apidocs/paths/search_published_pattern_id.yaml
+++ b/src/api/public/apidocs/paths/search_published_pattern_id.yaml
@@ -32,7 +32,6 @@ get:
 post:
   deprecated: true
   summary: Search for published patterns.
-  description: |
-    This endpoint is exactly the same as `GET /search/published/pattern/id`, please use that one.
+  description: This endpoint is exactly the same as `GET /search/published/pattern/id`, please use that one.
   tags:
     - Search

--- a/src/api/public/apidocs/paths/search_published_repoinfo_id.yaml
+++ b/src/api/public/apidocs/paths/search_published_repoinfo_id.yaml
@@ -32,7 +32,6 @@ get:
 post:
   deprecated: true
   summary: Search for currently available repositories in the publish area.
-  description: |
-    This endpoint is exactly the same as `GET /search/published/repoinfo/id`, please use that one.
+  description: This endpoint is exactly the same as `GET /search/published/repoinfo/id`, please use that one.
   tags:
     - Search

--- a/src/api/public/apidocs/paths/search_released_binary.yaml
+++ b/src/api/public/apidocs/paths/search_released_binary.yaml
@@ -129,7 +129,6 @@ get:
 post:
   deprecated: true
   summary: List released binaries that match a XPath condition.
-  description: |
-    This endpoint is exactly the same as `GET /search/released/binary`, please use that one.
+  description: This endpoint is exactly the same as `GET /search/released/binary`, please use that one.
   tags:
     - Search

--- a/src/api/public/apidocs/paths/search_released_binary_id.yaml
+++ b/src/api/public/apidocs/paths/search_released_binary_id.yaml
@@ -110,7 +110,6 @@ get:
 post:
   deprecated: true
   summary: List released binaries that match a XPath condition.
-  description: |
-    This endpoint is exactly the same as `GET /search/released/binary/id`, please use that one.
+  description: This endpoint is exactly the same as `GET /search/released/binary/id`, please use that one.
   tags:
     - Search

--- a/src/api/public/apidocs/paths/search_repository_id.yaml
+++ b/src/api/public/apidocs/paths/search_repository_id.yaml
@@ -69,7 +69,6 @@ get:
 post:
   deprecated: true
   summary: List repositories that match a XPath condition.
-  description: |
-    This endpoint is exactly the same as `GET /search/repository/id`, please use that one.
+  description: This endpoint is exactly the same as `GET /search/repository/id`, please use that one.
   tags:
     - Search

--- a/src/api/public/apidocs/paths/search_request.yaml
+++ b/src/api/public/apidocs/paths/search_request.yaml
@@ -242,7 +242,6 @@ get:
 post:
   deprecated: true
   summary: List requests objects that match a XPath condition.
-  description: |
-    This endpoint is exactly the same as `GET /search/request`, please use that one.
+  description: This endpoint is exactly the same as `GET /search/request`, please use that one.
   tags:
     - Search

--- a/src/api/public/apidocs/paths/search_request_id.yaml
+++ b/src/api/public/apidocs/paths/search_request_id.yaml
@@ -81,7 +81,6 @@ get:
 post:
   deprecated: true
   summary: List request numbers that match a XPath condition.
-  description: |
-    This endpoint is exactly the same as `GET /search/request/id`, please use that one.
+  description: This endpoint is exactly the same as `GET /search/request/id`, please use that one.
   tags:
     - Search

--- a/src/api/public/apidocs/paths/source.yaml
+++ b/src/api/public/apidocs/paths/source.yaml
@@ -41,8 +41,7 @@ get:
     '401':
       $ref: '../components/responses/unauthorized.yaml'
     '403':
-      description: |
-        No permission to access deleted projects.
+      description: No permission to access deleted projects.
       content:
         application/xml; charset=utf-8:
           schema:

--- a/src/api/public/apidocs/paths/source_project_name_attribute_attribute_name.yaml
+++ b/src/api/public/apidocs/paths/source_project_name_attribute_attribute_name.yaml
@@ -1,7 +1,6 @@
 get:
   summary: Get project's attribute
-  description: |
-    Get a specified attribute of the project
+  description: Get a specified attribute of the project
   security:
   - basic_authentication: []
   parameters:
@@ -68,8 +67,7 @@ get:
 
 post:
   summary: Modifies the specified attribute
-  description: |
-    Modifies the specified attribute
+  description: Modifies the specified attribute
   security:
     - basic_authentication: []
   parameters:
@@ -111,8 +109,7 @@ post:
 
 delete:
   summary: Removes a specified attribute
-  description: |
-    Removes a specified attribute
+  description: Removes a specified attribute
   security:
     - basic_authentication: []
   parameters:

--- a/src/api/public/apidocs/paths/source_project_name_cmd_freezelink.yaml
+++ b/src/api/public/apidocs/paths/source_project_name_cmd_freezelink.yaml
@@ -1,7 +1,6 @@
 post:
   summary: Freeze a project link.
-  description: |
-    Freeze a project link, either creating the freeze or updating it.
+  description: Freeze a project link, either creating the freeze or updating it.
   security:
     - basic_authentication: []
   parameters:

--- a/src/api/public/apidocs/paths/source_project_name_cmd_lock.yaml
+++ b/src/api/public/apidocs/paths/source_project_name_cmd_lock.yaml
@@ -1,7 +1,6 @@
 post:
   summary: Locks the project.
-  description: |
-    Locks the project given as parameter. You can pass a comment with the reason of the lock.
+  description: Locks the project given as parameter. You can pass a comment with the reason of the lock.
   security:
     - basic_authentication: []
   parameters:

--- a/src/api/public/apidocs/paths/source_project_name_cmd_release.yaml
+++ b/src/api/public/apidocs/paths/source_project_name_cmd_release.yaml
@@ -1,7 +1,6 @@
 post:
   summary: Release the project.
-  description: |
-    Release source and binaries for a repository of the project, if you have the permissions to do so.
+  description: Release source and binaries for a repository of the project, if you have the permissions to do so.
   security:
     - basic_authentication: []
   parameters:

--- a/src/api/public/apidocs/paths/source_project_name_cmd_showlinked.yaml
+++ b/src/api/public/apidocs/paths/source_project_name_cmd_showlinked.yaml
@@ -1,7 +1,6 @@
 post:
   summary: List projects linking to the provided project.
-  description: |
-    Return a list of projects linking to the provided project. This command doesn't perform any action.
+  description: Return a list of projects linking to the provided project. This command doesn't perform any action.
   security:
     - basic_authentication: []
   parameters:

--- a/src/api/public/apidocs/paths/source_project_name_cmd_unlock.yaml
+++ b/src/api/public/apidocs/paths/source_project_name_cmd_unlock.yaml
@@ -1,7 +1,6 @@
 post:
   summary: Unlocks the project.
-  description: |
-    Unlocks the previously locked project, given as parameter. You can pass a comment with the reason of the lock.
+  description: Unlocks the previously locked project, given as parameter. You can pass a comment with the reason of the lock.
   security:
     - basic_authentication: []
   parameters:
@@ -37,8 +36,7 @@ post:
                 summary: project 'Sandbox' is not locked.
               summary: Not Locked
     '403':
-      description: |
-        No permission to execute command 'unlock' because the user do not have permission to modify the project.
+      description: No permission to execute command 'unlock' because the user do not have permission to modify the project.
       content:
         application/xml; charset=utf-8:
           schema:

--- a/src/api/public/apidocs/paths/source_project_name_config.yaml
+++ b/src/api/public/apidocs/paths/source_project_name_config.yaml
@@ -1,7 +1,6 @@
 get:
   summary: Get project's configuration
-  description: |
-    Read configuration for the specified project
+  description: Read configuration for the specified project
   security:
     - basic_authentication: []
   parameters:
@@ -31,8 +30,7 @@ get:
 
 put:
   summary: Update project's configuration
-  description: |
-    Update configuration for the specified project
+  description: Update configuration for the specified project
   security:
     - basic_authentication: []
   parameters:

--- a/src/api/public/apidocs/paths/source_project_name_keyinfo.yaml
+++ b/src/api/public/apidocs/paths/source_project_name_keyinfo.yaml
@@ -1,7 +1,6 @@
 get:
   summary: Get a projects signing keys
-  description: |
-    Read information about the signing keys for the specified project
+  description: Read information about the signing keys for the specified project
   security:
     - basic_authentication: []
   parameters:

--- a/src/api/public/apidocs/paths/source_project_name_meta.yaml
+++ b/src/api/public/apidocs/paths/source_project_name_meta.yaml
@@ -1,7 +1,6 @@
 get:
   summary: Get project meta file
-  description: |
-    Get project meta file
+  description: Get project meta file
   security:
     - basic_authentication: []
   parameters:
@@ -53,8 +52,7 @@ get:
 
 put:
   summary: Write project meta file
-  description: |
-    Write project's meta file. Create the project if it doesn't exist.
+  description: Write project's meta file. Create the project if it doesn't exist.
   security:
     - basic_authentication: []
   parameters:
@@ -93,8 +91,7 @@ put:
     '401':
       $ref: '../components/responses/unauthorized.yaml'
     '403':
-      description: |
-        The user does not have permission to change the project.
+      description: The user does not have permission to change the project.
       content:
         application/xml; charset=utf-8:
           schema:

--- a/src/api/public/apidocs/paths/source_project_name_package_name_attribute_attribute_name.yaml
+++ b/src/api/public/apidocs/paths/source_project_name_package_name_attribute_attribute_name.yaml
@@ -1,7 +1,6 @@
 get:
   summary: Get package's attribute
-  description: |
-    Get the specified attribute of the package
+  description: Get the specified attribute of the package
   security:
     - basic_authentication: []
   parameters:
@@ -85,8 +84,7 @@ get:
 
 post:
   summary: Create or update an attribute of a package
-  description: |
-    Create or update the specified attribute of the package
+  description: Create or update the specified attribute of the package
   security:
     - basic_authentication: []
   parameters:

--- a/src/api/public/apidocs/paths/source_project_name_package_name_binary_filename_attribute.yaml
+++ b/src/api/public/apidocs/paths/source_project_name_package_name_binary_filename_attribute.yaml
@@ -1,7 +1,6 @@
 get:
   summary: Get list of attributes and attribute values with binary parameter
-  description: |
-    Get a list of all attributes and their values for a given binary
+  description: Get a list of all attributes and their values for a given binary
   security:
     - basic_authentication: []
   parameters:
@@ -31,8 +30,7 @@ get:
 
 post:
   summary: Add an attribute
-  description: |
-    Add an attribute with binary to a package
+  description: Add an attribute with binary to a package
   security:
     - basic_authentication: []
   parameters:

--- a/src/api/public/apidocs/paths/source_project_name_package_name_binary_filename_attribute_name.yaml
+++ b/src/api/public/apidocs/paths/source_project_name_package_name_binary_filename_attribute_name.yaml
@@ -1,7 +1,6 @@
 get:
   summary: Get values of an attribute
-  description: |
-    Get attribute and attribute values of a given attribute and binary
+  description: Get attribute and attribute values of a given attribute and binary
   security:
     - basic_authentication: []
   parameters:

--- a/src/api/public/apidocs/paths/source_project_name_package_name_cmd_deleteuploadrev.yaml
+++ b/src/api/public/apidocs/paths/source_project_name_package_name_cmd_deleteuploadrev.yaml
@@ -1,7 +1,6 @@
 post:
   summary: Delete all uploaded sources which are not committed yet.
-  description: |
-    Removes all changes made to the upload revision and reverts to last committed revision
+  description: Removes all changes made to the upload revision and reverts to last committed revision
   security:
     - basic_authentication: []
   parameters:

--- a/src/api/public/apidocs/paths/source_project_name_package_name_cmd_unlock.yaml
+++ b/src/api/public/apidocs/paths/source_project_name_package_name_cmd_unlock.yaml
@@ -1,7 +1,6 @@
 post:
   summary: Unlock a locked package.
-  description: |
-    Unlock a locked package (`<lock><enable/></lock>` flag present in the package `_meta` file).
+  description: Unlock a locked package (`<lock><enable/></lock>` flag present in the package `_meta` file).
   security:
     - basic_authentication: []
   parameters:

--- a/src/api/public/apidocs/paths/source_project_name_pattern.yaml
+++ b/src/api/public/apidocs/paths/source_project_name_pattern.yaml
@@ -1,7 +1,6 @@
 get:
   summary: Get list of patterns
-  description: |
-    Get a list of all patterns for the project
+  description: Get a list of all patterns for the project
   security:
     - basic_authentication: []
   parameters:

--- a/src/api/public/apidocs/paths/source_project_name_pattern_file_name.yaml
+++ b/src/api/public/apidocs/paths/source_project_name_pattern_file_name.yaml
@@ -70,8 +70,7 @@ put:
             comment:
             requestid:
     '400':
-      description: |
-        Error: Bad request.
+      description: "Error: Bad request."
       content:
         application/xml; charset=utf-8:
           schema:

--- a/src/api/public/apidocs/paths/source_project_name_project.yaml
+++ b/src/api/public/apidocs/paths/source_project_name_project.yaml
@@ -1,7 +1,6 @@
 get:
   summary: List project files
-  description: |
-    List all the files in project
+  description: List all the files in project
   security:
     - basic_authentication: []
   parameters:

--- a/src/api/public/apidocs/paths/source_project_name_project_file.yaml
+++ b/src/api/public/apidocs/paths/source_project_name_project_file.yaml
@@ -1,7 +1,6 @@
 get:
   summary: Read a project file
-  description: |
-    Read a project file
+  description: Read a project file
   security:
     - basic_authentication: []
   parameters:
@@ -61,8 +60,7 @@ get:
     '401':
       $ref: '../components/responses/unauthorized.yaml'
     '403':
-      description: |
-        The user does not have permission to access the source.
+      description: The user does not have permission to access the source.
       content:
         application/xml; charset=utf-8:
           schema:

--- a/src/api/public/apidocs/paths/source_project_name_pubkey.yaml
+++ b/src/api/public/apidocs/paths/source_project_name_pubkey.yaml
@@ -46,8 +46,7 @@ get:
 
 delete:
   summary: Removes the current gpg key
-  description: |
-    Removes the current gpg key if it exists
+  description: Removes the current gpg key if it exists
   security:
     - basic_authentication: []
   parameters:

--- a/src/api/public/apidocs/paths/staging_project_name_backlog.yaml
+++ b/src/api/public/apidocs/paths/staging_project_name_backlog.yaml
@@ -1,7 +1,6 @@
 get:
   summary: List the requests in the staging backlog.
-  description: |
-    List the requests that can be assigned to the staging project (backlog).
+  description: List the requests that can be assigned to the staging project (backlog).
   security:
     - basic_authentication: []
   parameters:

--- a/src/api/public/apidocs/paths/staging_project_name_staging_projects.yaml
+++ b/src/api/public/apidocs/paths/staging_project_name_staging_projects.yaml
@@ -32,8 +32,7 @@ get:
         type: string
         example:
           1
-      description: |
-        "Set to `1` if you want to include the history of the staging project, otherwise don't pass this query parameter."
+      description: "Set to `1` if you want to include the history of the staging project, otherwise don't pass this query parameter."
   responses:
     '200':
       description: OK. The request has succeeded.

--- a/src/api/public/apidocs/paths/staging_project_name_staging_projects_staging_project_name.yaml
+++ b/src/api/public/apidocs/paths/staging_project_name_staging_projects_staging_project_name.yaml
@@ -32,8 +32,7 @@ get:
         type: string
         enum:
           - 1
-      description: |
-        Set to `1` if you want to include the history of the staging project, otherwise don't pass this query parameter.
+      description: Set to `1` if you want to include the history of the staging project, otherwise don't pass this query parameter.
   responses:
     '200':
       description: Get the state of a staging project.

--- a/src/api/public/apidocs/paths/staging_project_name_workflow.yaml
+++ b/src/api/public/apidocs/paths/staging_project_name_workflow.yaml
@@ -1,7 +1,6 @@
 post:
   summary: Create a staging workflow for the specified project
-  description: |
-    Create a staging workflow associated to the project and the manager group specified in the body of the request
+  description: Create a staging workflow associated to the project and the manager group specified in the body of the request
   security:
     - basic_authentication: []
   parameters:
@@ -51,8 +50,7 @@ post:
 
 put:
   summary: Change the managers group of a staging workflow
-  description: |
-    Change the managers group of the staging workflow associated to the specified project.
+  description: Change the managers group of the staging workflow associated to the specified project.
   security:
     - basic_authentication: []
   parameters:

--- a/src/api/public/apidocs/paths/statistics_deprecated_not_documented.yaml
+++ b/src/api/public/apidocs/paths/statistics_deprecated_not_documented.yaml
@@ -1,7 +1,6 @@
 get:
   deprecated: true
   summary: This endpoint is deprecated
-  description: |
-    This endpoint is no longer supported or might not work as expected.
+  description: This endpoint is no longer supported or might not work as expected.
   tags:
     - Statistics

--- a/src/api/public/apidocs/paths/status_message.yaml
+++ b/src/api/public/apidocs/paths/status_message.yaml
@@ -1,7 +1,6 @@
 get:
   summary: Get list of status messages
-  description: |
-    Get a list of all status messages
+  description: Get a list of all status messages
   security:
     - basic_authentication: []
   parameters:

--- a/src/api/public/apidocs/paths/status_messages.yaml
+++ b/src/api/public/apidocs/paths/status_messages.yaml
@@ -1,7 +1,6 @@
 get:
   summary: Get list of status messages
-  description: |
-    Get a list of all status messages
+  description: Get a list of all status messages
   security:
     - basic_authentication: []
   parameters:

--- a/src/api/public/apidocs/paths/status_messages_id.yaml
+++ b/src/api/public/apidocs/paths/status_messages_id.yaml
@@ -1,7 +1,6 @@
 get:
   summary: Get a status message
-  description: |
-    Find a status message with id
+  description: Find a status message with id
   security:
     - basic_authentication: []
   parameters:
@@ -33,8 +32,7 @@ get:
 
 delete:
   summary: Delete a status message
-  description: |
-    Delete a status message with id
+  description: Delete a status message with id
   security:
     - basic_authentication: []
   parameters:

--- a/src/api/public/apidocs/paths/status_project_name.yaml
+++ b/src/api/public/apidocs/paths/status_project_name.yaml
@@ -1,7 +1,6 @@
 get:
   summary: Get list of packages inside a project
-  description: |
-    Get a full list of packages and their status
+  description: Get a full list of packages and their status
   security:
     - basic_authentication: []
   parameters:

--- a/src/api/public/apidocs/paths/trigger_operation.yaml
+++ b/src/api/public/apidocs/paths/trigger_operation.yaml
@@ -43,15 +43,13 @@ post:
       example: 123458568938927827827
     - in: header
       name: X-GitLab-Token
-      description: |
-        The API token secret.
+      description: The API token secret.
       schema:
         type: string
       example: THE_TOKEN_SECRET
     - in: header
       name: Authorization
-      description: |
-        The API token secret in the Token realm.
+      description: The API token secret in the Token realm.
       schema:
         type: string
       example: Token THE_TOKEN_SECRET

--- a/src/api/public/apidocs/paths/trigger_webhook.yaml
+++ b/src/api/public/apidocs/paths/trigger_webhook.yaml
@@ -1,8 +1,7 @@
 post:
   deprecated: true
   summary: Trigger an operation
-  description: |
-    This endpoint behaves exactly as the [/trigger](#/Trigger) endpoint.
+  description: This endpoint behaves exactly as the [/trigger](#/Trigger) endpoint.
   security:
     - GitLab_key_authentication: []
   tags:

--- a/src/api/public/apidocs/paths/trigger_workflow.yaml
+++ b/src/api/public/apidocs/paths/trigger_workflow.yaml
@@ -38,15 +38,13 @@ post:
       example: 123458568938927827827
     - in: header
       name: X-GitLab-Token
-      description: |
-        The API token secret.
+      description: The API token secret.
       schema:
         type: string
       example: THE_TOKEN_SECRET
     - in: header
       name: Authorization
-      description: |
-        The API token secret in the Token realm.
+      description: The API token secret in the Token realm.
       schema:
         type: string
       example: Token THE_TOKEN_SECRET

--- a/src/api/public/apidocs/paths/worker__status.yaml
+++ b/src/api/public/apidocs/paths/worker__status.yaml
@@ -1,7 +1,6 @@
 get:
   summary: Lists status of workers, jobs, backend services and general statistics.
-  description: |
-    Lists status of workers, running jobs, waiting jobs, status of the backend services and general statistics.
+  description: Lists status of workers, running jobs, waiting jobs, status of the backend services and general statistics.
   security:
     - basic_authentication: []
   responses:


### PR DESCRIPTION
This is related to PR #15505.
This PR addresses another issue found with the `|` string literal symbol:
If used on single line strings, the formatter of the documentation generator will cause otherwise legal YAML strings to become invalid by moving terminating quotes to the very start of a new line. Since these strings aren't multi-line in the first place, we should be able to simply move them into the same line.

## Before
```yaml
...
      responses:
        '200':
          description: 'OK. The request has succeeded.

'
          content:
...
```
## After
```yaml
...
      responses:
        '200':
          description: OK. The request has succeeded.
          content:
...
```