### PR TITLE
[api] add some missing api parameters

### DIFF
--- a/docs/api/api/api.txt
+++ b/docs/api/api/api.txt
@@ -505,6 +505,7 @@ Parameters:
 
   deleted: bool, show deleted package instead of existing, optional
   expand: bool, include also packages from linked projects, optional
+  package: specify the packages to be shown with view=info, optional, multiple
   view: issues, can be used to show all tracked issues for all packages in project
         productlist, shows all containing products, unifies result when used with expand
         verboseproductlist, same as productlist, but with detailed information about the product
@@ -908,6 +909,7 @@ Parameters:
   noservice: do not run source services
   comment: comment for history, optional
   meta: switch to meta files
+  file: limit operation (eg. diffing) to certains files, optional, multiple
   arch: architecture when using flag modifing command
   repository: repository when using flag modifing command
   view: may be "xml" for structured answered (for diff commands)
@@ -1262,6 +1264,12 @@ GET /build/<project>/<repository>/<arch>/_jobhistory?package=<package>&code=succ
   time and trigger reason. Optional filtering for one ore more packages/codes is
   possible.
 
+Parameters:
+
+  package       string, filter package container, can be used multiple times
+  code          string, filter by build state, can be used multiple times
+  limit         num, Limit number of entries, optional
+
 Result: jobhistory
 
 
@@ -1269,6 +1277,17 @@ GET /build/<project>/<repository>/<arch>/_repository
 
   Get list of binaries in given repository (binaries produced by all packages
   of the project)
+
+Parameters:
+
+  view       string, can be cache, cpio, solv, solvstate, binaryversions
+  nometa     bool, exclude meta for binaryversions
+  nossource  bool, exclude source for binaryversions
+  withevr    bool, include evr in binaryversions
+  withmd5    bool, include md5 sums
+  withccache bool, include ccache files
+  module     string, rpm module name, can be used multiple times
+  binary     string, filter binaries, can be used multiple times
 
 Result: binarylist
 
@@ -1480,6 +1499,11 @@ Parameters:
 GET /build/<project>/<repository>/<arch>/<package>/_buildinfo
 
   Get build information for local building
+
+Parameters:
+
+  add:   package_name, Add additional package, optional, multiple
+  debug: bool, report solving reasons
 
 XmlResult: buildinfo
 
@@ -2156,7 +2180,20 @@ GET /configuration
 
 XmlResult: configuration configuration.rng
 
+== Interconnect
+
+GET /lastevents
+
+  AJAX event reporting interface for OBS interconnects.
+
+Parameters:
+  filter: Filter given resources in the queue, optional, multiple
+  start: last processed entry, optional
+  obsname: reporting OBS instance name, optional
+  block: bool, for disabling AJAX mode
 
 == Internal only routes
 
    /public shall not be used in any tools, it is for OBS remote support only and may change or disappear at any time. The route is only working when anonymous mode is enabled.
+
+


### PR DESCRIPTION
Reviewing all places where a CGI parameter can be used multiple times _and_ is exposed via the api.

Some of the /build/_workerstatus parameters are currently not support, but used to be in the past IIRC. However, not documented yet, but we may want to bring these back.