### PR TITLE
Don't show delete links for deleted users in admin pages

### DIFF
--- a/src/api/app/helpers/webui/user_helper.rb
+++ b/src/api/app/helpers/webui/user_helper.rb
@@ -25,9 +25,11 @@ module Webui::UserHelper
         mail_to(user.email) do
           tag.i(nil, class: 'fas fa-envelope text-secondary pe-1', title: 'Send Email to User')
         end,
-        link_to('#', title: 'Delete User', data: { 'bs-toggle': 'modal',
-                                                   'bs-target': '#delete-user-modal', 'user-login': user.login, action: user_path(user.login) }) do
-          tag.i(nil, class: 'fas fa-times-circle text-danger pe-1')
+        unless user.state == 'deleted'
+          link_to('#', title: 'Delete User', data: { 'bs-toggle': 'modal',
+                                                     'bs-target': '#delete-user-modal', 'user-login': user.login, action: user_path(user.login) }) do
+            tag.i(nil, class: 'fas fa-times-circle text-danger pe-1')
+          end
         end
       ]
     )

--- a/src/api/app/views/webui/user/_basic_info.html.haml
+++ b/src/api/app/views/webui/user/_basic_info.html.haml
@@ -14,7 +14,7 @@
                     'reportable-id': user.id }) do
         %i.fas.fa-regular.fa-flag
         %span.nav-item-name Report
-    - if User.possibly_nobody.is_admin?
+    - if User.possibly_nobody.is_admin? && user.state != 'deleted'
       = link_to('#', title: 'Delete user', class: 'ms-2', data: { 'bs-toggle': 'modal', 'bs-target': '#delete-user-modal' }) do
         %i.fas.fa-times-circle.text-danger
         %span.nav-item-name.text-danger Delete


### PR DESCRIPTION
Related to: #15559.

### Before

![Screenshot from 2024-01-29 15-32-51](https://github.com/openSUSE/open-build-service/assets/24919/03d9fe07-6142-4ea5-9eb7-af9a93ab2121)

For a deleted user:

![Screenshot from 2024-01-29 15-35-03](https://github.com/openSUSE/open-build-service/assets/24919/e06ef15b-85dd-401e-99ab-45d6a69b32d3)


### After

![Screenshot from 2024-01-29 15-33-08](https://github.com/openSUSE/open-build-service/assets/24919/b3c6e686-da20-4595-89fa-67ee3ec6a687)

For a deleted user:

![Screenshot from 2024-01-29 15-34-52](https://github.com/openSUSE/open-build-service/assets/24919/5399847b-1445-4299-be8d-e88fbb681769)

