### PR TITLE
Replace repository status with build result status

### DIFF
--- a/src/api/app/components/build_results_monitor_component.html.haml
+++ b/src/api/app/components/build_results_monitor_component.html.haml
@@ -41,7 +41,7 @@
                   .build-result-architecture
                     - results_per_package_repository_and_architecture(package_name, repository_name, architecture_name).each do |result|
                       = render partial: 'webui/shared/build_status_badge', locals: { status: result[:status],
-                                                                                     text: helpers.repository_status(result),
+                                                                                     text: result[:status].humanize,
                                                                                      architecture: result[:architecture],
                                                                                      url: helpers.live_build_log_url(result[:status],
                                                                                                              project_name,


### PR DESCRIPTION
The repository status is not relevant in requests. Moreover, the badge was confusing having an icon a color that represented something that didn't match the text.

Now it looks like this:

![Screenshot 2024-03-21 at 14-08-00 Open Build Service](https://github.com/openSUSE/open-build-service/assets/2581944/99102672-139e-4eab-b222-b5d7c7fc1dcd)
