### PR TITLE
Fix filter counts: consider the full set, not the paginated one

### DIFF
--- a/src/api/app/components/workflow_run_filter_component.rb
+++ b/src/api/app/components/workflow_run_filter_component.rb
@@ -1,14 +1,14 @@
 class WorkflowRunFilterComponent < ApplicationComponent
-  def initialize(token:, selected_filter:, workflow_runs:)
+  def initialize(token:, selected_filter:, workflow_runs_relation:)
     super
 
     @count = {
-      'success' => workflow_runs.success.count,
-      'running' => workflow_runs.running.count,
-      'fail' => workflow_runs.fail.count,
-      'pull_request' => workflow_runs.pull_request.count,
-      'push' => workflow_runs.push.count,
-      'tag_push' => workflow_runs.tag_push.count
+      'success' => workflow_runs_relation.success.count,
+      'running' => workflow_runs_relation.running.count,
+      'fail' => workflow_runs_relation.fail.count,
+      'pull_request' => workflow_runs_relation.pull_request.count,
+      'push' => workflow_runs_relation.push.count,
+      'tag_push' => workflow_runs_relation.tag_push.count
     }
 
     @selected_filter = selected_filter

--- a/src/api/app/controllers/webui/workflow_runs_controller.rb
+++ b/src/api/app/controllers/webui/workflow_runs_controller.rb
@@ -12,6 +12,7 @@ class Webui::WorkflowRunsController < Webui::WebuiController
     relation = relation.with_event_source_name(params[:pr_mr]) if params[:pr_mr].present?
     relation = relation.with_event_source_name(params[:commit_sha]) if params[:commit_sha].present?
 
+    @workflow_runs_relation = relation
     @workflow_runs = relation.all.page(params[:page])
 
     @selected_filter = { status: status_params, event_type: event_type_params, request_action: request_action, pr_mr: params[:pr_mr], commit_sha: params[:commit_sha] }

--- a/src/api/app/views/webui/workflow_runs/index.html.haml
+++ b/src/api/app/views/webui/workflow_runs/index.html.haml
@@ -8,7 +8,8 @@
         Filtered by: #{params[:status]&.humanize}
         %i.float-end.mt-1.fa.fa-chevron-down#workflow-runs-dropdown-trigger
       .collapse#filters
-        = render WorkflowRunFilterComponent.new(token: @token, selected_filter: @selected_filter, workflow_runs: @workflow_runs)
+        = render WorkflowRunFilterComponent.new(token: @token, selected_filter: @selected_filter,
+                                                workflow_runs: @workflow_runs.except(:limit, :offset))
   .col-md-8.col-lg-9.px-0.px-md-3#workflow-run-list
     .card
       .card-body

--- a/src/api/app/views/webui/workflow_runs/index.html.haml
+++ b/src/api/app/views/webui/workflow_runs/index.html.haml
@@ -9,7 +9,7 @@
         %i.float-end.mt-1.fa.fa-chevron-down#workflow-runs-dropdown-trigger
       .collapse#filters
         = render WorkflowRunFilterComponent.new(token: @token, selected_filter: @selected_filter,
-                                                workflow_runs: @workflow_runs.except(:limit, :offset))
+                                                workflow_runs_relation: @workflow_runs_relation)
   .col-md-8.col-lg-9.px-0.px-md-3#workflow-run-list
     .card
       .card-body


### PR DESCRIPTION
Fix computing the counts of WorkflowRuns in the filters: do it over the full set of filtered entries, not only on the visible page.