### PR TITLE
Fix errors when updating a notification

### DIFF
--- a/src/api/app/views/webui/users/notifications/_update.js.erb
+++ b/src/api/app/views/webui/users/notifications/_update.js.erb
@@ -1,5 +1,5 @@
 $('#filters').html("<%= j(render NotificationFilterComponent.new(selected_filter: selected_filter, user: user)) %>");
-$('#notifications-list').html("<%= j(render partial: 'notifications_list', locals: { notifications: notifications, selected_filter: selected_filter, show_read_all_button: show_read_all_button }) %>");
+$('#notifications-list').html("<%= j(render partial: 'notifications_list', locals: { notifications: notifications, selected_filter: selected_filter, show_read_all_button: show_read_all_button, current_user: user }) %>");
 $('#flash').html("<%= escape_javascript(render(layout: false, partial: 'layouts/webui/flash', object: flash)) %>");
 $('#top-notifications-counter, #bottom-notifications-counter').html("<%= escape_javascript(render partial: 'layouts/webui/unread_notifications_counter') %>");
 $(document).ready(function() { handleNotificationCheckboxSelection(); });


### PR DESCRIPTION
Fixes #15691

Before this PR you cannot check off a notification, and the rails log shows an error. After applying this, there is no error anymore and the notifications can be checked off.