### PR TITLE
Prevent N+1 query in project page

### DIFF
--- a/src/api/app/datatables/package_datatable.rb
+++ b/src/api/app/datatables/package_datatable.rb
@@ -27,7 +27,7 @@ class PackageDatatable < Datatable
   # rubocop:enable Naming/AccessorMethodName
 
   def data
-    records.map do |record|
+    records.eager_load(:package_kinds).select("packages.*, bit_or(kind = 'link') AS kind_link").group('packages.id').map do |record|
       {
         name: name_with_link(record),
         changed: format('%{duration} ago',
@@ -39,7 +39,7 @@ class PackageDatatable < Datatable
   def name_with_link(record)
     name = []
     name << link_to(record.name, package_show_path(package: record, project: @project))
-    name << tag.span('Link', class: 'badge text-bg-info') if record.is_link?
+    name << tag.span('Link', class: 'badge text-bg-info') if record.kind_link == 1
     safe_join(name, ' ')
   end
 end


### PR DESCRIPTION
Before, an aditional query was performed to check if a package was a link, for each package of a project.

Check if a package is a link by joining the `package_links` table into the query that retrieves the packages of a project.

These are logs from loading a project page ( http://localhost:3000/project/show/home:Admin for this example ) in a development environment:

**Before:**

```
frontend-1  |     ↳ app/controllers/webui/package_controller.rb:32:in `index'                                               
frontend-1  |     Package Load (0.8ms)  SELECT `packages`.* FROM `packages` WHERE `packages`.`id` NOT IN (SELECT `packages`.`id` FROM `packages` WHERE `packages`.`project_id` = 0) AND `packages`.`project_id` = 2 ORDER BY packages.name ASC LIMIT 50 OFFSET 0
[...]
frontend-1  |    ↳ app/models/package.rb:504:in `is_of_kind?'
frontend-1  |    PackageKind Exists? (0.6ms)  SELECT 1 AS one FROM `package_kinds` WHERE `package_kinds`.`package_id` = 29
[...]
Completed 200 OK in 186ms (Views: 131.1ms | ActiveRecord: 26.9ms | Allocations: 74875)
```

**After:**

```
frontend-1  |    ↳ app/controllers/webui/package_controller.rb:32:in `index'
frontend-1  |    SQL (1.9ms)  SELECT packages.*, bit_or(kind = 'link') AS kind_link, `packages`.`id` AS t0_r0, `package_kinds`.`id` AS t1_r0, `package_kinds`.`package_id` AS t1_r1, `package_kinds`.`kind` AS t1_r2 FROM `packages` LEFT OUTER JOIN `package_kinds` ON `package_kinds`.`package_id` = `packages`.`id` WHERE `packages`.`id` NOT IN (SELECT `packages`.`id` FROM `packages` WHERE `packages`.`project_id` = 0) AND `packages`.`project_id` = 2 GROUP BY `packages`.`id` ORDER BY packages.name ASC LIMIT 50 OFFSET 0
[...]
Completed 200 OK in 81ms (Views: 44.6ms | ActiveRecord: 7.0ms | Allocations: 40892)
```