### PR TITLE
Strong migration wrapped by safety_assured catch

### DIFF
--- a/src/api/db/migrate/20230224114624_add_diff_ref_to_comments.rb
+++ b/src/api/db/migrate/20230224114624_add_diff_ref_to_comments.rb
@@ -1,5 +1,13 @@
 class AddDiffRefToComments < ActiveRecord::Migration[7.0]
-  def change
-    add_column :comments, :diff_ref, :string
+  def up
+    safety_assured do
+      add_column :comments, :diff_ref, :string
+    end
+  end
+
+  def down
+    safety_assured do
+      remove_column :comments, :diff_ref
+    end
   end
 end


### PR DESCRIPTION
Fix #15583

In the former issue the target migration is detected as a `strong migration`, thus the `add_column` instruction is now wrapped with the `safety_assured` catch.