### PR TITLE
Fix dbclean make target

### DIFF
--- a/dist/t/Makefile
+++ b/dist/t/Makefile
@@ -14,10 +14,12 @@ test:
 	bundle exec rspec --format documentation
 
 dbclean:
-	cd /srv/www/obs/api/
 	@echo "DISABLE_DATABASE_ENVIRONMENT_CHECK=$(DISABLE_DATABASE_ENVIRONMENT_CHECK) should be =1"
 	@echo "SAFETY_ASSURED=$(SAFETY_ASSURED) should be =1"
-	rake db:drop db:create db:setup RAILS_ENV=production
+	cd /srv/www/obs/api/ &&\
+	bundle install &&\
+	bundle exec rake db:drop db:create db:setup RAILS_ENV=production
+	rm -rf /srv/obs/{trees/*,sources/[^:]*,projects/[^_]*,build/[^_]*,repos/*,*cache/*}
 
 installclean:
 	zypper -n rm -u chromedriver xorg-x11-fonts libxml2-devel libxslt-devel ruby2.7-devel


### PR DESCRIPTION
Fix `dbclean` make target (in openQA-like test)
to allow to re-run `make test`