### PR TITLE
Fix spec warning

### DIFF
--- a/src/api/spec/cassettes/Requests_Submissions/submit_package/when_under_the_beta_program/submit_several_packages_at_once_against_a_factory_staging_project/shows_the_beta_version_of_the_requests_page.yml
+++ b/src/api/spec/cassettes/Requests_Submissions/submit_package/when_under_the_beta_program/submit_several_packages_at_once_against_a_factory_staging_project/shows_the_beta_version_of_the_requests_page.yml
@@ -1,14 +1,16 @@
 ---
 http_interactions:
 - request:
-    method: get
-    uri: http://backend:5352/source/home:madam_submitter/package_a
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/_meta?user=user_1
     body:
-      encoding: US-ASCII
-      string: ''
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory">
+          <title>Mr Standfast</title>
+          <description/>
+        </project>
     headers:
-      X-Request-Id:
-      - 6bd9dec4-d784-497b-a9cf-cc0ef29ae606
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -27,16 +29,590 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '404'
+      - '105'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_a" rev="3" vrev="3" srcmd5="01dfd385eb6f75ea017e69bd3e5a965f">
-          <entry name="README.txt" md5="20a18412e38905538f0872327d5efd17" size="55" mtime="1677769909"/>
-          <entry name="package_a.changes" md5="76b9e6eb94954487f45e468537669d17" size="33" mtime="1677769910"/>
-          <entry name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470" mtime="1677082556"/>
-        </directory>
-  recorded_at: Fri, 03 Mar 2023 08:08:30 GMT
+        <project name="openSUSE:Factory">
+          <title>Mr Standfast</title>
+          <description></description>
+        </project>
+  recorded_at: Wed, 20 Mar 2024 13:32:21 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/_project/_staging_workflow?user=user_3
+    body:
+      encoding: UTF-8
+      string: |
+        <workflow project="openSUSE:Factory" managers="group_1">
+          <staging_project name="openSUSE:Factory:Staging:A"/>
+        </workflow>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '169'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="21">
+          <srcmd5>855ca4c8a51f444848eca1a4a8164fe6</srcmd5>
+          <time>1710941542</time>
+          <user>user_3</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 20 Mar 2024 13:32:22 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:A/_meta?user=user_3
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title/>
+          <description/>
+          <group groupid="group_1" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '150'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:A">
+          <title></title>
+          <description></description>
+          <group groupid="group_1" role="maintainer"/>
+        </project>
+  recorded_at: Wed, 20 Mar 2024 13:32:22 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/_project/_staging_workflow?user=user_3
+    body:
+      encoding: UTF-8
+      string: |
+        <workflow project="openSUSE:Factory" managers="group_1">
+          <staging_project name="openSUSE:Factory:Staging:A"/>
+          <staging_project name="openSUSE:Factory:Staging:B"/>
+        </workflow>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '169'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="22">
+          <srcmd5>761abadd20bf5e8eb79df3df4aad59fc</srcmd5>
+          <time>1710941542</time>
+          <user>user_3</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 20 Mar 2024 13:32:22 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory:Staging:B/_meta?user=user_3
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title/>
+          <description/>
+          <group groupid="group_1" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '150'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory:Staging:B">
+          <title></title>
+          <description></description>
+          <group groupid="group_1" role="maintainer"/>
+        </project>
+  recorded_at: Wed, 20 Mar 2024 13:32:22 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/_meta?user=user_3
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory">
+          <title>Mr Standfast</title>
+          <description/>
+          <group groupid="group_1" role="reviewer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '150'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="openSUSE:Factory">
+          <title>Mr Standfast</title>
+          <description></description>
+          <group groupid="group_1" role="reviewer"/>
+        </project>
+  recorded_at: Wed, 20 Mar 2024 13:32:22 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:mr_receiver/_meta?user=mr_receiver
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:mr_receiver">
+          <title/>
+          <description/>
+          <person userid="mr_receiver" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '144'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:mr_receiver">
+          <title></title>
+          <description></description>
+          <person userid="mr_receiver" role="maintainer"/>
+        </project>
+  recorded_at: Wed, 20 Mar 2024 13:32:22 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:mr_receiver/Quebec/_meta?user=mr_receiver
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="Quebec" project="home:mr_receiver">
+          <title>No Highway</title>
+          <description>Quos molestiae et at.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '141'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="Quebec" project="home:mr_receiver">
+          <title>No Highway</title>
+          <description>Quos molestiae et at.</description>
+        </package>
+  recorded_at: Wed, 20 Mar 2024 13:32:23 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:mr_receiver/Quebec/_config
+    body:
+      encoding: UTF-8
+      string: Commodi voluptatum voluptatem. Qui vitae est. Et id laborum.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="17" vrev="17">
+          <srcmd5>a6bf6cd0ca7104e43140ab4f6b6ea3c2</srcmd5>
+          <version>unknown</version>
+          <time>1710941543</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 20 Mar 2024 13:32:23 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:mr_receiver/Quebec/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Reiciendis commodi in. Optio sapiente labore. Blanditiis voluptates
+        aut.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="18" vrev="18">
+          <srcmd5>04cf4ffb7a13ab1aff81933bb07698ff</srcmd5>
+          <version>unknown</version>
+          <time>1710941543</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 20 Mar 2024 13:32:23 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:madam_submitter/_meta?user=madam_submitter
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:madam_submitter">
+          <title/>
+          <description/>
+          <person userid="madam_submitter" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '152'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:madam_submitter">
+          <title></title>
+          <description></description>
+          <person userid="madam_submitter" role="maintainer"/>
+        </project>
+  recorded_at: Wed, 20 Mar 2024 13:32:23 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:madam_submitter/package_a/_meta?user=mr_receiver
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_a" project="home:madam_submitter">
+          <title>What's Become of Waring</title>
+          <description>Similique sit voluptatibus voluptate.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '177'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_a" project="home:madam_submitter">
+          <title>What's Become of Waring</title>
+          <description>Similique sit voluptatibus voluptate.</description>
+        </package>
+  recorded_at: Wed, 20 Mar 2024 13:32:24 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:madam_submitter/package_a/README.txt
+    body:
+      encoding: UTF-8
+      string: Quibusdam natus occaecati. Nemo architecto debitis. Ipsam suscipit assumenda.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '203'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="25" vrev="25">
+          <srcmd5>7acf1b037e0b65f2d7d9b2fb51ef53f7</srcmd5>
+          <version>1</version>
+          <time>1710941544</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 20 Mar 2024 13:32:24 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:madam_submitter/package_a/package_a.spec
+    body:
+      encoding: UTF-8
+      string: |
+        Name:       package_a
+        Version:    1
+        Release:    1
+        Summary:    Most simple RPM package
+        License:    CC0-1.0
+
+        %description
+        This is my first RPM package, which does nothing.
+
+        %prep
+        # we have no source, so nothing here
+
+        %build
+        cat > package_a.sh <<EOF
+        #!/usr/bin/bash
+        echo Hello world, from package_a.
+        EOF
+
+        %install
+        mkdir -p %{buildroot}/usr/bin/
+        install -m 755 package_a.sh %{buildroot}/usr/bin/package_a.sh
+
+        %files
+        /usr/bin/package_a.sh
+
+        %changelog
+        # let skip this for now
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '203'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="26" vrev="26">
+          <srcmd5>7acf1b037e0b65f2d7d9b2fb51ef53f7</srcmd5>
+          <version>1</version>
+          <time>1710941544</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 20 Mar 2024 13:32:24 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:madam_submitter/package_a/package_a.changes
+    body:
+      encoding: UTF-8
+      string: "- Fixes boo#1111101 CVE-2011-1101"
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '203'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="27" vrev="27">
+          <srcmd5>7acf1b037e0b65f2d7d9b2fb51ef53f7</srcmd5>
+          <version>1</version>
+          <time>1710941544</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 20 Mar 2024 13:32:24 GMT
 - request:
     method: get
     uri: http://backend:5352/source/home:madam_submitter/package_a
@@ -44,8 +620,6 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      X-Request-Id:
-      - 6bd9dec4-d784-497b-a9cf-cc0ef29ae606
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -64,27 +638,60 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '404'
+      - '406'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_a" rev="3" vrev="3" srcmd5="01dfd385eb6f75ea017e69bd3e5a965f">
-          <entry name="README.txt" md5="20a18412e38905538f0872327d5efd17" size="55" mtime="1677769909"/>
-          <entry name="package_a.changes" md5="76b9e6eb94954487f45e468537669d17" size="33" mtime="1677769910"/>
-          <entry name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470" mtime="1677082556"/>
+        <directory name="package_a" rev="27" vrev="27" srcmd5="7acf1b037e0b65f2d7d9b2fb51ef53f7">
+          <entry name="README.txt" md5="88753147b7bc2a641401043afbcf64b7" size="77" mtime="1710941544"/>
+          <entry name="package_a.changes" md5="76b9e6eb94954487f45e468537669d17" size="33" mtime="1710837940"/>
+          <entry name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470" mtime="1709823259"/>
         </directory>
-  recorded_at: Fri, 03 Mar 2023 08:08:30 GMT
+  recorded_at: Wed, 20 Mar 2024 13:32:25 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:madam_submitter/package_a
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '406'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_a" rev="27" vrev="27" srcmd5="7acf1b037e0b65f2d7d9b2fb51ef53f7">
+          <entry name="README.txt" md5="88753147b7bc2a641401043afbcf64b7" size="77" mtime="1710941544"/>
+          <entry name="package_a.changes" md5="76b9e6eb94954487f45e468537669d17" size="33" mtime="1710837940"/>
+          <entry name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470" mtime="1709823259"/>
+        </directory>
+  recorded_at: Wed, 20 Mar 2024 13:32:25 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/home:madam_submitter/package_a?cacheonly=1&cmd=diff&expand=1&filelimit=10000&orev=0&rev=3&tarlimit=10000&view=xml&withissues=1
+    uri: http://backend:5352/source/home:madam_submitter/package_a?cmd=diff&expand=1&filelimit=10000&orev=0&rev=27&tarlimit=10000&view=xml&withissues=1
     body:
       encoding: UTF-8
       string: ''
     headers:
       Content-Type:
       - application/octet-stream
-      X-Request-Id:
-      - 6bd9dec4-d784-497b-a9cf-cc0ef29ae606
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -98,23 +705,23 @@ http_interactions:
     headers:
       Content-Type:
       - text/xml
-      Content-Length:
-      - '1765'
       Cache-Control:
       - no-cache
       Connection:
       - close
+      Content-Length:
+      - '1788'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="fd1afd86624097e53be31fc97fc9c239">
+        <sourcediff key="2d103febc199912771962febccf01493">
           <old project="home:madam_submitter" package="package_a" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
-          <new project="home:madam_submitter" package="package_a" rev="3" srcmd5="01dfd385eb6f75ea017e69bd3e5a965f"/>
+          <new project="home:madam_submitter" package="package_a" rev="27" srcmd5="7acf1b037e0b65f2d7d9b2fb51ef53f7"/>
           <files>
             <file state="added">
-              <new name="README.txt" md5="20a18412e38905538f0872327d5efd17" size="55"/>
+              <new name="README.txt" md5="88753147b7bc2a641401043afbcf64b7" size="77"/>
               <diff lines="3">@@ -0,0 +1,1 @@
-        +Repudiandae pariatur harum. Est et sunt. Nisi odio non.
+        +Quibusdam natus occaecati. Nemo architecto debitis. Ipsam suscipit assumenda.
         \ No newline at end of file
         </diff>
             </file>
@@ -163,16 +770,177 @@ http_interactions:
             <issue state="added" tracker="bnc" name="1111101" label="boo#1111101" url="https://bugzilla.opensuse.org/show_bug.cgi?id=1111101"/>
           </issues>
         </sourcediff>
-  recorded_at: Fri, 03 Mar 2023 08:08:30 GMT
+  recorded_at: Wed, 20 Mar 2024 13:32:25 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/openSUSE:Factory/package_b/_meta?user=mr_receiver
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_b" project="openSUSE:Factory">
+          <title>Far From the Madding Crowd</title>
+          <description>Laudantium nesciunt at corrupti.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '171'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_b" project="openSUSE:Factory">
+          <title>Far From the Madding Crowd</title>
+          <description>Laudantium nesciunt at corrupti.</description>
+        </package>
+  recorded_at: Wed, 20 Mar 2024 13:32:25 GMT
 - request:
     method: get
-    uri: http://backend:5352/build/home:madam_submitter/_result?package=package_a&view=status
+    uri: http://backend:5352/source/home:madam_submitter/package_a
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '406'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_a" rev="27" vrev="27" srcmd5="7acf1b037e0b65f2d7d9b2fb51ef53f7">
+          <entry name="README.txt" md5="88753147b7bc2a641401043afbcf64b7" size="77" mtime="1710941544"/>
+          <entry name="package_a.changes" md5="76b9e6eb94954487f45e468537669d17" size="33" mtime="1710837940"/>
+          <entry name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470" mtime="1709823259"/>
+        </directory>
+  recorded_at: Wed, 20 Mar 2024 13:32:25 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/home:madam_submitter/package_a?cmd=diff&expand=1&filelimit=10000&opackage=package_b&oproject=openSUSE:Factory&tarlimit=10000&view=xml&withissues=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '1784'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="e988a51f080c3f142489346e348a3932">
+          <old project="openSUSE:Factory" package="package_b" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="home:madam_submitter" package="package_a" rev="27" srcmd5="7acf1b037e0b65f2d7d9b2fb51ef53f7"/>
+          <files>
+            <file state="added">
+              <new name="README.txt" md5="88753147b7bc2a641401043afbcf64b7" size="77"/>
+              <diff lines="3">@@ -0,0 +1,1 @@
+        +Quibusdam natus occaecati. Nemo architecto debitis. Ipsam suscipit assumenda.
+        \ No newline at end of file
+        </diff>
+            </file>
+            <file state="added">
+              <new name="package_a.changes" md5="76b9e6eb94954487f45e468537669d17" size="33"/>
+              <diff lines="3">@@ -0,0 +1,1 @@
+        +- Fixes boo#1111101 CVE-2011-1101
+        \ No newline at end of file
+        </diff>
+            </file>
+            <file state="added">
+              <new name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470"/>
+              <diff lines="28">@@ -0,0 +1,27 @@
+        +Name:       package_a
+        +Version:    1
+        +Release:    1
+        +Summary:    Most simple RPM package
+        +License:    CC0-1.0
+        +
+        +%description
+        +This is my first RPM package, which does nothing.
+        +
+        +%prep
+        +# we have no source, so nothing here
+        +
+        +%build
+        +cat &gt; package_a.sh &lt;&lt;EOF
+        +#!/usr/bin/bash
+        +echo Hello world, from package_a.
+        +EOF
+        +
+        +%install
+        +mkdir -p %{buildroot}/usr/bin/
+        +install -m 755 package_a.sh %{buildroot}/usr/bin/package_a.sh
+        +
+        +%files
+        +/usr/bin/package_a.sh
+        +
+        +%changelog
+        +# let skip this for now
+        </diff>
+            </file>
+          </files>
+          <issues>
+            <issue state="added" tracker="cve" name="2011-1101" label="CVE-2011-1101" url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=2011-1101"/>
+            <issue state="added" tracker="bnc" name="1111101" label="boo#1111101" url="https://bugzilla.opensuse.org/show_bug.cgi?id=1111101"/>
+          </issues>
+        </sourcediff>
+  recorded_at: Wed, 20 Mar 2024 13:32:25 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:madam_submitter/_result?lastbuild=0&locallink=1&multibuild=1&package=package_a&view=status
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - 5d80d14b-4f5f-41c1-b8de-d0e78cc03d99
+      - a9c5af76-5a6e-421c-8df6-266e0543c1e7
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -197,7 +965,7 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Fri, 03 Mar 2023 08:08:30 GMT
+  recorded_at: Wed, 20 Mar 2024 13:32:30 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:madam_submitter/_result?lastbuild=0&locallink=1&multibuild=1&package=package_a&view=status
@@ -206,7 +974,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - fc4073e1-5973-4aed-86b0-d58f603caf2a
+      - a9c5af76-5a6e-421c-8df6-266e0543c1e7
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -215,8 +983,8 @@ http_interactions:
       - Ruby
   response:
     status:
-      code: 404
-      message: project 'home madam_submitter' does not exist
+      code: 200
+      message: OK
     headers:
       Content-Type:
       - text/xml
@@ -225,15 +993,177 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '168'
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 20 Mar 2024 13:32:30 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:madam_submitter/package_a
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - a9c5af76-5a6e-421c-8df6-266e0543c1e7
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '406'
     body:
       encoding: UTF-8
       string: |
-        <status code="404">
-          <summary>project 'home:madam_submitter' does not exist</summary>
-          <details>404 project 'home:madam_submitter' does not exist</details>
-        </status>
-  recorded_at: Mon, 04 Sep 2023 09:11:47 GMT
+        <directory name="package_a" rev="27" vrev="27" srcmd5="7acf1b037e0b65f2d7d9b2fb51ef53f7">
+          <entry name="README.txt" md5="88753147b7bc2a641401043afbcf64b7" size="77" mtime="1710941544"/>
+          <entry name="package_a.changes" md5="76b9e6eb94954487f45e468537669d17" size="33" mtime="1710837940"/>
+          <entry name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470" mtime="1709823259"/>
+        </directory>
+  recorded_at: Wed, 20 Mar 2024 13:32:30 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:madam_submitter/package_a
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - a9c5af76-5a6e-421c-8df6-266e0543c1e7
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '406'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_a" rev="27" vrev="27" srcmd5="7acf1b037e0b65f2d7d9b2fb51ef53f7">
+          <entry name="README.txt" md5="88753147b7bc2a641401043afbcf64b7" size="77" mtime="1710941544"/>
+          <entry name="package_a.changes" md5="76b9e6eb94954487f45e468537669d17" size="33" mtime="1710837940"/>
+          <entry name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470" mtime="1709823259"/>
+        </directory>
+  recorded_at: Wed, 20 Mar 2024 13:32:30 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/home:madam_submitter/package_a?cacheonly=1&cmd=diff&expand=1&filelimit=10000&orev=0&rev=27&tarlimit=10000&view=xml&withissues=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      X-Request-Id:
+      - a9c5af76-5a6e-421c-8df6-266e0543c1e7
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '1788'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="2d103febc199912771962febccf01493">
+          <old project="home:madam_submitter" package="package_a" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="home:madam_submitter" package="package_a" rev="27" srcmd5="7acf1b037e0b65f2d7d9b2fb51ef53f7"/>
+          <files>
+            <file state="added">
+              <new name="README.txt" md5="88753147b7bc2a641401043afbcf64b7" size="77"/>
+              <diff lines="3">@@ -0,0 +1,1 @@
+        +Quibusdam natus occaecati. Nemo architecto debitis. Ipsam suscipit assumenda.
+        \ No newline at end of file
+        </diff>
+            </file>
+            <file state="added">
+              <new name="package_a.changes" md5="76b9e6eb94954487f45e468537669d17" size="33"/>
+              <diff lines="3">@@ -0,0 +1,1 @@
+        +- Fixes boo#1111101 CVE-2011-1101
+        \ No newline at end of file
+        </diff>
+            </file>
+            <file state="added">
+              <new name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470"/>
+              <diff lines="28">@@ -0,0 +1,27 @@
+        +Name:       package_a
+        +Version:    1
+        +Release:    1
+        +Summary:    Most simple RPM package
+        +License:    CC0-1.0
+        +
+        +%description
+        +This is my first RPM package, which does nothing.
+        +
+        +%prep
+        +# we have no source, so nothing here
+        +
+        +%build
+        +cat &gt; package_a.sh &lt;&lt;EOF
+        +#!/usr/bin/bash
+        +echo Hello world, from package_a.
+        +EOF
+        +
+        +%install
+        +mkdir -p %{buildroot}/usr/bin/
+        +install -m 755 package_a.sh %{buildroot}/usr/bin/package_a.sh
+        +
+        +%files
+        +/usr/bin/package_a.sh
+        +
+        +%changelog
+        +# let skip this for now
+        </diff>
+            </file>
+          </files>
+          <issues>
+            <issue state="added" tracker="cve" name="2011-1101" label="CVE-2011-1101" url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=2011-1101"/>
+            <issue state="added" tracker="bnc" name="1111101" label="boo#1111101" url="https://bugzilla.opensuse.org/show_bug.cgi?id=1111101"/>
+          </issues>
+        </sourcediff>
+  recorded_at: Wed, 20 Mar 2024 13:32:30 GMT
 - request:
     method: get
     uri: http://backend:5352/build/home:madam_submitter/_result?lastbuild=0&locallink=1&multibuild=1&package=package_a&view=status
@@ -242,7 +1172,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - fc4073e1-5973-4aed-86b0-d58f603caf2a
+      - 45530bed-cda1-4b14-a75a-360bdd031503
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -251,8 +1181,8 @@ http_interactions:
       - Ruby
   response:
     status:
-      code: 404
-      message: project 'home madam_submitter' does not exist
+      code: 200
+      message: OK
     headers:
       Content-Type:
       - text/xml
@@ -261,13 +1191,45 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '168'
+      - '55'
     body:
       encoding: UTF-8
-      string: |
-        <status code="404">
-          <summary>project 'home:madam_submitter' does not exist</summary>
-          <details>404 project 'home:madam_submitter' does not exist</details>
-        </status>
-  recorded_at: Mon, 04 Sep 2023 09:11:47 GMT
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 20 Mar 2024 13:32:31 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:madam_submitter/_result?lastbuild=0&locallink=1&multibuild=1&package=package_a&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 45530bed-cda1-4b14-a75a-360bdd031503
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Wed, 20 Mar 2024 13:32:31 GMT
 recorded_with: VCR 6.2.0

--- a/src/api/spec/features/webui/requests/submissions_spec.rb
+++ b/src/api/spec/features/webui/requests/submissions_spec.rb
@@ -137,12 +137,14 @@ RSpec.describe 'Requests_Submissions', :js, :vcr do
         let!(:staging_workflow) { create(:staging_workflow, project: factory) }
         # Create another action to submit new files from different packages to package_b
         let!(:another_bs_request_action) do
-          create(:bs_request_action_submit,
-                 bs_request: bs_request,
-                 source_project: source_project,
-                 source_package: source_package,
-                 target_project: factory,
-                 target_package: target_package_b)
+          receiver.run_as do
+            create(:bs_request_action_submit,
+                   bs_request: bs_request,
+                   source_project: source_project,
+                   source_package: source_package,
+                   target_project: factory,
+                   target_package: target_package_b)
+          end
         end
         let(:bs_request) do
           create(:bs_request_with_submit_action,
@@ -167,7 +169,8 @@ RSpec.describe 'Requests_Submissions', :js, :vcr do
           login receiver
           visit request_show_path(bs_request.number)
 
-          expect(page).to have_text(bs_request.bs_request_actions.first[:name])
+          action = bs_request.bs_request_actions.first
+          expect(page).to have_text("#{action.target_project} / #{action.target_package}")
           expect(page).to have_text('Next')
           expect(page).to have_text("(of #{bs_request.bs_request_actions.count})")
           expect(page).to have_css('.bg-staging')


### PR DESCRIPTION
`bs_request.bs_request_actions.first[:name]` was returning `nil`, and that raised a warning like this one:

```
Checking for expected text of nil is confusing and/or pointless since it will always match. Please specify a string or regexp instead. /obs/src/api/spec/features/webui/requests/submissions_spec.rb:142
```

Obviously that expectation was wrong.