### PR TITLE
Replace repository status with build result status (part2)

### DIFF
--- a/src/api/app/components/chart_component.html.haml
+++ b/src/api/app/components/chart_component.html.haml
@@ -31,7 +31,7 @@
               - raw_data.each do |result|
                 - if result[:repository] == repo
                   = render partial: 'webui/shared/build_status_badge', locals: { status: result[:status],
-                                                                                 text: helpers.repository_status(result),
+                                                                                 text: result[:status].humanize,
                                                                                  architecture: result[:architecture],
                                                                                  url: helpers.live_build_log_url(result[:status],
                                                                                                          result[:project_name],

--- a/src/api/app/helpers/webui/buildresult_helper.rb
+++ b/src/api/app/helpers/webui/buildresult_helper.rb
@@ -84,10 +84,4 @@ module Webui::BuildresultHelper
                                 repository: repository,
                                 arch: architecture)
   end
-
-  def repository_status(result)
-    return 'Outdated' unless result[:is_repository_in_db]
-
-    result[:repository_status].humanize
-  end
 end


### PR DESCRIPTION
@saraycp I am afraid we missed this changes in https://github.com/openSUSE/open-build-service/pull/15851, right? It is for the simplified build summary in this case instead.