### PR TITLE
Remove package_files method from Webui::PackageController

### DIFF
--- a/src/api/app/helpers/webui/package_helper.rb
+++ b/src/api/app/helpers/webui/package_helper.rb
@@ -75,8 +75,14 @@ module Webui::PackageHelper
     state != 'deleted' && filename.exclude?('/') && (filename == '_patchinfo' || filename.ends_with?('.spec', '.changes'))
   end
 
-  def viewable_file?(filename)
+  def viewable_file?(filename, size = nil)
+    return false if size && size > 1.megabyte
+
     !binary_file?(filename) && filename.exclude?('/')
+  end
+
+  def editable_file?(filename, size = nil)
+    viewable_file?(filename, size) && !filename.match?(/^_service[_:]/)
   end
 
   def binary_file?(filename)

--- a/src/api/app/views/webui/package/_file.html.haml
+++ b/src/api/app/views/webui/package/_file.html.haml
@@ -1,26 +1,26 @@
-- can_be_removed = removable_file?(file_name: file[:name], package: package) && can_modify
-%tr{ id: "file-#{valid_xml_id(file[:name])}" }
+- can_be_removed = removable_file?(file_name: file['name'], package: package) && can_modify
+%tr{ id: "file-#{valid_xml_id(file['name'])}" }
   %td.text-word-break-all
-    - link_opts = { action: :view_file, project: project, package: package, filename: file[:name], expand: expand }
+    - link_opts = { action: :view_file, project: project, package: package, filename: file['name'], expand: expand }
     - unless is_current_rev
-      - link_opts[:rev] = file[:srcmd5]
-    = link_to_if(file[:viewable], nbsp(file[:name]), link_opts)
+      - link_opts[:rev] = srcmd5
+    = link_to_if(viewable_file?(file['name'], file['size'].to_i), nbsp(file['name']), link_opts)
   %td.text-nowrap
-    %span.d-none= file[:size].rjust(10, '0')
-    = human_readable_fsize(file[:size])
-  %td.text-nowrap{ data: { order: "-#{file[:mtime]}" } }
-    = render TimeComponent.new(time: Time.zone.at(file[:mtime].to_i))
+    %span.d-none= file['size'].rjust(10, '0')
+    = human_readable_fsize(file['size'])
+  %td.text-nowrap{ data: { order: "-#{file['mtime']}" } }
+    = render TimeComponent.new(time: Time.zone.at(file['mtime'].to_i))
   / limit download for anonymous user to avoid getting killed by crawlers
   - unless nobody
     %td.text-center<
-      = link_to(file_url(project.name, package.name, file[:name], file[:srcmd5]), title: 'Download file', class: 'me-1') do
+      = link_to(file_url(project.name, package.name, file['name'], srcmd5), title: 'Download file', class: 'me-1') do
         %i.fas.fa-download.text-secondary
       - if can_be_removed
         = link_to('#', title: 'Delete file', data: { 'bs-toggle': 'modal',
                                                      'bs-target': '#delete-file-modal',
-                                                     confirmation_text: "Please confirm deletion of file '#{file[:name]}'",
+                                                     confirmation_text: "Please confirm deletion of file '#{file['name']}'",
                                                      action: url_for(action: :remove_file,
                                                                      project: project,
                                                                      package: package,
-                                                                     filename: file[:name]) }) do
+                                                                     filename: file['name']) }) do
           %i.fas.fa-times-circle.text-danger

--- a/src/api/app/views/webui/package/_files_view.html.haml
+++ b/src/api/app/views/webui/package/_files_view.html.haml
@@ -13,9 +13,9 @@
             %th Actions
       %tbody
         - file_locals = { package: package, project: project, expand: expand, is_current_rev: is_current_rev,
-        can_modify: user_can_modify_package, nobody: nobody }
+        can_modify: user_can_modify_package, nobody: nobody, srcmd5: srcmd5 }
         = render partial: 'file', collection: files,
-        cached: proc { |file| [file[:name], file[:mtime], file[:md5], file_locals].hash }, locals: file_locals
+        cached: proc { |file| [file['name'], file['mtime'], file['md5'], file_locals].hash }, locals: file_locals
   - else
     %i This package has no files yet
   - if user_can_modify_package


### PR DESCRIPTION
This method recreated a hash that already exists, so this PR just uses the hash directly