### PR TITLE
Update bundler version

### DIFF
--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -630,4 +630,4 @@ DEPENDENCIES
   yajl-ruby
 
 BUNDLED WITH
-   2.3.26
+   2.3.27

--- a/src/api/Gemfile.next.lock
+++ b/src/api/Gemfile.next.lock
@@ -609,4 +609,4 @@ DEPENDENCIES
   yajl-ruby
 
 BUNDLED WITH
-   2.3.26
+   2.3.27


### PR DESCRIPTION
The builds in OBS are currently failing because of the following:
```
...
Bundler 2.3.27 is running, but your lockfile was generated with 2.3.26. Installing Bundler 2.3.26 and restarting using that version.
...
```

https://build.opensuse.org/package/live_build_log/OBS:Server:Unstable/obs-server/15.5/x86_64