### PR TITLE
 [backend] add ipv6 support for workers

### DIFF
--- a/src/backend/BSRPC.pm
+++ b/src/backend/BSRPC.pm
@@ -129,7 +129,7 @@ sub createreq {
     return ('', undef, undef, $req, undef);
   }
   my ($proxyauth, $proxytunnel);
-  die("bad uri: $uri\n") unless $uri =~ /^(https?):\/\/(?:([^\/\@]*)\@)?([^\/:]+)(:\d+)?(\/.*)$/;
+  die("bad uri: $uri\n") unless $uri =~ /^(https?):\/\/(?:([^\/\@]*)\@)?([^\/:]+|(?:\[(?:[:0-9A-Fa-f]+)\]))(:\d+)?(\/.*)$/;
   my ($proto, $auth, $host, $port, $path) = ($1, $2, $3, $4, $5);
   my $hostport = $port ? "$host$port" : $host;
   undef $proxy if $proxy && !useproxy($param, $host);
@@ -220,6 +220,7 @@ my $ai_addrconfig = eval { Socket::AI_ADDRCONFIG() } || 0;
 
 sub lookuphost {
   my ($host, $port, $cache) = @_;
+  $host=~ s/^\[|\]$//g;
   my $hostaddr;
   if ($cache && $cache->{$host} && $cache->{$host}->[1] > time()) {
     $hostaddr = $cache->{$host}->[0];

--- a/src/backend/bs_repserver
+++ b/src/backend/bs_repserver
@@ -1695,7 +1695,7 @@ sub workerstate {
       'hostarch' => $harch,
       'ip' => $peerip,
       'port' => $peerport,
-      'uri' => "$peerproto://$peerip:$peerport",
+      'uri' => ( $peerip =~ m/:/ ? "$peerproto://[$peerip]:$peerport" : "$peerproto://$peerip:$peerport" ),
       'workerid' => $workerid,
     };
     $worker = { %$workerskel, %$worker } if $workerskel;
@@ -1704,7 +1704,7 @@ sub workerstate {
     # make sure that we can connect to the client
     if ($BSConfig::checkclientconnectivity || $BSConfig::checkclientconnectivity) {
       my $param = {
-	'uri' => "http://$peerip:$peerport/status",
+	'uri' => ( $peerip =~ m/:/ ? "$peerproto://[$peerip]:$peerport/status" : "$peerproto://$peerip:$peerport/status" ),
         'async' => 1,
         'timeout' => 1,
 	'sender' => sub {},


### PR DESCRIPTION
Currently OBS does not support workers connected from IPv6.
This commit enables BSRPC to parse IPv6 hosts, which allows jobs to be dispatched via IPv6.

(Tested on [self-hosted OBS instance for eweOS](https://os-build.ewe.moe))