### PR TITLE
Display a list of files included in the binary

### DIFF
--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -406,6 +406,7 @@ Metrics/ModuleLength:
 Metrics/ParameterLists:
   Exclude:
     - 'app/helpers/maintenance_helper.rb'
+    - 'app/lib/backend/api/build_results/binaries.rb'
     - 'app/lib/backend/api/build_results/status.rb'
     - 'app/lib/backend/api/sources/package.rb'
     - 'app/lib/backend/logger.rb'

--- a/src/api/app/controllers/webui/packages/binaries_controller.rb
+++ b/src/api/app/controllers/webui/packages/binaries_controller.rb
@@ -13,10 +13,10 @@ module Webui
       before_action :set_project
       before_action :set_package
       before_action :set_repository
-      before_action :set_architecture, only: %i[show dependency]
+      before_action :set_architecture, only: %i[show dependency filelist]
       before_action :set_dependant_project, only: :dependency
       before_action :set_dependant_repository, only: :dependency
-      before_action :set_filename, only: %i[show dependency]
+      before_action :set_filename, only: %i[show dependency filelist]
 
       prepend_before_action :lockout_spiders
 
@@ -83,6 +83,12 @@ module Webui
         end
 
         redirect_to project_package_repository_binaries_path(project_name: @project, package_name: @package_name, repository_name: @repository)
+      end
+
+      def filelist
+        data = Backend::Api::BuildResults::Binaries.fileinfo_ext(@project.name, @package_name, @repository.name, @architecture.name, @filename, withfilelist: 1)
+        filelist = data.elements('filelist')
+        render json: { data: filelist.map { |f| { name: f } } }
       end
 
       private

--- a/src/api/app/lib/backend/api/build_results/binaries.rb
+++ b/src/api/app/lib/backend/api/build_results/binaries.rb
@@ -52,8 +52,9 @@ module Backend
 
         # special view on a binary file for details display
         # @return [Hash]
-        def self.fileinfo_ext(project_name, package_name, repository, arch, filename)
-          fileinfo = http_get(['/build/:project/:repository/:arch/:package/:filename?view=fileinfo_ext', project_name, repository, arch, package_name, filename])
+        def self.fileinfo_ext(project_name, package_name, repository, arch, filename, options = {})
+          fileinfo = http_get(['/build/:project/:repository/:arch/:package/:filename', project_name, repository, arch, package_name, filename],
+                              params: options, defaults: { view: 'fileinfo_ext' }, accepted: %i[withfilelist])
           Xmlhash.parse(fileinfo) if fileinfo
         end
 

--- a/src/api/app/views/webui/packages/binaries/_deps.html.haml
+++ b/src/api/app/views/webui/packages/binaries/_deps.html.haml
@@ -82,3 +82,15 @@
           %tr
             %td{ colspan: '2' }
               %em No recommends
+
+  .table-responsive.col-sm-12.col-md-6.mt-4
+    %h4 File List
+    %table.table.table-sm.table-bordered#filelist-table{ 'data-source': project_package_repository_binary_filelist_path(project,
+                                                                                                                        package,
+                                                                                                                        repository,
+                                                                                                                        architecture,
+                                                                                                                        filename) }
+      %thead
+        %tr
+          %th Name
+      %tbody

--- a/src/api/app/views/webui/packages/binaries/_fileinfo.html.haml
+++ b/src/api/app/views/webui/packages/binaries/_fileinfo.html.haml
@@ -37,3 +37,14 @@
                                     package: package,
                                     repository: repository,
                                     architecture: architecture }
+
+- content_for :ready_function do
+  :plain
+    initializeRemoteDatatable('#filelist-table', {
+        "columns": [
+          {"data": "name"}
+        ],
+        paging: false,
+        searching: false,
+        info: false
+      });

--- a/src/api/config/routes/webui.rb
+++ b/src/api/config/routes/webui.rb
@@ -289,6 +289,7 @@ constraints(RoutesHelper::WebuiMatcher) do
         # Binaries with the exact same name can exist in multiple architectures, so we have to use arch param here additionally
         resources :binaries, controller: 'webui/packages/binaries', only: [:show], constraints: cons, param: :filename, path: 'binaries/:arch/' do
           get :dependency
+          get :filelist
         end
         # We wipe all binaries at once, so this is resource instead of resources
         resource :binaries, controller: 'webui/packages/binaries', only: [:destroy], constraints: cons


### PR DESCRIPTION
Fixes #613

This displays a list of files inside of a built binary.

It uses datatables, to not slow down the rest of the page.

![Screenshot from 2024-04-16 12-54-20](https://github.com/openSUSE/open-build-service/assets/114928900/0dca0874-fe68-47dc-9e61-7c950588c0b9)
