### PR TITLE
Consider only current build results for the badge

### DIFF
--- a/src/api/app/controllers/webui/packages/badge_controller.rb
+++ b/src/api/app/controllers/webui/packages/badge_controller.rb
@@ -8,6 +8,10 @@ module Webui
         results = @package.buildresult(@project, false, true).results[@package.name]
         results = results.select { |r| r.architecture == params[:architecture] } if params[:architecture]
         results = results.select { |r| r.repository == params[:repository] } if params[:repository]
+        # discard results with excluded and disabled status
+        results = results.reject { |r| Buildresult.new(r.code).refused_status? }
+        # discard possible disabled results with previous failed status
+        results = results.reject { |r| @package.disabled_for?('build', r.repository, r.architecture) } unless results.nil? # discard disabled
         badge = Badge.new(params[:type], results)
         send_data(badge.xml, type: 'image/svg+xml', disposition: 'inline')
       end


### PR DESCRIPTION
Fixes https://github.com/openSUSE/open-build-service/issues/15427

The issue: when using the flag `lastbuild = true` the `buildresults` contains (among the rest of builds) also the last known build of the disabled repositories/architectures. If it occurs that one of the disabled build failed the last time, this makes the set of builds to contain a `failed` one, thus the badge reflects that. By discarding the disabled ones the badge reflects only the status of the current active set of builds.

E.g.:
- enable build for `15.5` and `SLE_11_SP4`
- say `15.5` build succeeded
- say `SLE_11_SP4` build failed
- the badge reflects the status: `failed`
- disable the build for `SLE_11_SP4`
- the only enabled build is for `15.5` which is succeeding at the moment
- **Before**: the badge reports a build `failed` red one (_which is wrong_)
- **After**: badge reflects that with a build `succeeded` green one


## TODO
- [ ] add test for this scenario