### PR TITLE
[api] support source file download of deleted package for obs-lfs-ro

### DIFF
--- a/src/api/test/functional/source_controller_test.rb
+++ b/src/api/test/functional/source_controller_test.rb
@@ -1909,7 +1909,6 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     # source access check via public route (critical for obs-git-lfs-ro)
     get '/source/kde4/kdelibs?deleted=1'
     assert_response :success
-    puts @response.body
     node = Xmlhash.parse(@response.body)
     srcmd5 = node['srcmd5']
     get "/public/source/kde4/kdelibs/DUMMYFILE?rev=#{srcmd5}"

--- a/src/api/test/functional/source_controller_test.rb
+++ b/src/api/test/functional/source_controller_test.rb
@@ -1906,6 +1906,15 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     assert_xml_tag(parent: { tag: 'revision' }, tag: 'user', content: 'fredlibs')
     assert_xml_tag(parent: { tag: 'revision' }, tag: 'comment', content: 'test deleted')
     assert_response :success
+    # source access check via public route (critical for obs-git-lfs-ro)
+    get '/source/kde4/kdelibs?deleted=1'
+    assert_response :success
+    puts @response.body
+    node = Xmlhash.parse(@response.body)
+    srcmd5 = node['srcmd5']
+    get "/public/source/kde4/kdelibs/DUMMYFILE?rev=#{srcmd5}"
+    puts @response.body
+    assert_response :success
 
     # list deleted packages of existing project
     get '/source/kde4', params: { deleted: 1 }

--- a/src/api/test/functional/source_controller_test.rb
+++ b/src/api/test/functional/source_controller_test.rb
@@ -1912,7 +1912,6 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     node = Xmlhash.parse(@response.body)
     srcmd5 = node['srcmd5']
     get "/public/source/kde4/kdelibs/DUMMYFILE?rev=#{srcmd5}"
-    puts @response.body
     assert_response :success
 
     # list deleted packages of existing project


### PR DESCRIPTION
This is fixing git clone operations where OBS is LFS fallback and the package got deleted.

OBS-285