### PR TITLE
Fix fetching a nil sourcediff

### DIFF
--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -555,7 +555,7 @@ class Webui::RequestController < Webui::WebuiController
     @staging_status = staging_status(@bs_request, target_project) if Staging::Workflow.find_by(project: target_project)
 
     # Collecting all issues in a hash. Each key is the issue name and the value is a hash containing all the issue details.
-    @issues = @action.fetch(:sourcediff, []).reduce({}) { |accumulator, sourcediff| accumulator.merge(sourcediff.fetch('issues', {})) }
+    @issues = (@action.fetch(:sourcediff, []) || []).reduce({}) { |accumulator, sourcediff| accumulator.merge(sourcediff.fetch('issues', {})) }
 
     # retrieve a list of all package maintainers that are assigned to at least one target package
     @package_maintainers = target_package_maintainers


### PR DESCRIPTION
This fixes an "undefined method `reduce' for nil:NilClass" error.

The fetch has a default option for when the `:sourcediff` key does not exist, but if the sourcediff is actually nil, the reduce fails.

This PR adds a default empty array for the reduce to work.