### PR TITLE
[api] relax package meta

### DIFF
--- a/docs/api/api/package.rng
+++ b/docs/api/api/package.rng
@@ -45,90 +45,108 @@
         <attribute name="project"/>
       </optional>
 
-      <element ns="" name="title">
-        <text/>
-      </element>
+      <interleave>
 
-      <element ns="" name="description">
-        <text/>
-      </element>
+        <optional>
+          <element ns="" name="title">
+            <text/>
+          </element>
+        </optional>
 
-<interleave>
+        <optional>
+          <element ns="" name="description">
+            <text/>
+          </element>
+        </optional>
 
-      <optional>
-        <element ns="" name="devel">
-          <optional>
-              <attribute name="project"/>
-          </optional>
-          <optional>
-              <attribute name="package"/>
-          </optional>
-          <empty/>
-        </element>
-      </optional>
-      <optional>
-        <element ns="" name="releasename">
-          <text/>
-        </element>
-      </optional>
-      <zeroOrMore>
-        <ref name="person-element"/>
-      </zeroOrMore>
-      <zeroOrMore>
-        <ref name="group-element"/>
-      </zeroOrMore>
-      <optional>
-        <element ns="" name="lock">
-          <ref name="simple-flag-element"/>
-        </element>
-      </optional>
-      <optional>
-        <element ns="" name="build">
-          <ref name="flag-element"/>
-        </element>
-      </optional>
-      <optional>
-        <element ns="" name="publish">
-          <ref name="flag-element"/>
-        </element>
-      </optional>
-      <optional>
-        <element ns="" name="useforbuild">
-          <ref name="flag-element"/>
-        </element>
-      </optional>
-      <optional>
-        <element ns="" name="debuginfo">
-          <ref name="flag-element"/>
-        </element>
-      </optional>
-      <optional>
-        <element ns="" name="binarydownload">
-          <ref name="flag-element"/>
-        </element>
-      </optional>
-      <optional>
-        <element ns="" name="sourceaccess">
-          <ref name="simple-flag-element"/>
-        </element>
-      </optional>
-      <optional>
-        <element ns="" name="url">
-          <text/>
-        </element>
-      </optional>
-      <optional>
-        <element ns="" name="scmsync">
-          <text/>
-        </element>
-      </optional>
-      <optional>
-        <element ns="" name="bcntsynctag">
-          <text/>
-        </element>
-      </optional>
+        <optional>
+          <element ns="" name="devel">
+            <optional>
+                <attribute name="project"/>
+            </optional>
+            <optional>
+                <attribute name="package"/>
+            </optional>
+            <empty/>
+          </element>
+        </optional>
 
-</interleave>
+        <optional>
+          <element ns="" name="releasename">
+            <text/>
+          </element>
+        </optional>
+
+        <zeroOrMore>
+          <ref name="person-element"/>
+        </zeroOrMore>
+
+        <zeroOrMore>
+          <ref name="group-element"/>
+        </zeroOrMore>
+
+        <optional>
+          <element ns="" name="lock">
+            <ref name="simple-flag-element"/>
+          </element>
+        </optional>
+
+        <optional>
+          <element ns="" name="build">
+            <ref name="flag-element"/>
+          </element>
+        </optional>
+
+        <optional>
+          <element ns="" name="publish">
+            <ref name="flag-element"/>
+          </element>
+        </optional>
+
+        <optional>
+          <element ns="" name="useforbuild">
+            <ref name="flag-element"/>
+          </element>
+        </optional>
+
+        <optional>
+          <element ns="" name="debuginfo">
+            <ref name="flag-element"/>
+          </element>
+        </optional>
+
+        <optional>
+          <element ns="" name="binarydownload">
+            <ref name="flag-element"/>
+          </element>
+        </optional>
+
+        <optional>
+          <element ns="" name="sourceaccess">
+            <ref name="simple-flag-element"/>
+          </element>
+        </optional>
+
+        <optional>
+          <element ns="" name="url">
+            <text/>
+          </element>
+        </optional>
+
+        <optional>
+          <element ns="" name="scmsync">
+            <text/>
+          </element>
+        </optional>
+
+        <optional>
+          <element ns="" name="bcntsynctag">
+            <text/>
+          </element>
+        </optional>
+
+      </interleave>
+
     </element>
   </define>
 </grammar>

--- a/src/api/test/functional/source_controller_test.rb
+++ b/src/api/test/functional/source_controller_test.rb
@@ -269,6 +269,23 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     assert_xml_tag(tag: 'comment', content: 'fixtures')
   end
 
+  def test_put_minimal_package_meta
+    login_tom
+    # ensure that api and backend takes this minimal meta
+    raw_put '/source/home:tom/MINIMAL/_meta', '<package name="MINIMAL"/>'
+    assert_response :success
+
+    # check created package in api and backend
+    get '/source/home:tom/MINIMAL/_meta'
+    assert_response :success
+    get '/source/home:tom/MINIMAL'
+    assert_response :success
+
+    # cleanup
+    delete '/source/home:tom/MINIMAL'
+    assert_response :success
+  end
+
   def test_get_package_meta_from_hidden_project
     login_tom
     get '/source/HiddenProject/pack/_meta'


### PR DESCRIPTION
OBS is not always delivering title and description elements itself anymore (when they come from pure backend projects). So accept package meta also without it to avoid that tooling can not read and write same meta from OBS instances.

Also the order of title and description does not matter to us.

Rest is just indenting fixes.