### PR TITLE
Fix colouring for footer text

### DIFF
--- a/src/api/app/assets/stylesheets/webui/sponsors.scss
+++ b/src/api/app/assets/stylesheets/webui/sponsors.scss
@@ -4,7 +4,6 @@
 
     font-size: 0.9rem;
     text-transform: uppercase;
-    color: $gray-700;
     font-weight: bold;
 }
 

--- a/src/api/app/assets/stylesheets/webui/sticky-footer.scss
+++ b/src/api/app/assets/stylesheets/webui/sticky-footer.scss
@@ -7,26 +7,12 @@ body {
 }
 
 #footer {
-  strong {
-    color: $gray-300;
-  }
-
   & a {
     font-size: .9rem;
-    color: $gray-400;
-
-    &:hover {
-        color: $gray-300;
-    }
   }
 
   ul {
     @extend .list-unstyled;
     @extend .mt-1;
-  }
-  #footer-legal {
-    p {
-      color: $gray-300;
-    }
   }
 }


### PR DESCRIPTION
Before it was coloured based on the light theme but we need it to adapt to each theme. On the dark theme the text was too dark and made difficult to read.

Before:
![image](https://github.com/openSUSE/open-build-service/assets/11314634/cccd1c8e-7dd1-4af0-95c7-947fa144f94a)

After:
![image](https://github.com/openSUSE/open-build-service/assets/11314634/b07d50cf-feec-4f2c-8656-2729cd77cfb6)
