### PR TITLE
Fix display of the bs_request monitor with more architectures

### DIFF
--- a/src/api/app/assets/stylesheets/webui/build-results.scss
+++ b/src/api/app/assets/stylesheets/webui/build-results.scss
@@ -226,6 +226,7 @@
   @include media-breakpoint-up(xl) {
     display: grid;
     grid-template-columns: 1fr repeat(20, auto);
+    overflow-x: scroll;
 
     .build-result-architectures, .build-result-row, .build-result-legend {
       display: contents;
@@ -237,7 +238,7 @@
     }
 
     .build-result-architecture {
-      padding: 0.25rem 1rem;
+      padding: 0.25rem;
       text-align: end;
       .architecture { display: none }
     }

--- a/src/api/app/components/build_results_monitor_component.html.haml
+++ b/src/api/app/components/build_results_monitor_component.html.haml
@@ -35,7 +35,7 @@
                         project_package_repository_binaries_path(project_name: project_name,
                                                                  package_name: package_name,
                                                                  repository_name: repository_name),
-                        title: "Binaries for #{repository_name}", class: 'build-result-name text-break')
+                        title: "Binaries for #{repository_name}", class: 'build-result-name')
               .build-result-architectures
                 - filtered_architecture_names.each do |architecture_name|
                   .build-result-architecture


### PR DESCRIPTION
Displays the monitor with a larger amount of architectures in a less broken way