### PR TITLE
Add annotate comments after indexing state in users

### DIFF
--- a/src/api/app/models/unregistered_user.rb
+++ b/src/api/app/models/unregistered_user.rb
@@ -87,7 +87,7 @@ end
 #  password_digest               :string(255)
 #  realname                      :string(200)      default(""), not null
 #  rss_secret                    :string(200)      indexed
-#  state                         :string           default("unconfirmed")
+#  state                         :string           default("unconfirmed"), indexed
 #  created_at                    :datetime
 #  updated_at                    :datetime
 #  owner_id                      :integer
@@ -97,6 +97,7 @@ end
 #  index_users_on_in_beta     (in_beta)
 #  index_users_on_in_rollout  (in_rollout)
 #  index_users_on_rss_secret  (rss_secret) UNIQUE
+#  index_users_on_state       (state)
 #  users_login_index          (login) UNIQUE
 #  users_password_index       (deprecated_password)
 #

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -970,7 +970,7 @@ end
 #  password_digest               :string(255)
 #  realname                      :string(200)      default(""), not null
 #  rss_secret                    :string(200)      indexed
-#  state                         :string           default("unconfirmed")
+#  state                         :string           default("unconfirmed"), indexed
 #  created_at                    :datetime
 #  updated_at                    :datetime
 #  owner_id                      :integer
@@ -980,6 +980,7 @@ end
 #  index_users_on_in_beta     (in_beta)
 #  index_users_on_in_rollout  (in_rollout)
 #  index_users_on_rss_secret  (rss_secret) UNIQUE
+#  index_users_on_state       (state)
 #  users_login_index          (login) UNIQUE
 #  users_password_index       (deprecated_password)
 #


### PR DESCRIPTION
This could not be included in #15615 because of the checks we perform in `check_changed_files`.