### PR TITLE
[api] Fix crash on package removal

### DIFF
--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -109,9 +109,7 @@ class Package < ApplicationRecord
   validate :valid_name
 
   has_one :backend_package, foreign_key: :package_id, dependent: :destroy, inverse_of: :package # rubocop:disable Rails/RedundantForeignKey
-  has_one :token, class_name: 'Token::Service', dependent: :destroy
-
-  has_many :tokens, class_name: 'Token::Service', dependent: :destroy, inverse_of: :package
+  has_many :tokens, class_name: 'Token', dependent: :destroy, inverse_of: :package
 
   def self.check_access?(package)
     return false if package.nil?

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -109,7 +109,7 @@ class Package < ApplicationRecord
   validate :valid_name
 
   has_one :backend_package, foreign_key: :package_id, dependent: :destroy, inverse_of: :package # rubocop:disable Rails/RedundantForeignKey
-  has_many :tokens, class_name: 'Token', dependent: :destroy, inverse_of: :package
+  has_many :tokens, dependent: :destroy
 
   def self.check_access?(package)
     return false if package.nil?

--- a/src/api/spec/controllers/person/token_controller_spec.rb
+++ b/src/api/spec/controllers/person/token_controller_spec.rb
@@ -82,13 +82,15 @@ RSpec.describe Person::TokenController do
 
       before do
         login user
-        post :create, params: { login: user.login, package: package, project: package.project, operation: 'runservice' }, format: :xml
       end
 
+      subject { post :create, params: { login: user.login, package: package, project: package.project, operation: 'runservice' }, format: :xml }
+
       it { expect(response).to have_http_status(:success) }
-      it { expect(response).to render_template(:create) }
-      it { expect(user.tokens.where(package: package)).to exist }
-      it { expect(assigns(:token)).to eq(package.tokens.first) }
+
+      it 'creates a token' do
+        expect { subject }.to change { user.tokens.count }.by(+1)
+      end
     end
 
     context 'operation is workflow' do

--- a/src/api/spec/controllers/person/token_controller_spec.rb
+++ b/src/api/spec/controllers/person/token_controller_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Person::TokenController do
       it { expect(response).to have_http_status(:success) }
       it { expect(response).to render_template(:create) }
       it { expect(user.tokens.where(package: package)).to exist }
-      it { expect(assigns(:token)).to eq(package.token) }
+      it { expect(assigns(:token)).to eq(package.tokens.first) }
     end
 
     context 'operation is workflow' do


### PR DESCRIPTION
Any token still might exist and they need to be cleaned up. Otherwise we run into a database constraint error.

Discovered by osc test suite.