### PR TITLE
[backend] speed up container publishing with noclean

### DIFF
--- a/src/backend/BSRekor.pm
+++ b/src/backend/BSRekor.pm
@@ -132,6 +132,21 @@ sub upload_intoto {
   return upload_entry($server, $entry);
 }
 
+sub upload_intoto_v2 {
+  my ($server, $envelope, $pubkey) = @_;
+  my $e = JSON::XS::decode_json($envelope);
+  $_->{'publicKey'} ||= $pubkey for @{$e->{'signatures'} || []};
+  my $spec = {
+    'content' => { 'envelope' => $e },
+  };
+  my $entry = {
+    'kind' => 'intoto',
+    'apiVersion' => '0.0.2',
+    'spec' => $spec,
+  };
+  return upload_entry($server, $entry);
+}
+
 sub upload_dsse {
   my ($server, $envelope, $pubkey) = @_;
   my $verifier = mime_encode($pubkey);

--- a/src/backend/bs_regpush
+++ b/src/backend/bs_regpush
@@ -412,7 +412,7 @@ sub delete_tag {
 }
 
 sub list_tag {
-  my ($tag) = @_;
+  my ($tag, $maniids) = @_;
 
   if ($no_cosign_info && $tag =~ /^[a-z0-9]+-[a-f0-9]+\.(?:sig|att)$/) {
     printf "%-20s -\n", $tag;
@@ -432,6 +432,12 @@ sub list_tag {
       my $annotations = $mani->{'layers'}->[0]->{'annotations'} || {};
       my $cookie = $annotations->{$cosign_cookie_name};
       $extra = " cosigncookie=$cookie" if $cookie;
+    }
+  }
+  if ($mani && $maniids && $tag !~ /^[a-z0-9]+-[a-f0-9]+\.(?:sig|att)$/) {
+    $maniids->{$maniid} = 1;
+    if ($mani->{'mediaType'} eq $BSContar::mt_docker_manifestlist || $mani->{'mediaType'} eq $BSContar::mt_oci_index) {
+      $maniids->{$_->{'digest'}} = 1 for @{$mani->{'manifests'} || []};
     }
   }
   if (!$mani) {
@@ -631,8 +637,20 @@ if ($list_mode) {
     $keepalive = {};
     my %tags = map {$_ => 1} @tags;
     $tags{$_} = 1 for tags_from_digestfile();
-    %tags = map {$_ => 1} get_all_tags() unless %tags;
-    list_tag($_) for sort keys %tags;
+    if (%tags && $cosign) {
+      my %maniids;
+      list_tag($_, \%maniids) for sort keys %tags;
+      %tags = ();
+      if (%maniids) {
+        for (get_all_tags()) {
+          $tags{$_} = 1 if /^([a-z0-9]+)-([a-f0-9]+)\.(?:sig|att)$/ && $maniids{"$1:$2"}
+        }
+      }
+      list_tag($_) for sort keys %tags;
+    } else {
+      %tags = map {$_ => 1} get_all_tags() unless %tags;
+      list_tag($_) for sort keys %tags;
+    }
   } elsif (@ARGV == 3) {
     my ($mani, $maniid, $mani_json) = get_manifest_for_tag($ARGV[2]);
     print "$mani_json\n" if $mani_json;

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -1453,9 +1453,12 @@ sub getprojpack {
 	next;
       }
 
-      if ($plocked && !$pinfo->{'lock'}) {
-	$pinfo->{'error'} = 'locked';
-	next;
+      if ($plocked) {
+        my $plock = $pinfo->{'lock'};
+	if (!$plock || !$plock->{'disable'} || !grep {!BSUtil::enabled($_->{'name'}, $plock, 1, $arch)} @{$proj->{'repository'} || []}) {
+	  $pinfo->{'error'} = 'locked';
+	  next;
+	}
       }
 
       my $enable = defined($penable) ? {%$penable} : undef;

--- a/src/backend/examples/createrepo_rpmmd_hook.pm
+++ b/src/backend/examples/createrepo_rpmmd_hook.pm
@@ -426,7 +426,7 @@ sub createrepo_rpmmd_hook {
       if ($supportstatus{$path}) {
 	push @kw, $supportstatus{$path};
       }
-      s/^(l\d|unsupported|acc)$/support_$1/ for @kw;
+      s/^(l\d|unsupported|acc|superseded)$/support_$1/ for @kw;
 
       next unless @pe || @kw || $options->{'diskusage'};
 


### PR DESCRIPTION
We only need to query the registry about the tags we know, as we do not touch all the other ones anyway.

This also needs a change in bs_regpush as we need to extend the tag list with the cosign tags. This can be enabled by adding '--cosign' to the ps_regpush query call.