### PR TITLE
Add spec for the comment `history?` pundit policy 

### DIFF
--- a/src/api/spec/policies/comment_policy_spec.rb
+++ b/src/api/spec/policies/comment_policy_spec.rb
@@ -173,4 +173,26 @@ RSpec.describe CommentPolicy do
       end
     end
   end
+
+  permissions :history? do
+    let(:staff_user) { create(:staff_user) }
+    let(:moderator) { create(:moderator) }
+    let(:comment_moderated) { create(:comment_project, commentable: project, moderated_at: DateTime.now.utc, moderator_id: moderator.id) }
+
+    before do
+      Flipper.enable(:content_moderation)
+    end
+
+    it { is_expected.to permit(other_user, comment) }
+    it { is_expected.not_to permit(other_user, comment_deleted) }
+    it { is_expected.not_to permit(other_user, comment_moderated) }
+
+    it { is_expected.to permit(moderator, comment_deleted) }
+    it { is_expected.to permit(admin_user, comment_deleted) }
+    it { is_expected.to permit(staff_user, comment_deleted) }
+
+    it { is_expected.to permit(moderator, comment_moderated) }
+    it { is_expected.to permit(admin_user, comment_moderated) }
+    it { is_expected.to permit(staff_user, comment_moderated) }
+  end
 end


### PR DESCRIPTION
~~We have to make sure the policy returns false unless it is
a admin/staff/moderator user that attempts to access the history.
Otherwise, in case of a regular user it simply doesn't
match the condition and returns true in the next line if the comment
is not soft deleted.~~

The policy was missing specs.