### PR TITLE
Show the user roles alongside the comment

### DIFF
--- a/src/api/app/components/bs_request_comment_component.html.haml
+++ b/src/api/app/components/bs_request_comment_component.html.haml
@@ -24,12 +24,17 @@
                                     action: comment_path(comment) },
                             class: 'dropdown-item delete_link', title: 'Delete comment') do
                 Delete
-      .px-3.py-2.border-bottom
-        - unless @nodecoration
-          = link_to(helpers.realname_with_login(comment.user), user_path(comment.user))
-          \-
-        = link_to_comment(comment)
-        = render CommentHistoryComponent.new(comment)
+      .px-3.py-2.border-bottom.d-flex.flex-column.flex-lg-row.justify-content-between.align-items-start
+        .d-inline-flex.justify-content-start
+          - unless @nodecoration
+            = link_to(helpers.realname_with_login(comment.user), user_path(comment.user))
+            \-
+          = link_to_comment(comment)
+          = render CommentHistoryComponent.new(comment)
+        .d-inline-flex.justify-content-end
+          - helpers.comment_user_role_titles(comment).each do |title|
+            %span.badge.text-bg-secondary.mx-1
+              = title.upcase
       - if comment.diff_ref && diff
         - action = comment.commentable
         .comment-diff

--- a/src/api/app/components/bs_request_comment_component.html.haml
+++ b/src/api/app/components/bs_request_comment_component.html.haml
@@ -24,17 +24,17 @@
                                     action: comment_path(comment) },
                             class: 'dropdown-item delete_link', title: 'Delete comment') do
                 Delete
-      .px-3.py-2.border-bottom.d-flex.flex-column.flex-lg-row.justify-content-between.align-items-start
+      .px-3.py-2.border-bottom.d-flex.flex-column.flex-lg-row.justify-content-between.align-items-start.gap-2
         .d-inline-flex.justify-content-start
           - unless @nodecoration
             = link_to(helpers.realname_with_login(comment.user), user_path(comment.user))
             \-
           = link_to_comment(comment)
           = render CommentHistoryComponent.new(comment)
-        .d-inline-flex.justify-content-end
+        .d-inline-flex.justify-content-end.gap-1
           - helpers.comment_user_role_titles(comment).each do |title|
-            %span.badge.text-bg-secondary.mx-1
-              = title.upcase
+            %span.badge.border.border-secondary.text-secondary.text-capitalize
+              = title
       - if comment.diff_ref && diff
         - action = comment.commentable
         .comment-diff

--- a/src/api/app/helpers/webui/comments_helper.rb
+++ b/src/api/app/helpers/webui/comments_helper.rb
@@ -1,0 +1,47 @@
+module Webui::CommentsHelper
+  def comment_user_role_titles(comment)
+    roles = comment.user.roles.global.pluck(:title)
+
+    roles += roles_for_project(comment) if comment.commentable.is_a?(Project)
+
+    roles += roles_for_package(comment) if comment.commentable.is_a?(Package)
+
+    roles = roles_for_request(comment) if comment.commentable.is_a?(BsRequest)
+
+    roles.uniq
+  end
+
+  private
+
+  def roles_for_project(comment)
+    comment.user.relationships.where(project_id: comment.commentable.id)
+           .joins(:role)
+           .pluck(:title)
+  end
+
+  def roles_for_package(comment)
+    comment.user.relationships.where(package_id: comment.commentable.id)
+           .joins(:role)
+           .pluck(:title)
+  end
+
+  def roles_for_request(comment)
+    roles = []
+    roles << 'Submitter' if comment.commentable.creator == comment.user.login
+    comment.commentable.bs_request_actions.inject(roles) do |acc, action|
+      acc += Relationship
+             .joins(:role)
+             .joins(:project)
+             .where(projects: { name: action.target_project })
+             .where(user: comment.user)
+             .pluck('roles.title')
+
+      acc + Relationship
+            .joins(:role)
+            .joins(:package)
+            .where(packages: { name: action.target_package })
+            .where(user: comment.user)
+            .pluck('roles.title')
+    end
+  end
+end

--- a/src/api/app/helpers/webui/comments_helper.rb
+++ b/src/api/app/helpers/webui/comments_helper.rb
@@ -6,7 +6,7 @@ module Webui::CommentsHelper
 
     roles += roles_for_package(comment) if comment.commentable.is_a?(Package)
 
-    roles = roles_for_request(comment) if comment.commentable.is_a?(BsRequest)
+    roles += roles_for_request(comment) if comment.commentable.is_a?(BsRequest)
 
     roles.uniq
   end

--- a/src/api/app/views/webui/comment/_content.html.haml
+++ b/src/api/app/views/webui/comment/_content.html.haml
@@ -3,12 +3,17 @@
   .flex-shrink-0
     = image_tag_for(comment.user, size: 35, custom_class: 'me-3 d-none d-sm-block')
   .comment.flex-grow-1.text-break
-    .mb-3{ id: "comment-#{comment.id}-user" }
-      = link_to(realname_with_login(comment.user), user_path(comment.user))
-      wrote
-      = link_to("#comment-#{comment.id}", title: I18n.l(comment.created_at.utc), name: "comment-#{comment.id}") do
-        = render TimeComponent.new(time: comment.created_at)
-      = render CommentHistoryComponent.new(comment)
+    .mb-3.d-flex.flex-column.flex-lg-row.justify-content-between.align-items-start{ id: "comment-#{comment.id}-user" }
+      .d-inline-flex.justify-content-start
+        = link_to(realname_with_login(comment.user), user_path(comment.user))
+        \-
+        = link_to("#comment-#{comment.id}", title: l(comment.created_at.utc), name: "comment-#{comment.id}") do
+          = render TimeComponent.new(time: comment.created_at)
+        = render CommentHistoryComponent.new(comment)
+      .d-inline-flex.justify-content-end
+        - comment_user_role_titles(comment).each do |title|
+          %span.badge.text-bg-secondary.mx-1
+            = title.upcase
     - if level == 1 && comment.commentable.is_a?(BsRequestAction)
       - sourcediff = comment.commentable.bs_request.webui_actions(action_id: comment.commentable, diffs: true, cacheonly: 1).first[:sourcediff].first
       - unless sourcediff[:error]

--- a/src/api/app/views/webui/comment/_content.html.haml
+++ b/src/api/app/views/webui/comment/_content.html.haml
@@ -3,17 +3,17 @@
   .flex-shrink-0
     = image_tag_for(comment.user, size: 35, custom_class: 'me-3 d-none d-sm-block')
   .comment.flex-grow-1.text-break
-    .mb-3.d-flex.flex-column.flex-lg-row.justify-content-between.align-items-start{ id: "comment-#{comment.id}-user" }
+    .mb-3.d-flex.flex-column.flex-lg-row.justify-content-between.align-items-start.gap-2{ id: "comment-#{comment.id}-user" }
       .d-inline-flex.justify-content-start
         = link_to(realname_with_login(comment.user), user_path(comment.user))
         \-
         = link_to("#comment-#{comment.id}", title: l(comment.created_at.utc), name: "comment-#{comment.id}") do
           = render TimeComponent.new(time: comment.created_at)
         = render CommentHistoryComponent.new(comment)
-      .d-inline-flex.justify-content-end
+      .d-inline-flex.justify-content-end.gap-1
         - comment_user_role_titles(comment).each do |title|
-          %span.badge.text-bg-secondary.mx-1
-            = title.upcase
+          %span.badge.border.border-secondary.text-secondary.text-capitalize
+            = title
     - if level == 1 && comment.commentable.is_a?(BsRequestAction)
       - sourcediff = comment.commentable.bs_request.webui_actions(action_id: comment.commentable, diffs: true, cacheonly: 1).first[:sourcediff].first
       - unless sourcediff[:error]

--- a/src/api/spec/helpers/webui/comments_helper_spec.rb
+++ b/src/api/spec/helpers/webui/comments_helper_spec.rb
@@ -1,0 +1,100 @@
+RSpec.describe Webui::CommentsHelper do
+  describe 'comment_user_role_titles' do
+    subject { comment_user_role_titles(comment) }
+
+    context 'when the commenter has a moderator global role' do
+      let(:comment) { create(:comment_package) }
+
+      before { comment.user.roles << Role.find_by_title!('Moderator') }
+
+      it { is_expected.to include('Moderator') }
+    end
+
+    context 'when the commenter is the maintainer of the commented package' do
+      let(:comment) { create(:comment_package) }
+
+      before { comment.commentable.add_maintainer(comment.user) }
+
+      it { is_expected.to include('maintainer') }
+    end
+
+    context 'when the commenter is the maintainer of the commented project' do
+      let(:comment) { create(:comment_project) }
+
+      before { comment.commentable.add_maintainer(comment.user) }
+
+      it { is_expected.to include('maintainer') }
+    end
+
+    context 'when the commenter is the submitter of the commented request' do
+      let(:comment) { create(:comment_request) }
+
+      before { comment.user = User.find_by(login: comment.commentable.creator) }
+
+      it { is_expected.to include('Submitter') }
+    end
+
+    context 'when the commenter is the maintainer of the target project of the request' do
+      let(:comment) { create(:comment_request, :bs_request_action) }
+
+      before do
+        action = comment.commentable.bs_request_actions.first
+        User.session = create(:admin_user)
+        project = create(:project_with_package, package_name: 'package1')
+        action.target_project = project
+        action.target_package = project.packages.first
+        tprj = comment.commentable.bs_request_actions.first.target_project
+        Project.find_by_name(tprj).add_maintainer(comment.user)
+      end
+
+      it { is_expected.to include('maintainer') }
+    end
+
+    context 'when the commenter is the maintainer of the target package of the request' do
+      let(:comment) { create(:comment_request, :bs_request_action) }
+
+      before do
+        action = comment.commentable.bs_request_actions.first
+        User.session = create(:admin_user)
+        project = create(:project_with_package, package_name: 'package1')
+        action.target_project = project.name
+        action.target_package = project.packages.first.name
+        project.packages.first.add_maintainer(comment.user)
+        comment.commentable.bs_request_actions.first.target_project
+        comment.commentable.bs_request_actions.first.target_package
+      end
+
+      it { is_expected.to include('maintainer') }
+    end
+
+    context 'when the commenter is not the maintainer of the targe project of the request' do
+      let(:comment) { create(:comment_request, :bs_request_action) }
+      let(:somebody) { create(:user, :with_home) }
+
+      before do
+        action = comment.commentable.bs_request_actions.first
+        User.session = create(:admin_user)
+        project = create(:project_with_package, package_name: 'package1')
+        action.target_project = project
+        action.target_package = project.packages.first
+        tprj = comment.commentable.bs_request_actions.first.target_project
+        Project.find_by_name(tprj).add_maintainer(somebody)
+      end
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'when having several request actions but the user is the maintainer of the second one' do
+      let(:comment) { create(:comment_request, :bs_request_action) }
+
+      before do
+        create(:bs_request_action_submit_with_diff, bs_request: comment.commentable)
+        action = comment.commentable.reload.bs_request_actions.second
+        User.session = create(:admin_user)
+        Project.find_by_name(action.target_project).add_maintainer(comment.user)
+      end
+
+      it { is_expected.to include('maintainer') }
+    end
+  end
+end


### PR DESCRIPTION
In order to provide more context to who wrote a comment, we want to render the user role also.

This is how it looks like in the comments on a request:
![image](https://github.com/openSUSE/open-build-service/assets/2650/c5227dfb-9c0f-469c-8f13-b6132e77fbdb)

And this is how it looks like in the comments on a package for example:
![image](https://github.com/openSUSE/open-build-service/assets/2650/adc8eef0-d10e-4019-8c6e-84040e560bfe)

## Tips for reviewing:
1. Go to https://obs-reviewlab.opensuse.org/danidoni-label-user-roles-in-comments/
2. Log in as Iggy, password 'opensuse'
3. Visit https://obs-reviewlab.opensuse.org/danidoni-label-user-roles-in-comments/request/show/1 and check how the badges look like