### PR TITLE
[backend] triggerscmsync: find matching git repo case insensitive

### DIFF
--- a/src/backend/BSSrcServer/ScmsyncDB.pm
+++ b/src/backend/BSSrcServer/ScmsyncDB.pm
@@ -81,16 +81,17 @@ sub getscmsyncpackages {
   my $h = $db->{'sqlite'} || BSSrcServer::SQLite::connectdb($db);
 
   $scmsync_repo   =~ s/\.git$//;
+  $scmsync_repo   = lc($scmsync_repo);
 
   my $sh;
   if ($scmsync_branch) {
-    $sh = BSSQLite::dbdo_bind($h, 'SELECT project, package FROM scmsync WHERE scmsync_repo = ? AND scmsync_branch = ?', [$scmsync_repo], [$scmsync_branch]);
+    $sh = BSSQLite::dbdo_bind($h, 'SELECT project, package FROM scmsync WHERE LOWER(scmsync_repo) = ? AND scmsync_branch = ?', [$scmsync_repo], [$scmsync_branch]);
   } elsif ($scmsync_branch eq '') {
     # default branch only
-    $sh = BSSQLite::dbdo_bind($h, 'SELECT project, package FROM scmsync WHERE scmsync_repo = ? AND scmsync_branch IS NULL', [$scmsync_repo]);
+    $sh = BSSQLite::dbdo_bind($h, 'SELECT project, package FROM scmsync WHERE LOWER(scmsync_repo) = ? AND scmsync_branch IS NULL', [$scmsync_repo]);
   } else {
     # all branches
-    $sh = BSSQLite::dbdo_bind($h, 'SELECT project, package FROM scmsync WHERE scmsync_repo = ?', [$scmsync_repo]);
+    $sh = BSSQLite::dbdo_bind($h, 'SELECT project, package FROM scmsync WHERE LOWER(scmsync_repo) = ?', [$scmsync_repo]);
   };
   my ($project, $package);
   $sh->bind_columns(\$project, \$package);


### PR DESCRIPTION
Clone urls are usually case insensitive. This means meta may contain a different url then the emitting repo. Doing therefore the lookup case insensitive by converting it to lower case.