### PR TITLE
Info popover partial

### DIFF
--- a/src/api/app/components/workflow_run_filter_component.html.haml
+++ b/src/api/app/components/workflow_run_filter_component.html.haml
@@ -1,14 +1,26 @@
+:ruby
+  status_info_text = '<p>Filter your workflow runs by the current state</p>
+                      <p><b>Succeeded: </b>Workflow run execution was successful</p>
+                      <p><b>Running: </b>Workflow run is still in progress</p>
+                      <p><b>Failed: </b>Workflow run failed at some point</p>'
+  event_type_info_text = '<p>Filter your workflow runs by the event reported by the SCM,
+                          which triggered the execution in the Open Build Service</p>
+                          <p><b>Pull/Merge request: </b>
+                          A pull/merge request got opened against a selected branch</p>
+                          <p><b>Push: </b>A push event occured on a selected branch</p>'
+  event_source_info_text = '<p>Filter your workflow runs by the event source. The event source
+                            is what triggered this workflow on the SCM.</p>
+                            <p> A pull/merge request number like <em>12345</em></p>
+                            <p>or a git commit hash like
+                            <em>97561db8664eaf86a1e4c7b77d5fb5d5bff6681e</em></p>'
+
 .list-group.list-group-flush.my-2
   = render WorkflowRunFilterLinkComponent.new(token: @token, text: 'All', amount: @count['all'],
                                               filter_item: {}, selected_filter: @selected_filter)
 .list-group.list-group-flush.mt-5.mb-2
   %h5.mx-3
     Status
-    %i.fa.fa-question-circle.text-info{ data: { 'bs-placement': 'bottom', 'bs-toggle': 'popover', 'bs-html': 'true',
-                                                'bs-content': '<p>Filter your workflow runs by the current state</p>
-                                                               <p><b>Succeeded: </b>Workflow run execution was successful</p>
-                                                               <p><b>Running: </b>Workflow run is still in progress</p>
-                                                               <p><b>Failed: </b>Workflow run failed at some point</p>' } }
+    = render partial: 'webui/shared/info_popover', locals: { position: 'bottom', text: status_info_text }
   = render WorkflowRunFilterLinkComponent.new(token: @token, text: 'Succeeded', amount: @count['success'], icon: 'fas fa-check text-primary',
                                               filter_item: { status: 'success' }, selected_filter: @selected_filter)
   = render WorkflowRunFilterLinkComponent.new(token: @token, text: 'Running', amount: @count['running'], icon: 'fas fa-running',
@@ -18,12 +30,7 @@
 .list-group.list-group-flush.mt-5.mb-2
   %h5.mx-3
     Event Type
-    %i.fa.fa-question-circle.text-info{ data: { 'bs-placement': 'bottom', 'bs-toggle': 'popover', 'bs-html': 'true',
-                                                'bs-content': '<p>Filter your workflow runs by the event reported by the SCM,
-                                                               which triggered the execution in the Open Build Service</p>
-                                                               <p><b>Pull/Merge request: </b>
-                                                               A pull/merge request got opened against a selected branch</p>
-                                                               <p><b>Push: </b>A push event occured on a selected branch</p>' } }
+    = render partial: 'webui/shared/info_popover', locals: { position: 'bottom', text: event_type_info_text }
   = render WorkflowRunFilterLinkComponent.new(token: @token, text: 'Pull/Merge Request', amount: @count['pull_request'],
                                               filter_item: { generic_event_type: 'pull_request' }, selected_filter: @selected_filter)
   = render WorkflowRunFilterLinkComponent.new(token: @token, text: 'Push', amount: @count['push'],
@@ -33,12 +40,7 @@
 .list-group.list-group-flush.mt-5.mb-2
   %h5.mx-3
     Event Source
-    %i.fa.fa-question-circle.text-info{ data: { 'bs-placement': 'bottom', 'bs-toggle': 'popover', 'bs-html': 'true',
-                                                'bs-content': '<p>Filter your workflow runs by the event source. The event source
-                                                               is what triggered this workflow on the SCM.</p>
-                                                               <p> A pull/merge request number like <em>12345</em></p>
-                                                               <p>or a git commit hash like
-                                                               <em>97561db8664eaf86a1e4c7b77d5fb5d5bff6681e</em></p>' } }
+    = render partial: 'webui/shared/info_popover', locals: { position: 'bottom', text: event_source_info_text }
   = render WorkflowRunFilterInputComponent.new(token_id: @token.id, text: 'PR/MR', selected_input_filter: @selected_filter[:pr_number],
                                                placeholder: '12345')
   = render WorkflowRunFilterInputComponent.new(token_id: @token.id, text: 'Commit', selected_input_filter: @selected_filter[:commit_sha],

--- a/src/api/app/views/webui/distributions/new.html.haml
+++ b/src/api/app/views/webui/distributions/new.html.haml
@@ -1,5 +1,10 @@
-- @pagetitle = "Add distribution repository to #{@project}"
-
+:ruby
+  - @pagetitle = "Add distribution repository to #{@project}"
+  - variants_info_text = 'Variants are distributions of the same general kind that
+                          only differ in the set of packages they include. You should
+                          consult the distributions documentation to learn more about
+                          the variants. It is only possible to add one distribution
+                          variant as repository.'
 
 .card.mb-3
   = render partial: 'webui/project/tabs', locals: { project: @project }
@@ -20,13 +25,7 @@
                     - if variants.length > 1
                       = variants.first.reponame
                       Variants
-                      %i.fa.fa-question-circle.text-info{ data: { 'bs-placement': 'top',
-                                                                  'bs-toggle': 'popover',
-                                                                  'bs-content': 'Variants are distributions of the same general kind that
-                                                                                 only differ in the set of packages they include. You should
-                                                                                 consult the distributions documentation to learn more about
-                                                                                 the variants. It is only possible to add one distribution
-                                                                                 variant as repository.' } }
+                      = render partial: 'webui/shared/info_popover', locals: { position: 'top', text: variants_info_text }
                       \:
                     - variants.each do |variant|
                       = form_tag(toggle_project_distributions_path, remote: true, id: "distribution-#{variant.id}-form") do

--- a/src/api/app/views/webui/main/_system_status.html.haml
+++ b/src/api/app/views/webui/main/_system_status.html.haml
@@ -1,14 +1,16 @@
+:ruby
+  busy_info_text = render(partial: 'system_status_legend',
+                          locals: { building_workers: building_workers,
+                                    overall_workers: overall_workers,
+                                    waiting_packages: waiting_packages,
+                                    host_title: host_title,
+                                    system_stats: system_stats })
+
 .card.mb-3
   %h5.card-header
     System Status
     - if busy
-      %i.fa.fa-question-circle.text-info{ data: { 'bs-placement': 'top', 'bs-toggle': 'popover', 'bs-html': 'true',
-                                                  'bs-content': render(partial: 'system_status_legend',
-                                                                       locals: { building_workers: building_workers,
-                                                                                 overall_workers: overall_workers,
-                                                                                 waiting_packages: waiting_packages,
-                                                                                 host_title: host_title,
-                                                                                 system_stats: system_stats }) } }
+      = render partial: 'webui/shared/info_popover', locals: { position: 'top', text: busy_info_text }
   .card-body
     - if busy
       .aligncenter#overallgraph

--- a/src/api/app/views/webui/shared/_info_popover.haml
+++ b/src/api/app/views/webui/shared/_info_popover.haml
@@ -1,0 +1,4 @@
+%i.fa.fa-question-circle.text-info{ data: { 'bs-placement': position,
+                                            'bs-toggle': 'popover',
+                                            'bs-html': 'true',
+                                            'bs-content': text } }

--- a/src/api/app/views/webui/shared/_info_popover.haml
+++ b/src/api/app/views/webui/shared/_info_popover.haml
@@ -1,4 +1,4 @@
-%i.fa.fa-question-circle.text-info{ data: { 'bs-placement': position,
-                                            'bs-toggle': 'popover',
-                                            'bs-html': 'true',
-                                            'bs-content': text } }
+%i.fa-regular.fa-question-circle.text-info{ data: { 'bs-placement': position,
+                                                    'bs-toggle': 'popover',
+                                                    'bs-html': 'true',
+                                                    'bs-content': text } }


### PR DESCRIPTION
A partial to reuse the same template for the question-mark-info-icon-popover.
This PR standardize all the occurrences into one partial template, plus it moves the icon from `fa` to `fa-regular`, that means it moves from
![image](https://github.com/openSUSE/open-build-service/assets/7080830/f77d6771-e0f7-41ea-9776-40f1d2620119)
to the following instances: 

![image](https://github.com/openSUSE/open-build-service/assets/7080830/da05de80-472b-48ba-9af1-a71f179f21dd)
---
![image](https://github.com/openSUSE/open-build-service/assets/7080830/15d5f5e1-4f14-4cda-a4d0-984390ad4c9d)
---
![image](https://github.com/openSUSE/open-build-service/assets/7080830/1ac17631-013f-4bb0-a682-a2ab2a37716e)