### PR TITLE
Bugfix: do not create link over a non-existing object

### DIFF
--- a/src/api/app/helpers/webui/reportables_helper.rb
+++ b/src/api/app/helpers/webui/reportables_helper.rb
@@ -4,6 +4,8 @@ module Webui::ReportablesHelper
 
   def link_to_reportables(report_id:, reportable_type:, host:)
     reportable = Report.find(report_id).reportable
+    return if reportable.blank?
+
     case reportable_type
     when 'Comment'
       link_to_commentables_on_reportables(commentable: reportable.commentable, host: host)


### PR DESCRIPTION
Fixes: #15532 Fixes: #15533

Do not try to create any link if the `reportable` object is not found/does not exist anymore.