### PR TITLE
Add link to create a New Image to the main page

### DIFF
--- a/src/api/app/views/webui/main/_index_actions.html.haml
+++ b/src/api/app/views/webui/main/_index_actions.html.haml
@@ -4,3 +4,7 @@
       = link_to(new_project_path, class: 'nav-link', title: 'Create Project') do
         %i.fas.fa-plus-circle.fa-lg.me-2
         %span.nav-item-name Create Project
+    %li.nav-item
+      = link_to(image_templates_path, class: 'nav-link', title: 'New Image') do
+        %i.fas.fa-compact-disc.fa-lg.me-2
+        %span.nav-item-name New Image


### PR DESCRIPTION
Some users aren't aware OBS can be used to create images. They only see this link when they enter a project page.

![Screenshot from 2024-01-24 16-31-05_with_box](https://github.com/openSUSE/open-build-service/assets/24919/bc044849-71b0-4726-8ee9-725438e433dd)
