### PR TITLE
Use resources instead of resource for file controller actions

### DIFF
--- a/src/api/app/controllers/webui/packages/files_controller.rb
+++ b/src/api/app/controllers/webui/packages/files_controller.rb
@@ -3,6 +3,7 @@ module Webui
     class FilesController < Packages::MainController
       before_action :set_project
       before_action :set_package
+      before_action :set_filename, only: :update
       after_action :verify_authorized
 
       def new
@@ -55,7 +56,7 @@ module Webui
         errors = []
 
         begin
-          @package.save_file(file: params[:file], filename: params[:filename],
+          @package.save_file(file: params[:file], filename: @filename,
                              comment: params[:comment])
         rescue APIError, StandardError => e
           errors << e.message
@@ -64,14 +65,20 @@ module Webui
         end
 
         if errors.blank?
-          flash.now[:success] = "'#{params[:filename]}' has been successfully saved."
+          flash.now[:success] = "'#{@filename}' has been successfully saved."
         else
-          flash.now[:error] = "Error while adding '#{params[:filename]}': #{errors.compact.join("\n")}."
+          flash.now[:error] = "Error while adding '#{@filename}': #{errors.compact.join("\n")}."
           status = 400
         end
 
         status ||= 200
         render layout: false, status: status, partial: 'layouts/webui/flash', object: flash
+      end
+
+      private
+
+      def set_filename
+        @filename = params[:filename]
       end
     end
   end

--- a/src/api/app/views/webui/package/_files_view.html.haml
+++ b/src/api/app/views/webui/package/_files_view.html.haml
@@ -26,7 +26,7 @@
           %i.fas.fa-hard-drive.text-primary
           Add local files
       .nav-item
-        = link_to(new_project_package_files_path(project, package), class: 'nav-link') do
+        = link_to(new_project_package_file_path(project, package), class: 'nav-link') do
           %i.fas.fa-plus-circle.text-primary
           Add an empty file or service
     = render DeleteConfirmationDialogComponent.new(modal_id: 'delete-file-modal',

--- a/src/api/app/views/webui/package/view_file.html.haml
+++ b/src/api/app/views/webui/package/view_file.html.haml
@@ -24,7 +24,7 @@
 
       -# TODO: Provide a comments field through a callback
       = render(partial: 'webui/shared/editor', locals: { text: @file, mode: guess_code_class(@filename),
-        save: { url: project_package_files_path(@project, @package), method: :put,
+        save: { url: project_package_file_path(@project, @package, @filename), method: :put,
         data: { project: @project.name, package: @package.name, submit: 'file', comment: '', filename: @filename, rev: @rev } } })
     - else
       = render(partial: 'webui/shared/editor', locals: { text: @file, mode: guess_code_class(@filename), style: { read_only: true } })

--- a/src/api/config/routes/webui_routes.rb
+++ b/src/api/config/routes/webui_routes.rb
@@ -283,7 +283,7 @@ OBSApi::Application.routes.draw do
         resources :deletions, controller: 'webui/requests/deletions', only: %i[new create], constraints: cons
         resources :devel_project_changes, controller: 'webui/requests/devel_project_changes', only: %i[new create], constraints: cons
         resources :submissions, controller: 'webui/requests/submissions', only: %i[new create], constraints: cons
-        resource :files, controller: 'webui/packages/files', only: %i[new create update], constraints: cons
+        resources :files, controller: 'webui/packages/files', only: %i[new create update], constraints: cons, param: :filename, format: false
         put 'toggle_watched_item', controller: 'webui/watched_items', constraints: cons
         resource :badge, controller: 'webui/packages/badge', only: [:show], constraints: cons.merge(format: :svg)
         resources :repositories, only: [], param: :name do


### PR DESCRIPTION
Changes all the actions to use resources routes, so that it aligns more with how it's used. In practice that means that in update action, there is a file name parameter. Depends on #15753