### PR TITLE
Handle deleted patchinfos in request workflow beta

### DIFF
--- a/src/api/app/views/webui/request/_patchinfo_details.html.haml
+++ b/src/api/app/views/webui/request/_patchinfo_details.html.haml
@@ -1,6 +1,13 @@
 #patchinfo-details
   %h4.my-3 Patches
   - bs_request.bs_request_actions.where(source_package: 'patchinfo').each do |patchinfo|
-    - patchinfo_package = Package.find_by_project_and_name(patchinfo.source_project, patchinfo.source_package)
-    - patchinfo_text = patchinfo_package.source_file('_patchinfo', rev: patchinfo.source_rev || patchinfo_package.rev)
-    = render PatchinfoComponent.new(patchinfo_text, request_changes_path(number: bs_request.number, request_action_id: patchinfo.id))
+    - patchinfo_source_package = Package.find_by_project_and_name(patchinfo.source_project, patchinfo.source_package)
+    - patchinfo_target_package = patchinfo.target_package_object
+    - if patchinfo_source_package.present?
+      - patchinfo_text = patchinfo_source_package.source_file('_patchinfo', rev: patchinfo.source_rev || patchinfo_source_package.rev)
+      = render PatchinfoComponent.new(patchinfo_text, request_changes_path(number: bs_request.number, request_action_id: patchinfo.id))
+    - elsif patchinfo.bs_request_action_accept_info.present? && patchinfo_target_package.present?
+      - patchinfo_text = patchinfo_target_package.source_file('_patchinfo', rev: patchinfo.bs_request_action_accept_info.rev)
+      = render PatchinfoComponent.new(patchinfo_text, request_changes_path(number: bs_request.number, request_action_id: patchinfo.id))
+    - else
+      %p The source and target of #{patchinfo.target_project}/#{patchinfo.target_package} does not exist anymore.

--- a/src/api/app/views/webui/request/_patchinfo_details.html.haml
+++ b/src/api/app/views/webui/request/_patchinfo_details.html.haml
@@ -1,0 +1,6 @@
+#patchinfo-details
+  %h4.my-3 Patches
+  - bs_request.bs_request_actions.where(source_package: 'patchinfo').each do |patchinfo|
+    - patchinfo_package = Package.find_by_project_and_name(patchinfo.source_project, patchinfo.source_package)
+    - patchinfo_text = patchinfo_package.source_file('_patchinfo', rev: patchinfo.source_rev || patchinfo_package.rev)
+    = render PatchinfoComponent.new(patchinfo_text, request_changes_path(number: bs_request.number, request_action_id: patchinfo.id))

--- a/src/api/app/views/webui/request/beta_show.html.haml
+++ b/src/api/app/views/webui/request/beta_show.html.haml
@@ -37,13 +37,7 @@
                 - else
                   %i No description set
               - if @bs_request.bs_request_actions.exists?(source_package: 'patchinfo')
-                #patchinfo-details
-                  %h4.my-3 Patches
-                  - @bs_request.bs_request_actions.where(source_package: 'patchinfo').each do |patchinfo|
-                    - patchinfo_package = Package.find_by_project_and_name(patchinfo.source_project, patchinfo.source_package)
-                    - patchinfo_text = patchinfo_package.source_file('_patchinfo', rev: patchinfo.source_rev || patchinfo_package.rev)
-                    = render PatchinfoComponent.new(patchinfo_text, request_changes_path(number: @bs_request.number, request_action_id: patchinfo.id))
-
+                = render partial: 'patchinfo_details', locals: { bs_request: @bs_request }
             #comments-list
               .timeline.pb-2.ms-3{ data: { comment_counter: local_assigns[:comment_counter_id] } }
                 %h4.list-group.mb-4.ms-3.pt-3 Comments & History


### PR DESCRIPTION
The source project for maintenance release requests gets deleted in many cases after it is accepted. Therefore we
have to fetch the `patchinfo` from the target in those cases. We also should handle the case of a removed source and target to prevent nil exceptions.

Fixes #16030 

**AFTER**
![image](https://github.com/openSUSE/open-build-service/assets/22001671/7d8eaa1f-2c6e-43c2-bf2e-b05b2983578b)

How to test this:
1. Run `rake dev:test_data:create` in your dev env
2. Navigate to project `openSUSE:Leap:15.4:Update` and add `repository_1` to the project repositories (its missing, and required in order to accept the release request... I will fix this in another PR)
3. Navigate to project `openSUSE:Backports:SLE-15-SP3:Update` and add `repository_2` to the project repositories (same issue as point 2)
4. Navigate to the maintenance release request http://localhost:3000/request/show/12
5. Accept the request
6. Delete the patchinfo package from the source project of the request http://localhost:3000/project/show/openSUSE:Maintenance:0
7. See code 500 without the changes of this PR. With the changes it will keep rendering the patchinfo using the target of the request.
8. Now delete the patchinfo target package as well http://localhost:3000/package/show/openSUSE:Backports:SLE-15-SP3:Update/patchinfo.0
9. See the info about the missing patchinfo on the request page without failure
