### PR TITLE
Ignore notifying `ActionController::BadRequest` errors

### DIFF
--- a/src/api/config/initializers/airbrake.rb
+++ b/src/api/config/initializers/airbrake.rb
@@ -100,12 +100,14 @@ def ignore_by_backend_400_message?(message)
 end
 
 def ignore_by_class?(notice)
-  exceptions_to_ignore = ['ActiveRecord::RecordNotFound', 'ActionController::InvalidAuthenticityToken',
-                          'CGI::Session::CookieStore::TamperedWithCookie', 'ActionController::UnknownAction',
-                          'AbstractController::ActionNotFound', 'Bunny::TCPConnectionFailedForAllHosts',
-                          'Timeout::Error', 'Net::HTTPBadResponse', 'Errno::ECONNRESET', 'Interrupt',
-                          'RoutesHelper::WebuiMatcher::InvalidRequestFormat', 'ActionDispatch::Http::MimeNegotiation::InvalidType',
-                          'ActionController::UnknownFormat', 'Backend::NotFoundError', 'AMQ::Protocol::EmptyResponseError']
+  exceptions_to_ignore = ['AMQ::Protocol::EmptyResponseError', 'AbstractController::ActionNotFound',
+                          'ActionController::BadRequest', 'ActionController::InvalidAuthenticityToken',
+                          'ActionController::UnknownAction', 'ActionController::UnknownFormat',
+                          'ActionDispatch::Http::MimeNegotiation::InvalidType',
+                          'ActiveRecord::RecordNotFound', 'Backend::NotFoundError',
+                          'Bunny::TCPConnectionFailedForAllHosts', 'CGI::Session::CookieStore::TamperedWithCookie',
+                          'Errno::ECONNRESET', 'Interrupt', 'Net::HTTPBadResponse',
+                          'RoutesHelper::WebuiMatcher::InvalidRequestFormat', 'Timeout::Error']
 
   notice[:errors].pluck(:type).intersect?(exceptions_to_ignore)
 end


### PR DESCRIPTION
HTTP requests with bad characters are correctly handled returning a bad request (400 code) error. We don't need to be notified about wrong HTTP requests.

Also sort elements of the array. Make it more readable and easier to find elements while inspecting the code.

Fixes #15745.