### PR TITLE
Remove reference to nonexistent .xsd files

### DIFF
--- a/docs/api/Makefile
+++ b/docs/api/Makefile
@@ -7,9 +7,6 @@ apidocs:
 
 doc: apidocs
 	xsltproc xs3p.xsl package.xsd >package.html
-	xsltproc xs3p.xsl project.xsd >project.html
-	xsltproc xs3p.xsl platform.xsd >platform.html
-	xsltproc xs3p.xsl projectresult.xsd >projectresult.html
 	xsltproc xs3p.xsl packageresult.xsd >packageresult.html
 	xsltproc xs3p.xsl status.xsd >status.html
 


### PR DESCRIPTION
We cannot create an .html file from a .xsd file which doesn't exist.