### PR TITLE
Add `decision_type` column to canned responses

### DIFF
--- a/src/api/app/models/canned_response.rb
+++ b/src/api/app/models/canned_response.rb
@@ -43,6 +43,7 @@ end
 #  content       :text(65535)
 #  decision_kind :integer
 #  title         :string(255)
+#  decision_type :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  user_id       :integer          not null, indexed

--- a/src/api/db/migrate/20240418155847_add_decision_type_to_canned_response.rb
+++ b/src/api/db/migrate/20240418155847_add_decision_type_to_canned_response.rb
@@ -1,0 +1,5 @@
+class AddDecisionTypeToCannedResponse < ActiveRecord::Migration[7.0]
+  def change
+    add_column :canned_responses, :decision_type, :integer
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_04_17_122758) do
+ActiveRecord::Schema[7.0].define(version: 2024_04_18_155847) do
   create_table "appeals", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.text "reason", null: false
     t.integer "appellant_id", null: false
@@ -239,6 +239,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_17_122758) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "decision_kind"
+    t.integer "decision_type"
     t.index ["user_id"], name: "index_canned_responses_on_user_id"
   end
 


### PR DESCRIPTION
This is the first step to rename `decision_kind` to `decision_type` in the table `canned_responses`.

This pull request is safe to merge. Following pull requests will address the next steps described in [renaming a column](https://github.com/ankane/strong_migrations?tab=readme-ov-file#good-2).