### PR TITLE
Point out which commentable is locked in the locked alert

### DIFF
--- a/src/api/app/helpers/webui/comment_locks_helper.rb
+++ b/src/api/app/helpers/webui/comment_locks_helper.rb
@@ -1,0 +1,14 @@
+module Webui::CommentLocksHelper
+  def comment_lock_alert(commentable)
+    alert = 'You can remove the lock by clicking on the button below.'
+    return alert if commentable.comment_lock
+
+    if commentable.is_a?(Package) && commentable.project.comment_lock
+      text = 'You can remove the lock by visiting'
+      link = link_to(commentable.project.name, project_show_path(commentable.project))
+      safe_join([text, ' ', content_tag(:a, link)])
+    else
+      alert
+    end
+  end
+end

--- a/src/api/app/views/webui/comment/_new.html.haml
+++ b/src/api/app/views/webui/comment/_new.html.haml
@@ -3,7 +3,7 @@
     .alert.alert-warning{ role: 'alert' }
       Commenting on this is locked.
       - if CommentLockPolicy.new(User.session, commentable).create?
-        You can remove the lock by clicking on the button below.
+        = comment_lock_alert(commentable)
       - if commentable.respond_to?(:bugowner_emails) && commentable.bugowner_emails.present? && Configuration.bugzilla_url.present?
         If you need to report a bug, make use of the
         - commentable_name = commentable.respond_to?(:project) ? "#{commentable.project}/#{commentable.name}" : commentable.name

--- a/src/api/spec/cassettes/CommentLocks/on_a_request/with_comments_locked/lock_alert_for_package/shows_comment_lock_alert.yml
+++ b/src/api/spec/cassettes/CommentLocks/on_a_request/with_comments_locked/lock_alert_for_package/shows_comment_lock_alert.yml
@@ -1,0 +1,363 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/home:titan/_meta?user=titan
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:titan">
+          <title/>
+          <description/>
+          <person userid="titan" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '132'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:titan">
+          <title></title>
+          <description></description>
+          <person userid="titan" role="maintainer"/>
+        </project>
+  recorded_at: Mon, 29 Jan 2024 15:39:42 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:kugelblitz/_meta?user=kugelblitz
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:kugelblitz">
+          <title/>
+          <description/>
+          <person userid="kugelblitz" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '142'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:kugelblitz">
+          <title></title>
+          <description></description>
+          <person userid="kugelblitz" role="maintainer"/>
+        </project>
+  recorded_at: Mon, 29 Jan 2024 15:39:42 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:burdenski/_meta?user=burdenski
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:burdenski">
+          <title/>
+          <description/>
+          <person userid="burdenski" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '140'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:burdenski">
+          <title></title>
+          <description></description>
+          <person userid="burdenski" role="maintainer"/>
+        </project>
+  recorded_at: Mon, 29 Jan 2024 15:39:43 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:burdenski/test_package/_meta?user=moderator
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:burdenski">
+          <title>If I Forget Thee Jerusalem</title>
+          <description>Mollitia dolorum autem nihil.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '169'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:burdenski">
+          <title>If I Forget Thee Jerusalem</title>
+          <description>Mollitia dolorum autem nihil.</description>
+        </package>
+  recorded_at: Mon, 29 Jan 2024 15:39:50 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:burdenski/test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 53c46df3-7a6f-4fba-a22b-95d79ee9d412
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '87'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Mon, 29 Jan 2024 15:39:51 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:burdenski/test_package?expand=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '87'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="test_package" srcmd5="d41d8cd98f00b204e9800998ecf8427e">
+        </directory>
+  recorded_at: Mon, 29 Jan 2024 15:39:51 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:burdenski/test_package/_history?deleted=0&meta=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 53c46df3-7a6f-4fba-a22b-95d79ee9d412
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+        </revisionlist>
+  recorded_at: Mon, 29 Jan 2024 15:39:51 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:burdenski/_result?lastbuild=1&locallink=1&multibuild=1&package=test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 4aa3526b-0cff-4173-8037-13d6b40d34b6
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Mon, 29 Jan 2024 15:39:51 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:burdenski/_result?lastbuild=1&locallink=1&multibuild=1&package=test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 2595a6ee-8346-4d59-8e3a-10724cbd073c
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Mon, 29 Jan 2024 15:39:51 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:burdenski/_result?package=test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - b0b905cd-27e4-4c6c-910d-9812bf398014
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Mon, 29 Jan 2024 15:39:51 GMT
+recorded_with: VCR 6.2.0

--- a/src/api/spec/features/webui/comment_locks_spec.rb
+++ b/src/api/spec/features/webui/comment_locks_spec.rb
@@ -1,7 +1,7 @@
 require 'browser_helper'
 
-RSpec.describe 'CommentLocks' do
-  let!(:moderator_user) { create(:moderator) }
+RSpec.describe 'CommentLocks', :vcr do
+  let!(:moderator_user) { create(:moderator, login: 'moderator') }
 
   before do
     Flipper.enable(:content_moderation)
@@ -90,6 +90,21 @@ RSpec.describe 'CommentLocks' do
         it 'cannot comment' do
           expect(page).to have_text('Commenting on this is locked')
           expect(page).to have_no_button('Add comment')
+        end
+      end
+
+      context 'lock alert for package' do
+        let!(:comment_lock_project) { create(:comment_lock, commentable: user.home_project, moderator: moderator_user) }
+        let(:package) { create(:package, project: user.home_project, name: 'test_package') }
+
+        before do
+          login moderator_user
+          visit package_show_path(package.project, package)
+        end
+
+        it 'shows comment lock alert' do
+          alert = "You can remove the lock by visiting #{package.project.name}"
+          expect(page).to have_text(alert)
         end
       end
     end


### PR DESCRIPTION
Prior to this PR, the comment lock alert on the package page showed the wrong message `You can remove the lock by clicking on the button below` even when a package is not locked. This PR fixes this message and points out which commendable is locked.

Notes for test: 
1. lock a project
2. go into a package in the project
3. look at the comments
4. the alert should say the project is locked