### PR TITLE
Handle Kind of canned responses

### DIFF
--- a/src/api/app/assets/javascripts/webui/canned_responses.js
+++ b/src/api/app/assets/javascripts/webui/canned_responses.js
@@ -1,6 +1,7 @@
 function setupCannedResponses() { // jshint ignore:line
   $('[data-canned-controller]').on('click', '[data-canned-response]', function(e) {
     $(e.target).closest('[data-canned-controller]').find('textarea').val(e.target.dataset.cannedResponse);
+    $(e.target).closest('[data-canned-controller]').find('#decision_kind').val(e.target.dataset.decisionKind);
     // we have to enable the submit button for the comments form
     $(e.target).closest('[class*="-comment-form"]').find('input[type="submit"]').prop('disabled', false);
   });

--- a/src/api/app/components/canned_responses_dropdown_component.html.haml
+++ b/src/api/app/components/canned_responses_dropdown_component.html.haml
@@ -2,13 +2,14 @@
   %button.btn.btn-link.text-decoration-none.dropdown-toggle{ type: 'button', 'data-bs-toggle': 'dropdown', 'aria-expanded': false }
     %i.fas.fa-comment-dots
     Canned Responses
-  %ul.dropdown-menu.dropdown-menu-end
-    - @canned_responses.each do |canned_response|
-      %li.dropdown-item{ data: { 'canned-response': canned_response.content }, role: 'button' }= canned_response.title
-    %li
-      %hr.dropdown-divider/
-    %li
-      = link_to('Create and modify' , canned_responses_path, class: 'dropdown-item')
+  %ul.dropdown-menu
+    - @canned_responses_by_kind.each do |decision_kind, canned_responses|
+      .dropdown-header= decision_kind&.capitalize || 'Generic'
+      - canned_responses.each do |canned_response|
+        %li.dropdown-item{ data: { 'canned-response': canned_response.content, 'decision_kind': decision_kind }, role: 'button' }
+          = canned_response.title
+    %hr.dropdown-divider/
+    = link_to('Create and modify' , canned_responses_path, class: 'dropdown-item')
 :javascript
   $(document).ready(function(){
     setupCannedResponses();

--- a/src/api/app/components/canned_responses_dropdown_component.rb
+++ b/src/api/app/components/canned_responses_dropdown_component.rb
@@ -3,5 +3,17 @@ class CannedResponsesDropdownComponent < ApplicationComponent
     super
 
     @canned_responses = canned_responses
+    @canned_responses_by_kind = canned_responses_by_kind
+  end
+
+  private
+
+  def canned_responses_by_kind
+    # Only the kinds available in the user's canned responses
+    kinds = @canned_responses.pluck(:decision_kind).uniq
+
+    kinds.index_with do |decision_kind|
+      @canned_responses.where(decision_kind: decision_kind)
+    end
   end
 end

--- a/src/api/app/components/reports_modal_component.html.haml
+++ b/src/api/app/components/reports_modal_component.html.haml
@@ -18,6 +18,7 @@
             %h5 Decision
             .d-flex.align-items-center.justify-content-between.mb-1
               = form.label(:reason)
+              -# Decision-related canned responses exclusively:
               = render CannedResponsesDropdownComponent.new(canned_responses)
             = form.text_area(:reason, class: 'form-control mb-3', required: true, placeholder: 'Reason for the decision')
             = form.select(:kind, Decision.kinds.keys, {}, class: 'form-select')

--- a/src/api/app/components/reports_modal_component.rb
+++ b/src/api/app/components/reports_modal_component.rb
@@ -12,5 +12,6 @@ class ReportsModalComponent < ApplicationComponent
 
   def canned_responses
     CannedResponsePolicy::Scope.new(user, CannedResponse).resolve
+                               .where(decision_kind: ['favor', 'cleared']).order(:decision_kind, :title)
   end
 end

--- a/src/api/app/controllers/webui/users/canned_responses_controller.rb
+++ b/src/api/app/controllers/webui/users/canned_responses_controller.rb
@@ -61,6 +61,6 @@ class Webui::Users::CannedResponsesController < Webui::WebuiController
   end
 
   def canned_response_params
-    params.require(:canned_response).permit(:title, :content)
+    params.require(:canned_response).permit(:title, :content, :decision_kind)
   end
 end

--- a/src/api/app/models/canned_response.rb
+++ b/src/api/app/models/canned_response.rb
@@ -34,12 +34,13 @@ end
 #
 # Table name: canned_responses
 #
-#  id         :bigint           not null, primary key
-#  content    :text(65535)
-#  title      :string(255)
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  user_id    :integer          not null, indexed
+#  id            :bigint           not null, primary key
+#  content       :text(65535)
+#  decision_kind :integer
+#  title         :string(255)
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  user_id       :integer          not null, indexed
 #
 # Indexes
 #

--- a/src/api/app/models/canned_response.rb
+++ b/src/api/app/models/canned_response.rb
@@ -9,6 +9,11 @@ class CannedResponse < ApplicationRecord
   validates :title, length: { maximum: 255 }
   validates :content, length: { maximum: 65_535 }
 
+  enum decision_kind: {
+    cleared: 0,
+    favor: 1
+  }
+
   #### Attributes
 
   #### Associations macros (Belongs to, Has one, Has many)

--- a/src/api/app/views/webui/comment/_comment_field.html.haml
+++ b/src/api/app/views/webui/comment/_comment_field.html.haml
@@ -22,7 +22,7 @@ data: { preview_message_url: preview_comments_path, message_body_param: 'comment
                                        'data-canned-controller': '' }
         - if Flipper.enabled?(:content_moderation, User.session)
           .d-flex.justify-content-end
-            = render CannedResponsesDropdownComponent.new(policy_scope(CannedResponse))
+            = render CannedResponsesDropdownComponent.new(policy_scope(CannedResponse).where(decision_kind: nil).order(:title))
         ~ f.text_area :body, id: "#{element_suffix}_body", rows: '4',
         placeholder: 'Write your comment here... (Markdown markup is supported)', required: true,
         class: 'w-100 form-control comment-field message-field'

--- a/src/api/app/views/webui/users/canned_responses/edit.html.haml
+++ b/src/api/app/views/webui/users/canned_responses/edit.html.haml
@@ -10,4 +10,8 @@
       .mb-3
         = f.label :content, 'Content:'
         = f.text_area :content, class: 'form-control'
+      - if policy(Decision.new).create?
+        .mb-3
+          = f.label :decision_kind, "Choose 'cleared' or 'favor' if this is a decision's reason"
+          = f.select(:decision_kind, CannedResponse.decision_kinds.keys, { include_blank: 'none' }, class: 'form-select')
       = f.submit 'Save', class: 'btn btn-primary'

--- a/src/api/app/views/webui/users/canned_responses/index.html.haml
+++ b/src/api/app/views/webui/users/canned_responses/index.html.haml
@@ -10,6 +10,10 @@
       .mb-3
         = f.label :content, 'Content:'
         = f.text_area :content, class: 'form-control'
+      - if policy(Decision.new).create?
+        .mb-3
+          = f.label :decision_kind, "Choose 'cleared' or 'favor' if this is a decision's reason"
+          = f.select(:decision_kind, CannedResponse.decision_kinds.keys, { include_blank: 'none', selected: nil }, class: 'form-select')
       = f.submit 'Create', class: 'btn btn-primary'
 
 .card.mt-2
@@ -27,7 +31,7 @@
             .accordion-collapse.collapse{ id: "#{canned_response.title.parameterize}-collapse" }
               .accordion-body
                 .d-flex.justify-content-between
-                  = canned_response.content
+                  %strong= canned_response.decision_kind.try(:capitalize) || 'Generic'
                   .d-flex
                     = link_to(edit_canned_response_path(canned_response), class: 'btn py-0 px-1 btn-link') do
                       %i.fas.fa-edit
@@ -36,5 +40,6 @@
                                 'data-confirm': 'Do you really want to delete this canned response?') do
                       %i.fas.fa-trash
                       Delete
+                = canned_response.content
     - else
       %p.m-4 No canned responses yet

--- a/src/api/spec/components/canned_responses_dropdown_component_spec.rb
+++ b/src/api/spec/components/canned_responses_dropdown_component_spec.rb
@@ -1,0 +1,50 @@
+RSpec.describe CannedResponsesDropdownComponent, type: :component do
+  let(:moderator) { create(:moderator) }
+  let!(:generic_canned_response) { create(:canned_response, title: 'LGTM', user: moderator) }
+  let!(:cleared_canned_response) { create(:cleared_canned_response, title: 'No spam', user: moderator) }
+  let!(:favor_canned_response) { create(:favor_canned_response, title: 'I agree', user: moderator) }
+
+  context 'with generic responses only' do
+    before do
+      render_inline(described_class.new(CannedResponse.where(decision_kind: nil)))
+    end
+
+    it { expect(rendered_content).to have_text('Generic') }
+    it { expect(rendered_content).to have_text('LGTM') }
+  end
+
+  context 'with cleared decision responses only' do
+    before do
+      render_inline(described_class.new(CannedResponse.where(decision_kind: 'cleared')))
+    end
+
+    it { expect(rendered_content).to have_no_text('Generic') }
+    it { expect(rendered_content).to have_no_text('Favor') }
+    it { expect(rendered_content).to have_text('Cleared') }
+    it { expect(rendered_content).to have_text('No spam') }
+  end
+
+  context 'with favor decision responses only' do
+    before do
+      render_inline(described_class.new(CannedResponse.where(decision_kind: 'favor')))
+    end
+
+    it { expect(rendered_content).to have_no_text('Generic') }
+    it { expect(rendered_content).to have_no_text('Cleared') }
+    it { expect(rendered_content).to have_text('Favor') }
+    it { expect(rendered_content).to have_text('I agree') }
+  end
+
+  context 'with the three types of responses' do
+    before do
+      render_inline(described_class.new(CannedResponse.all))
+    end
+
+    it { expect(rendered_content).to have_text('Generic') }
+    it { expect(rendered_content).to have_text('Cleared') }
+    it { expect(rendered_content).to have_text('Favor') }
+    it { expect(rendered_content).to have_text('LGTM') }
+    it { expect(rendered_content).to have_text('No spam') }
+    it { expect(rendered_content).to have_text('I agree') }
+  end
+end

--- a/src/api/spec/factories/canned_responses.rb
+++ b/src/api/spec/factories/canned_responses.rb
@@ -1,3 +1,16 @@
 FactoryBot.define do
-  factory :canned_response
+  factory :canned_response do
+    title { Faker::Lorem.word }
+    content { Faker::Lorem.paragraph }
+    user { association :confirmed_user }
+
+    factory :cleared_canned_response do
+      decision_kind { 'cleared' }
+      user { association :moderator }
+    end
+    factory :favor_canned_response do
+      decision_kind { 'favor' }
+      user { association :moderator }
+    end
+  end
 end

--- a/src/api/spec/features/webui/canned_responses_spec.rb
+++ b/src/api/spec/features/webui/canned_responses_spec.rb
@@ -49,4 +49,21 @@ RSpec.describe 'Canned responses', :js do
       expect(page).to have_no_text('wow')
     end
   end
+
+  context 'with decision-related canned response' do
+    let(:moderator) { create(:moderator) }
+
+    before do
+      login moderator
+      visit canned_responses_path
+      fill_in(name: 'canned_response[title]', with: 'wow')
+      fill_in(name: 'canned_response[content]', with: 'a decision-related canned response')
+      find(:id, 'canned_response_decision_kind').select('favor')
+      click_button('Create')
+      find('.accordion-button').click
+    end
+
+    it { expect(page).to have_text('Favor') }
+    it { expect(page).to have_text('a decision-related canned response') }
+  end
 end


### PR DESCRIPTION
Follow-up https://github.com/openSUSE/open-build-service/pull/15703

Canned responses are used for normal comments and also for the moderator's decision reasons.

In the second case, we want to group the responses by  Cleared or Favor, to make it easier for the moderator.
For those responses which are non-decision related, the `decision_kind` column will contain a `null` in the database (default value).

In the decision form, the user sees the decision-related responses only.
In a normal comment form, the user will see the non-decision-related responses.

Creating/editing canned responses:

![Screenshot from 2024-03-01 16-01-59](https://github.com/openSUSE/open-build-service/assets/2581944/2c095143-de1f-4334-afcf-204ab9b28f79)

Using canned responses:

![Screenshot from 2024-03-01 16-06-33](https://github.com/openSUSE/open-build-service/assets/2581944/170da109-6488-4f5c-bcbb-5bf1d50bc8f6)
