### PR TITLE
Fix maintained projects datatable search

### DIFF
--- a/src/api/app/datatables/maintained_project_datatable.rb
+++ b/src/api/app/datatables/maintained_project_datatable.rb
@@ -30,7 +30,7 @@ class MaintainedProjectDatatable < Datatable
 
   # rubocop:disable Naming/AccessorMethodName
   def get_raw_records
-    @project.maintained_projects.includes(:project)
+    @project.maintained_projects.joins(:project)
   end
   # rubocop:enable Naming/AccessorMethodName
 


### PR DESCRIPTION
We need the `joins` so the 'project name' the datatable looks for is matched against the `projects` table instead of the `maintained_projects` table.

Fixes #15665