### PR TITLE
[backend] change default compression for createrepo to gz

### DIFF
--- a/dist/functions.setup-appliance.sh
+++ b/dist/functions.setup-appliance.sh
@@ -155,7 +155,8 @@ function get_hostname {
     done
     if [ -z "$FQHOSTNAME" -o "$FQHOSTNAME" = "localhost" ] && [ -x "$(command -v hostnamectl)" ];then
       FQHOSTNAME=`hostnamectl --static 2>/dev/null`
-    elif [ -s /etc/hostname ];then
+    fi
+    if [ -z "$FQHOSTNAME" -o "$FQHOSTNAME" = "localhost" -a -s /etc/hostname ];then
       FQHOSTNAME=`cat /etc/hostname`
     fi
   fi

--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -199,7 +199,8 @@ Requires(pre):  shadow
 %endif
 
 %if 0%{?suse_version:1}
-Recommends:     yum yum-metadata-parser repoview dpkg
+Recommends:     yum yum-metadata-parser repoview 
+Recommends:     dpkg >= 1.20
 Recommends:     deb >= 1.5
 Recommends:     lvm2
 Recommends:     openslp-server

--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -640,8 +640,10 @@ sub createrepo_rpmmd {
   # createrepo_c 1.0.0 changed the default to zstd. In order to preserve
   # compatibility with SLE12 and SLE15 GA we need to set gz
   if ($options{'compression-zstd'}) {
-    push @legacyargs, '--compress-type=zst';
+    push @createrepoargs, '--general-compress-type=zstd';
+    push @legacyargs, '--compress-type=zstd';
   } else {
+    push @createrepoargs, '--general-compress-type=gz';
     push @legacyargs, '--compress-type=gz';
   }
   my @updateargs;


### PR DESCRIPTION
According to the documentation, the correct option for createrepo_c to compress also primary/filelists/other xml files with gz compression is `--general-compress-type=gz`

Taken from `createrepo_c --help`:

```
--general-compress-type=COMPRESSION_TYPE     Which compression type to use (even for primary, filelists and other xml).
```