### PR TITLE
Remove canned response `decision_kind`

### DIFF
--- a/src/api/app/models/canned_response.rb
+++ b/src/api/app/models/canned_response.rb
@@ -1,9 +1,6 @@
 # Canned responses are predetermined comment responses to common questions in a project/package/request
 # Each user can manage their own set of canned responses
 class CannedResponse < ApplicationRecord
-  # TODO: remove after the migration is in production
-  self.ignored_columns += ['decision_kind']
-
   #### Includes and extends
 
   #### Constants
@@ -47,7 +44,6 @@ end
 #
 #  id            :bigint           not null, primary key
 #  content       :text(65535)
-#  decision_kind :integer
 #  title         :string(255)
 #  decision_type :integer
 #  created_at    :datetime         not null

--- a/src/api/db/data/20240419092811_backfill_decision_type_in_canned_responses.rb
+++ b/src/api/db/data/20240419092811_backfill_decision_type_in_canned_responses.rb
@@ -2,12 +2,16 @@
 
 class BackfillDecisionTypeInCannedResponses < ActiveRecord::Migration[7.0]
   def up
+    return unless CannedResponse.columns.any? { |c| c.name == 'decision_kind' }
+
     CannedResponse.where.not(decision_kind: nil).find_each do |canned_response|
       canned_response.update(decision_type: CannedResponse.decision_kinds[canned_response[:decision_kind]])
     end
   end
 
   def down
+    return unless CannedResponse.columns.any? { |c| c.name == 'decision_kind' }
+
     # rubocop:disable Rails/SkipsModelValidations
     CannedResponse.where.not(decision_type: nil).in_batches.update_all(decision_type: nil)
     # rubocop:enable Rails/SkipsModelValidations

--- a/src/api/db/migrate/20240424141833_remove_decision_kind_from_canned_responses.rb
+++ b/src/api/db/migrate/20240424141833_remove_decision_kind_from_canned_responses.rb
@@ -1,0 +1,5 @@
+class RemoveDecisionKindFromCannedResponses < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured { remove_column :canned_responses, :decision_kind, :integer }
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_04_23_073041) do
+ActiveRecord::Schema[7.0].define(version: 2024_04_24_141833) do
   create_table "appeals", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.text "reason", null: false
     t.integer "appellant_id", null: false
@@ -247,7 +247,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_23_073041) do
     t.text "content", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "decision_kind"
     t.integer "decision_type"
     t.index ["user_id"], name: "index_canned_responses_on_user_id"
   end


### PR DESCRIPTION
Drop the column from the database.

Can't be merged until PR #16015 is deployed in. ~Same staff in IBS, because the column should exist to do the backfill first.~