### PR TITLE
Set background to dropdown header

### DIFF
--- a/src/api/app/views/webui/request/_actions_details.html.haml
+++ b/src/api/app/views/webui/request/_actions_details.html.haml
@@ -14,7 +14,7 @@
                                                                           :type => 'button', 'data-boundary' => 'viewport' }
           = action[:name]
         %ul.dropdown-menu.dropdown-menu-start.scrollable-dropdown.pt-0
-          %li.card-header.px-1.sticky-top
+          %li.card-header.px-1.sticky-top.bg-body-tertiary
             %h6.dropdown-header
               - if User.session
                 %span Seen


### PR DESCRIPTION
Use `.bg-body-tertiary` to set a greyish background to the dropdown header. 

Light theme:

![Screenshot 2024-03-20 at 14-49-26 Open Build Service](https://github.com/openSUSE/open-build-service/assets/2581944/0a4cae24-3a02-4f23-9f61-da912e11b02a)

Dark theme:

![Screenshot 2024-03-20 at 14-47-37 Open Build Service](https://github.com/openSUSE/open-build-service/assets/2581944/38c8fd7c-8d94-46ea-acc8-83676da42199)

Test it here: https://obs-reviewlab.opensuse.org/saraycp-dropdown_header_bg/request/show/6/request_action/6
