### PR TITLE
Less global variables, more methods call

### DIFF
--- a/src/api/app/components/add_review_dropdown_component.rb
+++ b/src/api/app/components/add_review_dropdown_component.rb
@@ -1,11 +1,10 @@
 class AddReviewDropdownComponent < ApplicationComponent
-  def initialize(bs_request:, user:, my_open_reviews:, history_elements:)
+  def initialize(bs_request:, user:, my_open_reviews:)
     super
 
     @bs_request = bs_request
     @user = user
     @my_open_reviews = my_open_reviews
-    @history_elements = history_elements
   end
 
   def render?
@@ -26,7 +25,8 @@ class AddReviewDropdownComponent < ApplicationComponent
   end
 
   def reason_when_review_was_requested(review:)
-    reason = @history_elements.reverse.find { |history_element| history_element.type == 'HistoryElement::RequestReviewAdded' && history_element.description_extension == review.id.to_s }&.comment
+    history_elements = bs_request.history_elements.includes(user)
+    reason = history_elements.reverse.find { |history_element| history_element.type == 'HistoryElement::RequestReviewAdded' && history_element.description_extension == review.id.to_s }&.comment
 
     reason || ''
   end

--- a/src/api/app/components/bs_request_activity_timeline_component.rb
+++ b/src/api/app/components/bs_request_activity_timeline_component.rb
@@ -6,7 +6,7 @@
 class BsRequestActivityTimelineComponent < ApplicationComponent
   attr_reader :bs_request, :creator, :timeline, :request_reviews_for_non_staging_projects
 
-  def initialize(bs_request:, history_elements:, request_reviews_for_non_staging_projects: [])
+  def initialize(bs_request:, request_reviews_for_non_staging_projects: [])
     super
     @bs_request = bs_request
     @creator = User.find_by_login(bs_request.creator) || User.nobody
@@ -17,7 +17,7 @@ class BsRequestActivityTimelineComponent < ApplicationComponent
     @timeline = (
       action_comments +
       @bs_request.comments.without_parent.includes(:user) +
-      history_elements
+      bs_request.history_elements.includes(:user)
     ).compact.sort_by(&:created_at)
     @request_reviews_for_non_staging_projects = request_reviews_for_non_staging_projects
   end

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -29,7 +29,6 @@ class Webui::RequestController < Webui::WebuiController
   def show
     # TODO: Remove this `if` condition, and the `else` clause once request_show_redesign is rolled out
     if Flipper.enabled?(:request_show_redesign, User.session)
-      @history_elements = @bs_request.history_elements.includes(:user)
       @active_tab = 'conversation'
       render :beta_show
     else

--- a/src/api/app/views/webui/request/beta_show.html.haml
+++ b/src/api/app/views/webui/request/beta_show.html.haml
@@ -25,8 +25,7 @@
                     request_reviews: @request_reviews,
                     package_maintainers: @package_maintainers,
                     project_maintainers: @project_maintainers,
-                    show_project_maintainer_hint: @show_project_maintainer_hint,
-                    history_elements: @history_elements }
+                    show_project_maintainer_hint: @show_project_maintainer_hint }
 
         .col-md-8.order-md-1.order-sm-2
           .row
@@ -79,10 +78,8 @@
                         Collapse history from superseded request ##{superseding_request.number}
                   .collapse.mb-4#collapse-superseding
                     = render BsRequestActivityTimelineComponent.new(bs_request: superseding_request,
-                                                                    history_elements: @history_elements,
                                                                     request_reviews_for_non_staging_projects: @request_reviews)
                 = render BsRequestActivityTimelineComponent.new(bs_request: @bs_request,
-                                                                history_elements: @history_elements,
                                                                 request_reviews_for_non_staging_projects: @request_reviews)
 
               .comment_new

--- a/src/api/app/views/webui/request/beta_show_tabs/_conversation_aside.html.haml
+++ b/src/api/app/views/webui/request/beta_show_tabs/_conversation_aside.html.haml
@@ -3,8 +3,7 @@
   - if request_reviews.present?
     .text-end
       = render AddReviewDropdownComponent.new(bs_request: bs_request, user: User.session,
-                                              my_open_reviews: my_open_reviews,
-                                              history_elements: history_elements)
+                                              my_open_reviews: my_open_reviews)
     = render AddReviewCollapsibleComponent.new
     .mb-2
       %h6


### PR DESCRIPTION
_[Targeting Beta RequestWorkflowRedesign only]_

Use the Model method instead of storing data into a global variable and carry it around.