### PR TITLE
Be consistent in how we render the username in comments

### DIFF
--- a/src/api/app/views/webui/comment/_content.html.haml
+++ b/src/api/app/views/webui/comment/_content.html.haml
@@ -4,7 +4,7 @@
     = image_tag_for(comment.user, size: 35, custom_class: 'me-3 d-none d-sm-block')
   .comment.flex-grow-1.text-break
     .mb-3{ id: "comment-#{comment.id}-user" }
-      = link_to(comment.user, user_path(comment.user))
+      = link_to(realname_with_login(comment.user), user_path(comment.user))
       wrote
       = link_to("#comment-#{comment.id}", title: I18n.l(comment.created_at.utc), name: "comment-#{comment.id}") do
         = render TimeComponent.new(time: comment.created_at)


### PR DESCRIPTION
We show the real name next to the login in the comments on a request, but we show only the login in the comments in packages, projects, etc.

This is how it looks like in a request's comments:
![2024-01-31_12-37](https://github.com/openSUSE/open-build-service/assets/2650/6aa4e303-4297-40ec-b1b7-cc5a5fd7c265)

This is how it looked like in a package's comments (for example):
![2024-01-31_12-29](https://github.com/openSUSE/open-build-service/assets/2650/ddd6ba30-2aa4-4349-8234-fcb01ae4721c)


This is how it looks like now:
![2024-01-31_12-30](https://github.com/openSUSE/open-build-service/assets/2650/6f2c857d-87c7-45cc-ac61-d29d67e84abe)
