### PR TITLE
Authorize comment `#create` api endpoint

### DIFF
--- a/src/api/app/controllers/comments_controller.rb
+++ b/src/api/app/controllers/comments_controller.rb
@@ -8,7 +8,9 @@ class CommentsController < ApplicationController
   end
 
   def create
-    @obj.comments.create!(body: request.raw_post, user: User.session!, parent_id: params[:parent_id])
+    comment = @obj.comments.new(body: request.raw_post, user: User.session!, parent_id: params[:parent_id])
+    authorize comment, :create?
+    comment.save!
     render_ok
   end
 


### PR DESCRIPTION
Currently there is not authorization going on, in some cases the `CommentLockingValidator` still prevents comments from being created if permission is insufficient in certain cases. But some things are not handled, for example when a user is blocked for commenting.

This should be handled on the controller level using our pundit policy.

@a-chris thanks bringing this up