### PR TITLE
Let the build result sub content breathe with space

### DIFF
--- a/src/api/app/assets/stylesheets/webui/build-results.scss
+++ b/src/api/app/assets/stylesheets/webui/build-results.scss
@@ -241,6 +241,7 @@
       padding: 0.25rem;
       text-align: end;
       .architecture { display: none }
+      &:last-of-type { padding-right: 1rem }
     }
 
     .build-result-row {

--- a/src/api/app/components/build_results_monitor_component.html.haml
+++ b/src/api/app/components/build_results_monitor_component.html.haml
@@ -22,13 +22,13 @@
               - results_count_per_package_and_category(package_name).each do |key, value|
                 = render partial: 'webui/shared/build_status_count_badge', locals: { category: key, count: value.to_s }
 
-      .accordion-collapse.collapse{ id: "collapse-#{package_name.gsub(':', '_')}", class: show }
+      .accordion-collapse.collapse.my-3{ id: "collapse-#{package_name.gsub(':', '_')}", class: show }
         .build-result-table
           .build-result-legend
             .build-result-name
             - filtered_architecture_names.each do |architecture_name|
-              .build-result-architecture
-                = architecture_name
+              .build-result-architecture.mb-1
+                %b= architecture_name
           - filtered_repository_names.each do |repository_name|
             .build-result-row
               = link_to(helpers.word_break(repository_name, 22),


### PR DESCRIPTION
# Before
![more-space-before](https://github.com/openSUSE/open-build-service/assets/7080830/e40aabdd-fe8b-4d96-bd34-25256d0e8d7f)


# After
![more-space-after](https://github.com/openSUSE/open-build-service/assets/7080830/eaad43a6-f2a5-4eae-ab37-80fbd569e15d)

