### PR TITLE
Edit comment form alignment and visibility

### DIFF
--- a/src/api/app/assets/stylesheets/webui/timeline.scss
+++ b/src/api/app/assets/stylesheets/webui/timeline.scss
@@ -54,7 +54,7 @@
         }
     }
 
-    .collapse, .collapsing {
+    .collapse:not(.comment-edit), .collapsing:not(.comment-edit) {
         position: relative;
         left: $timeline-offset;
         .timeline-item {

--- a/src/api/app/components/bs_request_comment_component.html.haml
+++ b/src/api/app/components/bs_request_comment_component.html.haml
@@ -10,7 +10,7 @@
           .dropdown-menu
             - if policy(comment).update?
               = link_to("#edit_form_of_#{comment.id}", id: "edit_button_of_#{comment.id}", 'data-bs-toggle': 'collapse',
-                        class: 'dropdown-item collapsed') do
+                        'data-comment-id': comment.id, class: 'dropdown-item collapsed edit-comment-button') do
                 Edit
             - if Flipper.enabled?(:content_moderation, User.session)
               - if policy(comment).moderate?
@@ -79,3 +79,12 @@
 - if level > 3
   - comment.children.includes(:user).each do |children|
     = render BsRequestCommentComponent.new(comment: children, level: level + 1, commentable: commentable)
+
+:javascript
+  $(document).on('click', '.edit-comment-button', function() {
+    var commentId = $(this).data('comment-id');
+    $(`#comment-${commentId}-body`).hide();
+  });
+  $(document).on('click', '.cancel-comment', function() {
+    $(this).parents('.comment-bubble').children('.comment-bubble-content').show();
+  });

--- a/src/api/app/components/bs_request_comment_component.html.haml
+++ b/src/api/app/components/bs_request_comment_component.html.haml
@@ -49,7 +49,7 @@
         = helpers.render_as_markdown(comment)
 
       - if policy(comment).update?
-        .collapse{ id: "edit_form_of_#{comment.id}" }
+        .collapse.comment-edit{ id: "edit_form_of_#{comment.id}" }
           = render(partial: 'webui/comment/comment_field', locals: { form_method: :put,
           comment: comment, commentable: commentable, element_suffix: "edit_#{comment.id}", has_cancel: true })
 


### PR DESCRIPTION
# Before
- form disalignment to the left
- comment body still visible even if in edit mode with the edit form visible

![comment-editing](https://github.com/openSUSE/open-build-service/assets/7080830/65b994f3-ffe7-4545-a168-dd22ac23bbb0)




# After
- form is now aligned to the container borders
- the comment body visibility is reverse-toggled from the edit form

![comment-edit](https://github.com/openSUSE/open-build-service/assets/7080830/39253c55-8615-4aeb-a893-f030ec4bd53f)


## Note
The toggling visibility could have been implemented with the [Bootstrap collapse multitarget](https://getbootstrap.com/docs/5.0/components/collapse/#multiple-targets) option, but the `Cancel` button of the form edit couldn't be included in the mechanism, therefore it would have been handled via `js` eitherway. Thus, the decision was to handle both the cases (`showing` and `hiding`) via `js` anyway.