### PR TITLE
apidocs: Add missing params for branch

### DIFF
--- a/src/api/public/apidocs/paths/source_project_name_package_name_cmd_branch.yaml
+++ b/src/api/public/apidocs/paths/source_project_name_package_name_cmd_branch.yaml
@@ -77,6 +77,19 @@ post:
           - 1
       description: Set to ignore validation and resolving of devel package or devel project definition.
     - in: query
+      name: force
+      schema:
+        type: string
+        enum:
+          - 1
+      allowEmptyValue: true
+      description: Set to allow overwriting of a pre-existing package.
+    - in: query
+      name: rev
+      schema:
+        type: string
+      description: Set to branch against a specific revision.
+    - in: query
       name: maintenance
       schema:
         type: string


### PR DESCRIPTION
Add missing parameters for `/source/{project_name}/{package_name}?cmd=branch`
as used by `osc branch -f -r 123 ...`

https://github.com/openSUSE/osc/blob/ec363bb/osc/core.py#L6138