### PR TITLE
[src/api] feature: Add BsRequest labels

### DIFF
--- a/src/api/app/controllers/webui/projects/bs_request_labels_controller.rb
+++ b/src/api/app/controllers/webui/projects/bs_request_labels_controller.rb
@@ -1,0 +1,61 @@
+module Webui
+  module Projects
+    class BsRequestLabelsController < WebuiController
+      before_action :find_label, only: [:destroy, :update]
+      before_action :set_project
+
+      def index
+        @labels = BsRequestLabel.all
+      end
+
+      def new
+        @label = BsRequestLabel.new
+
+        @labels = BsRequestLabel.all
+      end
+
+      def create
+        authorize @project, :create?
+        @label = BsRequestLabel.new(label_params)
+        respond_to do |format|
+          if @label.save
+            format.js { render 'create_success' }
+          else
+            format.js { render 'create_failure'}
+          end
+        end
+      end
+
+      def destroy
+        authorize @project, :destroy?
+
+        if @label.destroy
+          flash[:success] = "Label was successfully deleted."
+        else
+          flash[:error] = "Failed to delete label"
+        end
+        redirect_to new_project_label_path
+      end
+
+      def update
+        respond_to do |format|
+          if @label.update(label_params)
+            format.js { render 'update_success' }
+          else
+            format.js { render 'update_failure'}
+          end
+        end
+      end
+
+      private
+
+      def find_label
+        @label = BsRequestLabel.find(params[:id])
+      end
+
+      def label_params
+        params.require(:label).permit(:name, :description)
+      end
+    end
+  end
+end

--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -70,6 +70,8 @@ class BsRequest < ApplicationRecord
       .includes(:reviews)
   }
 
+  has_many :bs_request_bs_request_labels
+  has_many :labels, through: :bs_request_bs_request_labels, source: :bs_request_label
   has_many :bs_request_actions, dependent: :destroy
   has_many :reviews, dependent: :delete_all
   has_many :comments, as: :commentable, dependent: :destroy

--- a/src/api/app/models/bs_request_bs_request_label.rb
+++ b/src/api/app/models/bs_request_bs_request_label.rb
@@ -1,0 +1,27 @@
+class BsRequestBsRequestLabel < ApplicationRecord
+  belongs_to :bs_request, required: true
+  belongs_to :bs_request_label, required: true
+
+  validates :bs_request_id, uniqueness: { scope: :bs_request_label_id }
+end
+
+# == Schema Information
+#
+# Table name: bs_request_bs_request_labels
+#
+#  id                  :integer          not null, primary key
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  bs_request_id       :integer          not null, indexed
+#  bs_request_label_id :integer          not null, indexed
+#
+# Indexes
+#
+#  index_bs_request_bs_request_labels_on_bs_request_id        (bs_request_id)
+#  index_bs_request_bs_request_labels_on_bs_request_label_id  (bs_request_label_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (bs_request_id => bs_requests.id)
+#  fk_rails_...  (bs_request_label_id => bs_request_labels.id)
+#

--- a/src/api/app/models/bs_request_label.rb
+++ b/src/api/app/models/bs_request_label.rb
@@ -1,0 +1,20 @@
+class BsRequestLabel < ApplicationRecord
+  validates :name, presence: true
+  validates :name, uniqueness: true
+  validates :name, length: { maximum: 50 }
+  validates :description, length: { maximum: 255 }
+
+  has_many :bs_request_bs_request_labels
+  has_many :bs_requests, through: :bs_request_bs_request_labels
+end
+
+# == Schema Information
+#
+# Table name: bs_request_labels
+#
+#  id          :integer          not null, primary key
+#  description :text(65535)
+#  name        :string(255)      not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#

--- a/src/api/app/views/webui/project/_tabs.html.haml
+++ b/src/api/app/views/webui/project/_tabs.html.haml
@@ -19,6 +19,7 @@
       = tab_link('Attributes', [index_attribs_path(project)], controller_name == 'attribute', 'scrollable-tab-link')
       = tab_link('Signing Keys', project_signing_keys_path(project), false, 'scrollable-tab-link')
       = tab_link('Meta', project_meta_path(project), false, 'scrollable-tab-link')
+      = tab_link('Labels', new_project_label_path(project_name: project.name), false, 'scrollable-tab-link')
       - unless project.defines_remote_instance? || project.is_maintenance?
         = tab_link('Status', project_status_path(project), false, 'scrollable-tab-link')
       = tab_link('Pulse', project_pulse_path(project), false, 'scrollable-tab-link')

--- a/src/api/app/views/webui/projects/bs_request_labels/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui/projects/bs_request_labels/_breadcrumb_items.html.haml
@@ -1,0 +1,3 @@
+= render partial: 'webui/project/breadcrumb_items'
+%li.breadcrumb-item.active{ 'aria-current' => 'page' }
+  Submit as Update

--- a/src/api/app/views/webui/projects/bs_request_labels/_edit_label_modal.html.haml
+++ b/src/api/app/views/webui/projects/bs_request_labels/_edit_label_modal.html.haml
@@ -1,0 +1,19 @@
+#editLabelModal.modal.fade{ tabindex: "-1", role: "dialog", aria: { labelledby: "editLabelModalLabel", hidden: "true" } }
+  .modal-dialog.modal-dialog-centered{ role: "document" }
+    .modal-content
+      .modal-header
+        %h5.modal-title#editLabelModalLabel
+          Edit Label
+          %i.fas.fa-edit.ml-2
+        %button.close{ aria: { label: "Close" }, type: "button", data: { dismiss: "modal" } }
+          %span{ aria: { hidden: "true" } } &times;
+      .modal-body
+        = form_tag project_label_path(project_name: project_name, id: id), method: :patch, remote: true do
+          .form-group
+            = label_tag 'label[name]', 'Name'
+            = text_field_tag 'label[name]', nil, class: 'form-control', id: 'edit-label-name'
+          .form-group
+            = label_tag 'label[description]', 'Description'
+            = text_area_tag 'label[description]', nil, class: 'form-control', id: 'edit-label-description'
+          %br
+          = submit_tag 'Save', class: 'btn btn-primary'

--- a/src/api/app/views/webui/projects/bs_request_labels/_new_label_modal.html.haml
+++ b/src/api/app/views/webui/projects/bs_request_labels/_new_label_modal.html.haml
@@ -1,0 +1,17 @@
+#newLabelModal.modal.fade{ tabindex: "-1", role: "dialog", aria: { labelledby: "newLabelModalLabel", hidden: "true" } }
+  .modal-dialog.modal-dialog-centered{ role: "document" }
+    .modal-content
+      .modal-header
+        %h5.modal-title#newLabelModalLabel New Label
+        %button.close{ aria: { label: "Close" }, type: "button", data: { dismiss: "modal" } }
+          %span{ aria: { hidden: "true" } } &times;
+      .modal-body
+        = form_tag project_labels_path, method: :post, remote: true do
+          .form-group
+            = label_tag 'label[name]', 'Name'
+            = text_field_tag 'label[name]', nil, class: 'form-control', id: 'new-label-name'
+          .form-group
+            = label_tag 'label[description]', 'Description'
+            = text_area_tag 'label[description]', nil, class: 'form-control', id: 'new-label-description'
+          %br
+          = submit_tag 'Save', class: 'btn btn-primary'

--- a/src/api/app/views/webui/projects/bs_request_labels/create_failure.js.erb
+++ b/src/api/app/views/webui/projects/bs_request_labels/create_failure.js.erb
@@ -1,0 +1,2 @@
+var errorMessage = "<%= j(@label.errors.full_messages.join(', ')) %>";
+alert(errorMessage);

--- a/src/api/app/views/webui/projects/bs_request_labels/create_success.js.erb
+++ b/src/api/app/views/webui/projects/bs_request_labels/create_success.js.erb
@@ -1,0 +1,2 @@
+$('#newLabelModal').modal('hide');
+location.reload();

--- a/src/api/app/views/webui/projects/bs_request_labels/new.html.haml
+++ b/src/api/app/views/webui/projects/bs_request_labels/new.html.haml
@@ -1,0 +1,53 @@
+:javascript
+  $(document).ready(function() {
+    $('.edit-label').click(function() {
+      var labelName = $(this).data('name');
+      var labelDescription = $(this).data('description');
+      $('#edit-label-name').val(labelName);
+      $('#edit-label-description').val(labelDescription);
+      $('#editLabelModal').modal('show');
+    });
+
+    $('#newLabelButton').click(function() {
+      $('#newLabelModal').modal('show');
+    });
+
+    $('.modal .close').click(function() {
+      $(this).closest('.modal').modal('hide');
+    });
+  });
+:ruby
+  content_for(:content_for_head, javascript_include_tag('webui/cm2/codemirror-xml'))
+  @pagetitle = "Labels of #{@project}"
+  @metarobots = 'noindex'
+
+.card
+  = render(partial: 'webui/project/tabs', locals: { project: @project })
+
+  .card-body
+    %h3= @pagetitle
+  .container
+    .container
+    %h2 Existing Labels
+    %table.table.table-striped
+      %thead
+        %tr
+          %th Name
+          %th Description
+          %th Edit
+          %th Delete
+      %tbody
+        - @labels.each do |label|
+          %tr
+            %td= label.name
+            %td= label.description
+            %td
+              = link_to 'Edit', '#', class: 'btn btn-primary edit-label', data: { name: label.name, description: label.description }, data_toggle: 'modal'
+            %td
+              = link_to 'Delete', project_label_path(project_name: @project.name, id: label.id), method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger'
+          = render(partial: 'edit_label_modal', locals: {project_name: @project.name, id: label.id})
+          = render(partial: 'new_label_modal', locals: {project_name: @project.name, id: label.id})
+    %button.btn.btn-primary#newLabelButton New Label
+
+
+

--- a/src/api/app/views/webui/projects/bs_request_labels/update_failure.js.erb
+++ b/src/api/app/views/webui/projects/bs_request_labels/update_failure.js.erb
@@ -1,0 +1,2 @@
+var errorMessage = "<%= j(@label.errors.full_messages.join(', ')) %>";
+alert(errorMessage);

--- a/src/api/app/views/webui/projects/bs_request_labels/update_success.js.erb
+++ b/src/api/app/views/webui/projects/bs_request_labels/update_success.js.erb
@@ -1,0 +1,1 @@
+$('#editLabelModal').modal('hide');

--- a/src/api/app/views/webui/request/_add_label_relation.html.haml
+++ b/src/api/app/views/webui/request/_add_label_relation.html.haml
@@ -1,0 +1,15 @@
+#addLabelModal.modal.fade{ tabindex: "-1", role: "dialog", aria: { labelledby: "addLabelModalLabel", hidden: "true" } }
+  .modal-dialog{ role: "document" }
+    .modal-content
+      .modal-header
+        %h5.modal-title#addLabelModalLabel Add Label
+        %button.close{ aria: { label: "Close" }, type: "button", data: { dismiss: "modal" } }
+          %span{ aria: { hidden: "true" } } &times;
+      .modal-body
+        = form_tag request_add_label_relation_path, method: :post do
+          .form-group
+            = label_tag 'label_id', 'Select Labels'
+            = select_tag 'label_id', options_for_select(@all_labels.map { |label| [label.name, label.id] }), class: 'form-control'
+          %br
+          = hidden_field_tag 'number', @bs_request.number
+          = submit_tag 'Add Label', class: 'btn btn-primary'

--- a/src/api/app/views/webui/request/_show_labels.html.haml
+++ b/src/api/app/views/webui/request/_show_labels.html.haml
@@ -1,0 +1,33 @@
+:javascript
+  $(document).ready(function() {
+    $('#addLabelButton').click(function() {
+      $('#addLabelModal').modal('show');
+    });
+
+    $('#addLabelModal .close').click(function() {
+      $('#addLabelModal').modal('hide');
+    });
+  });
+
+.card.mb-3
+  .card-header.d-flex.justify-content-between
+    %h5 Labels
+  .card-body
+    .row
+      .col-md-8#labels
+        .container
+          %table.table.table-striped
+            %thead
+              %tr
+                %th Label Name
+                %th Actions
+            %tbody
+              - @bs_request.labels.each do |label|
+                %tr
+                  %td= label.name
+                  %td
+                    = link_to 'Delete', request_destroy_label_relation_path(label_id: label.id, number: @bs_request.number), method: :delete, class: 'btn btn-danger', data: { confirm: 'Are you sure you want to delete this label?' }
+
+        = link_to 'Add Label', '#', id: 'addLabelButton', class: 'btn btn-primary add-label', data: { bs_request: @bs_request}, data_toggle: 'modal'
+
+  = render(partial: 'add_label_relation', locals: { bs_request: @bs_request })

--- a/src/api/app/views/webui/request/show.html.haml
+++ b/src/api/app/views/webui/request/show.html.haml
@@ -24,10 +24,13 @@
                                                      bs_requests: @watched_requests,
                                                      packages: @watched_packages,
                                                      projects: @watched_projects }
+
       .col-md-4#side-links
         = render partial: 'show_side_links', locals: { bs_request: @bs_request, package_maintainers: @package_maintainers }
       - if @can_add_reviews
         = render partial: 'actions'
+
+= render partial: 'webui/request/show_labels', locals: { bs_request: @bs_request, all_labels: @all_labels }
 
 .card.mb-3
   .card-header.p-0

--- a/src/api/app/views/webui/shared/_add_bs_request_label_dialog.html.haml
+++ b/src/api/app/views/webui/shared/_add_bs_request_label_dialog.html.haml
@@ -1,0 +1,15 @@
+.modal.fade#add-label-modal{ tabindex: -1, role: 'dialog', aria: { labelledby: 'add-label-modal-label', hidden: true } }
+  .modal-dialog.modal-dialog-centered{ role: 'document' }
+    .modal-content
+      = form_tag project_labels_path, remote: true do
+        .modal-header
+          %h5.modal-title#add-label-modal-label Add Label
+        .modal-body
+          .form-group
+            = label_tag 'label_name', 'Name'
+            = text_field_tag 'name', nil, class: 'form-control'
+          .form-group
+            = label_tag 'label_description', 'Description'
+            = text_area_tag 'description', nil, class: 'form-control'
+        .modal-footer
+          = render partial: 'webui/shared/dialog_action_buttons'

--- a/src/api/config/routes/webui_routes.rb
+++ b/src/api/config/routes/webui_routes.rb
@@ -271,6 +271,7 @@ OBSApi::Application.routes.draw do
       resource :signing_keys, controller: 'webui/projects/signing_keys', only: [:show], constraints: cons do
         get 'download'
       end
+      resources :labels, controller: 'webui/projects/bs_request_labels', only: [:index, :new, :create, :edit, :update, :destroy]
       resource :pulse, controller: 'webui/projects/pulse', only: [:show], constraints: cons
       resource :meta, controller: 'webui/projects/meta', only: [:show, :update], constraints: cons
       resource :prjconf, controller: 'webui/projects/project_configuration', only: [:show, :update], as: :config, constraints: cons
@@ -305,6 +306,8 @@ OBSApi::Application.routes.draw do
     end
 
     controller 'webui/request' do
+      post 'request/add_label_relation'=> :add_label_relation
+      delete 'request/destroy_label_relation'=> :destroy_label_relation
       post 'request/add_reviewer' => :add_reviewer
       post 'request/modify_review' => :modify_review
       get 'request/show/:number/(request_action/:request_action_id)' => :show, as: 'request_show', constraints: cons

--- a/src/api/db/migrate/20240221161956_create_bs_request_labels.rb
+++ b/src/api/db/migrate/20240221161956_create_bs_request_labels.rb
@@ -1,0 +1,10 @@
+class CreateBsRequestLabels < ActiveRecord::Migration[7.0]
+  def change
+    create_table :bs_request_labels, id: :integer do |t|
+      t.string :name, null: false
+      t.text :description
+
+      t.timestamps
+    end
+  end
+end

--- a/src/api/db/migrate/20240222080033_create_bs_request_bs_request_labels.rb
+++ b/src/api/db/migrate/20240222080033_create_bs_request_bs_request_labels.rb
@@ -1,0 +1,10 @@
+class CreateBsRequestBsRequestLabels < ActiveRecord::Migration[7.0]
+  def change
+    create_table :bs_request_bs_request_labels, id: :integer do |t|
+      t.references :bs_request, null: false, foreign_key: true, type: :integer
+      t.references :bs_request_label, null: false, foreign_key: true, type: :integer
+
+      t.timestamps
+    end
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_02_07_080349) do
+ActiveRecord::Schema[7.0].define(version: 2024_02_22_080033) do
   create_table "appeals", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.text "reason", null: false
     t.integer "appellant_id", null: false
@@ -206,8 +206,24 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_07_080349) do
     t.index ["bs_request_action_id", "user_id"], name: "bs_request_actions_seen_by_users_index"
   end
 
+  create_table "bs_request_bs_request_labels", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.integer "bs_request_id", null: false
+    t.integer "bs_request_label_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["bs_request_id"], name: "index_bs_request_bs_request_labels_on_bs_request_id"
+    t.index ["bs_request_label_id"], name: "index_bs_request_bs_request_labels_on_bs_request_label_id"
+  end
+
   create_table "bs_request_counter", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "counter", default: 1
+  end
+
+  create_table "bs_request_labels", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "name", null: false
+    t.text "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "bs_requests", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
@@ -1232,6 +1248,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_07_080349) do
   add_foreign_key "binary_releases", "repositories", name: "binary_releases_ibfk_1"
   add_foreign_key "bs_request_action_accept_infos", "bs_request_actions", name: "bs_request_action_accept_infos_ibfk_1"
   add_foreign_key "bs_request_actions", "bs_requests", name: "bs_request_actions_ibfk_1"
+  add_foreign_key "bs_request_bs_request_labels", "bs_request_labels"
+  add_foreign_key "bs_request_bs_request_labels", "bs_requests"
   add_foreign_key "canned_responses", "users"
   add_foreign_key "channel_binaries", "architectures", name: "channel_binaries_ibfk_4"
   add_foreign_key "channel_binaries", "channel_binary_lists", name: "channel_binaries_ibfk_1"


### PR DESCRIPTION
## Why are the changes necessary?
We want to have similar functionality of adding creating `labels` and adding them to a `BsRequest` just like in Github.

## What does this pull request cover?

An initial implementation of BsRequestLabels

### Screenshots or -captures
<img width="1243" alt="Screenshot 2024-02-22 at 12 04 06" src="https://github.com/openSUSE/open-build-service/assets/24634178/2325dfdd-84e6-4693-aa2e-209b6d83a248">

<img width="1240" alt="Screenshot 2024-02-22 at 12 04 27" src="https://github.com/openSUSE/open-build-service/assets/24634178/657f471d-f024-4d2b-ad4b-3ad0668b6c76">