### PR TITLE
Add validations to canned responses' attributes

### DIFF
--- a/src/api/app/models/canned_response.rb
+++ b/src/api/app/models/canned_response.rb
@@ -6,8 +6,8 @@ class CannedResponse < ApplicationRecord
   #### Constants
 
   #### Self config
-  validates :title, length: { maximum: 255 }
-  validates :content, length: { maximum: 65_535 }
+  validates :title, presence: true, length: { maximum: 255 }
+  validates :content, presence: true, length: { maximum: 65_535 }
 
   enum decision_kind: {
     cleared: 0,

--- a/src/api/db/migrate/20240307122241_make_canned_responses_title_and_content_not_null.rb
+++ b/src/api/db/migrate/20240307122241_make_canned_responses_title_and_content_not_null.rb
@@ -1,0 +1,6 @@
+class MakeCannedResponsesTitleAndContentNotNull < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :canned_responses, :title, false
+    change_column_null :canned_responses, :content, false
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_02_27_153505) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_07_122241) do
   create_table "appeals", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.text "reason", null: false
     t.integer "appellant_id", null: false
@@ -234,8 +234,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_27_153505) do
 
   create_table "canned_responses", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "user_id", null: false
-    t.string "title"
-    t.text "content"
+    t.string "title", null: false
+    t.text "content", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "decision_kind"


### PR DESCRIPTION
The `title` and the content should be present, it makes little sense otherwise.

For consistency, the database is updated to avoid null values. It's a safe migration according to [strong migrations](https://github.com/ankane/strong_migrations?tab=readme-ov-file#setting-not-null-on-an-existing-column).

**NOTE**: please ignore the Isolated Migrations check, these two commits should go together.