### PR TITLE
Improve event email for reportable

### DIFF
--- a/src/api/app/helpers/webui/reportables_helper.rb
+++ b/src/api/app/helpers/webui/reportables_helper.rb
@@ -4,7 +4,7 @@ module Webui::ReportablesHelper
 
   def link_to_reportables(report_id:, reportable_type:, host:)
     reportable = Report.find(report_id).reportable
-    return if reportable.blank?
+    return "The reported #{reportable_type.downcase} does not exist anymore." if reportable.blank?
 
     case reportable_type
     when 'Comment'

--- a/src/api/app/models/event/appeal_created.rb
+++ b/src/api/app/models/event/appeal_created.rb
@@ -8,7 +8,7 @@ module Event
 
     def subject
       appeal = Appeal.find(payload['id'])
-      "Appeal to #{appeal.decision.reports.first.reportable&.class&.name} decision".squish
+      "Appeal to #{appeal.decision.reports.first.reportable&.class&.name || appeal.decision.reports.first.reportable_type} decision".squish
     end
   end
 end

--- a/src/api/app/models/event/cleared_decision.rb
+++ b/src/api/app/models/event/cleared_decision.rb
@@ -7,7 +7,7 @@ module Event
 
     def subject
       decision = Decision.find(payload['id'])
-      "Cleared #{decision.reports.first.reportable&.class&.name} Report".squish
+      "Cleared #{decision.reports.first.reportable&.class&.name || decision.reports.first.reportable_type} Report".squish
     end
 
     def parameters_for_notification

--- a/src/api/app/models/event/favored_decision.rb
+++ b/src/api/app/models/event/favored_decision.rb
@@ -7,7 +7,7 @@ module Event
 
     def subject
       decision = Decision.find(payload['id'])
-      "Favored #{decision.reports.first.reportable&.class&.name} Report".squish
+      "Favored #{decision.reports.first.reportable&.class&.name || decision.reports.first.reportable_type} Report".squish
     end
 
     def parameters_for_notification

--- a/src/api/spec/mailers/event_mailer_spec.rb
+++ b/src/api/spec/mailers/event_mailer_spec.rb
@@ -585,5 +585,50 @@ RSpec.describe EventMailer, :vcr do
         expect(mail.body.encoded).to include("<a href=\"https://build.example.com/project/show/#{project}#comments-list\">#{project}</a>")
       end
     end
+
+    context 'for an event of type Event::AppealCreated of a no longer existing reportable object' do
+      let(:moderator) { create(:admin_user) }
+      let(:offender) { create(:confirmed_user, login: 'offender') } # user who wrote the offensive comment
+      let(:reporter) { create(:confirmed_user, login: 'reporter') }
+      let(:appellant) { create(:confirmed_user, login: 'appellant') }
+
+      let(:comment) { create(:comment_project, user: offender) }
+      let(:project) { comment.commentable }
+      let(:report) { create(:report, user: reporter, reportable: comment) }
+
+      let!(:moderator_subscription) { create(:event_subscription_appeal_created, user: moderator) }
+
+      let(:decision) { create(:decision, :favor, moderator: moderator, reason: 'This is spam for sure.', reports: [report]) }
+      let(:appeal) { create(:appeal, appellant: appellant, decision: decision, reason: 'I strongly disagree!') }
+      let(:event) { Event::AppealCreated.last }
+      let(:mail) { EventMailer.with(subscribers: event.subscribers, event: event).notification_email.deliver_now }
+
+      before do
+        login(moderator)
+        comment.destroy!
+        appeal
+      end
+
+      it 'gets delivered' do
+        expect(ActionMailer::Base.deliveries).to include(mail)
+      end
+
+      it 'is sent to the moderator' do
+        expect(mail.to).to contain_exactly(decision.moderator.email)
+      end
+
+      it 'has a subject' do
+        expect(mail.subject).to eq("Appeal to #{decision.reports.first.reportable&.class&.name.downcase} decision")
+      end
+
+      it 'contains the correct text' do
+        expect(mail.body.encoded).to include("'#{appellant}' decided to appeal to the decision '#{decision.reason}'. This is the reason:")
+        expect(mail.body.encoded).to include('I strongly disagree!')
+      end
+
+      it 'renders the text about the missing reported comment' do
+        expect(mail.body.encoded).to include("The reported #{decision.reports.first.reportable&.class&.name&.downcase} does not exist anymore.")
+      end
+    end
   end
 end

--- a/src/api/spec/mailers/event_mailer_spec.rb
+++ b/src/api/spec/mailers/event_mailer_spec.rb
@@ -618,7 +618,7 @@ RSpec.describe EventMailer, :vcr do
       end
 
       it 'has a subject' do
-        expect(mail.subject).to eq("Appeal to #{decision.reports.first.reportable&.class&.name.downcase} decision")
+        expect(mail.subject).to eq("Appeal to #{decision.reports.first.reportable&.class&.name} decision")
       end
 
       it 'contains the correct text' do


### PR DESCRIPTION
In case the `reportable` got already deleted, in the email for `Appeal|Cleared Decision|Favored Decision` event two issues occurres:
- the subject of the email does not contain the `reportable type` due to the lack of the reported object
- the link to the reported object is not available (#15551) but there is no clue about the fact the reported object is gone

This PR addresses those two points from above:
- fetch the `reportable type` from the event `payload_key` value instead
- add a simple text message in the email body about the missing reported object