### PR TITLE
Return the project attribute always for `_keyinfo`

### DIFF
--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -6151,7 +6151,7 @@ sub getkeyinfo {
     $pk = readstr($BSConfig::keyfile, 1);
   }
   my $keyinfo = {};
-  $keyinfo->{'project'} = $skprojid if $skprojid;
+  $keyinfo->{'project'} = $skprojid ? $skprojid : $projid;
   if ($pk) {
     $keyinfo->{'pubkey'} = BSSrcServer::Signkey::pubkeyinfo($pk);
     $keyinfo->{'pubkey'}->{'_content'} = $pk;


### PR DESCRIPTION
Fixes #15790.