### PR TITLE
Refresh Build Results Summary only in the request page

### DIFF
--- a/src/api/app/assets/javascripts/webui/request_show_redesign/chart_build_results.js
+++ b/src/api/app/assets/javascripts/webui/request_show_redesign/chart_build_results.js
@@ -13,5 +13,3 @@ function updateChartBuildResults() {
     }
   });
 }
-
-setInterval(updateChartBuildResults, 60000);

--- a/src/api/app/views/webui/request/beta_show.html.haml
+++ b/src/api/app/views/webui/request/beta_show.html.haml
@@ -112,6 +112,7 @@
               .chart_build_results_wrapper{ data: { url: request_chart_build_results_path } }
               :javascript
                 updateChartBuildResults();
+                setInterval(updateChartBuildResults, 60000);
 
               = render AccordionReviewsComponent.new(@request_reviews, @bs_request)
               = render RequestDecisionComponent.new(bs_request: @bs_request, action: @action,


### PR DESCRIPTION
Prevent from requesting an update on the Build Results Summary on every page. We only update the summary in the main page of the request.

Seen while working on #15537.