### PR TITLE
Store a project definition when a flag is updated

### DIFF
--- a/src/api/app/models/workflow/step/set_flags.rb
+++ b/src/api/app/models/workflow/step/set_flags.rb
@@ -27,11 +27,13 @@ class Workflow::Step::SetFlags < Workflow::Step
         architecture_id = Architecture.find_by_name(flag[:architecture]).id if flag[:architecture]
         existing_flag = main_object.flags.find_by(flag: flag[:type], repo: flag[:repository], architecture_id: architecture_id)
 
-        # We have to update the flag status if the flag already exist and only the status differs
-        existing_flag.update!(status: flag[:status]) if existing_flag.present? && existing_flag.status != flag[:status]
-        next if existing_flag.present?
+        next if existing_flag.present? && existing_flag.status == flag[:status]
 
-        main_object.add_flag(flag[:type], flag[:status], flag[:repository], flag[:architecture])
+        if existing_flag.present?
+          existing_flag.update!(status: flag[:status])
+        else
+          main_object.add_flag(flag[:type], flag[:status], flag[:repository], flag[:architecture])
+        end
         main_object.store(comment: 'SCM/CI integration, set_flags step')
       end
     end

--- a/src/api/spec/models/workflow/step/set_flags_step_spec.rb
+++ b/src/api/spec/models/workflow/step/set_flags_step_spec.rb
@@ -203,6 +203,7 @@ RSpec.describe Workflow::Step::SetFlags do
       before do
         target_project.add_flag('publish', 'disable', 'openSUSE_Tumbleweed', 'x86_64')
         target_project.save!
+        login(user)
       end
 
       it 'does not raise an error and updates the status' do


### PR DESCRIPTION
Fixes #14978.

Before, we only call the `store` method a project or a package when a flag was added. This prevented the backend from starting new builds when a flag was updated.

From now on, call the `store` method when a flag is updated. Therefore, the backend will start new builds.