### PR TITLE
Refine exclusions for Style/MultilineBlockChain

### DIFF
--- a/src/api/.rubocop.yml
+++ b/src/api/.rubocop.yml
@@ -195,7 +195,8 @@ Style/MethodCallWithArgsParentheses:
 # We disabled this cop because of Rantly.
 Style/MultilineBlockChain:
   Exclude:
-    - 'spec/**/*'
+    - 'spec/helpers/webui/**/*'
+    - 'spec/models/**/*'
 
 # We disabled this cop because HAML doesn't work well with ActiveSupport::SafeBuffer and the to_s method of it is always returning the same object class
 Style/RedundantInterpolation:


### PR DESCRIPTION
Prevent from overlooking Rubocop offenses from this kind in other specs.