### PR TITLE
Implement Favor Decision and create a Delete Request

### DIFF
--- a/src/api/app/components/notification_excerpt_component.rb
+++ b/src/api/app/components/notification_excerpt_component.rb
@@ -14,7 +14,7 @@ class NotificationExcerptComponent < ApplicationComponent
              @notifiable.description.to_s # description can be nil
            when 'Comment'
              helpers.render_without_markdown(@notifiable.body)
-           when 'Report', 'Decision', 'Appeal'
+           when 'Report', 'Decision', 'Appeal', 'DecisionFavoredWithDeleteRequest'
              @notifiable.reason
            when 'WorkflowRun'
              "In repository #{@notifiable.repository_full_name}"

--- a/src/api/app/models/canned_response.rb
+++ b/src/api/app/models/canned_response.rb
@@ -16,6 +16,7 @@ class CannedResponse < ApplicationRecord
     cleared: 0,
     favored: 1,
     favored_with_comment_moderation: 2,
+    favored_with_delete_request: 3,
     favored_with_user_deletion: 4
   }
 

--- a/src/api/app/models/decision.rb
+++ b/src/api/app/models/decision.rb
@@ -1,5 +1,5 @@
 class Decision < ApplicationRecord
-  TYPES = %w[DecisionFavored DecisionCleared DecisionFavoredWithCommentModeration DecisionFavoredWithUserDeletion].freeze
+  TYPES = %w[DecisionFavored DecisionCleared DecisionFavoredWithCommentModeration DecisionFavoredWithUserDeletion DecisionFavoredWithDeleteRequest].freeze
 
   validates :reason, presence: true, length: { maximum: 65_535 }
   validates :type, presence: true, length: { maximum: 255 }

--- a/src/api/app/models/decision_favored_with_delete_request.rb
+++ b/src/api/app/models/decision_favored_with_delete_request.rb
@@ -1,0 +1,41 @@
+class DecisionFavoredWithDeleteRequest < Decision
+  after_create :create_event
+  after_create :create_delete_request
+
+  def description
+    "The moderator decided to favor the report and ask for the #{reportable.class.name.downcase}'s deletion"
+  end
+
+  def self.display_name
+    'favored with delete request'
+  end
+
+  def self.display?(reportable)
+    return false unless reportable.is_a?(Project) || reportable.is_a?(Package)
+
+    true
+  end
+
+  def create_delete_request
+    reportable = reports.first.reportable
+    return unless reportable.is_a?(Project) || reportable.is_a?(Package)
+
+    bs_request = BsRequest.new
+    bs_request.description = "After evaluation, the moderators decided to remove the #{reportable.class.name.downcase} with the following reason: #{reason}"
+    opts = if reportable.is_a?(Project)
+             { target_project: reportable.name }
+           else
+             { target_package: reportable.name, target_project: reportable.project.name }
+           end
+    action = BsRequestActionDelete.new(opts)
+    bs_request.bs_request_actions << action
+
+    bs_request.save!
+  end
+
+  private
+
+  def create_event
+    Event::FavoredDecision.create(event_parameters)
+  end
+end

--- a/src/api/app/policies/decision_favored_with_delete_request_policy.rb
+++ b/src/api/app/policies/decision_favored_with_delete_request_policy.rb
@@ -1,0 +1,2 @@
+class DecisionFavoredWithDeleteRequestPolicy < DecisionPolicy
+end

--- a/src/api/spec/factories/decision_favored_with_delete_request.rb
+++ b/src/api/spec/factories/decision_favored_with_delete_request.rb
@@ -1,0 +1,19 @@
+FactoryBot.define do
+  factory :decision_favored_with_delete_request_for_package, class: 'DecisionFavoredWithDeleteRequest' do
+    moderator factory: [:user]
+    reason { Faker::Markdown.emphasis }
+
+    after(:build) do |decision|
+      decision.reports << create(:report, reportable: create(:package), reason: 'This is spam!') if decision.reports.empty?
+    end
+  end
+
+  factory :decision_favored_with_delete_request_for_project, class: 'DecisionFavoredWithDeleteRequest' do
+    moderator factory: [:user]
+    reason { Faker::Markdown.emphasis }
+
+    after(:build) do |decision|
+      decision.reports << create(:report, reportable: create(:project_with_package), reason: 'This is spam!') if decision.reports.empty?
+    end
+  end
+end

--- a/src/api/spec/models/decision_favored_with_delete_request_spec.rb
+++ b/src/api/spec/models/decision_favored_with_delete_request_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe DecisionFavoredWithDeleteRequest do
+  let(:user) { create(:confirmed_user) }
+
+  before { login user }
+
+  context 'when reporting a package' do
+    let(:decision) { create(:decision_favored_with_delete_request_for_package) }
+
+    it 'creates a delete request for a package' do
+      expect { decision.create_delete_request }.to change(BsRequest, :count)
+      expect { decision.create_delete_request }.to change(BsRequestActionDelete, :count)
+    end
+  end
+
+  context 'when reporting a project' do
+    let(:decision) { create(:decision_favored_with_delete_request_for_project) }
+
+    it 'creates a delete request for a project' do
+      expect { decision.create_delete_request }.to change(BsRequest, :count)
+      expect { decision.create_delete_request }.to change(BsRequestActionDelete, :count)
+    end
+  end
+end


### PR DESCRIPTION
When someone reports a Package or a Project and a moderator favors the report, it can additionally create a Delete request for that offending Package or Project.

This is how it looks like:
![image](https://github.com/openSUSE/open-build-service/assets/2650/9c018ae4-ca53-41c7-9932-92756412250d)
