### PR TITLE
Display all kinds of canned responses in decision dropdown

### DIFF
--- a/src/api/app/components/reports_modal_component.rb
+++ b/src/api/app/components/reports_modal_component.rb
@@ -11,7 +11,6 @@ class ReportsModalComponent < ApplicationComponent
   end
 
   def canned_responses
-    CannedResponsePolicy::Scope.new(user, CannedResponse).resolve
-                               .where(decision_kind: ['favor', 'cleared']).order(:decision_kind, :title)
+    CannedResponsePolicy::Scope.new(user, CannedResponse).resolve.order(:decision_kind, :title)
   end
 end


### PR DESCRIPTION
After our latest changes, users who had canned responses already, won't see them in the dropdown of the decision form. Why? because they have `decision_kind = nil` by default. This means they are considered "generic" and are only displayed in the dropdown of the normal comments.

Now we display the generic canned responses as well in the decision form. This way, users who had canned responses before the latest changes will be able to use them. We now have to recommend them to update the response to move it to the right kind.

![Screenshot 2024-03-06 at 09-54-49 home Admin](https://github.com/openSUSE/open-build-service/assets/2581944/6be62161-9369-4d19-b66b-99d3e96b5131)
