### PR TITLE
List all comments for a specific user

### DIFF
--- a/src/api/app/components/bs_request_comment_component.html.haml
+++ b/src/api/app/components/bs_request_comment_component.html.haml
@@ -1,6 +1,7 @@
 .d-flex.mt-3.align-items-start
-  %i{ title: 'Comment', class: "fas fa-lg fa-comment #{ level > 1 ? 'd-none' : '' }" }
-  = render(AvatarComponent.new(name: comment.user.name, email: comment.user.email, size: 35, shape: :circle, custom_css: 'avatars-counter'))
+  - unless @nodecoration
+    %i{ title: 'Comment', class: "fas fa-lg fa-comment #{ level > 1 ? 'd-none' : '' }" }
+    = render(AvatarComponent.new(name: comment.user.name, email: comment.user.email, size: 35, shape: :circle, custom_css: 'avatars-counter'))
   .timeline-item-comment.ms-0.flex-fill.overflow-auto
     .comment-bubble.ms-3
       - if policy(comment).update? || policy(comment).destroy?
@@ -24,10 +25,10 @@
                             class: 'dropdown-item delete_link', title: 'Delete comment') do
                 Delete
       .px-3.py-2.border-bottom
-        = link_to(helpers.realname_with_login(comment.user), user_path(comment.user))
-        \-
-        = link_to("#comment-#{comment.id}", title: l(comment.created_at.utc), name: "comment-#{comment.id}") do
-          = render TimeComponent.new(time: comment.created_at)
+        - unless @nodecoration
+          = link_to(helpers.realname_with_login(comment.user), user_path(comment.user))
+          \-
+        = link_to_comment(comment)
         = render CommentHistoryComponent.new(comment)
       - if comment.diff_ref && diff
         - action = comment.commentable

--- a/src/api/app/components/bs_request_comment_component.rb
+++ b/src/api/app/components/bs_request_comment_component.rb
@@ -5,17 +5,26 @@
 class BsRequestCommentComponent < ApplicationComponent
   attr_reader :comment, :commentable, :level, :diff
 
-  def initialize(comment:, commentable:, level:, diff: nil)
+  def initialize(comment:, commentable:, level:, diff: nil, nodecoration: false)
     super
 
     @comment = comment
     @commentable = commentable
     @level = level
     @diff = diff
+    @nodecoration = nodecoration
   end
 
   def range
     line_index = @comment.diff_ref.match(/diff_[0-9]+_n([0-9]+)/).captures.first
     ((line_index.to_i - 4).clamp(0..)..(line_index.to_i - 1))
+  end
+
+  def link_to_comment(comment)
+    helpers.link_to(helpers.commentable_path(comment: comment),
+                    title: l(comment.created_at.utc),
+                    name: "comment-#{comment.id}") do
+      render TimeComponent.new(time: comment.created_at)
+    end
   end
 end

--- a/src/api/app/controllers/webui/users_controller.rb
+++ b/src/api/app/controllers/webui/users_controller.rb
@@ -32,6 +32,8 @@ class Webui::UsersController < Webui::WebuiController
     @date = params[:date]
     @activities_per_day = UserDailyContribution.new(@displayed_user, @date).call
     handle_notification
+
+    @comments = paged_comments
   end
 
   def new
@@ -195,5 +197,11 @@ class Webui::UsersController < Webui::WebuiController
 
     @current_notification = Notification.find(params[:notification_id])
     authorize @current_notification, :update?, policy_class: NotificationPolicy
+  end
+
+  def paged_comments
+    comments = @displayed_user.comments.newest_first
+    params[:page] = comments.page(params[:page]).total_pages if comments.page(params[:page]).out_of_range?
+    comments.page(params[:page])
   end
 end

--- a/src/api/app/helpers/webui/reportables_helper.rb
+++ b/src/api/app/helpers/webui/reportables_helper.rb
@@ -34,4 +34,24 @@ module Webui::ReportablesHelper
       link_to("#{commentable.name}", Rails.application.routes.url_helpers.project_show_url(commentable, anchor: 'comments-list', only_path: false, host: host))
     end
   end
+
+  def commentable_path(comment:)
+    anchor = "comment-#{comment.id}"
+    case comment.commentable
+    when BsRequest
+      Rails.application.routes.url_helpers.request_show_path(comment.commentable.number,
+                                                             anchor: anchor)
+    when BsRequestAction
+      Rails.application.routes.url_helpers.request_show_path(number: comment.commentable.bs_request.number,
+                                                             request_action_id: comment.commentable.id,
+                                                             anchor: 'tab-pane-changes')
+    when Package
+      Rails.application.routes.url_helpers.package_show_path(package: comment.commentable,
+                                                             project: comment.commentable.project,
+                                                             anchor: anchor)
+    when Project
+      Rails.application.routes.url_helpers.project_show_path(comment.commentable,
+                                                             anchor: anchor)
+    end
+  end
 end

--- a/src/api/app/models/comment.rb
+++ b/src/api/app/models/comment.rb
@@ -30,6 +30,7 @@ class Comment < ApplicationRecord
 
   scope :on_actions_for_request, ->(bs_request) { where(commentable: BsRequestAction.where(bs_request: bs_request)) }
   scope :without_parent, -> { where(parent_id: nil) }
+  scope :newest_first, -> { order(created_at: :desc) }
 
   def to_s
     body

--- a/src/api/app/views/webui/user/_comments.html.haml
+++ b/src/api/app/views/webui/user/_comments.html.haml
@@ -1,0 +1,6 @@
+.card.mb-3
+  .card-body
+    %h5 These are all the comments this user made
+    - comments.each do |comment|
+      = render BsRequestCommentComponent.new(comment: comment, level: 1, commentable: comment.commentable, nodecoration: true)
+    = paginate comments, view_prefix: 'webui', window: 2, params: { anchor: 'tab-pane-comments', id: nil }

--- a/src/api/app/views/webui/user/_involvement_and_activity.html.haml
+++ b/src/api/app/views/webui/user/_involvement_and_activity.html.haml
@@ -15,6 +15,12 @@
           = link_to('#activity', id: 'activity-tab', class: 'nav-link text-nowrap',
                     data: { 'bs-toggle': 'tab' }, role: 'tab', aria: { controls: 'activity', selected: false }) do
             Contributions
+        - if Flipper.enabled?(:content_moderation, User.session)
+          - if policy(Report.new(reportable: displayed_user)).create?
+            %li.nav-item
+              = link_to('#comments', id: 'comments-tab', class: 'nav-link text-nowrap',
+                        data: { 'bs-toggle': 'tab' }, role: 'tab', aria: { controls: 'comments', selected: false }) do
+                Comments
 
   .card-body.p-0#involvement-and-activity
     = render partial: 'webui/user/involvement', locals: { involved_items_service: involved_items_service }
@@ -31,6 +37,10 @@
                                                              user: displayed_user,
                                                              date: date,
                                                              activities_per_day: activities_per_day }
+    - if Flipper.enabled?(:content_moderation, User.session)
+      - if policy(Report.new(reportable: displayed_user)).create?
+        .tab-pane.fade#comments{ role: 'tabpanel', aria: { labelledby: 'comments-tab' } }
+          = render partial: 'webui/user/comments', locals: { comments: comments }
 
 - content_for :ready_function do
   :plain

--- a/src/api/app/views/webui/users/show.html.haml
+++ b/src/api/app/views/webui/users/show.html.haml
@@ -13,7 +13,7 @@
                                                    configuration: @configuration,
                                                    account_edit_link: @account_edit_link }
   .col-12.col-md-8.col-xxl-9.ps-md-0
-    - locals = { involved_items_service: @involved_items_service }
+    - locals = { involved_items_service: @involved_items_service, comments: @comments }
     - locals.merge!({ displayed_user: @displayed_user,
                       activities_per_year: @activities_per_year,
                       first_day: @first_day,


### PR DESCRIPTION
We're rendering the comments in a new tab under the user profile, alongside the involvement and the activity.

This is how it looks like now:
![image](https://github.com/openSUSE/open-build-service/assets/2650/d8eb1e03-4f0b-4808-8526-4bc5489463cf)
