### PR TITLE
Enhance the visual difference from placeholder to real input value

### DIFF
--- a/src/api/app/assets/stylesheets/webui/colors.scss
+++ b/src/api/app/assets/stylesheets/webui/colors.scss
@@ -8,9 +8,11 @@ $themed-dark-nav-bg: #121212;
 :root {
   --navbar-themed-bg: #{$gray-800};
   --breadcrumbs-item-text-color: #{$gray-700};
+  --placeholder-text: #{$gray-600};
 }
 
 @include color-mode(dark) {
   --navbar-themed-bg: #{$themed-dark-nav-bg};
   --breadcrumbs-item-text-color: #{$gray-400};
+  --placeholder-text: #{$gray-500};
 }

--- a/src/api/app/assets/stylesheets/webui/mixin.scss
+++ b/src/api/app/assets/stylesheets/webui/mixin.scss
@@ -5,3 +5,8 @@
 .text-bg-hover {
   box-shadow: 0px 0px 5px $hover;
 }
+
+::placeholder {
+  color: var(--placeholder-text)!important;
+  font-style: italic;
+}


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/CSS/::placeholder#color_contrast
https://developer.mozilla.org/en-US/docs/Web/CSS/::placeholder#change_placeholder_appearance

## Before
![before-placeholder-2](https://github.com/openSUSE/open-build-service/assets/7080830/6702e252-f44d-4e84-9e87-4cd7fd71d4e0)
![before-placeholder](https://github.com/openSUSE/open-build-service/assets/7080830/c96c7eb4-f80d-4846-a529-2a8bc4c6eb46)
![before-placeholder-3](https://github.com/openSUSE/open-build-service/assets/7080830/e546c729-a5ca-40f2-aefa-d591f07a3a4c)
![before-placeholder-4](https://github.com/openSUSE/open-build-service/assets/7080830/ce4fa3b6-614c-4cb0-89e3-a7b95f1277b5)


## After
![after-placeholder-2](https://github.com/openSUSE/open-build-service/assets/7080830/a65da78f-c27a-46bd-948a-0617e0f6f201)
![after-placeholder](https://github.com/openSUSE/open-build-service/assets/7080830/f545ec58-7662-4754-996f-6a8d32f5207a)
![after-placeholder-3](https://github.com/openSUSE/open-build-service/assets/7080830/771a0676-891b-4649-a85d-ae5dc8f916a6)
![after-placeholder-4](https://github.com/openSUSE/open-build-service/assets/7080830/4aedd47d-0db6-467c-a1b7-80a6ced28d42)
