### PR TITLE
Display category and reason differently for reports

### DIFF
--- a/src/api/app/components/reports_modal_component.html.haml
+++ b/src/api/app/components/reports_modal_component.html.haml
@@ -10,8 +10,10 @@
             = render UserAvatarComponent.new(report.user.login)
             reported
             = render TimeComponent.new(time: report.created_at)
+            as
+            = report.category.humanize
           .ms-4
-            = report.reason
+            %p= report.reason
       - if policy(Decision.new).create?
         = form_for(:decision, url: decisions_path, method: :post) do |form|
           .modal-body{ 'data-canned-controller': '' }

--- a/src/api/app/models/event/report.rb
+++ b/src/api/app/models/event/report.rb
@@ -3,7 +3,7 @@ module Event
     receiver_roles :moderator
     self.description = 'Report for inappropriate content has been created'
 
-    payload_keys :id, :user_id, :reportable_id, :reportable_type, :reason
+    payload_keys :id, :user_id, :reportable_id, :reportable_type, :reason, :category
 
     def parameters_for_notification
       super.merge(notifiable_type: 'Report')

--- a/src/api/app/models/report.rb
+++ b/src/api/app/models/report.rb
@@ -24,14 +24,6 @@ class Report < ApplicationRecord
 
   scope :without_decision, -> { where(decision: nil) }
 
-  # TODO: remove the first part of the condition `category.present?`. It's a temprary patch to
-  # avoid problems during deployment.
-  def reason
-    return category.humanize if category.present? && (category != 'other')
-
-    super
-  end
-
   private
 
   def create_event
@@ -51,7 +43,7 @@ class Report < ApplicationRecord
   end
 
   def event_parameters
-    { id: id, user_id: user_id, reportable_id: reportable_id, reportable_type: reportable_type, reason: reason }
+    { id: id, user_id: user_id, reportable_id: reportable_id, reportable_type: reportable_type, reason: reason, category: category }
   end
 
   def event_parameters_for_comment(commentable:)

--- a/src/api/app/views/event_mailer/report_for_comment.html.haml
+++ b/src/api/app/views/event_mailer/report_for_comment.html.haml
@@ -1,6 +1,6 @@
 %p
   = User.find(event['user_id']).login
-  reported a #{event['reportable_type'].downcase} for the following reason:
+  reported a #{event['reportable_type'].downcase} as #{event['category'].humanize} for the following reason:
 %p
   = event['reason']
 %p

--- a/src/api/app/views/event_mailer/report_for_package.html.haml
+++ b/src/api/app/views/event_mailer/report_for_package.html.haml
@@ -1,6 +1,6 @@
 %p
   = User.find(event['user_id']).login
-  reported a #{event['reportable_type'].downcase} for the following reason:
+  reported a #{event['reportable_type'].downcase} as #{event['category'].humanize} for the following reason:
 %p
   = event['reason']
 %p

--- a/src/api/app/views/event_mailer/report_for_project.html.haml
+++ b/src/api/app/views/event_mailer/report_for_project.html.haml
@@ -1,6 +1,6 @@
 %p
   = User.find(event['user_id']).login
-  reported a #{event['reportable_type'].downcase} for the following reason:
+  reported a #{event['reportable_type'].downcase} as #{event['category'].humanize} for the following reason:
 %p
   = event['reason']
 %p

--- a/src/api/app/views/event_mailer/report_for_user.html.haml
+++ b/src/api/app/views/event_mailer/report_for_user.html.haml
@@ -1,6 +1,6 @@
 %p
   = User.find(event['user_id']).login
-  reported a #{event['reportable_type'].downcase} for the following reason:
+  reported a #{event['reportable_type'].downcase} as #{event['category'].humanize} for the following reason:
 %p
   = event['reason']
 %p

--- a/src/api/app/views/webui/appeals/_list_reports.html.haml
+++ b/src/api/app/views/webui/appeals/_list_reports.html.haml
@@ -4,7 +4,8 @@
     %ul
       - decision.reports.each do |report|
         %li
-          Report for a
+          = report.category
+          report for a
           = link_to report.reportable_type, report.reportable
           received. The reason was:
           = report.reason

--- a/src/api/spec/mailers/event_mailer_spec.rb
+++ b/src/api/spec/mailers/event_mailer_spec.rb
@@ -270,7 +270,7 @@ RSpec.describe EventMailer, :vcr do
       end
 
       it 'contains the correct text' do
-        expect(mail.body.encoded).to include('reported a project for the following reason:')
+        expect(mail.body.encoded).to include('reported a project as Other for the following reason:')
         expect(mail.body.encoded).to include('Because reasons')
       end
 
@@ -295,7 +295,7 @@ RSpec.describe EventMailer, :vcr do
       end
 
       it 'contains the correct text' do
-        expect(mail.body.encoded).to include('reported a package for the following reason:')
+        expect(mail.body.encoded).to include('reported a package as Other for the following reason:')
         expect(mail.body.encoded).to include('Because reasons')
       end
 
@@ -319,7 +319,7 @@ RSpec.describe EventMailer, :vcr do
       end
 
       it 'contains the correct text' do
-        expect(mail.body.encoded).to include('reported a user for the following reason:')
+        expect(mail.body.encoded).to include('reported a user as Other for the following reason:')
         expect(mail.body.encoded).to include('Because reasons')
       end
 
@@ -344,7 +344,7 @@ RSpec.describe EventMailer, :vcr do
       end
 
       it 'contains the correct text' do
-        expect(mail.body.encoded).to include('reported a comment for the following reason:')
+        expect(mail.body.encoded).to include('reported a comment as Other for the following reason:')
         expect(mail.body.encoded).to include('Because reasons')
       end
 


### PR DESCRIPTION
We don't currently have a separation between the two because of the existing method in the model. Let's display the full information about the reportable

|Before|After|
|:---|:---|
|![Screenshot from 2024-04-22 15-42-46](https://github.com/openSUSE/open-build-service/assets/114928900/8d7caef1-9e5c-445c-9f32-eaca88c17bfd)|![Screenshot from 2024-04-22 15-42-19](https://github.com/openSUSE/open-build-service/assets/114928900/e040135f-63bd-4ed0-9b1e-dc52ea976ff1)|
