### PR TITLE
[backend] patchinfo: allow to skip updateinfo.xml generation

### DIFF
--- a/docs/api/api/patchinfo.rng
+++ b/docs/api/api/patchinfo.rng
@@ -75,7 +75,12 @@
         </element>
 
         <optional>
-          <element name="stopped"> 
+          <element name="seperate_build_arch">
+            <empty/>
+          </element>
+        </optional>
+        <optional>
+          <element name="stopped">
             <text/>
           </element>
         </optional>

--- a/docs/api/api/patchinfo.rng
+++ b/docs/api/api/patchinfo.rng
@@ -133,6 +133,7 @@
       <value>optional</value>
       <value>feature</value>
       <value>ptf</value>
+      <value>no_updateinfo</value>
     </choice>
   </define>
 

--- a/src/backend/BSSched/BuildJob/Patchinfo.pm
+++ b/src/backend/BSSched/BuildJob/Patchinfo.pm
@@ -719,8 +719,10 @@ sub build {
   };
   $update->{'pkglist'} = {'collection' => [ $col ] };
   $update->{'patchinforef'} = "$projid/$packid";        # deleted in publisher...
-  writexml("$jobdatadir/updateinfo.xml", undef, {'update' => [$update]}, $BSXML::updateinfo);
-  $bininfo->{'updateinfo.xml'} = genbininfo($jobdatadir, 'updateinfo.xml');
+  if ($category ne 'no_updateinfo') {
+    writexml("$jobdatadir/updateinfo.xml", undef, {'update' => [$update]}, $BSXML::updateinfo);
+    $bininfo->{'updateinfo.xml'} = genbininfo($jobdatadir, 'updateinfo.xml');
+  };
   writestr("$jobdatadir/logfile", undef, "update built succeeded ".localtime($now)."\n");
   $updateinfodata = {
     'packages' => \@tocopy,

--- a/src/backend/BSSched/BuildJob/Patchinfo.pm
+++ b/src/backend/BSSched/BuildJob/Patchinfo.pm
@@ -110,10 +110,14 @@ sub check {
   my $myarch = $gctx->{'arch'};
   my @archs = @{$repo->{'arch'}};
   return ('broken', 'missing archs') unless @archs;     # can't happen
-  my $buildarch = $archs[0];    # always build in first arch
+  my $patchinfo = $pdata->{'patchinfo'};
+  if (exists $patchinfo->{'seperate_build_arch'}) {
+    # build on all schedulers, but don't take content from each other
+    @archs = ($myarch);
+  };
+  my $buildarch = $archs[0];
   my $reporoot = $gctx->{'reporoot'};
   my $markerdir = "$reporoot/$prp/$buildarch/$packid";
-  my $patchinfo = $pdata->{'patchinfo'};
   my $projpacks = $gctx->{'projpacks'};
   my $proj = $projpacks->{$projid} || {};
 

--- a/src/backend/BSVerify.pm
+++ b/src/backend/BSVerify.pm
@@ -111,7 +111,7 @@ sub verify_patchinfo {
   # This verifies the absolute minimum required content of a patchinfo file
   my $p = $_[0];
   verify_filename($p->{'name'}) if defined($p->{'name'});
-  my %allowed_categories = map {$_ => 1} qw{security recommended optional feature ptf};
+  my %allowed_categories = map {$_ => 1} qw{security recommended optional feature ptf no_updateinfo};
   die("Invalid category defined in _patchinfo\n") if defined($p->{'category'}) && !$allowed_categories{$p->{'category'}};
   for my $rt (@{$p->{'releasetarget'} || []}) {
     verify_projid($rt->{'project'});

--- a/src/backend/BSXML.pm
+++ b/src/backend/BSXML.pm
@@ -268,6 +268,7 @@ our $patchinfo = [
             'packager',
             'retracted',
             'stopped',
+            'seperate_build_arch', # for builds on each scheduler arch
             'zypp_restart_needed',
             'reboot_needed',
             'relogin_needed',


### PR DESCRIPTION
To be able collect binaries without creating update meta information.

OBS-298