### PR TITLE
Add more precise receiver role text for commenter

### DIFF
--- a/src/api/app/models/event_subscription.rb
+++ b/src/api/app/models/event_subscription.rb
@@ -7,7 +7,7 @@ class EventSubscription < ApplicationRecord
     source_maintainer: 'Maintainer of the source',
     target_maintainer: 'Maintainer of the target',
     reviewer: 'Reviewer',
-    commenter: 'Commenter',
+    commenter: 'Commenter or mentioned user',
     creator: 'Creator',
     watcher: 'Watching the project',
     source_watcher: 'Watching the source project',


### PR DESCRIPTION
When users subscribe to new comment events as `Commenter`., I mean this:

![Screenshot 2024-02-26 at 13-04-30 openSUSE Build Service](https://github.com/openSUSE/open-build-service/assets/2581944/7c1cc8a6-3f21-4d44-bcb3-1a65d56486d0)

they will receive notifications if they wrote any of the comments in the project/package/request ( commenters) but also when they were **mentioned** in any of those comments. Look at this [code](https://github.com/openSUSE/open-build-service/blob/936644bea0b4d6ae7c7227b9b920d867c1805f25/src/api/app/models/comment.rb#L106).

We need to clarify that. I propose this text:

![Screenshot 2024-02-26 at 14-26-57 Open Build Service](https://github.com/openSUSE/open-build-service/assets/2581944/8e11f157-22d5-419f-8f50-2d6204a32320)
