### PR TITLE
[backend] BSX509::keydata2pubkey: add a default NULL parameter for rsa

### DIFF
--- a/src/backend/BSX509.pm
+++ b/src/backend/BSX509.pm
@@ -363,6 +363,7 @@ sub keydata2pubkey {
   my ($algoparams, $bits);
   if ($algo eq 'rsa') {
     $bits = BSASN1::pack_sequence(BSASN1::pack_integer_mpi($keydata->{'mpis'}->[0]->{'data'}), BSASN1::pack_integer_mpi($keydata->{'mpis'}->[1]->{'data'}));
+    $algoparams = BSASN1::pack_null();	# compat
   } elsif ($algo eq 'dsa') {
     my @mpis = @{$keydata->{'mpis'} || []};
     $bits = BSASN1::pack_integer_mpi((pop @mpis)->{'data'});


### PR DESCRIPTION
We already did this in the past, but since commit
617380990f447497b552f7eb85623334cde39944 passing an undef does not automatically add a NULL.