### PR TITLE
Fix the commenter's badges space issue

### DIFF
--- a/src/api/app/components/bs_request_comment_component.html.haml
+++ b/src/api/app/components/bs_request_comment_component.html.haml
@@ -2,9 +2,9 @@
   %i{ title: 'Comment', class: "fas fa-lg fa-comment #{ level > 1 ? 'd-none' : '' }" }
   = render(AvatarComponent.new(name: comment.user.name, email: comment.user.email, size: 35, shape: :circle, custom_css: 'avatars-counter'))
   .timeline-item-comment.ms-0.flex-fill.overflow-auto
-    .comment-bubble.ms-3
+    .comment-bubble.ms-3.position-relative
       - if policy(comment).update? || policy(comment).destroy?
-        .dropdown.dropleft.float-end.mx-3
+        .dropdown.dropleft.float-end.mx-3.position-absolute.top-0.end-0
           = link_to('#', role: 'button', 'data-bs-toggle': 'dropdown', 'aria-expanded': 'false') do
             %i.fas.fa-ellipsis
           .dropdown-menu
@@ -23,7 +23,7 @@
                                     action: comment_path(comment) },
                             class: 'dropdown-item delete_link', title: 'Delete comment') do
                 Delete
-      .px-3.py-2.border-bottom.d-flex.flex-column.flex-lg-row.justify-content-between.align-items-start.gap-2
+      .ps-3.pe-5.py-2.border-bottom.d-flex.flex-column.flex-lg-row.justify-content-between.align-items-start.gap-2
         .d-inline-flex.justify-content-start
           = link_to(helpers.realname_with_login(comment.user), user_path(comment.user))
           \-


### PR DESCRIPTION
This PR fixes a small spacing issue on the commenter's role badges.

This is how it looked like before:
![2024-02-14_10-59](https://github.com/openSUSE/open-build-service/assets/2650/2c104860-d16a-4990-a97c-8f3b6a760c00)

And this is how it looks like now:
![2024-02-14_10-58](https://github.com/openSUSE/open-build-service/assets/2650/dbae298f-7397-46a5-b843-1644940538bb)
