### PR TITLE
Avoid confusion with Feature Toggles link

### DIFF
--- a/src/api/app/controllers/webui/global_feature_toggles_controller.rb
+++ b/src/api/app/controllers/webui/global_feature_toggles_controller.rb
@@ -1,0 +1,5 @@
+class Webui::GlobalFeatureTogglesController < Webui::WebuiController
+  before_action :require_admin
+
+  def index; end
+end

--- a/src/api/app/views/layouts/webui/_places.html.haml
+++ b/src/api/app/views/layouts/webui/_places.html.haml
@@ -37,11 +37,13 @@
         = link_to(configuration_path, class: 'nav-link', title: 'Configuration') do
           %i.fas.fa-cogs.me-2
           %span.nav-item-name Configuration
-    - if User.admin_session? || User.possibly_nobody.is_staff?
+    - if User.possibly_nobody.is_staff? && !User.admin_session?
       %li.nav-item
-        = link_to("#{root_url}/flipper", class: 'nav-link', title: 'Feature Toggles') do
+        = link_to("#{root_url}/flipper", class: 'nav-link',
+                  title: 'Global Feature Toggles',
+                  data: { confirm: 'Do you really want to manage feature toggles globally? This might affect all the users of the application.' }) do
           %i.fas.fa-toggle-on.me-2
-          %span.nav-item-name Feature Toggles
+          %span.nav-item-name Global Feature Toggles
     - if navigation != :left
       %li.nav-item
         = link_to(session_path, method: :delete, id: 'logout-link', class: 'nav-link') do

--- a/src/api/app/views/webui/configuration/_tabs.html.haml
+++ b/src/api/app/views/webui/configuration/_tabs.html.haml
@@ -6,4 +6,5 @@
     = tab_link('Manage Groups', groups_path, false, 'scrollable-tab-link')
     = tab_link('Manage News', news_items_path, false, 'scrollable-tab-link')
     = tab_link('Notifications', notifications_path, false, 'scrollable-tab-link')
+    = tab_link('Feature Toggles', global_feature_toggles_path, false, 'scrollable-tab-link')
     = tab_link('Interconnect', new_interconnect_path, false, 'scrollable-tab-link')

--- a/src/api/app/views/webui/global_feature_toggles/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui/global_feature_toggles/_breadcrumb_items.html.haml
@@ -1,0 +1,4 @@
+= render partial: 'webui/configuration/breadcrumb_items'
+
+%li.breadcrumb-item.active{ 'aria-current' => 'page' }
+  Global Feature Toggles

--- a/src/api/app/views/webui/global_feature_toggles/index.html.haml
+++ b/src/api/app/views/webui/global_feature_toggles/index.html.haml
@@ -1,0 +1,11 @@
+- @pagetitle = 'Global Feature Toggles'
+
+.card.mb-3
+  = render partial: 'webui/configuration/tabs'
+  .card-body
+    %h3.mb-4 Global Feature Toggles
+    %p
+      Go to the
+      = link_to('Flipper Dashboard', "#{root_url}/flipper", title: 'Global Feature Toggles')
+      to manage feature toggles globally. Your actions could affect all the users of the application
+      by modifying what they can or can't see under the beta program.

--- a/src/api/config/routes/webui.rb
+++ b/src/api/config/routes/webui.rb
@@ -458,3 +458,5 @@ controller 'webui/comment_locks' do
 end
 
 resources :code_of_conduct, only: [:index], controller: 'webui/code_of_conduct'
+
+resources :global_feature_toggles, only: [:index], controller: 'webui/global_feature_toggles'


### PR DESCRIPTION
Fixes: #14417

For admins, the Feature Toggle link is moved to a new tab inside Configuration.

![Screenshot 2024-04-15 at 19-38-12 Open Build Service](https://github.com/openSUSE/open-build-service/assets/2581944/b7bec55e-5efa-4cbb-b5d9-a2c194f6cf9b)

Staff users need to use the link but don't have access to Configuration. Therefore, the link stays in the same place for them but uses a clearer text "_Global Feature Toggles_" and opens a confirmation message.

![Screenshot from 2024-04-15 19-35-10](https://github.com/openSUSE/open-build-service/assets/2581944/c638282c-cb94-41bd-986c-0b27bc3b3177)

In the future, we could have a section similar to Configuration but only for Staff, something like "Staff Global Settings" to include all the global actions they can do. Right now, it's not worth doing so, just to include the link to Flipper dashboard.