### PR TITLE
Replace kind with type

### DIFF
--- a/src/api/app/components/canned_responses_dropdown_component.html.haml
+++ b/src/api/app/components/canned_responses_dropdown_component.html.haml
@@ -3,11 +3,11 @@
     %i.fas.fa-comment-dots
     Canned Responses
   %ul.dropdown-menu
-    - @canned_responses_by_kind.each do |decision_kind, canned_responses|
-      .dropdown-header= decision_kind&.humanize || 'Generic'
+    - @canned_responses_by_type.each do |decision_type, canned_responses|
+      .dropdown-header= decision_type&.humanize || 'Generic'
       - canned_responses.each do |canned_response|
-        - decision_type = "Decision#{decision_kind.camelize}" if decision_kind.present?
-        %li.dropdown-item{ data: { 'canned-response': canned_response.content, 'decision-type': decision_type }, role: 'button' }
+        - decision_type = "Decision#{decision_type.camelize}" if decision_type.present?
+        %li.dropdown-item{ data: { 'canned-response': canned_response.content, 'decision_type': decision_type }, role: 'button' }
           = canned_response.title
     %hr.dropdown-divider/
     = link_to('Create and modify' , canned_responses_path, class: 'dropdown-item')

--- a/src/api/app/components/canned_responses_dropdown_component.rb
+++ b/src/api/app/components/canned_responses_dropdown_component.rb
@@ -3,17 +3,17 @@ class CannedResponsesDropdownComponent < ApplicationComponent
     super
 
     @canned_responses = canned_responses
-    @canned_responses_by_kind = canned_responses_by_kind
+    @canned_responses_by_type = canned_responses_by_type
   end
 
   private
 
-  def canned_responses_by_kind
-    # Only the kinds available in the user's canned responses
-    kinds = @canned_responses.pluck(:decision_kind).uniq
+  def canned_responses_by_type
+    # Only the types available in the user's canned responses
+    types = @canned_responses.pluck(:decision_type).uniq
 
-    kinds.index_with do |decision_kind|
-      @canned_responses.where(decision_kind: decision_kind)
+    types.index_with do |decision_type|
+      @canned_responses.where(decision_type: decision_type)
     end
   end
 end

--- a/src/api/app/components/reports_modal_component.rb
+++ b/src/api/app/components/reports_modal_component.rb
@@ -11,6 +11,6 @@ class ReportsModalComponent < ApplicationComponent
   end
 
   def canned_responses
-    CannedResponsePolicy::Scope.new(user, CannedResponse).resolve.order(:decision_kind, :title)
+    CannedResponsePolicy::Scope.new(user, CannedResponse).resolve.order(:decision_type, :title)
   end
 end

--- a/src/api/app/controllers/webui/users/canned_responses_controller.rb
+++ b/src/api/app/controllers/webui/users/canned_responses_controller.rb
@@ -61,8 +61,6 @@ class Webui::Users::CannedResponsesController < Webui::WebuiController
   end
 
   def canned_response_params
-    # TODO: remove merge and replace decision_kind with decision_type
-    decision_type_number = CannedResponse.decision_kinds[params[:canned_response][:decision_kind]]
-    params.require(:canned_response).permit(:title, :content, :decision_kind).merge(decision_type: decision_type_number)
+    params.require(:canned_response).permit(:title, :content, :decision_type)
   end
 end

--- a/src/api/app/models/canned_response.rb
+++ b/src/api/app/models/canned_response.rb
@@ -9,7 +9,7 @@ class CannedResponse < ApplicationRecord
   validates :title, presence: true, length: { maximum: 255 }
   validates :content, presence: true, length: { maximum: 65_535 }
 
-  enum decision_kind: {
+  enum decision_type: {
     cleared: 0,
     favored: 1
   }

--- a/src/api/app/models/canned_response.rb
+++ b/src/api/app/models/canned_response.rb
@@ -1,6 +1,9 @@
 # Canned responses are predetermined comment responses to common questions in a project/package/request
 # Each user can manage their own set of canned responses
 class CannedResponse < ApplicationRecord
+  # TODO: remove after the migration is in production
+  self.ignored_columns += ['decision_kind']
+
   #### Includes and extends
 
   #### Constants

--- a/src/api/app/views/webui/comment/_comment_field.html.haml
+++ b/src/api/app/views/webui/comment/_comment_field.html.haml
@@ -22,7 +22,7 @@ data: { preview_message_url: preview_comments_path, message_body_param: 'comment
                                        'data-canned-controller': '' }
         - if Flipper.enabled?(:content_moderation, User.session)
           .d-flex.justify-content-end
-            = render CannedResponsesDropdownComponent.new(policy_scope(CannedResponse).where(decision_kind: nil).order(:title))
+            = render CannedResponsesDropdownComponent.new(policy_scope(CannedResponse).where(decision_type: nil).order(:title))
         ~ f.text_area :body, id: "#{element_suffix}_body", rows: '4',
         placeholder: 'Write your comment here... (Markdown markup is supported)', required: true,
         class: 'w-100 form-control comment-field message-field'

--- a/src/api/app/views/webui/users/canned_responses/edit.html.haml
+++ b/src/api/app/views/webui/users/canned_responses/edit.html.haml
@@ -12,7 +12,7 @@
         = f.text_area :content, class: 'form-control'
       - if policy(Decision.new).create?
         .mb-3
-          = f.label :decision_kind, "Choose 'cleared' or 'favored' if this is a decision's reason"
-          - kinds = CannedResponse.decision_kinds.keys.to_h { |k| [k.humanize, k] }
-          = f.select(:decision_kind, kinds, { include_blank: 'none' }, class: 'form-select')
+          = f.label :decision_type, "Choose 'cleared' or 'favored' if this is a decision's reason"
+          - types = CannedResponse.decision_types.keys.to_h { |t| [t.humanize, t] }
+          = f.select(:decision_type, types , { include_blank: 'none' }, class: 'form-select')
       = f.submit 'Save', class: 'btn btn-primary'

--- a/src/api/app/views/webui/users/canned_responses/index.html.haml
+++ b/src/api/app/views/webui/users/canned_responses/index.html.haml
@@ -12,9 +12,9 @@
         = f.text_area :content, class: 'form-control'
       - if policy(Decision.new).create?
         .mb-3
-          = f.label :decision_kind, "Choose 'cleared' or 'favored' if this is a decision's reason"
-          - kinds = CannedResponse.decision_kinds.keys.to_h { |k| [k.humanize, k] }
-          = f.select(:decision_kind, kinds, { include_blank: 'none', selected: nil }, class: 'form-select')
+          = f.label :decision_type, "Choose 'cleared' or 'favored' if this is a decision's reason"
+          - types = CannedResponse.decision_types.keys.to_h { |t| [t.humanize, t] }
+          = f.select(:decision_type, types, { include_blank: 'none', selected: nil }, class: 'form-select')
       = f.submit 'Create', class: 'btn btn-primary'
 
 .card.mt-2
@@ -32,7 +32,7 @@
             .accordion-collapse.collapse{ id: "canned-response-#{canned_response.id}-collapse" }
               .accordion-body
                 .d-flex.justify-content-between
-                  %strong= canned_response.decision_kind.try(:humanize) || 'Generic'
+                  %strong= canned_response.decision_type.try(:humanize) || 'Generic'
                   .d-flex
                     = link_to(edit_canned_response_path(canned_response), class: 'btn py-0 px-1 btn-link') do
                       %i.fas.fa-edit

--- a/src/api/spec/components/canned_responses_dropdown_component_spec.rb
+++ b/src/api/spec/components/canned_responses_dropdown_component_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe CannedResponsesDropdownComponent, type: :component do
 
   context 'with generic responses only' do
     before do
-      render_inline(described_class.new(CannedResponse.where(decision_kind: nil)))
+      render_inline(described_class.new(CannedResponse.where(decision_type: nil)))
     end
 
     it { expect(rendered_content).to have_text('Generic') }
@@ -15,7 +15,7 @@ RSpec.describe CannedResponsesDropdownComponent, type: :component do
 
   context 'with cleared decision responses only' do
     before do
-      render_inline(described_class.new(CannedResponse.where(decision_kind: 'cleared')))
+      render_inline(described_class.new(CannedResponse.where(decision_type: 'cleared')))
     end
 
     it { expect(rendered_content).to have_no_text('Generic') }
@@ -26,7 +26,7 @@ RSpec.describe CannedResponsesDropdownComponent, type: :component do
 
   context 'with favored decision responses only' do
     before do
-      render_inline(described_class.new(CannedResponse.where(decision_kind: 'favored')))
+      render_inline(described_class.new(CannedResponse.where(decision_type: 'favored')))
     end
 
     it { expect(rendered_content).to have_no_text('Generic') }

--- a/src/api/spec/controllers/webui/users/canned_responses_controller_spec.rb
+++ b/src/api/spec/controllers/webui/users/canned_responses_controller_spec.rb
@@ -1,0 +1,40 @@
+RSpec.describe Webui::Users::CannedResponsesController do
+  let(:user) { create(:confirmed_user) }
+  let(:title) { 'I agree' }
+  let(:decision_type) { nil }
+  let(:content) { Faker::Lorem.sentence }
+
+  before do
+    login(user)
+    Flipper.enable(:content_moderation)
+
+    post :create, params: { canned_response: { title: title, content: content, decision_type: decision_type } }
+  end
+
+  describe 'POST create' do
+    context 'when content is missing' do
+      let(:content) { nil }
+
+      it 'does not create the canned response' do
+        expect(flash[:error]).to start_with('Failed to create canned response:')
+        expect(CannedResponse.where(title: title)).not_to exist
+      end
+    end
+
+    context 'when the response is for normal comments' do
+      it 'creates the canned response with decision_type nil' do
+        expect(flash[:success]).to eq('Canned response successfully created!')
+        expect(CannedResponse.where(title: title, decision_type: nil)).to exist
+      end
+    end
+
+    context 'when the response is for decisions comments' do
+      let(:decision_type) { 'favored' }
+
+      it 'creates the canned response with decision_type "favored"' do
+        expect(flash[:success]).to eq('Canned response successfully created!')
+        expect(CannedResponse.where(title: title, decision_type: 'favored')).to exist
+      end
+    end
+  end
+end

--- a/src/api/spec/factories/canned_responses.rb
+++ b/src/api/spec/factories/canned_responses.rb
@@ -5,11 +5,11 @@ FactoryBot.define do
     user { association :confirmed_user }
 
     factory :cleared_canned_response do
-      decision_kind { 'cleared' }
+      decision_type { 'cleared' }
       user { association :moderator }
     end
     factory :favored_canned_response do
-      decision_kind { 'favored' }
+      decision_type { 'favored' }
       user { association :moderator }
     end
   end

--- a/src/api/spec/features/webui/canned_responses_spec.rb
+++ b/src/api/spec/features/webui/canned_responses_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe 'Canned responses', :js do
       visit canned_responses_path
       fill_in(name: 'canned_response[title]', with: 'wow')
       fill_in(name: 'canned_response[content]', with: 'a decision-related canned response')
-      find(:id, 'canned_response_decision_kind').select('Favored')
+      find(:id, 'canned_response_decision_type').select('Favored')
       click_button('Create')
       find('.accordion-button').click
     end


### PR DESCRIPTION
In the code related to canned responses, using the term `kind` doesn't make sense since we start using `Decision#type`. We rename all the related terms.

~DO NOT MERGE. This PR is based on  #16017, which should be deployed before we merge these changes.~