### PR TITLE
Handle ActionMailer producing nil

### DIFF
--- a/src/api/app/jobs/send_event_emails_job.rb
+++ b/src/api/app/jobs/send_event_emails_job.rb
@@ -27,7 +27,7 @@ class SendEventEmailsJob < ApplicationJob
     email = EventMailer.with(subscribers: subscribers, event: event).notification_email
     email.deliver_now
   rescue StandardError => e
-    Airbrake.notify(e, event_id: event.id, email_body: email.body)
+    Airbrake.notify(e, event_id: event.id, email: email.inspect)
   ensure
     event.update(mails_sent: true)
   end


### PR DESCRIPTION
We can't use assume `email` is a `Mail::Message` when we rescue `StandardError`. `ActionMailer` might fail to produce the `Mail::Message` object somehow already.

- `EventMailer` produces `nil`
- `nil.deliver_now` produces `NoMethodError`
- `email.body` in `Airbrake.notify` will produce `NoMethodError` again

