### PR TITLE
Create a database table for user blocks

### DIFF
--- a/src/api/app/models/blocked_user.rb
+++ b/src/api/app/models/blocked_user.rb
@@ -1,0 +1,27 @@
+class BlockedUser < ApplicationRecord
+  belongs_to :blocker, class_name: 'User', optional: false
+  belongs_to :blocked, class_name: 'User', optional: false
+
+  validates :blocked_id, uniqueness: { scope: :blocker_id, message: 'This user is already blocked.' }
+end
+
+# == Schema Information
+#
+# Table name: blocked_users
+#
+#  id         :bigint           not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  blocked_id :integer          not null, indexed, indexed => [blocker_id]
+#  blocker_id :integer          not null, indexed => [blocked_id]
+#
+# Indexes
+#
+#  index_blocked_users_on_blocked_id                 (blocked_id)
+#  index_blocked_users_on_blocker_id_and_blocked_id  (blocker_id,blocked_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (blocked_id => users.id)
+#  fk_rails_...  (blocker_id => users.id)
+#

--- a/src/api/db/migrate/20240423073041_create_blocked_users.rb
+++ b/src/api/db/migrate/20240423073041_create_blocked_users.rb
@@ -1,0 +1,11 @@
+class CreateBlockedUsers < ActiveRecord::Migration[7.0]
+  def change
+    create_table :blocked_users, id: :bigint do |t|
+      t.references :blocker, null: false, foreign_key: { to_table: :users }, type: :integer, index: false
+      t.references :blocked, null: false, foreign_key: { to_table: :users }, type: :integer
+
+      t.timestamps
+      t.index %i[blocker_id blocked_id], unique: true
+    end
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_04_18_155847) do
+ActiveRecord::Schema[7.0].define(version: 2024_04_23_073041) do
   create_table "appeals", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.text "reason", null: false
     t.integer "appellant_id", null: false
@@ -155,6 +155,15 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_18_155847) do
     t.index ["medium"], name: "index_binary_releases_on_medium"
     t.index ["release_package_id"], name: "release_package_id"
     t.index ["repository_id", "binary_name"], name: "ra_name_index"
+  end
+
+  create_table "blocked_users", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.integer "blocker_id", null: false
+    t.integer "blocked_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["blocked_id"], name: "index_blocked_users_on_blocked_id"
+    t.index ["blocker_id", "blocked_id"], name: "index_blocked_users_on_blocker_id_and_blocked_id", unique: true
   end
 
   create_table "bs_request_action_accept_infos", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
@@ -1236,6 +1245,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_18_155847) do
   add_foreign_key "backend_packages", "packages", name: "backend_packages_ibfk_1"
   add_foreign_key "binary_releases", "packages", column: "release_package_id", name: "binary_releases_ibfk_2"
   add_foreign_key "binary_releases", "repositories", name: "binary_releases_ibfk_1"
+  add_foreign_key "blocked_users", "users", column: "blocked_id"
+  add_foreign_key "blocked_users", "users", column: "blocker_id"
   add_foreign_key "bs_request_action_accept_infos", "bs_request_actions", name: "bs_request_action_accept_infos_ibfk_1"
   add_foreign_key "bs_request_actions", "bs_requests", name: "bs_request_actions_ibfk_1"
   add_foreign_key "canned_responses", "users"


### PR DESCRIPTION
Introduces a database table for associating users with whoever they block. We use this for creating associations between users. This way a user can block multiple users.