### PR TITLE
[backend] fix slepool maping for product composer naming

### DIFF
--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -1888,7 +1888,7 @@ sub mapslepool {
   my $p = $bin;
   if ($name eq 'nobuildid') {
     $p = "repo/$bin";
-    $p =~ s/-Build[\d\.]+//;
+    $p =~ s/-Build[\d\.]*\d//;
   } elsif ($bin =~ /.*-Media1?(\.license|)$/) {
     $p = "$name$1";
   } elsif ($bin =~ /-Media3$/ || $bin =~ /-Debug$/) {


### PR DESCRIPTION
slepool stripped away the dot from .license directories when build with product composer (since we have no more -Media strings behind build number.