### PR TITLE
Create migration to add decision kind to canned responses

### DIFF
--- a/src/api/db/migrate/20240227153505_add_decision_kind_to_canned_responses.rb
+++ b/src/api/db/migrate/20240227153505_add_decision_kind_to_canned_responses.rb
@@ -1,0 +1,5 @@
+class AddDecisionKindToCannedResponses < ActiveRecord::Migration[7.0]
+  def change
+    add_column :canned_responses, :decision_kind, :integer
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_02_07_080349) do
+ActiveRecord::Schema[7.0].define(version: 2024_02_27_153505) do
   create_table "appeals", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.text "reason", null: false
     t.integer "appellant_id", null: false
@@ -238,6 +238,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_07_080349) do
     t.text "content"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "decision_kind"
     t.index ["user_id"], name: "index_canned_responses_on_user_id"
   end
 


### PR DESCRIPTION
We'll need to group the canned responses by decision kind later on. The default is null for those canned responses not related to decisions.