### PR TITLE
Stop warning when data migration is shipped with other changes

### DIFF
--- a/.github/workflows/set_warnings_about_migrations.yml
+++ b/.github/workflows/set_warnings_about_migrations.yml
@@ -21,7 +21,6 @@ jobs:
           files_yaml: |
             migrations:
               - src/api/db/migrate/**
-              - src/api/db/data/**
             not_migrations:
               - '!src/api/db/migrate/**'
               - '!src/api/db/data/**'


### PR DESCRIPTION
It doesn't harm if we ship data migrations together with other changes. The GitHub action won't warn in such a case.