### PR TITLE
Add Metrics/ClassLength offense to Rubocop TODO

### DIFF
--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -205,6 +205,7 @@ Metrics/ClassLength:
     - 'app/controllers/webui/comments_controller.rb'
     - 'app/controllers/webui/kiwi/images_controller.rb'
     - 'app/controllers/webui/package_controller.rb'
+    - 'app/controllers/webui/packages/binaries_controller.rb'
     - 'app/controllers/webui/packages/build_log_controller.rb'
     - 'app/controllers/webui/packages/files_controller.rb'
     - 'app/controllers/webui/patchinfo_controller.rb'


### PR DESCRIPTION
This linter is failing in master, I add it to Rubocop TODO. It didn't turn up in the involved PR: https://github.com/openSUSE/open-build-service/pull/15994

