### PR TITLE
[backend] provide jobid when getting the logfile of a running job

### DIFF
--- a/src/backend/bs_repserver
+++ b/src/backend/bs_repserver
@@ -1248,6 +1248,7 @@ sub getlogfile {
     if (!$BSStdServer::isajax && !$cgi->{'view'}) {
       BSHandoff::handoff("/build/$projid/$repoid/$arch/$packid/_log", undef, @args);
     }
+    push @args, "jobid=$jobstatus->{'jobid'}" if $jobstatus->{'jobid'};
     my $param = {
       'uri' => "$jobstatus->{'uri'}/logfile",
       'joinable' => 1,


### PR DESCRIPTION
This makes sure that we do not get the logfile of the next job if our job is already done.