### PR TITLE
Reapply "Don't fetch unneeded information for JSON requests"

### DIFF
--- a/src/api/app/controllers/webui/webui_controller.rb
+++ b/src/api/app/controllers/webui/webui_controller.rb
@@ -19,8 +19,8 @@ class Webui::WebuiController < ActionController::Base
   before_action :check_anonymous
   before_action :set_influxdb_data
   before_action :require_configuration
-  before_action :current_announcement
-  before_action :fetch_watchlist_items
+  before_action :current_announcement, unless: -> { request.xhr? }
+  before_action :fetch_watchlist_items, unless: -> { request.xhr? }
   after_action :clean_cache
   before_action :set_paper_trail_whodunnit
 


### PR DESCRIPTION
This reverts commit 68f1d72ab93c333a037248273215b3a9b97daae0.

`undefined method 'any?' for nil:NilClass` errors were caused by requests performed by browsers with cached javascript. This javascript is no longer present in the codebase.

Those browsers still run AJAX calls which got removed from the codebase in #15544. Refreshing the page in the browser should prevent from performing this AJAX requests, and therefore, from registering these errors.

