### PR TITLE
[api] fix package unlock behaviour

### DIFF
--- a/src/api/app/controllers/source_controller.rb
+++ b/src/api/app/controllers/source_controller.rb
@@ -550,8 +550,12 @@ class SourceController < ApplicationController
                                                  use_source: use_source, follow_project_links: follow_project_links)
       if @package # for remote package case it's nil
         @project = @package.project
-        ignore_lock = @command == 'unlock'
-        raise CmdExecutionNoPermission, "no permission to modify package #{@package.name} in project #{@project.name}" unless READ_COMMANDS.include?(@command) || User.session!.can_modify?(@package, ignore_lock)
+        if @command == 'unlock'
+          # ignore a lock in the package, but not in the project.
+          raise CmdExecutionNoPermission, "no permission to unlock package #{@package.name} in project #{@project.name}" unless User.session!.can_modify?(@project) && User.session!.can_modify?(@package, true)
+        else
+          raise CmdExecutionNoPermission, "no permission to modify package #{@package.name} in project #{@project.name}" unless READ_COMMANDS.include?(@command) || User.session!.can_modify?(@package)
+        end
       end
     end
 

--- a/src/api/test/functional/source_controller_test.rb
+++ b/src/api/test/functional/source_controller_test.rb
@@ -899,8 +899,23 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     login_adrian
     post '/source/home:Iggy/TestLinkPack', params: { cmd: 'unlock', comment: 'BlahFasel' }
     assert_response 403
-    # do for real and cleanup
+
+    # ensure that unlocking is not working when project is locked as well
     login_Iggy
+    get '/source/home:Iggy/_meta'
+    assert_response :success
+    doc = REXML::Document.new(@response.body)
+    doc.elements['/project'].add_element 'lock'
+    doc.elements['/project/lock'].add_element 'enable'
+    put '/source/home:Iggy/_meta', params: doc.to_s
+    assert_response :success
+    post '/source/home:Iggy/TestLinkPack', params: { cmd: 'unlock', comment: 'BlahFasel' }
+    assert_response 403
+    assert_xml_tag tag: 'summary', content: 'no permission to unlock package TestLinkPack in project home:Iggy'
+    post '/source/home:Iggy', params: { cmd: 'unlock', comment: 'cleanup' }
+    assert_response :success
+
+    # do for real and cleanup
     post '/source/home:Iggy/TestLinkPack', params: { cmd: 'unlock', comment: 'BlahFasel' }
     assert_response :success
     delete '/source/home:Iggy/TestLinkPack'


### PR DESCRIPTION
it must not be allowed when project is still locked.

Regression which happened in 2.10 in a refactoring. (2.9 and before had the correct behaviour)