### PR TITLE
Wait in test 0030_project_spec

### DIFF
--- a/dist/t/spec/features/0030_project_spec.rb
+++ b/dist/t/spec/features/0030_project_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe 'Project', type: :feature do
       click_link('Your Home Project')
     end
     click_link('Repositories')
+    sleep(5)
     click_link('Add from a Distribution')
     check('openSUSE Leap 15.5')
     visit current_path


### PR DESCRIPTION
Wait in test `0030_project_spec.rb`

Without this change, tests would randomly fail with

    Failures:

      1) Project is able to add repositories
         Failure/Error: check('openSUSE Leap 15.5')

         Capybara::ElementNotFound:
           Unable to find checkbox "openSUSE Leap 15.5" that is not disabled
         # ./spec/features/0030_project_spec.rb:28:in `block (2 levels) in <top (required)>'

    Finished in 22.38 seconds (files took 0.16822 seconds to load)
    5 examples, 1 failure

    Failed examples:

    rspec ./spec/features/0030_project_spec.rb:20 # Project is able to add repositories