### PR TITLE
[backend] skip directories when downloading binaries with view=cpio

### DIFF
--- a/src/backend/bs_repserver
+++ b/src/backend/bs_repserver
@@ -992,6 +992,7 @@ sub getbinarylist {
     }
     for (sort @bins) {
       next if %binaries && !$binaries{$_};
+      next if -d "$reporoot/$prp/$arch/$packid/$_";
       if (/\.tar$/ && ! -e "$reporoot/$prp/$arch/$packid/$_") {
 	my $n = $_;
 	my $fd = BSRepServer::Containertar::open_container("$reporoot/$prp/$arch/$packid/$n");


### PR DESCRIPTION
That's in sync with the result you get if you request the binary list.

Fixes remote aggregates that request packages with subdirs, like some kiwi build results.