### PR TITLE
[backend] scmsync: allow to add build config lines via meta

### DIFF
--- a/src/backend/BSSrcServer/Scmsync.pm
+++ b/src/backend/BSSrcServer/Scmsync.pm
@@ -249,16 +249,22 @@ sub sync_project {
 
   # update the project config
   my $config = '';
+  # TEMPORARY HACK: checking for additional project config in project description
+  # we need to find a better place for outside of git overwrites
+  $config = join("\n",$proj->{'description'} =~ /^#!(.*)/mg);
   if ($files{'_config'}) {
+    my $gitconfig;
     eval {
-      $config = cpio_extract($cpiofd, \%files, '_config', 1000000);
+      $gitconfig = cpio_extract($cpiofd, \%files, '_config', 1000000);
     };
     if ($@) {
       warn($@);
-      undef $config;
+      undef $gitconfig;
+    } else {
+      $config = join("\n", $config, $gitconfig);
     }
   }
-  sync_config($cgi, $projid, $config) if defined $config;
+  sync_config($cgi, $projid, $config);
 
   return { 'project' => $projid, 'package' => '_project', 'rev' => 'obsscm' };
 }


### PR DESCRIPTION
A possible usecase is to build only a small set of packages from a large project. We need to have another place, beside the git source to define this subset for temporary test builds. This is because the git source must be always in a mergable state.

This implementation allows to add any build config line via project meta description. Any #! prefixed line of project meta will be put on top of the _config file.

Please note that this is not the final place, but avoids any compat breakage for now and allows people to play with it.

An example description may look like this:
...
 <description>
 This is my test build for Id X
 #!BuildFlags: onlybuild:acl
 #!BuildFlags: onlybuild:bc
 Some other text describing the project
 </description