### PR TITLE
Defer Diff Loading on Changes Tab

### DIFF
--- a/src/api/app/assets/javascripts/webui/request.js
+++ b/src/api/app/assets/javascripts/webui/request.js
@@ -185,13 +185,14 @@ function loadDiffs(element){
   });
 }
 
-function loadChanges(requestNumber, requestActionId) { // jshint ignore:line
-  $('.loading-diff').removeClass('invisible');
-  var url = '/request/' + requestNumber + '/request_action/' + requestActionId + '/changes';
+function loadChanges(requestNumber, requestActionId, diffToSupersededId) { // jshint ignore:line
+  $('.tab-content.sourcediff .loading').removeClass('invisible');
+  var queryString = diffToSupersededId ? '?diff_to_superseded=' + diffToSupersededId : '';
+  var url = '/request/' + requestNumber + '/request_action/' + requestActionId + '/changes' + queryString;
   $.ajax({
     url: url,
     success: function() {
-      $('.loading-diff').addClass('invisible');
+      $('.tab-content.sourcediff .loading').addClass('invisible');
     }
   });
 }

--- a/src/api/app/assets/javascripts/webui/request.js
+++ b/src/api/app/assets/javascripts/webui/request.js
@@ -185,8 +185,14 @@ function loadDiffs(element){
   });
 }
 
-function loadChanges(requestNumber, requestActionId, diffToSupersededId) { // jshint ignore:line
+function loadChanges() { // jshint ignore:line
   $('.tab-content.sourcediff .loading').removeClass('invisible');
+
+  // Take the parameters from the container data
+  var requestNumber = $('#sourcediff-container').data('bs-request-number');
+  var requestActionId = $('#sourcediff-container').data('action-id');
+  var diffToSupersededId = $('#sourcediff-container').data('diff-to-superseded-id');
+
   var queryString = diffToSupersededId ? '?diff_to_superseded=' + diffToSupersededId : '';
   var url = '/request/' + requestNumber + '/request_action/' + requestActionId + '/changes' + queryString;
   $.ajax({

--- a/src/api/app/assets/javascripts/webui/request.js
+++ b/src/api/app/assets/javascripts/webui/request.js
@@ -189,14 +189,12 @@ function loadChanges() { // jshint ignore:line
   $('.tab-content.sourcediff .loading').removeClass('invisible');
 
   // Take the parameters from the container data
-  var requestNumber = $('#sourcediff-container').data('bs-request-number');
-  var requestActionId = $('#sourcediff-container').data('action-id');
+  var url = $('#sourcediff-container').data('url');
   var diffToSupersededId = $('#sourcediff-container').data('diff-to-superseded-id');
-
   var queryString = diffToSupersededId ? '?diff_to_superseded=' + diffToSupersededId : '';
-  var url = '/request/' + requestNumber + '/request_action/' + requestActionId + '/changes' + queryString;
+
   $.ajax({
-    url: url,
+    url: url + queryString,
     success: function() {
       $('.tab-content.sourcediff .loading').addClass('invisible');
     },

--- a/src/api/app/assets/javascripts/webui/request.js
+++ b/src/api/app/assets/javascripts/webui/request.js
@@ -199,6 +199,9 @@ function loadChanges() { // jshint ignore:line
     url: url,
     success: function() {
       $('.tab-content.sourcediff .loading').addClass('invisible');
+    },
+    error: function() {
+      $('#sourcediff-container .result').text('Something went wrong while loading changes.');
     }
   });
 }

--- a/src/api/app/components/sourcediff_component.html.haml
+++ b/src/api/app/components/sourcediff_component.html.haml
@@ -2,7 +2,8 @@
   .col
     - if @action.diff_not_cached
       .clearfix.mb-2.text-center
-        .btn.btn-outline-primary.cache-refresh{ title: 'Refresh results', onclick: "loadChanges(#{@bs_request.number}, #{@action.id}, #{@diff_to_superseded&.number});" }
+        .btn.btn-outline-primary.cache-refresh{ title: 'Refresh results',
+                                                onclick: "loadChanges(#{@bs_request.number}, #{@action.id}, #{@diff_to_superseded_id});" }
           Crunching the latest data. Refresh again in a few seconds
           %i.fas.fa-sync-alt{ id: "cache#0-reload" }
         .text-center.p-4.loading.invisible

--- a/src/api/app/components/sourcediff_component.html.haml
+++ b/src/api/app/components/sourcediff_component.html.haml
@@ -2,9 +2,12 @@
   .col
     - if @action.diff_not_cached
       .clearfix.mb-2.text-center
-        .btn.btn-outline-primary.cache-refresh{ title: 'Refresh results', onclick: "loadChanges(#{@bs_request.number}, #{@action.id});" }
+        .btn.btn-outline-primary.cache-refresh{ title: 'Refresh results', onclick: "loadChanges(#{@bs_request.number}, #{@action.id}, #{@diff_to_superseded&.number});" }
           Crunching the latest data. Refresh again in a few seconds
           %i.fas.fa-sync-alt{ id: "cache#0-reload" }
+        .text-center.p-4.loading.invisible
+          %i.fas.fa-spinner.fa-spin.me-1
+          Loading changes...
     - else
       - (@action.webui_sourcediff).each do |sourcediff|
         .clearfix.mb-2

--- a/src/api/app/components/sourcediff_component.html.haml
+++ b/src/api/app/components/sourcediff_component.html.haml
@@ -2,8 +2,7 @@
   .col
     - if @action.diff_not_cached
       .clearfix.mb-2.text-center
-        .btn.btn-outline-primary.cache-refresh{ title: 'Refresh results',
-                                                onclick: "loadChanges(#{@bs_request.number}, #{@action.id}, #{@diff_to_superseded_id});" }
+        .btn.btn-outline-primary.cache-refresh{ title: 'Refresh results', onclick: "loadChanges()" }
           Crunching the latest data. Refresh again in a few seconds
           %i.fas.fa-sync-alt{ id: "cache#0-reload" }
         .text-center.p-4.loading.invisible

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -16,7 +16,6 @@ class Webui::RequestController < Webui::WebuiController
                              if: -> { Flipper.enabled?(:request_show_redesign, User.session) }
   before_action :set_influxdb_data_request_actions, only: %i[show build_results rpm_lint changes mentioned_issues],
                                                     if: -> { Flipper.enabled?(:request_show_redesign, User.session) }
-  before_action :set_diff_to_superseded_id, only: %i[show request_action request_action_changes build_results rpm_lint changes mentioned_issues]
   before_action :set_superseded_request, only: %i[show request_action request_action_changes build_results rpm_lint changes mentioned_issues]
   before_action :check_ajax, only: :sourcediff
   before_action :prepare_request_data, only: %i[show build_results rpm_lint changes mentioned_issues],
@@ -354,12 +353,8 @@ class Webui::RequestController < Webui::WebuiController
     end
   end
 
-  def set_diff_to_superseded_id
-    @diff_to_superseded_id = params[:diff_to_superseded]
-  end
-
   def set_superseded_request
-    return unless @diff_to_superseded_id
+    return unless (@diff_to_superseded_id = params[:diff_to_superseded])
 
     @diff_to_superseded = @bs_request.superseding.find_by(number: @diff_to_superseded_id)
     return if @diff_to_superseded

--- a/src/api/app/views/webui/request/_changes_content.html.haml
+++ b/src/api/app/views/webui/request/_changes_content.html.haml
@@ -1,0 +1,12 @@
+- if diff_to_superseded
+  You're reviewing changes from
+  = link_to("superseded request ##{diff_to_superseded.number}.", request_show_path(number: diff_to_superseded))
+  This only represents a small part of changes which are included in this request.
+  = surround('(', ')') do
+    = link_to('See the full changes for request', request_changes_path(number: bs_request.number))
+- else
+  - bs_request.superseding.each do |supersed|
+    See the changes from
+    = link_to "superseded request ##{supersed.number}", request_changes_path(bs_request, diff_to_superseded: supersed)
+
+= render SourcediffComponent.new(bs_request: bs_request, action: action)

--- a/src/api/app/views/webui/request/_changes_content.html.haml
+++ b/src/api/app/views/webui/request/_changes_content.html.haml
@@ -1,6 +1,6 @@
-- if diff_to_superseded
+- if diff_to_superseded_id
   You're reviewing changes from
-  = link_to("superseded request ##{diff_to_superseded.number}.", request_show_path(number: diff_to_superseded))
+  = link_to("superseded request ##{diff_to_superseded_id}.", request_show_path(number: diff_to_superseded_id))
   This only represents a small part of changes which are included in this request.
   = surround('(', ')') do
     = link_to('See the full changes for request', request_changes_path(number: bs_request.number))

--- a/src/api/app/views/webui/request/_changes_content.html.haml
+++ b/src/api/app/views/webui/request/_changes_content.html.haml
@@ -1,6 +1,6 @@
-- if diff_to_superseded_id
+- if diff_to_superseded
   You're reviewing changes from
-  = link_to("superseded request ##{diff_to_superseded_id}.", request_show_path(number: diff_to_superseded_id))
+  = link_to("superseded request ##{diff_to_superseded.number}.", request_show_path(number: diff_to_superseded.number))
   This only represents a small part of changes which are included in this request.
   = surround('(', ')') do
     = link_to('See the full changes for request', request_changes_path(number: bs_request.number))

--- a/src/api/app/views/webui/request/changes.html.haml
+++ b/src/api/app/views/webui/request/changes.html.haml
@@ -21,7 +21,7 @@
             %i.fas.fa-spinner.fa-spin.me-1
             Loading changes...
           :javascript
-            loadChanges('#{@bs_request.number}', '#{@action.id}', '#{@diff_to_superseded&.number}');
+            loadChanges('#{@bs_request.number}', '#{@action.id}', '#{@diff_to_superseded_id}');
   = render DeleteConfirmationDialogComponent.new(modal_id: 'delete-comment-modal',
                                                  method: :delete,
                                                  options: { modal_title: 'Delete comment?', remote: true })

--- a/src/api/app/views/webui/request/changes.html.haml
+++ b/src/api/app/views/webui/request/changes.html.haml
@@ -14,8 +14,7 @@
         locals: { bs_request: @bs_request, action: @action, issues: @issues,
                   actions_count: @actions.count, active_tab: @active_tab }
     .container.p-4
-      .tab-content.sourcediff{ data: { bs_request_number: @bs_request.number,
-                                       action_id: @action.id,
+      .tab-content.sourcediff{ data: { url: request_action_changes_path(@bs_request.number, @action.id),
                                        diff_to_superseded_id: @diff_to_superseded_id },
                                id: 'sourcediff-container' }
         .result

--- a/src/api/app/views/webui/request/changes.html.haml
+++ b/src/api/app/views/webui/request/changes.html.haml
@@ -14,14 +14,17 @@
         locals: { bs_request: @bs_request, action: @action, issues: @issues,
                   actions_count: @actions.count, active_tab: @active_tab }
     .container.p-4
-      .tab-content.sourcediff
+      .tab-content.sourcediff{ data: { bs_request_number: @bs_request.number,
+                                       action_id: @action.id,
+                                       diff_to_superseded_id: @diff_to_superseded_id },
+                               id: 'sourcediff-container' }
         .result
           // The content of this div is set by JavaScript which calls the partial ../_changes_content.html.haml
           .text-center.p-4
             %i.fas.fa-spinner.fa-spin.me-1
             Loading changes...
           :javascript
-            loadChanges('#{@bs_request.number}', '#{@action.id}', '#{@diff_to_superseded_id}');
+            loadChanges();
   = render DeleteConfirmationDialogComponent.new(modal_id: 'delete-comment-modal',
                                                  method: :delete,
                                                  options: { modal_title: 'Delete comment?', remote: true })

--- a/src/api/app/views/webui/request/changes.html.haml
+++ b/src/api/app/views/webui/request/changes.html.haml
@@ -15,17 +15,13 @@
                   actions_count: @actions.count, active_tab: @active_tab }
     .container.p-4
       .tab-content.sourcediff
-        - if @diff_to_superseded
-          You're reviewing changes from
-          = link_to("superseded request ##{@diff_to_superseded.number}.", request_show_path(number: @diff_to_superseded))
-          This only represents a small part of changes which are included in this request.
-          = surround('(', ')') do
-            = link_to('See the full changes for request', request_changes_path(number: @bs_request.number))
-        - else
-          - @bs_request.superseding.each do |supersed|
-            See the changes from
-            = link_to "superseded request ##{supersed.number}", request_changes_path(@bs_request, diff_to_superseded: supersed)
-        = render SourcediffComponent.new(bs_request: @bs_request, action: @action)
+        .result
+          // The content of this div is set by JavaScript which calls the partial ../_changes_content.html.haml
+          .text-center.p-4
+            %i.fas.fa-spinner.fa-spin.me-1
+            Loading changes...
+          :javascript
+            loadChanges('#{@bs_request.number}', '#{@action.id}', '#{@diff_to_superseded&.number}');
   = render DeleteConfirmationDialogComponent.new(modal_id: 'delete-comment-modal',
                                                  method: :delete,
                                                  options: { modal_title: 'Delete comment?', remote: true })

--- a/src/api/app/views/webui/request/request_action_changes.js.erb
+++ b/src/api/app/views/webui/request/request_action_changes.js.erb
@@ -1,1 +1,1 @@
-$('.tab-content.sourcediff').html("<%= escape_javascript(render(partial: 'webui/request/changes_content', locals: { bs_request: @bs_request, action: @action, diff_to_superseded_id: @diff_to_superseded_id })) %>");
+$('.tab-content.sourcediff').html("<%= escape_javascript(render(partial: 'webui/request/changes_content', locals: { bs_request: @bs_request, action: @action, diff_to_superseded: @diff_to_superseded })) %>");

--- a/src/api/app/views/webui/request/request_action_changes.js.erb
+++ b/src/api/app/views/webui/request/request_action_changes.js.erb
@@ -1,1 +1,1 @@
-$('.tab-content.sourcediff').html("<%= escape_javascript(render(partial: 'webui/request/changes_content', locals: { bs_request: @bs_request, action: @action, diff_to_superseded: @diff_to_superseded })) %>");
+$('.tab-content.sourcediff').html("<%= escape_javascript(render(partial: 'webui/request/changes_content', locals: { bs_request: @bs_request, action: @action, diff_to_superseded_id: @diff_to_superseded_id })) %>");

--- a/src/api/app/views/webui/request/request_action_changes.js.erb
+++ b/src/api/app/views/webui/request/request_action_changes.js.erb
@@ -1,1 +1,1 @@
-$('.tab-content.sourcediff').html("<%= escape_javascript(render(SourcediffComponent.new(bs_request: @bs_request, action: @action))) %>");
+$('.tab-content.sourcediff').html("<%= escape_javascript(render(partial: 'webui/request/changes_content', locals: { bs_request: @bs_request, action: @action, diff_to_superseded: @diff_to_superseded })) %>");


### PR DESCRIPTION
Applying the common pattern: load the static/text part of the page within the main page request, send an async call right after the page load to fetch the heavy content of the page while a loading message is visible.

## Test
Visit https://obs-reviewlab.opensuse.org/ncounter-async-loading-changes/request/show/1/changes

## Before: the page is loaded fully sync - spot the loading icon at the top of the browser tab
![before-async-loading](https://github.com/openSUSE/open-build-service/assets/7080830/f664cc6b-693e-4798-8be3-b1cbb746e39f)


## After: the page is quickly loaded in the header and the rest but the content, that starts loading async

![after-async-loading](https://github.com/openSUSE/open-build-service/assets/7080830/ded3da43-721b-4eee-a604-9cc609fa8790)
