### PR TITLE
Scrub the rpmlint log files

### DIFF
--- a/src/api/app/services/rpmlint_log_extractor.rb
+++ b/src/api/app/services/rpmlint_log_extractor.rb
@@ -41,6 +41,8 @@ class RpmlintLogExtractor
     @parse_internal_log_file = true
 
     log_content = Backend::Api::BuildResults::Binaries.file(project, repository, architecture, package, '_log')
+    # Remove invalid byte sequences
+    log_content.scrub!
 
     # The OBS rpmlint mark is defined here: https://github.com/openSUSE/obs-build/blob/44e43abe9da522c1c6685742aecc55be158da55b/build-recipe-spec#L331
     mark1 = '\[\s*\d+s\]\s\n'

--- a/src/api/spec/services/rpmlint_log_extractor_spec.rb
+++ b/src/api/spec/services/rpmlint_log_extractor_spec.rb
@@ -3,13 +3,16 @@ RSpec.describe RpmlintLogExtractor, type: :service do
 
   subject { described_class.new(parameters).call }
 
+  before do
+    Flipper.enable(:request_show_redesign)
+    allow(Backend::Api::BuildResults::Binaries).to receive(:rpmlint_log)
+      .with('home:user1', 'package1', 'repo1', 'arch1')
+      .and_raise(Backend::NotFoundError, 'rpmlint.log: No such file or directory')
+  end
+
   describe '#call' do
     context 'no rpmlint.log file available since error exceeds allowed badness level' do
       before do
-        Flipper.enable(:request_show_redesign)
-        allow(Backend::Api::BuildResults::Binaries).to receive(:rpmlint_log)
-          .with('home:user1', 'package1', 'repo1', 'arch1')
-          .and_raise(Backend::NotFoundError, 'rpmlint.log: No such file or directory')
         allow(Backend::Api::BuildResults::Binaries).to receive(:file)
           .with('home:user1', 'repo1', 'arch1', 'package1', '_log')
           .and_return(file_fixture('rpmlint_log_extractor_log').read)
@@ -17,6 +20,20 @@ RSpec.describe RpmlintLogExtractor, type: :service do
 
       it 'extracts the summary from the build log file' do
         expect(subject).to eq(file_fixture('rpmlint_log_extractor_expected').read)
+      end
+    end
+
+    context 'when the rpmlint log contains invalid byte sequences in UTF-8' do
+      let(:invalid_byte_sequence_in_utf8) { "this is an invalid byte sequence \xED" }
+
+      before do
+        allow(Backend::Api::BuildResults::Binaries).to receive(:file)
+          .with('home:user1', 'repo1', 'arch1', 'package1', '_log')
+          .and_return(invalid_byte_sequence_in_utf8)
+      end
+
+      it 'extracts the summary from the build log file' do
+        expect(subject).to eq('this is an invalid byte sequence �')
       end
     end
   end


### PR DESCRIPTION
To avoid errors like "invalid byte sequence in UTF-8" when fetching the rpmlint log file.

Fixes #15700