### PR TITLE
Link request build summary chart to build result tab

### DIFF
--- a/src/api/app/assets/javascripts/webui/request_show_redesign/chart_build_results.js
+++ b/src/api/app/assets/javascripts/webui/request_show_redesign/chart_build_results.js
@@ -13,3 +13,37 @@ function updateChartBuildResults() {
     }
   });
 }
+
+function linkBuildSummaryChartToBuildResultsTab() { // jshint ignore:line
+  var buildResultSummaryChart = Chartkick.charts['build-summary-chart'].getChartObject();
+
+  $("#build-summary-chart").click(function(e) {
+    var points = buildResultSummaryChart.getElementsAtEventForMode(e, 'nearest', { intersect: true }, true);
+    // click was not on a bar in the chart
+    if(!points.length) return;
+
+    var repositoryName = buildResultSummaryChart.data.labels[points[0].index];
+    var buildState = buildResultSummaryChart.data.datasets[points[0].datasetIndex].label;
+    // fetch url of the current request and create the link with the filter parameters
+    // to the build result tab
+    var requestShowUrl = window.location.pathname;
+    var requestBuildResultTabUrl = requestShowUrl + "/build_results" + "?repo_" + repositoryName + "=1" + buildResultStatusFilterQueryParams(buildState);
+
+    window.open(requestBuildResultTabUrl);
+  });
+}
+
+// the build result summary uses summarized build states, we have to map them back
+// to the original build state names in order to apply the filters
+function buildResultStatusFilterQueryParams(buildStateFromSummaryChart) {
+  switch(buildStateFromSummaryChart) {
+    case 'Published':
+      return '&status_succeeded=1';
+    case 'Failed':
+      return '&status_failed=1&status_unresolvable=1&status_broken=1';
+    case 'Building':
+      return '&status_blocked=1&status_dispatching=1&status_scheduled=1&status_building=1&status_finished=1&status_signing=1&status_locked=1&status_deleting=1&status_unknown=1';
+    case 'Excluded':
+      return '&status_disabled=1&status_excluded=1';
+  }
+}

--- a/src/api/app/components/chart_component.html.haml
+++ b/src/api/app/components/chart_component.html.haml
@@ -8,6 +8,7 @@
         Build Results Summary
     - if distinct_repositories.size > ChartComponent::MINIMUM_DISTINCT_BUILD_REPOSITORIES || raw_data.size > ChartComponent::MINIMUM_BUILD_RESULTS
       = column_chart( chart_data,
+                      id: 'build-summary-chart',
                       width: '100%',
                       height: '300px',
                       stacked: true,
@@ -15,6 +16,8 @@
                       colors: ['#008000', '#DC3545', '#FFCC00', '#EEEEEE'],
                       library: { scales: { y: { ticks: { stepSize: 1 }}}},
                     )
+      :javascript
+        linkBuildSummaryChartToBuildResultsTab();
     - else
       %div
         .row.p-2.ps-1


### PR DESCRIPTION
*How to test this:*

1. Create a request that includes a few build results
2. You can patch the following line if the amount of repositories is to low to show the chart summary https://github.com/openSUSE/open-build-service/blob/8fcea11ebc44bc9e0a8000cebdb85d509dd35010/src/api/app/components/chart_component.html.haml#L9
3. Click on the bars in the chart and see that it links to the build result tab and applies the corresponding repository and build state filters

*Note:*

There is currently no way to customize click events directly through Chartkick (and the underlying Chart.js library). I can also not generate the url's server side in ruby and provide them through the data hash that we pass to chartkick (additional keys are simply ignored and thrown away). So I have to generate the URL on the Javascript level and based on the data that is clicked on in the chart.     

![Peek 2024-02-15 17-55](https://github.com/openSUSE/open-build-service/assets/22001671/65d6ddfb-275c-41dc-aad2-bd9104aea439)
