### PR TITLE
[backend] mkosi: publish images to per-arch subdirectory

### DIFF
--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -2418,6 +2418,10 @@ sub publish {
 	  $kiwimedium = "$arch/$1" if $bin =~ /(.+)ONIE\.bin$/;
 	} elsif ($bin =~ /(.*)\.raw(?:\.install)?(?:\.(?:gz|bz2|xz|zst|zstd))?(?:\.sha256(?:\.asc)?)?$/) {
 	  $p = $bin;
+	  if (my @files = glob("$r/mkosi.*")) {
+		# mkosi image names don't include the arch
+		$p = "$arch/$bin";
+	  }
 	  $p = mapsleimage($sleimagedata, "$reporoot/$prp/$arch/:repo", $rbin, $p) if $sleimagedata;
 	  $kiwimedium = "$arch/$1" if !$2 && -e "$r/$1.packages";
 	} elsif ($bin =~ /(.*)\.install.tar?(?:\.sha256(?:\.asc)?)?$/) {


### PR DESCRIPTION
Images do not have the architecture in the name, so an image recipe building for multiple architectures would have clashing filenames, which means a single mkosi image build cannot currently enable multiple architectures. Change the publisher so that if we detect that we are publishing mkosi artifacts, they are stored in a per-architecture sub-folder.