### PR TITLE
Escape project and package title

### DIFF
--- a/src/api/app/views/webui/package/update.js.haml
+++ b/src/api/app/views/webui/package/update.js.haml
@@ -11,7 +11,7 @@ resetFormValidation();
       scrollToInPlace();
       $('.in-place-editing').html("#{escape_javascript(render(partial: 'webui/package/basic_info',
                                                               locals: { package: @package, project: @project }))}");
-      $('#package-title').html("#{@package.title.presence || @package.name}")
+      $('#package-title').html("#{escape_javascript(@package.title.presence || @package.name)}")
       setCollapsible();
       $('.in-place-editing').animate({ opacity: 1 }, 400, function() {
         $('#flash').html("#{escape_javascript(render(layout: false, partial: 'layouts/webui/flash', object: flash))}");

--- a/src/api/app/views/webui/project/update.js.haml
+++ b/src/api/app/views/webui/project/update.js.haml
@@ -10,7 +10,7 @@ resetFormValidation();
     }, 400, function() {
       scrollToInPlace();
       $('.in-place-editing').html("#{escape_javascript(render(partial: 'webui/project/basic_info', locals: { project: @project }))}");
-      $('#project-title').html("#{@project.title.presence || @project}")
+      $('#project-title').html("#{escape_javascript(@project.title.presence || @project)}")
       setCollapsible();
       $('.in-place-editing').animate({ opacity: 1 }, 400, function() {
         $('#flash').html("#{escape_javascript(render(layout: false, partial: 'layouts/webui/flash', object: flash))}");

--- a/src/api/spec/features/webui/packages_spec.rb
+++ b/src/api/spec/features/webui/packages_spec.rb
@@ -284,14 +284,14 @@ RSpec.describe 'Packages', :js, :vcr do
       wait_for_ajax
 
       within('#edit_package_details') do
-        fill_in('package_details[title]', with: 'test title')
+        fill_in('package_details[title]', with: 'test "little" title')
         fill_in('package_details[description]', with: 'test description')
         fill_in('package_details[url]', with: 'https://test.url')
         click_button('Update')
       end
 
       expect(find_by_id('flash')).to have_text('Package was successfully updated.')
-      expect(page).to have_text('test title')
+      expect(page).to have_text('test "little" title')
       expect(page).to have_text('test description')
       expect(page).to have_text('https://test.url')
     end

--- a/src/api/spec/features/webui/projects_spec.rb
+++ b/src/api/spec/features/webui/projects_spec.rb
@@ -26,13 +26,13 @@ RSpec.describe 'Projects', :js, :vcr do
         click_link('Edit')
         expect(page).to have_text("Edit Project #{project}")
 
-        fill_in 'project_title', with: 'My Title hopefully got changed'
+        fill_in 'project_title', with: 'My Title "hopefully" got changed'
         fill_in 'project_description', with: 'New description. No kidding.. Brand new!'
         fill_in 'project_url', with: 'https://test.url'
         click_button 'Update'
         wait_for_ajax
 
-        expect(find(:id, 'project-title')).to have_text('My Title hopefully got changed')
+        expect(find(:id, 'project-title')).to have_text('My Title "hopefully" got changed')
         expect(find(:id, 'description-text')).to have_text('New description. No kidding.. Brand new!')
         expect(page).to have_text('https://test.url')
       end
@@ -50,7 +50,7 @@ RSpec.describe 'Projects', :js, :vcr do
         click_link('Edit')
         expect(page).to have_text("Edit Project #{project}")
 
-        fill_in 'project_title', with: 'My Title hopefully got changed'
+        fill_in 'project_title', with: 'My Title "hopefully" got changed'
         fill_in 'project_description', with: 'New description. No kidding.. Brand new!'
         click_link 'Cancel'
         wait_for_ajax


### PR DESCRIPTION
When updating the title within an AJAX call, it crashed when the title contained quotes, like `My "new" title`. Escaping the title was missing.

Fixes: #15694