### PR TITLE
Show the reason in the notification excerpt for the new decision favored types

### DIFF
--- a/src/api/app/components/notification_excerpt_component.rb
+++ b/src/api/app/components/notification_excerpt_component.rb
@@ -14,7 +14,7 @@ class NotificationExcerptComponent < ApplicationComponent
              @notifiable.description.to_s # description can be nil
            when 'Comment'
              helpers.render_without_markdown(@notifiable.body)
-           when 'Report', 'Decision', 'Appeal', 'DecisionFavoredWithDeleteRequest', 'DecisionFavoredWithUserCommentingRestrictions'
+           when 'Report', 'Decision', 'Appeal', 'DecisionFavoredWithDeleteRequest', 'DecisionFavoredWithUserCommentingRestrictions', 'DecisionFavoredWithCommentModeration', 'DecisionFavoredWithUserDeletion'
              @notifiable.reason
            when 'WorkflowRun'
              "In repository #{@notifiable.repository_full_name}"


### PR DESCRIPTION
Depends on #16040 

This is how it looked like before:
![2024-04-23_17-05](https://github.com/openSUSE/open-build-service/assets/2650/93cfe519-0a55-4d2e-9887-9aba65a225ad)

This is how it looks like now:
![2024-04-23_17-04](https://github.com/openSUSE/open-build-service/assets/2650/9a30fdde-5b90-4df0-a9e9-207e620a1806)
