### PR TITLE
Implement favor decision and block user

### DIFF
--- a/src/api/app/components/notification_excerpt_component.rb
+++ b/src/api/app/components/notification_excerpt_component.rb
@@ -14,7 +14,7 @@ class NotificationExcerptComponent < ApplicationComponent
              @notifiable.description.to_s # description can be nil
            when 'Comment'
              helpers.render_without_markdown(@notifiable.body)
-           when 'Report', 'Decision', 'Appeal', 'DecisionFavoredWithDeleteRequest'
+           when 'Report', 'Decision', 'Appeal', 'DecisionFavoredWithDeleteRequest', 'DecisionFavoredWithUserCommentingRestrictions'
              @notifiable.reason
            when 'WorkflowRun'
              "In repository #{@notifiable.repository_full_name}"

--- a/src/api/app/models/canned_response.rb
+++ b/src/api/app/models/canned_response.rb
@@ -14,7 +14,8 @@ class CannedResponse < ApplicationRecord
     favored: 1,
     favored_with_comment_moderation: 2,
     favored_with_delete_request: 3,
-    favored_with_user_deletion: 4
+    favored_with_user_deletion: 4,
+    favored_with_user_commenting_restriction: 5
   }
 
   #### Attributes

--- a/src/api/app/models/decision.rb
+++ b/src/api/app/models/decision.rb
@@ -1,5 +1,5 @@
 class Decision < ApplicationRecord
-  TYPES = %w[DecisionFavored DecisionCleared DecisionFavoredWithCommentModeration DecisionFavoredWithUserDeletion DecisionFavoredWithDeleteRequest].freeze
+  TYPES = %w[DecisionFavored DecisionCleared DecisionFavoredWithCommentModeration DecisionFavoredWithUserDeletion DecisionFavoredWithDeleteRequest DecisionFavoredWithUserCommentingRestriction].freeze
 
   validates :reason, presence: true, length: { maximum: 65_535 }
   validates :type, presence: true, length: { maximum: 255 }

--- a/src/api/app/models/decision_favored_with_user_commenting_restriction.rb
+++ b/src/api/app/models/decision_favored_with_user_commenting_restriction.rb
@@ -1,0 +1,30 @@
+class DecisionFavoredWithUserCommentingRestriction < Decision
+  after_create :create_event
+  after_create :block_user
+
+  # TODO: Add who the user is
+  def description
+    'The moderator decided to favor the report and apply user commenting restrictions'
+  end
+
+  def self.display_name
+    'favored with applying user commenting restrictions'
+  end
+
+  def self.display?(reportable)
+    return false unless reportable.is_a?(Comment)
+    return false if reportable.user.blocked_from_commenting
+
+    true
+  end
+
+  private
+
+  def create_event
+    Event::FavoredDecision.create(event_parameters)
+  end
+
+  def block_user
+    reports.first.reportable.user.update(blocked_from_commenting: true)
+  end
+end

--- a/src/api/app/policies/decision_favored_with_user_commenting_restriction_policy.rb
+++ b/src/api/app/policies/decision_favored_with_user_commenting_restriction_policy.rb
@@ -1,0 +1,2 @@
+class DecisionFavoredWithUserCommentingRestrictionPolicy < DecisionPolicy
+end


### PR DESCRIPTION
The moderators decide to favor the report and block the user from commenting

This is how it looks like now:
![image](https://github.com/openSUSE/open-build-service/assets/2650/e69b3ed0-3cc5-4c60-a78d-7ab3d19bcf34)
