### PR TITLE
Add controller specs to test moderators blocking users from commenting

### DIFF
--- a/src/api/spec/controllers/webui/users_controller_spec.rb
+++ b/src/api/spec/controllers/webui/users_controller_spec.rb
@@ -365,6 +365,35 @@ RSpec.describe Webui::UsersController do
         it { expect(user.email).to eq('new_valid@email.es') }
       end
     end
+
+    context 'for a moderator' do
+      let(:moderator) { create(:moderator) }
+
+      context 'blocking the ability of a user to create comments' do
+        before do
+          login(moderator)
+          post :update, params: { login: user.login, user: { blocked_from_commenting: 'true' } }
+          user.reload
+        end
+
+        it { expect(user.blocked_from_commenting).to be(true) }
+        it { expect(flash[:success]).to eq("User data for user '#{user.login}' successfully updated.") }
+      end
+
+      context 'passing parameters other than the blocked_from_commenting' do
+        before do
+          login(moderator)
+          post :update, params: { login: user.login, user: { blocked_from_commenting: 'true', email: 'foo@bar.baz' } }
+          user.reload
+        end
+
+        it 'leaves the other attributes untouched' do
+          expect(user.email).not_to eq('foo@bar.baz')
+          expect(user.blocked_from_commenting).to be(true)
+          expect(flash[:success]).to eq("User data for user '#{user.login}' successfully updated.")
+        end
+      end
+    end
   end
 
   describe 'GET #autocomplete' do


### PR DESCRIPTION
This tests the "happy path" for a moderator and ensures that a moderator cannot update another's users attributes (other then the `:blocked_from_commenting`) since this was possible before fixing it in https://github.com/openSUSE/open-build-service/pull/15702

I already created a card which suggests to split those two scenarios into separate controller methods https://trello.com/c/vUl64ZAE/94-split-update-and-blockfromcommenting-into-two-separate-controller-endpoints 