### PR TITLE
Display link to staging project in conversation

### DIFF
--- a/src/api/app/components/bs_request_history_element_component.html.haml
+++ b/src/api/app/components/bs_request_history_element_component.html.haml
@@ -9,7 +9,10 @@
       - elsif element.instance_of?(HistoryElement::RequestReviewAdded) && element.review
         = element.user_action_prefix
         %strong
-          = element.action_target
+          - if element.review_by_staging_project?
+            = link_to element.action_target, project_show_path(element.action_target)
+          - else
+            = element.action_target
         = element.user_action_suffix
       - elsif element.instance_of?(HistoryElement::RequestAccepted) && pending_reviews?
         #{element.user_action} and dismissed pending reviews

--- a/src/api/app/models/history_element/request_review_added.rb
+++ b/src/api/app/models/history_element/request_review_added.rb
@@ -11,7 +11,7 @@ module HistoryElement
     end
 
     def user_action_prefix
-      return 'set' if review&.staging_project?
+      return 'set' if review_by_staging_project?
 
       'added'
     end
@@ -21,7 +21,7 @@ module HistoryElement
     end
 
     def user_action_suffix
-      return 'as a staging project' if review&.staging_project?
+      return 'as a staging project' if review_by_staging_project?
 
       'as a reviewer'
     end
@@ -31,6 +31,10 @@ module HistoryElement
       return if description_extension.blank?
 
       ::Review.find(description_extension)
+    end
+
+    def review_by_staging_project?
+      review&.staging_project?
     end
   end
 end


### PR DESCRIPTION
When the request has a review by project and that project is a staging one, we display a link to it instead of plain text.

![Screenshot 2024-03-22 at 09-38-04 Open Build Service](https://github.com/openSUSE/open-build-service/assets/2581944/b6a7ed50-c941-4c04-955f-cbd059af18a7)


Test with this review-app link: https://obs-reviewlab.opensuse.org/saraycp-staging_project_link/request/show/2
Or do:

- Join beta request redesign
- Add review
- Choose review by project
- Which project? A project which is a staging project already
- You'll see the new link in the conversation