### PR TITLE
Use the proper icon for relationship notifications

### DIFF
--- a/src/api/app/components/notification_component.rb
+++ b/src/api/app/components/notification_component.rb
@@ -24,10 +24,10 @@ class NotificationComponent < ApplicationComponent
   end
 
   def notification_icon
-    if NOTIFICATION_ICON[@notification.notifiable_type].present?
-      tag.i(class: ['fas', NOTIFICATION_ICON[@notification.notifiable_type]], title: NOTIFICATION_TITLE[@notification.notifiable_type])
-    else
+    if @notification.event_type.in?(['Event::RelationshipCreate', 'Event::RelationshipDelete'])
       tag.i(class: %w[fas fa-user-tag], title: 'Relationship notification')
+    elsif NOTIFICATION_ICON[@notification.notifiable_type].present?
+      tag.i(class: ['fas', NOTIFICATION_ICON[@notification.notifiable_type]], title: NOTIFICATION_TITLE[@notification.notifiable_type])
     end
   end
 end

--- a/src/api/spec/components/notification_component_spec.rb
+++ b/src/api/spec/components/notification_component_spec.rb
@@ -1,0 +1,32 @@
+RSpec.describe NotificationComponent, type: :component do
+  let(:user) { create(:confirmed_user) }
+  let(:selected_filter) { {} }
+
+  context 'when the notification is about a relationship with package' do
+    let(:package) { create(:package_with_maintainer, maintainer: user) }
+    let(:event_payload) { { package: package.name, project: package.project.name } }
+    let(:notification) { create(:notification, :relationship_create_for_project, delivered: true, notifiable: package, event_payload: event_payload) }
+
+    before do
+      render_inline(described_class.new(notification: notification, selected_filter: selected_filter, page: 1, show_more: 1, current_user: user))
+    end
+
+    it 'renders the correct icon' do
+      expect(rendered_content).to have_css("i.fa-user-tag[title='Relationship notification']")
+    end
+  end
+
+  context 'when the notification is about a comment for project' do
+    let(:project) { create(:project, maintainer: user) }
+    let(:comment) { create(:comment, commentable: project) }
+    let(:notification) { create(:notification, :comment_for_project, delivered: true, notifiable: comment) }
+
+    before do
+      render_inline(described_class.new(notification: notification, selected_filter: selected_filter, page: 1, show_more: 1, current_user: user))
+    end
+
+    it 'renders the correct icon' do
+      expect(rendered_content).to have_css("i.fa-comments[title='Comment notification']")
+    end
+  end
+end

--- a/src/api/spec/factories/notification.rb
+++ b/src/api/spec/factories/notification.rb
@@ -63,6 +63,15 @@ FactoryBot.define do
       event_type { 'Event::RelationshipDelete' }
       notifiable factory: [:project]
     end
+    trait :relationship_create_for_package do
+      event_type { 'Event::RelationshipCreate' }
+      notifiable factory: [:package]
+    end
+
+    trait :relationship_delete_for_package do
+      event_type { 'Event::RelationshipDelete' }
+      notifiable factory: [:package]
+    end
 
     trait :build_failure do
       event_type { 'Event::BuildFail' }


### PR DESCRIPTION
Fixes: #15967

The notification about a _new relationship with a package_ displayed the wrong icon. For the _relationship with a project_, it was ok.

The relationship notifications shouldn't take the `notifiable_type` into account, all of them (for project or package) will have the same icon.

![Screenshot 2024-04-11 at 14-53-01 Open Build Service](https://github.com/openSUSE/open-build-service/assets/2581944/6249aae9-c82e-4049-bcf1-b0026f41e83a)
