### PR TITLE
Switch From-Header in emails

### DIFF
--- a/src/api/app/mailers/event_mailer.rb
+++ b/src/api/app/mailers/event_mailer.rb
@@ -1,26 +1,23 @@
 class EventMailer < ActionMailer::Base
   helper 'webui/markdown'
   helper 'webui/reportables'
-  DefaultSender = Struct.new('DefaultSender', :email, :realname)
 
   before_action :set_configuration
   before_action :set_recipients
   before_action :set_default_headers
   before_action :set_event
   before_action :set_event_headers
-  before_action :set_sender
 
   def notification_email
     return if @recipients.blank? || @event.blank?
 
-    template_name = @event.template_name
     mail(to: @recipients,
-         from: email_address_with_name(@sender.email, @sender.realname),
+         from: email_address_with_name(@configuration.admin_email, sender_realname),
          subject: @event.subject,
          date: @event.created_at) do |format|
-      format.html { render template_name, locals: { event: @event.expanded_payload } } if template_exists?("event_mailer/#{template_name}", formats: [:html])
+      format.html { render @event.template_name, locals: { event: @event.expanded_payload } } if template_exists?("event_mailer/#{@event.template_name}", formats: [:html])
 
-      format.text { render template_name, locals: { event: @event.expanded_payload } } if template_exists?("event_mailer/#{template_name}", formats: [:text])
+      format.text { render @event.template_name, locals: { event: @event.expanded_payload } } if template_exists?("event_mailer/#{@event.template_name}", formats: [:text])
     end
   end
 
@@ -45,7 +42,6 @@ class EventMailer < ActionMailer::Base
     headers['X-Mailer'] = 'OBS Notification System'
     headers['X-OBS-URL'] = ActionDispatch::Http::URL.url_for(controller: :main, action: :index, only_path: false, host: @configuration.obs_url)
     headers['Auto-Submitted'] = 'auto-generated'
-    headers['Return-Path'] = email_address_with_name(@configuration.admin_email, 'OBS Notification')
     headers['Sender'] = email_address_with_name(@configuration.admin_email, 'OBS Notification')
     headers['Message-ID'] = message_id
   end
@@ -61,11 +57,11 @@ class EventMailer < ActionMailer::Base
     headers(@event.custom_headers)
   end
 
-  def set_sender
+  def sender_realname
     return unless @event
+    return 'OBS Notification' unless @event.originator
 
-    @sender = @event.originator
-    @sender ||= DefaultSender.new(@configuration.admin_email, 'OBS Notification') # rubocop:disable Naming/MemoizedInstanceVariableName
+    "#{@event.originator.realname} (#{@event.originator.login})"
   end
 
   def message_id

--- a/src/api/spec/mailers/event_mailer_spec.rb
+++ b/src/api/spec/mailers/event_mailer_spec.rb
@@ -48,8 +48,7 @@ RSpec.describe EventMailer, :vcr do
       end
 
       it 'uses display name for FROM if originator exists' do
-        expect(mail.from).to include(originator.email)
-        expect(mail['From'].value).to eq(originator.display_name)
+        expect(mail['From'].value).to eq("\"#{originator.realname} (#{originator.login})\" <unconfigured@openbuildservice.org>")
       end
     end
 
@@ -87,7 +86,6 @@ RSpec.describe EventMailer, :vcr do
         expect(mail['X-Mailer'].value).to eq('OBS Notification System')
         expect(mail['X-OBS-URL'].value).to eq('https://build.example.com')
         expect(mail['Auto-Submitted'].value).to eq('auto-generated')
-        expect(mail['Return-Path'].value).to eq('OBS Notification <unconfigured@openbuildservice.org>')
         expect(mail['Sender'].value).to eq('OBS Notification <unconfigured@openbuildservice.org>')
       end
 
@@ -130,10 +128,6 @@ RSpec.describe EventMailer, :vcr do
           expect(ActionMailer::Base.deliveries).to include(mail)
         end
 
-        it 'sends an email as the user from which the event originates' do
-          expect(mail.from).to include(who.email)
-        end
-
         it 'sends an email to the subscribed user' do
           expect(mail.to).to include(receiver.email)
         end
@@ -156,10 +150,6 @@ RSpec.describe EventMailer, :vcr do
 
         it 'gets delivered' do
           expect(ActionMailer::Base.deliveries).to include(mail)
-        end
-
-        it 'sends an email as the user from which the event originates' do
-          expect(mail.from).to include(who.email)
         end
 
         it 'sends an email to the user belonging to the subscribed group' do
@@ -198,10 +188,6 @@ RSpec.describe EventMailer, :vcr do
           expect(ActionMailer::Base.deliveries).to include(mail)
         end
 
-        it 'sends an email as the user from which the event originates' do
-          expect(mail.from).to include(who.email)
-        end
-
         it 'sends an email to the subscribed user' do
           expect(mail.to).to include(receiver.email)
         end
@@ -224,10 +210,6 @@ RSpec.describe EventMailer, :vcr do
 
         it 'gets delivered' do
           expect(ActionMailer::Base.deliveries).to include(mail)
-        end
-
-        it 'sends an email as the user from which the event originates' do
-          expect(mail.from).to include(who.email)
         end
 
         it 'sends an email to the user belonging to the subscribed group' do
@@ -406,7 +388,6 @@ RSpec.describe EventMailer, :vcr do
       it 'renders the headers' do
         expect(mail.subject).to have_text('Build failure of project_2/package_2 in repository_2/i586')
         expect(mail.to).to eq([recipient.email])
-        expect(mail.from).to eq([from.email])
       end
 
       context 'and there is a payload' do

--- a/src/api/test/fixtures/event_mailer/repo_delete_request
+++ b/src/api/test/fixtures/event_mailer/repo_delete_request
@@ -1,5 +1,4 @@
-Return-Path: <obs-email@opensuse.org>
-From: Iggy Pop <Iggy@pop.org>
+From: "Iggy Pop (Iggy)" <obs-email@opensuse.org>
 Sender: OBS Notification <obs-email@opensuse.org>
 To: Thor <tschmidt@example.com>
 Message-ID: <obs-request-REQUESTID@localhost>

--- a/src/api/test/fixtures/event_mailer/request_event
+++ b/src/api/test/fixtures/event_mailer/request_event
@@ -1,5 +1,4 @@
-Return-Path: <obs-email@opensuse.org>
-From: Iggy Pop <Iggy@pop.org>
+From: "Iggy Pop (Iggy)" <obs-email@opensuse.org>
 Sender: OBS Notification <obs-email@opensuse.org>
 To: Thor <tschmidt@example.com>
 Message-ID: <obs-request-REQUESTID@localhost>

--- a/src/api/test/fixtures/event_mailer/set_bugowner_event
+++ b/src/api/test/fixtures/event_mailer/set_bugowner_event
@@ -1,5 +1,4 @@
-Return-Path: <obs-email@opensuse.org>
-From: Iggy Pop <Iggy@pop.org>
+From: "Iggy Pop (Iggy)" <obs-email@opensuse.org>
 Sender: OBS Notification <obs-email@opensuse.org>
 To: Thor <tschmidt@example.com>
 Message-ID: <obs-request-REQUESTID@localhost>

--- a/src/api/test/fixtures/event_mailer/tom_declined
+++ b/src/api/test/fixtures/event_mailer/tom_declined
@@ -1,5 +1,4 @@
-Return-Path: <obs-email@opensuse.org>
-From: Thor <tschmidt@example.com>
+From: "Thor (tom)" <obs-email@opensuse.org>
 Sender: OBS Notification <obs-email@opensuse.org>
 To: Iggy Pop <Iggy@pop.org>
 Message-ID: <notrandom@localhost>

--- a/src/api/test/fixtures/event_mailer/tom_gets_mail_too
+++ b/src/api/test/fixtures/event_mailer/tom_gets_mail_too
@@ -1,5 +1,4 @@
-Return-Path: <obs-email@opensuse.org>
-From: Iggy Pop <Iggy@pop.org>
+From: "Iggy Pop (Iggy)" <obs-email@opensuse.org>
 Sender: OBS Notification <obs-email@opensuse.org>
 To: Frederic Feuerstone <fred@feuerstein.de>, 
  Thor <tschmidt@example.com>, 


### PR DESCRIPTION
Nowadays this can cause problems with spam filters if the domain does not match the domain of the host the mail is sent from. Although the Internet Message Format RFC says differently...

https://www.rfc-editor.org/rfc/rfc5322#section-3.6.2