### PR TITLE
Make the attribute values on dark theme

### DIFF
--- a/src/api/app/assets/stylesheets/webui/package-attributes.scss
+++ b/src/api/app/assets/stylesheets/webui/package-attributes.scss
@@ -4,7 +4,7 @@ ul li.value {
   }
 
   & pre {
-    background-color: $body-bg;
+    background-color: var(--bs-secondary-bg);
     border: 1px dotted $primary;
     padding: 2px 3px;
   }


### PR DESCRIPTION
|Before|After|
|:---|:---|
|![Screenshot from 2024-04-15 12-25-30](https://github.com/openSUSE/open-build-service/assets/114928900/b8d04ff3-a1fe-48c9-b3ea-3777ea985af4)|![Screenshot from 2024-04-15 12-25-15](https://github.com/openSUSE/open-build-service/assets/114928900/ab767ac0-3ec5-4ab3-a7b7-4dd62fdb7a91)|

Fixes #15607