### PR TITLE
Include revision in the file url

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -466,7 +466,9 @@ class Webui::PackageController < Webui::WebuiController
       @revision = @current_rev if !@revision && !@srcmd5 # on very first page load only
 
       files_xml = @package.source_file(nil, { rev: @srcmd5 || @revision, expand: @expand }.compact)
-      @files = Xmlhash.parse(files_xml).elements('entry')
+      files_hash = Xmlhash.parse(files_xml)
+      @files = files_hash.elements('entry')
+      @srcmd5 = files_hash['srcmd5'] unless @revision == @current_rev
     rescue Backend::Error => e
       # TODO: crudest hack ever!
       if e.summary == 'service in progress' && @expand == 1

--- a/src/api/app/views/webui/package/_file.html.haml
+++ b/src/api/app/views/webui/package/_file.html.haml
@@ -1,4 +1,4 @@
-- can_be_removed = removable_file?(file_name: file['name'], package: package) && can_modify
+- can_be_removed = removable_file?(file_name: file['name'], package: package) && can_modify && is_current_rev
 %tr{ id: "file-#{valid_xml_id(file['name'])}" }
   %td.text-word-break-all
     - link_opts = { action: :show, controller: 'webui/packages/files', project_name: project,

--- a/src/api/spec/cassettes/Packages/Viewing_package_with_older_revision/contains_file_from_revision_including_the_revision_parameter.yml
+++ b/src/api/spec/cassettes/Packages/Viewing_package_with_older_revision/contains_file_from_revision_including_the_revision_parameter.yml
@@ -1,0 +1,967 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:package_test_user">
+          <title/>
+          <description/>
+          <person userid="package_test_user" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '156'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:package_test_user">
+          <title></title>
+          <description></description>
+          <person userid="package_test_user" role="maintainer"/>
+        </project>
+  recorded_at: Mon, 08 Apr 2024 09:09:39 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=user_3
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:package_test_user">
+          <title>Ring of Bright Water</title>
+          <description>Ut aliquam ex autem.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '162'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:package_test_user">
+          <title>Ring of Bright Water</title>
+          <description>Ut aliquam ex autem.</description>
+        </package>
+  recorded_at: Mon, 08 Apr 2024 09:09:39 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/test_package/_config
+    body:
+      encoding: UTF-8
+      string: Officia hic ratione. Qui neque nihil. Repellat adipisci aspernatur.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="23" vrev="23">
+          <srcmd5>db88d857855398353d6ef6e67ff544a8</srcmd5>
+          <version>unknown</version>
+          <time>1712567379</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Mon, 08 Apr 2024 09:09:39 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/test_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Quia dicta consequatur. Et quisquam tempore. Saepe quaerat qui.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="24" vrev="24">
+          <srcmd5>9683ca1eb22c42ac26ff9813318b1fd0</srcmd5>
+          <version>unknown</version>
+          <time>1712567379</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Mon, 08 Apr 2024 09:09:39 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_package_test_user/_meta?user=other_package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:other_package_test_user">
+          <title/>
+          <description/>
+          <person userid="other_package_test_user" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '168'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:other_package_test_user">
+          <title></title>
+          <description></description>
+          <person userid="other_package_test_user" role="maintainer"/>
+        </project>
+  recorded_at: Mon, 08 Apr 2024 09:09:39 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=user_4
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_package_test_user">
+          <title>This Lime Tree Bower</title>
+          <description>Officiis fuga atque repudiandae.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '187'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_package_test_user">
+          <title>This Lime Tree Bower</title>
+          <description>Officiis fuga atque repudiandae.</description>
+        </package>
+  recorded_at: Mon, 08 Apr 2024 09:09:39 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_config
+    body:
+      encoding: UTF-8
+      string: Dignissimos dicta nihil. Expedita ut non. Fugit vitae ratione.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="23" vrev="23">
+          <srcmd5>9404878e876222cef368e7f59d04390e</srcmd5>
+          <version>unknown</version>
+          <time>1712567379</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Mon, 08 Apr 2024 09:09:39 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Est sunt mollitia. Voluptatem in placeat. Magni perspiciatis voluptas.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="24" vrev="24">
+          <srcmd5>78127e0305e767447fc6880c80cd45dc</srcmd5>
+          <version>unknown</version>
+          <time>1712567379</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Mon, 08 Apr 2024 09:09:39 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/revision_test_package/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="revision_test_package" project="home:package_test_user">
+          <title>Look to Windward</title>
+          <description>Quia ratione aut veritatis.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '174'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="revision_test_package" project="home:package_test_user">
+          <title>Look to Windward</title>
+          <description>Quia ratione aut veritatis.</description>
+        </package>
+  recorded_at: Mon, 08 Apr 2024 09:09:41 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/revision_test_package/_config
+    body:
+      encoding: UTF-8
+      string: Voluptatem optio porro. Quia porro sunt. Aut rerum ab.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="4" vrev="4">
+          <srcmd5>afb46f37cbaf3995e87f7f8d1b2a4bc2</srcmd5>
+          <version>unknown</version>
+          <time>1712567381</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Mon, 08 Apr 2024 09:09:41 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/revision_test_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Rem omnis autem. Sapiente ut quia. Nostrum dignissimos expedita.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="5" vrev="5">
+          <srcmd5>f6ff111452a0b166b98fcd2dfa09ab56</srcmd5>
+          <version>unknown</version>
+          <time>1712567381</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Mon, 08 Apr 2024 09:09:41 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/revision_test_package/revision_file?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: new content
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '217'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="6" vrev="6">
+          <srcmd5>f6ff111452a0b166b98fcd2dfa09ab56</srcmd5>
+          <version>unknown</version>
+          <time>1712567381</time>
+          <user>package_test_user</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Mon, 08 Apr 2024 09:09:41 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/revision_test_package/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="revision_test_package" project="home:package_test_user">
+          <title>Look to Windward</title>
+          <description>Quia ratione aut veritatis.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '174'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="revision_test_package" project="home:package_test_user">
+          <title>Look to Windward</title>
+          <description>Quia ratione aut veritatis.</description>
+        </package>
+  recorded_at: Mon, 08 Apr 2024 09:09:41 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/revision_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '406'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="revision_test_package" rev="6" vrev="6" srcmd5="f6ff111452a0b166b98fcd2dfa09ab56">
+          <entry name="_config" md5="ec8bb8e4b79333590bb843c3ba3e1df2" size="54" mtime="1712567381"/>
+          <entry name="revision_file" md5="96c15c2bb2921193bf290df8cd85e2ba" size="11" mtime="1712567378"/>
+          <entry name="somefile.txt" md5="79d9dda58f7e44fc017b79ef1fdfabc0" size="64" mtime="1712567381"/>
+        </directory>
+  recorded_at: Mon, 08 Apr 2024 09:09:41 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/revision_test_package?view=info
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '239'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourceinfo package="revision_test_package" rev="6" vrev="6" srcmd5="f6ff111452a0b166b98fcd2dfa09ab56" verifymd5="f6ff111452a0b166b98fcd2dfa09ab56">
+          <error>bad build configuration, no build type defined or detected</error>
+        </sourceinfo>
+  recorded_at: Mon, 08 Apr 2024 09:09:41 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/revision_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '406'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="revision_test_package" rev="6" vrev="6" srcmd5="f6ff111452a0b166b98fcd2dfa09ab56">
+          <entry name="_config" md5="ec8bb8e4b79333590bb843c3ba3e1df2" size="54" mtime="1712567381"/>
+          <entry name="revision_file" md5="96c15c2bb2921193bf290df8cd85e2ba" size="11" mtime="1712567378"/>
+          <entry name="somefile.txt" md5="79d9dda58f7e44fc017b79ef1fdfabc0" size="64" mtime="1712567381"/>
+        </directory>
+  recorded_at: Mon, 08 Apr 2024 09:09:41 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/home:package_test_user/revision_test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '348'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="183eaa15533f837308429983215fd454">
+          <old project="home:package_test_user" package="revision_test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="home:package_test_user" package="revision_test_package" rev="6" srcmd5="f6ff111452a0b166b98fcd2dfa09ab56"/>
+          <files/>
+          <issues>
+          </issues>
+        </sourcediff>
+  recorded_at: Mon, 08 Apr 2024 09:09:41 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/revision_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '406'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="revision_test_package" rev="6" vrev="6" srcmd5="f6ff111452a0b166b98fcd2dfa09ab56">
+          <entry name="_config" md5="ec8bb8e4b79333590bb843c3ba3e1df2" size="54" mtime="1712567381"/>
+          <entry name="revision_file" md5="96c15c2bb2921193bf290df8cd85e2ba" size="11" mtime="1712567378"/>
+          <entry name="somefile.txt" md5="79d9dda58f7e44fc017b79ef1fdfabc0" size="64" mtime="1712567381"/>
+        </directory>
+  recorded_at: Mon, 08 Apr 2024 09:09:41 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/revision_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - d3263dc5-fb68-4811-a67a-76a4c01570d3
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '406'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="revision_test_package" rev="6" vrev="6" srcmd5="f6ff111452a0b166b98fcd2dfa09ab56">
+          <entry name="_config" md5="ec8bb8e4b79333590bb843c3ba3e1df2" size="54" mtime="1712567381"/>
+          <entry name="revision_file" md5="96c15c2bb2921193bf290df8cd85e2ba" size="11" mtime="1712567378"/>
+          <entry name="somefile.txt" md5="79d9dda58f7e44fc017b79ef1fdfabc0" size="64" mtime="1712567381"/>
+        </directory>
+  recorded_at: Mon, 08 Apr 2024 09:09:41 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/revision_test_package?expand=1&rev=5
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '406'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="revision_test_package" rev="5" vrev="5" srcmd5="f6ff111452a0b166b98fcd2dfa09ab56">
+          <entry name="_config" md5="ec8bb8e4b79333590bb843c3ba3e1df2" size="54" mtime="1712567381"/>
+          <entry name="revision_file" md5="96c15c2bb2921193bf290df8cd85e2ba" size="11" mtime="1712567378"/>
+          <entry name="somefile.txt" md5="79d9dda58f7e44fc017b79ef1fdfabc0" size="64" mtime="1712567381"/>
+        </directory>
+  recorded_at: Mon, 08 Apr 2024 09:09:41 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/revision_test_package/_history?deleted=0&meta=0&rev=5
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - d3263dc5-fb68-4811-a67a-76a4c01570d3
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '213'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+          <revision rev="5" vrev="5">
+            <srcmd5>f6ff111452a0b166b98fcd2dfa09ab56</srcmd5>
+            <version>unknown</version>
+            <time>1712567381</time>
+            <user>unknown</user>
+          </revision>
+        </revisionlist>
+  recorded_at: Mon, 08 Apr 2024 09:09:41 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/revision_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - d3263dc5-fb68-4811-a67a-76a4c01570d3
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '406'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="revision_test_package" rev="6" vrev="6" srcmd5="f6ff111452a0b166b98fcd2dfa09ab56">
+          <entry name="_config" md5="ec8bb8e4b79333590bb843c3ba3e1df2" size="54" mtime="1712567381"/>
+          <entry name="revision_file" md5="96c15c2bb2921193bf290df8cd85e2ba" size="11" mtime="1712567378"/>
+          <entry name="somefile.txt" md5="79d9dda58f7e44fc017b79ef1fdfabc0" size="64" mtime="1712567381"/>
+        </directory>
+  recorded_at: Mon, 08 Apr 2024 09:09:41 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/revision_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - d3263dc5-fb68-4811-a67a-76a4c01570d3
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '406'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="revision_test_package" rev="6" vrev="6" srcmd5="f6ff111452a0b166b98fcd2dfa09ab56">
+          <entry name="_config" md5="ec8bb8e4b79333590bb843c3ba3e1df2" size="54" mtime="1712567381"/>
+          <entry name="revision_file" md5="96c15c2bb2921193bf290df8cd85e2ba" size="11" mtime="1712567378"/>
+          <entry name="somefile.txt" md5="79d9dda58f7e44fc017b79ef1fdfabc0" size="64" mtime="1712567381"/>
+        </directory>
+  recorded_at: Mon, 08 Apr 2024 09:09:41 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:package_test_user/_result?lastbuild=1&locallink=1&multibuild=1&package=revision_test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - b2d4f92a-4426-4a5a-a721-03497a41444a
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Mon, 08 Apr 2024 09:09:41 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:package_test_user/_result?lastbuild=1&locallink=1&multibuild=1&package=revision_test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - b02e690b-c471-4394-84f3-581d5ba23f6c
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Mon, 08 Apr 2024 09:09:41 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/revision_test_package?rev=5
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '406'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="revision_test_package" rev="5" vrev="5" srcmd5="f6ff111452a0b166b98fcd2dfa09ab56">
+          <entry name="_config" md5="ec8bb8e4b79333590bb843c3ba3e1df2" size="54" mtime="1712567381"/>
+          <entry name="revision_file" md5="96c15c2bb2921193bf290df8cd85e2ba" size="11" mtime="1712567378"/>
+          <entry name="somefile.txt" md5="79d9dda58f7e44fc017b79ef1fdfabc0" size="64" mtime="1712567381"/>
+        </directory>
+  recorded_at: Mon, 08 Apr 2024 09:09:42 GMT
+recorded_with: VCR 6.2.0

--- a/src/api/spec/cassettes/Packages/Viewing_package_with_older_revision/does_not_display_delete_buttons_for_files.yml
+++ b/src/api/spec/cassettes/Packages/Viewing_package_with_older_revision/does_not_display_delete_buttons_for_files.yml
@@ -1,0 +1,965 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:package_test_user">
+          <title/>
+          <description/>
+          <person userid="package_test_user" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '156'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:package_test_user">
+          <title></title>
+          <description></description>
+          <person userid="package_test_user" role="maintainer"/>
+        </project>
+  recorded_at: Mon, 08 Apr 2024 09:09:30 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/test_package/_meta?user=user_1
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:package_test_user">
+          <title>Specimen Days</title>
+          <description>Corporis dolores in et.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '158'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="test_package" project="home:package_test_user">
+          <title>Specimen Days</title>
+          <description>Corporis dolores in et.</description>
+        </package>
+  recorded_at: Mon, 08 Apr 2024 09:09:30 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/test_package/_config
+    body:
+      encoding: UTF-8
+      string: Dolor deserunt quibusdam. Beatae totam inventore. Maiores ut nesciunt.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="21" vrev="21">
+          <srcmd5>7e540ab8871c144d4ed768520e3190c4</srcmd5>
+          <version>unknown</version>
+          <time>1712567370</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Mon, 08 Apr 2024 09:09:30 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/test_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Aut iusto rem. A omnis dicta. Ea non sed.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="22" vrev="22">
+          <srcmd5>9abf7a413ec2f8e585b5452b4b788779</srcmd5>
+          <version>unknown</version>
+          <time>1712567370</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Mon, 08 Apr 2024 09:09:30 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_package_test_user/_meta?user=other_package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:other_package_test_user">
+          <title/>
+          <description/>
+          <person userid="other_package_test_user" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '168'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:other_package_test_user">
+          <title></title>
+          <description></description>
+          <person userid="other_package_test_user" role="maintainer"/>
+        </project>
+  recorded_at: Mon, 08 Apr 2024 09:09:30 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_meta?user=user_2
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_package_test_user">
+          <title>Many Waters</title>
+          <description>Voluptatem ut magni pariatur.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '175'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="branch_test_package" project="home:other_package_test_user">
+          <title>Many Waters</title>
+          <description>Voluptatem ut magni pariatur.</description>
+        </package>
+  recorded_at: Mon, 08 Apr 2024 09:09:30 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/_config
+    body:
+      encoding: UTF-8
+      string: Enim dignissimos in. Veniam autem et. Omnis eveniet commodi.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="21" vrev="21">
+          <srcmd5>5da2aad24b4667d4e0b0465f7b0282ca</srcmd5>
+          <version>unknown</version>
+          <time>1712567370</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Mon, 08 Apr 2024 09:09:30 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:other_package_test_user/branch_test_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Perspiciatis eum non. Rem nemo ea. Voluptas velit architecto.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '209'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="22" vrev="22">
+          <srcmd5>5abee4d05edfeab0a956dddeea29812c</srcmd5>
+          <version>unknown</version>
+          <time>1712567370</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Mon, 08 Apr 2024 09:09:30 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/revision_test_package/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="revision_test_package" project="home:package_test_user">
+          <title>The Heart Is Deceitful Above All Things</title>
+          <description>Veritatis sequi rerum similique.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '202'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="revision_test_package" project="home:package_test_user">
+          <title>The Heart Is Deceitful Above All Things</title>
+          <description>Veritatis sequi rerum similique.</description>
+        </package>
+  recorded_at: Mon, 08 Apr 2024 09:09:38 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/revision_test_package/_config
+    body:
+      encoding: UTF-8
+      string: Aut assumenda nesciunt. Sed quia cum. Numquam eius neque.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="1" vrev="1">
+          <srcmd5>af687fa4fcbc0ad18ed8f6899bc412c7</srcmd5>
+          <version>unknown</version>
+          <time>1712567378</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Mon, 08 Apr 2024 09:09:38 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/revision_test_package/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Dolorem rerum tempora. Illo possimus ducimus. Eligendi eaque et.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="2" vrev="2">
+          <srcmd5>154fce1e8dba0f868a88c1d2909801b7</srcmd5>
+          <version>unknown</version>
+          <time>1712567378</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Mon, 08 Apr 2024 09:09:38 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/revision_test_package/revision_file?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: new content
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '217'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="3" vrev="3">
+          <srcmd5>f5ffbd2f15d02cb5b7835dc4205d3972</srcmd5>
+          <version>unknown</version>
+          <time>1712567378</time>
+          <user>package_test_user</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Mon, 08 Apr 2024 09:09:38 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/home:package_test_user/revision_test_package/_meta?user=package_test_user
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="revision_test_package" project="home:package_test_user">
+          <title>The Heart Is Deceitful Above All Things</title>
+          <description>Veritatis sequi rerum similique.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '202'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="revision_test_package" project="home:package_test_user">
+          <title>The Heart Is Deceitful Above All Things</title>
+          <description>Veritatis sequi rerum similique.</description>
+        </package>
+  recorded_at: Mon, 08 Apr 2024 09:09:38 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/revision_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '406'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="revision_test_package" rev="3" vrev="3" srcmd5="f5ffbd2f15d02cb5b7835dc4205d3972">
+          <entry name="_config" md5="1e7ed342f876dc5f3620efe20cf98e21" size="57" mtime="1712567378"/>
+          <entry name="revision_file" md5="96c15c2bb2921193bf290df8cd85e2ba" size="11" mtime="1712567378"/>
+          <entry name="somefile.txt" md5="6b54cf8397667611131e7ad4e8d545d3" size="64" mtime="1712567378"/>
+        </directory>
+  recorded_at: Mon, 08 Apr 2024 09:09:38 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/revision_test_package?view=info
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '239'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourceinfo package="revision_test_package" rev="3" vrev="3" srcmd5="f5ffbd2f15d02cb5b7835dc4205d3972" verifymd5="f5ffbd2f15d02cb5b7835dc4205d3972">
+          <error>bad build configuration, no build type defined or detected</error>
+        </sourceinfo>
+  recorded_at: Mon, 08 Apr 2024 09:09:38 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/revision_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '406'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="revision_test_package" rev="3" vrev="3" srcmd5="f5ffbd2f15d02cb5b7835dc4205d3972">
+          <entry name="_config" md5="1e7ed342f876dc5f3620efe20cf98e21" size="57" mtime="1712567378"/>
+          <entry name="revision_file" md5="96c15c2bb2921193bf290df8cd85e2ba" size="11" mtime="1712567378"/>
+          <entry name="somefile.txt" md5="6b54cf8397667611131e7ad4e8d545d3" size="64" mtime="1712567378"/>
+        </directory>
+  recorded_at: Mon, 08 Apr 2024 09:09:38 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/home:package_test_user/revision_test_package?cmd=diff&linkrev=base&onlyissues=1&orev=0&view=xml
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '348'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="7a2e7892b9e2251f1ca00fba070a79f1">
+          <old project="home:package_test_user" package="revision_test_package" rev="0" srcmd5="d41d8cd98f00b204e9800998ecf8427e"/>
+          <new project="home:package_test_user" package="revision_test_package" rev="3" srcmd5="f5ffbd2f15d02cb5b7835dc4205d3972"/>
+          <files/>
+          <issues>
+          </issues>
+        </sourcediff>
+  recorded_at: Mon, 08 Apr 2024 09:09:38 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/revision_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '406'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="revision_test_package" rev="3" vrev="3" srcmd5="f5ffbd2f15d02cb5b7835dc4205d3972">
+          <entry name="_config" md5="1e7ed342f876dc5f3620efe20cf98e21" size="57" mtime="1712567378"/>
+          <entry name="revision_file" md5="96c15c2bb2921193bf290df8cd85e2ba" size="11" mtime="1712567378"/>
+          <entry name="somefile.txt" md5="6b54cf8397667611131e7ad4e8d545d3" size="64" mtime="1712567378"/>
+        </directory>
+  recorded_at: Mon, 08 Apr 2024 09:09:38 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/revision_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 2440b93b-463f-4b1d-870f-3e94cd6436a8
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '406'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="revision_test_package" rev="3" vrev="3" srcmd5="f5ffbd2f15d02cb5b7835dc4205d3972">
+          <entry name="_config" md5="1e7ed342f876dc5f3620efe20cf98e21" size="57" mtime="1712567378"/>
+          <entry name="revision_file" md5="96c15c2bb2921193bf290df8cd85e2ba" size="11" mtime="1712567378"/>
+          <entry name="somefile.txt" md5="6b54cf8397667611131e7ad4e8d545d3" size="64" mtime="1712567378"/>
+        </directory>
+  recorded_at: Mon, 08 Apr 2024 09:09:38 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/revision_test_package?expand=1&rev=2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '306'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="revision_test_package" rev="2" vrev="2" srcmd5="154fce1e8dba0f868a88c1d2909801b7">
+          <entry name="_config" md5="1e7ed342f876dc5f3620efe20cf98e21" size="57" mtime="1712567378"/>
+          <entry name="somefile.txt" md5="6b54cf8397667611131e7ad4e8d545d3" size="64" mtime="1712567378"/>
+        </directory>
+  recorded_at: Mon, 08 Apr 2024 09:09:38 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/revision_test_package/_history?deleted=0&meta=0&rev=2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 2440b93b-463f-4b1d-870f-3e94cd6436a8
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '213'
+    body:
+      encoding: UTF-8
+      string: |
+        <revisionlist>
+          <revision rev="2" vrev="2">
+            <srcmd5>154fce1e8dba0f868a88c1d2909801b7</srcmd5>
+            <version>unknown</version>
+            <time>1712567378</time>
+            <user>unknown</user>
+          </revision>
+        </revisionlist>
+  recorded_at: Mon, 08 Apr 2024 09:09:38 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/revision_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 2440b93b-463f-4b1d-870f-3e94cd6436a8
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '406'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="revision_test_package" rev="3" vrev="3" srcmd5="f5ffbd2f15d02cb5b7835dc4205d3972">
+          <entry name="_config" md5="1e7ed342f876dc5f3620efe20cf98e21" size="57" mtime="1712567378"/>
+          <entry name="revision_file" md5="96c15c2bb2921193bf290df8cd85e2ba" size="11" mtime="1712567378"/>
+          <entry name="somefile.txt" md5="6b54cf8397667611131e7ad4e8d545d3" size="64" mtime="1712567378"/>
+        </directory>
+  recorded_at: Mon, 08 Apr 2024 09:09:38 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/home:package_test_user/revision_test_package
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 2440b93b-463f-4b1d-870f-3e94cd6436a8
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '406'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="revision_test_package" rev="3" vrev="3" srcmd5="f5ffbd2f15d02cb5b7835dc4205d3972">
+          <entry name="_config" md5="1e7ed342f876dc5f3620efe20cf98e21" size="57" mtime="1712567378"/>
+          <entry name="revision_file" md5="96c15c2bb2921193bf290df8cd85e2ba" size="11" mtime="1712567378"/>
+          <entry name="somefile.txt" md5="6b54cf8397667611131e7ad4e8d545d3" size="64" mtime="1712567378"/>
+        </directory>
+  recorded_at: Mon, 08 Apr 2024 09:09:38 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:package_test_user/_result?lastbuild=1&locallink=1&multibuild=1&package=revision_test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - a5886c6b-8e22-4808-8fb2-f783bf628811
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Mon, 08 Apr 2024 09:09:38 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:package_test_user/_result?lastbuild=1&locallink=1&multibuild=1&package=revision_test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 02d852cb-dda4-42bc-8b53-392f8ae80355
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Mon, 08 Apr 2024 09:09:39 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/home:package_test_user/_result?package=revision_test_package&view=status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 90cbed69-7823-44e8-afdc-33f358945aa6
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '55'
+    body:
+      encoding: UTF-8
+      string: '<resultlist state="00000000000000000000000000000000"/>
+
+'
+  recorded_at: Mon, 08 Apr 2024 09:09:39 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
We were missing `srcmd5` from the views in case we are displaying a revision. We need it to appear in links in order to link to the right file version. This also removes the delete file link from older revisions.

Fixes #15857