### PR TITLE
Show notification bar on user page

### DIFF
--- a/src/api/app/components/notification_notifiable_link_component.rb
+++ b/src/api/app/components/notification_notifiable_link_component.rb
@@ -123,7 +123,7 @@ class NotificationNotifiableLinkComponent < ApplicationComponent
     when 'Event::ReportForProject', 'Event::ReportForPackage'
       @notification.event_type.constantize.notification_link_path(@notification)
     when 'Event::ReportForUser'
-      Rails.application.routes.url_helpers.user_path(@notification.event_payload['user_login'])
+      Rails.application.routes.url_helpers.user_path(@notification.event_payload['user_login'], notification_id: @notification.id)
     when 'Event::ReportForRequest'
       bs_request = @notification.notifiable.reportable
       Rails.application.routes.url_helpers.request_show_path(bs_request.number, notification_id: @notification.id)

--- a/src/api/app/controllers/webui/users_controller.rb
+++ b/src/api/app/controllers/webui/users_controller.rb
@@ -31,6 +31,7 @@ class Webui::UsersController < Webui::WebuiController
     @activities_per_year = UserYearlyContribution.new(@displayed_user, @first_day).call
     @date = params[:date]
     @activities_per_day = UserDailyContribution.new(@displayed_user, @date).call
+    handle_notification
   end
 
   def new
@@ -187,5 +188,12 @@ class Webui::UsersController < Webui::WebuiController
   def assign_admin_attributes
     @displayed_user.assign_attributes(params[:user].slice(:state, :ignore_auth_services).permit!)
     @displayed_user.update_globalroles(Role.global.where(id: params[:user][:role_ids])) unless params[:user][:role_ids].nil?
+  end
+
+  def handle_notification
+    return unless User.session && params[:notification_id]
+
+    @current_notification = Notification.find(params[:notification_id])
+    authorize @current_notification, :update?, policy_class: NotificationPolicy
   end
 end


### PR DESCRIPTION
The notification bar is not available on the user page. The notification bar should be present if a user navigates to the user's profile through the notifications menu