### PR TITLE
Swap the source and the target file link addresses

### DIFF
--- a/src/api/app/components/diff_component.html.haml
+++ b/src/api/app/components/diff_component.html.haml
@@ -6,15 +6,15 @@
         %div{ class: "line #{line.state}" }>
           - case line.state
           - when 'range'
-            - if source_file
-              = link_to(source_file, title: 'See original file') do
+            - if target_file
+              = link_to(target_file, title: 'See original file') do
                 .number.p-0.text-center.link-danger<
                   %i.fas.fa-file-arrow-down
             - else
               %a
                 .number
-            - if target_file
-              = link_to(target_file, title: 'See submitted file') do
+            - if source_file
+              = link_to(source_file, title: 'See submitted file') do
                 .number.p-0.text-center.link-success<
                   %i.fas.fa-file-arrow-up
             - else


### PR DESCRIPTION
Fixes #15695

## How to Test This

1. Go to https://obs-reviewlab.opensuse.org/danidoni-fix-original-and-submitted-file-icons-in-submit-request-overview
2. Log in as 'Admin'
3. Open [this Submit request's changes](https://obs-reviewlab.opensuse.org/danidoni-fix-original-and-submitted-file-icons-in-submit-request-overview/request/show/4/changes) for example.
4. Click on the red icon to go to the original file.
5. Click on the green icon to go to the submitted file.