### PR TITLE
Fix duplicated before_action call

### DIFF
--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -10,7 +10,7 @@ class Webui::RequestController < Webui::WebuiController
                          changes mentioned_issues chart_build_results complete_build_results]
   before_action :set_actions, only: %i[inline_comment show build_results rpm_lint changes mentioned_issues chart_build_results complete_build_results request_action_changes],
                               if: -> { Flipper.enabled?(:request_show_redesign, User.session) }
-  before_action :set_actions, only: [:show]
+  before_action :set_actions_deprecated, only: [:show]
   before_action :build_results_data, only: [:show], if: -> { Flipper.enabled?(:request_show_redesign, User.session) }
   before_action :set_action, only: %i[inline_comment show build_results rpm_lint changes mentioned_issues],
                              if: -> { Flipper.enabled?(:request_show_redesign, User.session) }
@@ -464,6 +464,12 @@ class Webui::RequestController < Webui::WebuiController
 
   def set_actions
     @actions = @bs_request.bs_request_actions
+  end
+
+  # [DEPRECATED] TODO: remove once request_workflow_redesign beta is rolled out
+  # This method exists in order to have a set_actions in before_action for non beta too
+  def set_actions_deprecated
+    set_actions
   end
 
   def build_results_data


### PR DESCRIPTION
Fix for issue introduced in https://github.com/openSUSE/open-build-service/commit/323a5f156998906d591033be526896a232b4b7e6#diff-4240c3b55deedb4b829fef429bfc8fd6832885a1ed59928cabccd613a1494e18R11-R13 where the first `before_action` is overwritten by the second one