### PR TITLE
Make separate entries for multibuild packages

### DIFF
--- a/src/api/app/services/action_build_results_service/chart_data_extractor.rb
+++ b/src/api/app/services/action_build_results_service/chart_data_extractor.rb
@@ -9,32 +9,15 @@ module ActionBuildResultsService
     def call
       return [] if @actions.blank?
 
-      @actions.where(type: %i[submit maintenance_incident maintenance_release])
-              .map { |action| sources_from_action(action) }
-              .select { |sources| sources[:source_project].present? && sources[:source_package].present? }
-              .map do |sources|
-        build_results = package_build_results(sources[:source_package], sources[:source_project])
+      @actions.where(type: %i[submit maintenance_incident maintenance_release]).map do |action|
+        sources = sources_from_action(action)
+        next unless sources[:source_project].present? && sources[:source_package].present?
 
-        request_build_results(build_results, sources[:source_package], sources[:source_project])
-      end
-      .flatten
+        package_build_results(sources[:source_package], sources[:source_project])
+      end.flatten
     end
 
     private
-
-    def request_build_results(build_results, source_package, source_project)
-      build_results.map do |result_entry|
-        {
-          architecture: result_entry.architecture,
-          repository: result_entry.repository,
-          status: result_entry.code,
-          package_name: source_package.name,
-          project_name: source_project.name,
-          repository_status: result_entry.state,
-          is_repository_in_db: result_entry.is_repository_in_db
-        }
-      end
-    end
 
     def project_from_action(action)
       bs_request = BsRequest.find(action.bs_request_id)
@@ -50,7 +33,20 @@ module ActionBuildResultsService
     end
 
     def package_build_results(source_package, source_project)
-      source_package.buildresult(source_project, show_all: true).results.flat_map { |_k, v| v }
+      results = source_package.buildresult(source_project, show_all: true).results
+      results.flat_map do |pkg, build_results|
+        build_results.map do |result|
+          {
+            architecture: result.architecture,
+            repository: result.repository,
+            status: result.code,
+            package_name: pkg,
+            project_name: source_project.name,
+            repository_status: result.state,
+            is_repository_in_db: result.is_repository_in_db
+          }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Requests with multiple build flavors create duplicate entries on the build results page. This pull request implements a proposed solution to display separate entries for each multi-build flavor to resolve this issue.

Before:
![image](https://github.com/openSUSE/open-build-service/assets/12820609/38a25732-8d7d-4a25-b462-1994f783b96e)

After:
![image](https://github.com/openSUSE/open-build-service/assets/12820609/d362d1de-e6ad-4a2a-99d3-8a0991fcd9fb)
