### PR TITLE
Set warning color to Report button

### DIFF
--- a/src/api/app/assets/stylesheets/webui/links.scss
+++ b/src/api/app/assets/stylesheets/webui/links.scss
@@ -10,7 +10,10 @@ a {
 
 a.btn {
   &.btn-outline-danger { @extend .btn-outline-danger; }
-  &.btn-outline-warning { @extend .btn-outline-warning; }
   &.btn-outline-primary { @extend .btn-outline-primary; }
   &.btn-outline-secondary { @extend .btn-outline-secondary; }
+  &.btn-outline-warning {
+    @extend .btn-outline-warning;
+    &:hover { color: $white }
+  }
 }

--- a/src/api/app/views/webui/comment/_reply.html.haml
+++ b/src/api/app/views/webui/comment/_reply.html.haml
@@ -22,7 +22,7 @@
                     class: 'btn btn-outline-secondary', remote: true, form_class: 'moderate-form', params: { moderation_state: !comment.moderated? })
   - if policy(Report.new(reportable: comment)).create?
     %li.list-inline-item
-      = link_to('#', class: 'btn btn-outline-dark', id: "js-comment-#{comment.id}",
+      = link_to('#', class: 'btn btn-outline-warning', id: "js-comment-#{comment.id}",
             data: { 'bs-toggle': 'modal',
                     'bs-target': '#report-modal',
                     'modal-title': "Report comment from #{comment.user}",


### PR DESCRIPTION
The Report button used dark color for the button line and text, which is incompatible with the dark mode. Instead of changing it to use black over white and white over dark, I propose to use the warning color (yellow).


Using the same color in both modes can help users to match the color and the concept of reports, not only because of the consistent button but because the links to reports are also yellow (warning).

![Screenshot 2024-04-22 at 18-36-47  #39 The  quot Moving quot  #39 Toyshop](https://github.com/openSUSE/open-build-service/assets/2581944/be42a9d5-9967-49cc-82c7-320d62731e7b)

![Screenshot 2024-04-22 at 18-36-59  #39 The  quot Moving quot  #39 Toyshop](https://github.com/openSUSE/open-build-service/assets/2581944/96d5c9d8-2df7-4e6a-9661-9f0f08cba069)

![Screenshot 2024-04-22 at 18-37-49  #39 The  quot Moving quot  #39 Toyshop](https://github.com/openSUSE/open-build-service/assets/2581944/6f851b2d-a25b-417f-8bed-4377843c28bc)

![Screenshot 2024-04-22 at 18-38-12  #39 The  quot Moving quot  #39 Toyshop](https://github.com/openSUSE/open-build-service/assets/2581944/66317547-0193-4fc0-865d-cb22ba2dc553)
