### PR TITLE
Fix maintenance workflow flaky test

### DIFF
--- a/src/api/spec/browser_helper.rb
+++ b/src/api/spec/browser_helper.rb
@@ -9,7 +9,7 @@ require 'support/features/features_authentication'
 require 'support/features/features_attribute'
 require 'support/features/features_custom_checkbox'
 require 'support/features/features_responsive'
-require 'support/wait_for_ajax'
+require 'support/wait_helpers'
 
 # Shared examples. Per recommendation of RSpec,
 # https://www.relishapp.com/rspec/rspec-core/v/2-12/docs/example-groups/shared-examples

--- a/src/api/spec/features/webui/maintenance_workflow_spec.rb
+++ b/src/api/spec/features/webui/maintenance_workflow_spec.rb
@@ -71,7 +71,10 @@ RSpec.describe 'MaintenanceWorkflow', :js, :vcr do
     fill_in('reason', with: 'really? ok')
 
     click_button('Accept request')
-    expect(page).to have_css('#overview h3', text: "Request #{bs_request.number} accepted")
+    # Looks like accepting the request takes some time, so we allow it to take a bit more than usual
+    wait_up_to(12.seconds) do
+      expect(page).to have_css('#overview h3', text: "Request #{bs_request.number} accepted")
+    end
 
     # Step 4: The maintenance coordinator edits the patchinfo file
     ##############################################################

--- a/src/api/spec/support/wait_helpers.rb
+++ b/src/api/spec/support/wait_helpers.rb
@@ -1,5 +1,5 @@
 # See https://thoughtbot.com/blog/automatically-wait-for-ajax-with-capybara
-module WaitForAjax
+module WaitHelpers
   def wait_for_ajax
     Timeout.timeout(Capybara.default_max_wait_time) do
       loop until finished_all_ajax_requests?
@@ -12,5 +12,5 @@ module WaitForAjax
 end
 
 RSpec.configure do |config|
-  config.include WaitForAjax, type: :feature
+  config.include WaitHelpers, type: :feature
 end

--- a/src/api/spec/support/wait_helpers.rb
+++ b/src/api/spec/support/wait_helpers.rb
@@ -6,6 +6,19 @@ module WaitHelpers
     end
   end
 
+  def wait_up_to(seconds)
+    seconds_backup = Capybara.default_max_wait_time
+
+    begin
+      Capybara.default_max_wait_time = seconds
+      yield
+    ensure
+      Capybara.default_max_wait_time = seconds_backup
+    end
+  end
+
+  private
+
   def finished_all_ajax_requests?
     page.evaluate_script('jQuery.active').zero?
   end


### PR DESCRIPTION
Accepting the request may take a bit longer than 6 seconds, that is the
default timeout we have configured for Capybara operations.

We introduce a new helper to temporarily execute some code with a different timeout.


See https://github.com/teamcapybara/capybara?tab=readme-ov-file#asynchronous-javascript-ajax-and-friends for more details.