### PR TITLE
Reload js events on async content loaded

### DIFF
--- a/src/api/app/assets/javascripts/webui/comment.js
+++ b/src/api/app/assets/javascripts/webui/comment.js
@@ -17,7 +17,7 @@ function validateForm(e) {
   submitButton.prop('disabled', !$(e.target).val());
 }
 
-$(document).ready(function(){
+function handlingCommentEvents() {
   // Disable submit button if textarea is empty and enable otherwise
   $('.comments-list,.comment_new,.timeline,.diff').on('input', '.comment-field', function(e) {
     validateForm(e);
@@ -116,4 +116,8 @@ $(document).ready(function(){
   $('body').on('click', '.cancel-comment', function (e) {
     $(e.target).closest('.collapse').collapse('hide');
   });
+}
+
+$(document).ready(function(){
+  handlingCommentEvents();
 });

--- a/src/api/app/views/webui/request/request_action_changes.js.erb
+++ b/src/api/app/views/webui/request/request_action_changes.js.erb
@@ -1,1 +1,3 @@
 $('.tab-content.sourcediff').html("<%= escape_javascript(render(partial: 'webui/request/changes_content', locals: { bs_request: @bs_request, action: @action, diff_to_superseded: @diff_to_superseded })) %>");
+
+handlingCommentEvents();


### PR DESCRIPTION
Whenever a `js` event is defined as `$('.class-name').on` the event is attached and listened only to already existing HTML objects. We need either to attach those events on the `$(document)`, or to reload them on HTML that comes later on during the lifecycle (via async calls or anything else that generates HTML) after the page load.

This issue occurs for instance on the Request beta Changes page for the inline-comment: the button `Add Comment` never gets enabled because the event `input` on the `textarea` never gets triggered thus the `validateForm` function that enables the button never get triggered too.