### PR TITLE
Allow mentioning users with plus sign in the name

### DIFF
--- a/src/api/lib/obsapi/markdown_renderer.rb
+++ b/src/api/lib/obsapi/markdown_renderer.rb
@@ -13,7 +13,7 @@ module OBSApi
       # request#12345 links
       fulldoc.gsub!(/(sr|req|request)#(\d+)/i) { |s| "[#{s}](#{request_show_url(number: Regexp.last_match(2))})" }
       # @user links
-      fulldoc.gsub!(/([^\w]|^)@(\b[-.\w]+\b)(?:\b|$)/) { "#{Regexp.last_match(1)}[@#{Regexp.last_match(2)}](#{user_url(Regexp.last_match(2))})" }
+      fulldoc.gsub!(/([^\w]|^)@(\b[-.\+\w]+\b)(?:\b|$)/) { "#{Regexp.last_match(1)}[@#{Regexp.last_match(2)}](#{user_url(Regexp.last_match(2))})" }
       # bnc#12345 links
       IssueTracker.find_each do |t|
         fulldoc = t.get_markdown(fulldoc)

--- a/src/api/spec/helpers/webui/markdown_helper_spec.rb
+++ b/src/api/spec/helpers/webui/markdown_helper_spec.rb
@@ -13,10 +13,11 @@ RSpec.describe Webui::MarkdownHelper do
     end
 
     it 'detects all the mentions to users' do
-      expect(render_as_markdown('@alfie @milo and @Admin, please review. Also you, @test1 and @user.name.')).to eq(
+      expect(render_as_markdown('@alfie @milo @Admin and @ann+factory, please review. Also you, @test1 and @user.name.')).to eq(
         '<p><a href="https://unconfigured.openbuildservice.org/users/alfie" rel="nofollow">@alfie</a> ' \
         '<a href="https://unconfigured.openbuildservice.org/users/milo" rel="nofollow">@milo</a> ' \
-        'and <a href="https://unconfigured.openbuildservice.org/users/Admin" rel="nofollow">@Admin</a>, ' \
+        '<a href="https://unconfigured.openbuildservice.org/users/Admin" rel="nofollow">@Admin</a> ' \
+        'and <a href="https://unconfigured.openbuildservice.org/users/ann+factory" rel="nofollow">@ann+factory</a>, ' \
         'please review. Also you, <a href="https://unconfigured.openbuildservice.org/users/test1" rel="nofollow">@test1</a> ' \
         "and <a href=\"https://unconfigured.openbuildservice.org/users/user.name\" rel=\"nofollow\">@user.name</a>.</p>\n"
       )


### PR DESCRIPTION
Usernames like `cat+factory` are now handled correctly in comments mentions.

Fixes: #15635