### PR TITLE
Introduce a view for reports

### DIFF
--- a/src/api/app/components/reports_modal_component.html.haml
+++ b/src/api/app/components/reports_modal_component.html.haml
@@ -14,6 +14,7 @@
             = report.category.humanize
           .ms-4
             %p= report.reason
+            = link_to('Show more', report_path(report))
       - if policy(Decision.new).create?
         = form_for(:decision, url: decisions_path, method: :post) do |form|
           .modal-body{ 'data-canned-controller': '' }

--- a/src/api/app/controllers/webui/reports_controller.rb
+++ b/src/api/app/controllers/webui/reports_controller.rb
@@ -1,6 +1,13 @@
 class Webui::ReportsController < Webui::WebuiController
   before_action :require_login
+  before_action :set_report, only: :show
   after_action :verify_authorized
+
+  include Webui::ReportablesHelper
+
+  def show
+    authorize @report
+  end
 
   def create
     @user = User.session!
@@ -31,5 +38,9 @@ class Webui::ReportsController < Webui::WebuiController
 
   def report_params
     params.require(:report).permit(:reason, :reportable_id, :reportable_type, :category)
+  end
+
+  def set_report
+    @report = Report.find(params[:id])
   end
 end

--- a/src/api/app/views/webui/reports/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui/reports/_breadcrumb_items.html.haml
@@ -1,0 +1,4 @@
+%li.breadcrumb-item
+  Reports
+%li.breadcrumb-item.active{ 'aria-current' => 'page' }
+  Report ##{@report.id}

--- a/src/api/app/views/webui/reports/show.html.haml
+++ b/src/api/app/views/webui/reports/show.html.haml
@@ -1,0 +1,15 @@
+- @pagetitle = "Report ##{@report.id}"
+
+.card
+  .card-body
+    %h3.card-title
+      Report ##{@report.id}
+      .badge.text-bg-primary= @report.category.humanize
+    %p
+      Created by
+      = render UserAvatarComponent.new(@report.user.login)
+      on
+      = link_to_reportables(report_id: @report.id, reportable_type: @report.reportable_type, host: '')
+    %h5 Description
+    %p
+      = @report.reason

--- a/src/api/config/routes/webui.rb
+++ b/src/api/config/routes/webui.rb
@@ -448,7 +448,7 @@ resources :staging_workflows, except: :index, controller: 'webui/staging/workflo
   end
 end
 
-resources :reports, only: [:create], controller: 'webui/reports'
+resources :reports, only: %i[create show], controller: 'webui/reports'
 resources :decisions, only: [:create], controller: 'webui/decisions' do
   resources :appeals, only: %i[new create], controller: 'webui/appeals'
 end


### PR DESCRIPTION
Displays information about the report in the new view. It's accessible from the current reports list in reportable

![Screenshot from 2024-04-22 12-12-27](https://github.com/openSUSE/open-build-service/assets/114928900/119b2f20-3475-49c5-935c-5f46135380df)
