### PR TITLE
Let the user know when to click on the build chart

### DIFF
--- a/src/api/app/assets/javascripts/webui/request_show_redesign/chart_build_results.js
+++ b/src/api/app/assets/javascripts/webui/request_show_redesign/chart_build_results.js
@@ -17,6 +17,12 @@ function updateChartBuildResults() {
 function linkBuildSummaryChartToBuildResultsTab() { // jshint ignore:line
   var buildResultSummaryChart = Chartkick.charts['build-summary-chart'].getChartObject();
 
+  // If the mouse hovers a data point, let the cursor tell the user it is clickable
+  $("#build-summary-chart").on('mousemove', function(e) {
+    var points = buildResultSummaryChart.getElementsAtEventForMode(e, 'nearest', { intersect: true }, true);
+    $(this).css('cursor', points.length ? 'pointer' : 'default');
+  });
+
   $("#build-summary-chart").click(function(e) {
     var points = buildResultSummaryChart.getElementsAtEventForMode(e, 'nearest', { intersect: true }, true);
     // click was not on a bar in the chart


### PR DESCRIPTION
Let the cursor be a pointer when the chart has values behind because we link the data to the `Build Results` Tab

![click-chart](https://github.com/openSUSE/open-build-service/assets/7080830/2663e660-c4d5-4358-98cb-d547a2e135ba)
