### PR TITLE
Render text indented by four spaces as code

### DIFF
--- a/src/api/app/helpers/webui/markdown_helper.rb
+++ b/src/api/app/helpers/webui/markdown_helper.rb
@@ -7,7 +7,7 @@ module Webui::MarkdownHelper
     @md_parser ||= Redcarpet::Markdown.new(OBSApi::MarkdownRenderer.new(no_styles: true),
                                            autolink: true,
                                            no_intra_emphasis: true,
-                                           fenced_code_blocks: true, disable_indented_code_blocks: true)
+                                           fenced_code_blocks: true)
     ActionController::Base.helpers.sanitize(@md_parser.render(content.dup.to_s), scrubber: Loofah::Scrubbers::NoFollow.new)
   end
 


### PR DESCRIPTION
Fixes #8049.

For reviewers: https://obs-reviewlab.opensuse.org/eduardoj-fixissue_8049/request/show/16#comment-10