### PR TITLE
Fill `decision_type` from canned responses with data

### DIFF
--- a/src/api/app/controllers/webui/users/canned_responses_controller.rb
+++ b/src/api/app/controllers/webui/users/canned_responses_controller.rb
@@ -61,6 +61,8 @@ class Webui::Users::CannedResponsesController < Webui::WebuiController
   end
 
   def canned_response_params
-    params.require(:canned_response).permit(:title, :content, :decision_kind)
+    # TODO: remove merge and replace decision_kind with decision_type
+    decision_type_number = CannedResponse.decision_kinds[params[:canned_response][:decision_kind]]
+    params.require(:canned_response).permit(:title, :content, :decision_kind).merge(decision_type: decision_type_number)
   end
 end

--- a/src/api/db/data/20240419092811_backfill_decision_type_in_canned_responses.rb
+++ b/src/api/db/data/20240419092811_backfill_decision_type_in_canned_responses.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class BackfillDecisionTypeInCannedResponses < ActiveRecord::Migration[7.0]
+  def up
+    CannedResponse.where.not(decision_kind: nil).find_each do |canned_response|
+      canned_response.update(decision_type: CannedResponse.decision_kinds[canned_response[:decision_kind]])
+    end
+  end
+
+  def down
+    # rubocop:disable Rails/SkipsModelValidations
+    CannedResponse.where.not(decision_type: nil).in_batches.update_all(decision_type: nil)
+    # rubocop:enable Rails/SkipsModelValidations
+  end
+end

--- a/src/api/db/data_schema.rb
+++ b/src/api/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20240417122944)
+DataMigrate::Data.define(version: 20240419092811)


### PR DESCRIPTION
To be deployed after #16016. DO NOT MERGE.

TODO:
- [x] Write to both columns
- [x] Backfill data from the old column to the new column