### PR TITLE
[backend] do not send resumeproject events to the signer

### DIFF
--- a/src/backend/bs_repserver
+++ b/src/backend/bs_repserver
@@ -2708,8 +2708,9 @@ sub copybuild {
   writexml("$eventdir/$arch/.copybuild:$job$$", "$eventdir/$arch/copybuild:$job", $ev, $BSXML::event);
   if (%delayed_linking) {
     # see above
+    my $origarch = $info->{'arch'};
     $ev = {'type' => 'resumeproject', 'project' => $projid, 'job' => "copybuild:$job" };
-    writexml("$eventdir/$arch/.resumeproject:$job$$", "$eventdir/$arch/resumeproject:$job", $ev, $BSXML::event);
+    writexml("$eventdir/$origarch/.resumeproject:$job$$", "$eventdir/$origarch/resumeproject:$job", $ev, $BSXML::event);
   }
   BSUtil::ping("$eventdir/$arch/.ping");
   return $BSStdServer::return_ok;


### PR DESCRIPTION
When doing a copybuild we clobber the arch to 'signer' if something needs to be signed. When we do delayed linking and we want to send the resume, we must use the original architecture.