### PR TITLE
Keep track of diff_to_superseded parameter in all the cases

### DIFF
--- a/src/api/app/components/sourcediff_component.html.haml
+++ b/src/api/app/components/sourcediff_component.html.haml
@@ -1,13 +1,13 @@
 .row
   .col
-    - if @action.diff_not_cached
+    - if @action.diff_not_cached({ diff_to_superseded: @diff_to_superseded })
       .clearfix.mb-2.text-center
         .btn.btn-outline-primary.cache-refresh{ title: 'Refresh results', onclick: "loadChanges()" }
           Crunching the latest data. Refresh again in a few seconds
           %i.fas.fa-sync-alt{ id: "cache#0-reload" }
         = render partial: 'webui/shared/loading', locals: { text: 'Loading changes...', wrapper_css: ['loading', 'invisible'] }
     - else
-      - (@action.webui_sourcediff).each do |sourcediff|
+      - (@action.webui_sourcediff({ diff_to_superseded: @diff_to_superseded })).each do |sourcediff|
         .clearfix.mb-2
           .btn-group.float-end
             %button.btn.btn-outline-secondary.expand-diffs{ data: { object: @action.source_package } }
@@ -20,7 +20,7 @@
             %i.error
               = sourcediff[:error]
         - else
-          - if @action.webui_sourcediff.length > 1
+          - if @action.webui_sourcediff({ diff_to_superseded: @diff_to_superseded }).length > 1
             %h4
               #{diff_label(sourcediff['new'])} – #{diff_label(sourcediff['old'])}
           - if sourcediff['filenames'].present?

--- a/src/api/app/components/sourcediff_component.rb
+++ b/src/api/app/components/sourcediff_component.rb
@@ -1,14 +1,15 @@
 class SourcediffComponent < ApplicationComponent
-  attr_accessor :bs_request, :action, :refresh
+  attr_accessor :bs_request, :action, :refresh, :diff_to_superseded
 
   delegate :diff_label, to: :helpers
   delegate :diff_data, to: :helpers
 
-  def initialize(bs_request:, action:)
+  def initialize(bs_request:, action:, diff_to_superseded: nil)
     super
 
     @bs_request = bs_request
     @action = action
+    @diff_to_superseded = diff_to_superseded
   end
 
   def commentable

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -499,7 +499,7 @@ class Webui::RequestController < Webui::WebuiController
   end
 
   def cache_diff_data
-    return unless @action.diff_not_cached
+    return unless @action.diff_not_cached({ diff_to_superseded: @diff_to_superseded })
 
     job = Delayed::Job.where('handler LIKE ?', "%job_class: BsRequestActionWebuiInfosJob%#{@action.to_global_id.uri}%").count
     BsRequestActionWebuiInfosJob.perform_later(@action) if job.zero?

--- a/src/api/app/models/bs_request_action.rb
+++ b/src/api/app/models/bs_request_action.rb
@@ -255,7 +255,7 @@ class BsRequestAction < ApplicationRecord
 
   # Serve the sourcediff to the webui
   def webui_sourcediff(opts = {})
-    opts.merge(superseded_bs_request_action: find_action_with_same_target(opts[:diff_to_superseded])) if opts[:diff_to_superseded]
+    opts[:superseded_bs_request_action] = find_action_with_same_target(opts[:diff_to_superseded]) if opts[:diff_to_superseded]
 
     begin
       opts[:view] = 'xml'
@@ -269,8 +269,8 @@ class BsRequestAction < ApplicationRecord
     sorted_filenames_from_sourcediff(sd)
   end
 
-  def diff_not_cached
-    sourcediff_results = webui_sourcediff({ cacheonly: 1 })
+  def diff_not_cached(opts = {})
+    sourcediff_results = webui_sourcediff({ cacheonly: 1, diff_to_superseded: opts[:diff_to_superseded] })
 
     return false if sourcediff_results.present?
 

--- a/src/api/app/views/webui/request/_changes_content.html.haml
+++ b/src/api/app/views/webui/request/_changes_content.html.haml
@@ -9,4 +9,4 @@
     See the changes from
     = link_to "superseded request ##{supersed.number}", request_changes_path(bs_request, diff_to_superseded: supersed)
 
-= render SourcediffComponent.new(bs_request: bs_request, action: action)
+= render SourcediffComponent.new(bs_request: bs_request, action: action, diff_to_superseded: diff_to_superseded)

--- a/src/api/spec/components/sourcediff_component_spec.rb
+++ b/src/api/spec/components/sourcediff_component_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe SourcediffComponent, :vcr, type: :component do
            target_package: target_package,
            source_package: source_package)
   end
-  let(:bs_request_opts) { { filelimit: nil, tarlimit: nil, diff_to_superseded: nil, diffs: true, cacheonly: 1 } }
 
   context 'with a request with a submit action' do
     before do


### PR DESCRIPTION
Fix https://github.com/openSUSE/open-build-service/issues/15916

# Test:

### tl;dr:
As long as the review-app is not re-genarated, the following steps are already reflected into https://obs-reviewlab.opensuse.org/ncounter-fix-diff-to-superseded-changes/request/show/19/changes?diff_to_superseded=18

### long version
1. Go https://obs-reviewlab.opensuse.org/ncounter-fix-diff-to-superseded-changes/package/show/home:Admin/hello_world
2. Branch the package
3. Change some lines in README.txt and save
4. Submit the package (it creates a new submit request)
5. Go back to the branched package and change few more lines in the README.txt again
6. Submit the package again and checking that the submit request supersedes the previous one (a flag to be marked while creating the submit request)
7. Visit the latest submit request page at the changes tab (if in beta), it will show the full diff of the package from the initial branched one
8. Visit now the _(changes from superseded)_ link, it's in the header of the submit request
9. The visible diff includes only the changes from the first submit request to the latest one
