### PR TITLE
Remove version top-level element from `docker compose` files

### DIFF
--- a/docker-compose.ha.yml
+++ b/docker-compose.ha.yml
@@ -1,4 +1,3 @@
-version: "2.1"
 services:
   proxy:
     image: haproxy:1.7

--- a/docker-compose.minitest.yml
+++ b/docker-compose.minitest.yml
@@ -1,4 +1,3 @@
-version: "2.1"
 services:
   minitest:
     image: openbuildservice/minitest

--- a/docker-compose.sre.yml
+++ b/docker-compose.sre.yml
@@ -1,4 +1,3 @@
-version: "2.1"
 services:
   influx:
     image: influxdb:1.7

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "2.1"
 services:
   db:
     image: registry.opensuse.org/obs/server/unstable/containers/containers/openbuildservice/mariadb


### PR DESCRIPTION
When running `docker compose` commands, prevent this warning from happening: "WARN ... `version` is obsolete"

See: https://github.com/compose-spec/compose-spec/blob/master/spec.md#version-top-level-element