### PR TITLE
Missing check condition for a local variable

### DIFF
--- a/src/api/app/views/webui/shared/_loading.haml
+++ b/src/api/app/views/webui/shared/_loading.haml
@@ -1,3 +1,3 @@
-.text-center.p-4{ class: wrapper_css || '' }
+.text-center.p-4{ class: defined?(wrapper_css) ? wrapper_css : '' }
   %i.fas.fa-spinner.fa-spin.me-1
   = text


### PR DESCRIPTION
There are cases where the `wrapper_css` local variable does not exist while rendering the partial.