### PR TITLE
Don't fetch unneeded information for JSON requests

### DIFF
--- a/src/api/app/controllers/webui/webui_controller.rb
+++ b/src/api/app/controllers/webui/webui_controller.rb
@@ -19,8 +19,8 @@ class Webui::WebuiController < ActionController::Base
   before_action :check_anonymous
   before_action :set_influxdb_data
   before_action :require_configuration
-  before_action :current_announcement
-  before_action :fetch_watchlist_items
+  before_action :current_announcement, unless: -> { request.xhr? }
+  before_action :fetch_watchlist_items, unless: -> { request.xhr? }
   after_action :clean_cache
   before_action :set_paper_trail_whodunnit
 


### PR DESCRIPTION
The current announcement and the watchlist items are not needed to be fetched in JSON requests.

Seen while working on #15537.

These requests (taken from my development environment) will not show any more for every JSON request:
```
frontend-1 | StatusMessage Load (0.5ms)  SELECT `status_messages`.* FROM `status_messages` WHERE `status_messages`.`severity` = 4 Y created_at DESC LIMIT 1
frontend-1 | ↳ app/models/status_message.rb:40:in `latest_for_current_user'
frontend-1 | StatusMessageAcknowledgement Load (0.5ms)  SELECT `status_message_acknowledgements`.* FROM `status_message_acknowledg25 AND `status_message_acknowledgements`.`user_id` = 1 LIMIT 1
frontend-1 | ↳ app/models/status_message.rb:42:in `latest_for_current_user'
frontend-1 | WatchedItem Pluck (0.4ms)  SELECT `watched_items`.`watchable_id` FROM `watched_items` WHERE `watched_items`.`user_id`
frontend-1 | ↳ app/models/user.rb:870:in `watched_requests'
frontend-1 | WatchedItem Pluck (0.4ms)  SELECT `watched_items`.`watchable_id` FROM `watched_items` WHERE `watched_items`.`user_id`
frontend-1 | ↳ app/models/user.rb:874:in `watched_packages'
frontend-1 | WatchedItem Pluck (0.4ms)  SELECT `watched_items`.`watchable_id` FROM `watched_items` WHERE `watched_items`.`user_id` = 1 AND `watched_items`.`watchable_type` = 'Project'
```

### For reviewers

Take a look at the logs while going over paginated elements. For example: packages of a project, files of a package, ... Currently, you will see those queries being performed. After the changes, they will not appear in the logs.