### PR TITLE
Remove unneeded hyphens

### DIFF
--- a/src/api/app/views/webui/distributions/new.html.haml
+++ b/src/api/app/views/webui/distributions/new.html.haml
@@ -1,10 +1,10 @@
 :ruby
-  - @pagetitle = "Add distribution repository to #{@project}"
-  - variants_info_text = 'Variants are distributions of the same general kind that
-                          only differ in the set of packages they include. You should
-                          consult the distributions documentation to learn more about
-                          the variants. It is only possible to add one distribution
-                          variant as repository.'
+  @pagetitle = "Add distribution repository to #{@project}"
+  variants_info_text = 'Variants are distributions of the same general kind that
+                        only differ in the set of packages they include. You should
+                        consult the distributions documentation to learn more about
+                        the variants. It is only possible to add one distribution
+                        variant as repository.'
 
 .card.mb-3
   = render partial: 'webui/project/tabs', locals: { project: @project }


### PR DESCRIPTION
Those lines are already inside a `:ruby` block.