### PR TITLE
Use logarithmic scale for build result summary chart

### DIFF
--- a/src/api/app/components/chart_component.html.haml
+++ b/src/api/app/components/chart_component.html.haml
@@ -11,10 +11,10 @@
                       id: 'build-summary-chart',
                       width: '100%',
                       height: '300px',
-                      stacked: true,
+                      stacked: false,
                       responsive: true,
                       colors: ['#008000', '#DC3545', '#FFCC00', '#EEEEEE'],
-                      library: { scales: { y: { ticks: { stepSize: 1 }}}},
+                      library: { scales: { y: { ticks: { stepSize: 1 }, type: 'logarithmic' }}},
                     )
       :javascript
         linkBuildSummaryChartToBuildResultsTab();


### PR DESCRIPTION
Currently the click target is really small on the bars in the chart when there is a big margin between the values of the individual results (e.g. 100 Succeeding Builds and 1 Failed Build).
Using a logarithmic scale on the y-axis balances the difference on the bars in the chart.

In order to stay consistent with the ordering of the individual build results types and to distinguish the click target a little more I disabled stacking of the bars.

![stacked](https://github.com/openSUSE/open-build-service/assets/22001671/9e353344-3861-48a2-b504-c4629cd282f5)
![unstacked](https://github.com/openSUSE/open-build-service/assets/22001671/a96d543e-ab00-46b7-a8b2-151909576d96)

**With a few more repositories**

![image](https://github.com/openSUSE/open-build-service/assets/22001671/dfb55138-2cd6-4582-afa0-1a48ef77e8e9)


