### PR TITLE
Avoid database queries on sourcediff component

### DIFF
--- a/src/api/app/components/sourcediff_component.rb
+++ b/src/api/app/components/sourcediff_component.rb
@@ -1,30 +1,16 @@
 class SourcediffComponent < ApplicationComponent
-  attr_accessor :bs_request, :action, :refresh
+  attr_accessor :bs_request, :action, :refresh, :commentable, :source_package, :target_package
 
   delegate :diff_label, to: :helpers
   delegate :diff_data, to: :helpers
 
-  def initialize(bs_request:, action:)
+  def initialize(bs_request:, action:, commentable:, source_package:, target_package:)
     super
 
     @bs_request = bs_request
     @action = action
-  end
-
-  def commentable
-    BsRequestAction.find(@action.id)
-  end
-
-  def source_package
-    Package.get_by_project_and_name(@action.source_project, @action.source_package, { follow_multibuild: true })
-  rescue Package::UnknownObjectError, Project::Errors::UnknownObjectError
-  end
-
-  def target_package
-    # For not accepted maintenance incident requests, the package is not there.
-    return nil unless @action.target_package
-
-    Package.get_by_project_and_name(@action.target_project, @action.target_package, { follow_multibuild: true })
-  rescue Package::UnknownObjectError, Project::Errors::UnknownObjectError
+    @commentable = commentable
+    @source_package = source_package
+    @target_package = target_package
   end
 end

--- a/src/api/app/components/sourcediff_component.rb
+++ b/src/api/app/components/sourcediff_component.rb
@@ -7,7 +7,10 @@ class SourcediffComponent < ApplicationComponent
   def initialize(bs_request:, action:, commentable:, source_package:, target_package:)
     super
 
+    # Nomes es fa servir per extreure el numero de la request
     @bs_request = bs_request
+    # @action es bs_request.bs_request_actions.first quan ve per #changes
+    # @action es bs_request.bs_request_actions.find(params['id']) quan ve per #request_action_changes
     @action = action
     @commentable = commentable
     @source_package = source_package

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -23,6 +23,7 @@ class Webui::RequestController < Webui::WebuiController
   before_action :cache_diff_data, only: %i[show build_results rpm_lint changes mentioned_issues],
                                   if: -> { Flipper.enabled?(:request_show_redesign, User.session) }
   before_action :check_beta_user_redirect, only: %i[build_results rpm_lint changes mentioned_issues]
+  before_action :set_webui_actions, only: %i[request_action request_action_changes]
 
   after_action :verify_authorized, only: [:create]
 
@@ -154,11 +155,7 @@ class Webui::RequestController < Webui::WebuiController
 
   # TODO: Remove this once request_show_redesign is rolled out
   def request_action
-    @diff_limit = params[:full_diff] ? 0 : nil
     @index = params[:index].to_i
-    @actions = @bs_request.webui_actions(filelimit: @diff_limit, tarlimit: @diff_limit, diff_to_superseded: @diff_to_superseded, diffs: true,
-                                         action_id: params['id'].to_i, cacheonly: 1)
-    @action = @actions.find { |action| action[:id] == params['id'].to_i }
     @active = @action[:name]
 
     if @action[:diff_not_cached]
@@ -553,5 +550,16 @@ class Webui::RequestController < Webui::WebuiController
     InfluxDB::Rails.current.tags = {
       bs_request_action_type: @action.class.name
     }
+  end
+
+  def set_webui_actions
+    diff_limit = params[:full_diff] ? 0 : nil
+    @actions = @bs_request.webui_actions(filelimit: diff_limit,
+                                         tarlimit: diff_limit,
+                                         diff_to_superseded: @diff_to_superseded,
+                                         diffs: true,
+                                         action_id: params['id'].to_i,
+                                         cacheonly: 1)
+    @action = @actions.find { |action| action[:id] == params['id'].to_i }
   end
 end

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -23,7 +23,7 @@ class Webui::RequestController < Webui::WebuiController
   before_action :cache_diff_data, only: %i[show build_results rpm_lint changes mentioned_issues],
                                   if: -> { Flipper.enabled?(:request_show_redesign, User.session) }
   before_action :check_beta_user_redirect, only: %i[build_results rpm_lint changes mentioned_issues]
-  before_action :set_webui_actions, only: %i[request_action request_action_changes changes]
+  before_action :set_webui_actions, only: %i[request_action request_action_changes]
   before_action :set_source_package, only: %i[request_action_changes changes]
   before_action :set_target_package, only: %i[request_action_changes changes]
   before_action :set_commentable, only: %i[request_action_changes changes]
@@ -566,11 +566,15 @@ class Webui::RequestController < Webui::WebuiController
     @action = @actions.find { |action| action[:id] == params['id'].to_i }
   end
 
+  def set_commentable
+    @commentable = BsRequestAction.find(@action[:id])
+  end
+
   def source_package
     Package.get_by_project_and_name(@action.source_project, @action.source_package, { follow_multibuild: true })
   end
 
-  def target_package
+  def set_target_package
     # For not accepted maintenance incident requests, the package is not there.
     return nil unless @action.target_package
 

--- a/src/api/app/views/webui/request/changes.html.haml
+++ b/src/api/app/views/webui/request/changes.html.haml
@@ -25,7 +25,8 @@
           - @bs_request.superseding.each do |supersed|
             See the changes from
             = link_to "superseded request ##{supersed.number}", request_changes_path(@bs_request, diff_to_superseded: supersed)
-        = render SourcediffComponent.new(bs_request: @bs_request, action: @action)
+        = render SourcediffComponent.new(bs_request: @bs_request, action: @action, commentable: @commentable,
+                                         source_package: @source_package, target_package: @target_package)
   = render DeleteConfirmationDialogComponent.new(modal_id: 'delete-comment-modal',
                                                  method: :delete,
                                                  options: { modal_title: 'Delete comment?', remote: true })

--- a/src/api/app/views/webui/request/request_action_changes.js.erb
+++ b/src/api/app/views/webui/request/request_action_changes.js.erb
@@ -1,1 +1,1 @@
-$('.tab-content.sourcediff').html("<%= escape_javascript(render(SourcediffComponent.new(bs_request: @bs_request, action: @action, index: 0, commentable: @commentable, source_package: @source_package, target_package: @target_package))) %>");
+$('.tab-content.sourcediff').html("<%= escape_javascript(render(SourcediffComponent.new(bs_request: @bs_request, action: @action, commentable: @commentable, source_package: @source_package, target_package: @target_package))) %>");

--- a/src/api/app/views/webui/request/request_action_changes.js.erb
+++ b/src/api/app/views/webui/request/request_action_changes.js.erb
@@ -1,1 +1,1 @@
-$('.tab-content.sourcediff').html("<%= escape_javascript(render(SourcediffComponent.new(bs_request: @bs_request, action: @action))) %>");
+$('.tab-content.sourcediff').html("<%= escape_javascript(render(SourcediffComponent.new(bs_request: @bs_request, action: @action, index: 0, commentable: @commentable, source_package: @source_package, target_package: @target_package))) %>");

--- a/src/api/spec/components/sourcediff_component_spec.rb
+++ b/src/api/spec/components/sourcediff_component_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe SourcediffComponent, :vcr, type: :component do
            target_package: target_package,
            source_package: source_package)
   end
+  let(:commentable) { bs_request.bs_request_actions.first }
   let(:bs_request_opts) { { filelimit: nil, tarlimit: nil, diff_to_superseded: nil, diffs: true, cacheonly: 1 } }
 
   context 'with a request with a submit action' do


### PR DESCRIPTION
[ViewComponents recommends](https://viewcomponent.org/viewcomponents-at-github.html#avoid-database-queries) you run your database queries outside of the component. 

This PR extracts the database queries outside the SourcediffComponent.

Depends on #15794