### PR TITLE
Scroll to the specific comment on conversation

### DIFF
--- a/src/api/app/components/bs_request_comment_component.html.haml
+++ b/src/api/app/components/bs_request_comment_component.html.haml
@@ -3,7 +3,7 @@
     %i{ title: 'Comment', class: "fas fa-lg fa-comment #{ level > 1 ? 'd-none' : '' }" }
     = render(AvatarComponent.new(name: comment.user.name, email: comment.user.email, size: 35, shape: :circle, custom_css: 'avatars-counter'))
   .timeline-item-comment.ms-0.flex-fill.overflow-auto
-    .comment-bubble.ms-3.position-relative
+    .comment-bubble.ms-3.position-relative{ id: "comment-#{comment.id}-bubble" }
       - if policy(comment).update? || policy(comment).destroy?
         .dropdown.dropleft.float-end.mx-3.position-absolute.top-0.end-0
           = link_to('#', role: 'button', 'data-bs-toggle': 'dropdown', 'aria-expanded': 'false') do

--- a/src/api/app/components/notification_notifiable_link_component.rb
+++ b/src/api/app/components/notification_notifiable_link_component.rb
@@ -86,10 +86,8 @@ class NotificationNotifiableLinkComponent < ApplicationComponent
     when 'Event::RequestStatechange', 'Event::RequestCreate', 'Event::ReviewWanted'
       Rails.application.routes.url_helpers.request_show_path(@notification.notifiable.number, notification_id: @notification.id)
     when 'Event::CommentForRequest'
-      # TODO: It would be better to eager load the commentable association with `includes(...)`,
-      #      but it's complicated since this isn't for all notifications and it's nested 2 levels deep.
-      anchor = if @notification.notifiable.commentable.is_a?(BsRequestAction)
-                 'tab-pane-changes'
+      anchor = if Flipper.enabled?(:request_show_redesign, @current_user)
+                 "comment-#{@notification.notifiable.id}-bubble"
                else
                  'comments-list'
                end


### PR DESCRIPTION
The notifications about comments on requests used to point to the `Changes`  tab, something which was not working since we started to load a new page per tab.

Now, the link goes to the specific comment in the conversation tab. 