### PR TITLE
Restore constraints to the Webui::Packages::BinariesController#destroy route

### DIFF
--- a/src/api/config/routes/webui.rb
+++ b/src/api/config/routes/webui.rb
@@ -291,7 +291,7 @@ constraints(RoutesHelper::WebuiMatcher) do
           get :dependency
         end
         # We wipe all binaries at once, so this is resource instead of resources
-        resource :binaries, controller: 'webui/packages/binaries', only: [:destroy]
+        resource :binaries, controller: 'webui/packages/binaries', only: [:destroy], constraints: cons
       end
     end
 


### PR DESCRIPTION
This causes certain paths to report 404 instead of triggering the route