### PR TITLE
Bugfix: adjust comment edit history dropdown alignment

### DIFF
--- a/src/api/app/assets/stylesheets/webui/comments.scss
+++ b/src/api/app/assets/stylesheets/webui/comments.scss
@@ -66,11 +66,6 @@
     border-right-color: var(--comment-bubble-background);
   }
 
-  .dropdown {
-    top: -10px;
-    left: 5px;
-  }
-
   p:last-of-type {
     margin-bottom: 0;
   }

--- a/src/api/app/components/bs_request_comment_component.html.haml
+++ b/src/api/app/components/bs_request_comment_component.html.haml
@@ -4,7 +4,7 @@
   .timeline-item-comment.ms-0.flex-fill.overflow-auto
     .comment-bubble.ms-3
       - if policy(comment).update? || policy(comment).destroy?
-        .dropdown.dropleft.float-end.mt-3.mx-3
+        .dropdown.dropleft.float-end.mx-3
           = link_to('#', role: 'button', 'data-bs-toggle': 'dropdown', 'aria-expanded': 'false') do
             %i.fas.fa-ellipsis
           .dropdown-menu

--- a/src/api/app/components/comment_history_component.html.haml
+++ b/src/api/app/components/comment_history_component.html.haml
@@ -1,4 +1,4 @@
-%span.dropdown
+%span.dropdown.ms-1
   (edited
   = link_to('#', role: 'button', data: { 'bs-toggle': 'dropdown' }, 'aria-expanded': false, class: 'dropdown-toggle') do
     = render TimeComponent.new(time: @comment.versions.last.created_at)


### PR DESCRIPTION
Fix  #15563

The `position` of the `dropdown` is no longer `absolute`, so `top` and `left` properties are not supposed to be set.

# Before
![image](https://github.com/openSUSE/open-build-service/assets/7080830/3fba0866-7fdf-4fab-b0b0-14d0627e11ff)

# After
![image](https://github.com/openSUSE/open-build-service/assets/7080830/4ab8229e-b9ad-4d11-8802-a5de988aa0ae)
