### PR TITLE
Comments on reports

### DIFF
--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -364,6 +364,7 @@ Metrics/CyclomaticComplexity:
     - 'app/models/user_ldap_strategy.rb'
     - 'app/models/workflow_run_filter.rb'
     - 'app/policies/attrib_policy.rb'
+    - 'app/policies/comment_lock_policy.rb'
     - 'lib/memory_debugger.rb'
     - 'lib/xpath_engine.rb'
     - 'script/import_database.rb'

--- a/src/api/app/controllers/webui/comments_controller.rb
+++ b/src/api/app/controllers/webui/comments_controller.rb
@@ -158,7 +158,7 @@ class Webui::CommentsController < Webui::WebuiController
   end
 
   def set_commented
-    @commentable_type = [Project, Package, BsRequest, BsRequestActionSubmit].find { |klass| klass.name == params[:commentable_type] }
+    @commentable_type = [Project, Package, BsRequest, BsRequestActionSubmit, Report].find { |klass| klass.name == params[:commentable_type] }
     @commented = @commentable_type&.find_by(id: params[:commentable_id])
     return if @commentable_type.present?
 

--- a/src/api/app/models/report.rb
+++ b/src/api/app/models/report.rb
@@ -6,6 +6,7 @@ class Report < ApplicationRecord
 
   belongs_to :user, optional: false
   belongs_to :reportable, polymorphic: true, optional: true
+  has_many :comments, as: :commentable, dependent: :destroy
 
   belongs_to :decision, optional: true
 

--- a/src/api/app/policies/comment_lock_policy.rb
+++ b/src/api/app/policies/comment_lock_policy.rb
@@ -2,6 +2,8 @@ class CommentLockPolicy < ApplicationPolicy
   def create?
     return false unless Flipper.enabled?(:content_moderation, user)
 
+    return false if record.is_a?(Report)
+
     return true if user.is_moderator? || user.is_admin?
 
     case record

--- a/src/api/app/policies/comment_policy.rb
+++ b/src/api/app/policies/comment_policy.rb
@@ -63,6 +63,8 @@ class CommentPolicy < ApplicationPolicy
       record.commentable.project.comment_lock.present? || record.commentable.comment_lock.present?
     when BsRequestAction
       record.commentable.bs_request.comment_lock.present? || record.commentable.comment_lock.present?
+    when Report
+      false
     else
       record.commentable.comment_lock.present?
     end

--- a/src/api/app/policies/report_policy.rb
+++ b/src/api/app/policies/report_policy.rb
@@ -13,14 +13,15 @@ class ReportPolicy < ApplicationPolicy
     # We don't want reports twice...
     return false if user.submitted_reports.where(reportable: record.reportable).any?
 
-    # We don't want reports for things you can change yourself...
+    # We don't want reports for things you can change yourself nor for comment reports
     case record.reportable_type
     when 'Package'
       !PackagePolicy.new(user, record.reportable).update?
     when 'Project'
       !ProjectPolicy.new(user, record.reportable).update?
     when 'Comment'
-      !CommentPolicy.new(user, record.reportable).update?
+      !CommentPolicy.new(user, record.reportable).update? &&
+        !record.reportable.commentable.is_a?(Report)
     when 'User'
       !UserPolicy.new(user, record.reportable).update?
     when 'BsRequest'

--- a/src/api/app/views/webui/reports/show.html.haml
+++ b/src/api/app/views/webui/reports/show.html.haml
@@ -13,3 +13,12 @@
     %h5 Description
     %p
       = @report.reason
+
+.comments.mt-3
+  .card#comments-list
+    %h5.card-header.text-word-break-all
+      Comments
+      %span.badge.text-bg-primary{ id: "comment-counter-report-#{@report.id}" }
+        = @report.comments.length
+    .card-body#comments
+      = render partial: 'webui/comment/show', locals: { commentable: @report, comment_counter_id: "#comment-counter-report-#{@report.id}" }

--- a/src/api/spec/factories/comments.rb
+++ b/src/api/spec/factories/comments.rb
@@ -16,6 +16,10 @@ FactoryBot.define do
       commentable { create(:set_bugowner_request) }
     end
 
+    factory :comment_report do
+      commentable { create(:report) }
+    end
+
     trait :bs_request_action do
       commentable factory: [:bs_request_with_submit_action]
     end

--- a/src/api/spec/policies/comment_lock_policy_spec.rb
+++ b/src/api/spec/policies/comment_lock_policy_spec.rb
@@ -1,0 +1,18 @@
+RSpec.describe CommentLockPolicy do
+  subject { described_class }
+
+  let(:user) { create(:confirmed_user) }
+  let(:report) { create(:report) }
+  let(:non_maintaned_project) { create(:project) }
+  let(:project) { create(:project, maintainer: user) }
+
+  before do
+    Flipper.enable(:content_moderation)
+  end
+
+  permissions :create? do
+    it { is_expected.not_to permit(user, report) }
+    it { is_expected.not_to permit(user, non_maintaned_project) }
+    it { is_expected.to permit(user, project) }
+  end
+end

--- a/src/api/spec/policies/comment_policy_spec.rb
+++ b/src/api/spec/policies/comment_policy_spec.rb
@@ -72,6 +72,16 @@ RSpec.describe CommentPolicy do
       it { is_expected.to permit(user, comment_on_request) }
       it { is_expected.not_to permit(other_user, comment_on_request) }
     end
+
+    context 'with a comment of a Report' do
+      let(:user_with_moderator_role) { create(:moderator) }
+      let(:another_user_with_moderator_role) { create(:moderator) }
+      let(:comment_on_report) { create(:comment_request, user: user_with_moderator_role) }
+
+      it { is_expected.to permit(user_with_moderator_role, comment_on_report) }
+      it { is_expected.not_to permit(another_user_with_moderator_role, comment_on_report) }
+      it { is_expected.not_to permit(other_user, comment_on_report) }
+    end
   end
 
   permissions :update? do
@@ -233,6 +243,17 @@ RSpec.describe CommentPolicy do
 
         it { is_expected.to permit(author, comment_on_comment_locked_project) }
       end
+    end
+
+    context 'for a commentable which is a report' do
+      let(:user_with_moderator_role) { create(:moderator) }
+      let(:another_user) { create(:confirmed_user) }
+      let(:comment_on_report) { build(:comment_request, user: user_with_moderator_role) }
+
+      it { is_expected.to permit(user_with_moderator_role, comment_on_report) }
+      it { is_expected.to permit(admin_user, comment_on_report) }
+      it { is_expected.to permit(comment_author, comment_on_report) }
+      it { is_expected.to permit(another_user, comment_on_report) }
     end
   end
 end

--- a/src/api/spec/policies/comment_policy_spec.rb
+++ b/src/api/spec/policies/comment_policy_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe CommentPolicy do
       expect(subject).not_to permit(user, comment)
     end
 
-    context 'with a comment of a Package' do
+    context 'with a comment on a Package' do
       before do
         allow(user).to receive(:has_local_permission?).with('change_package', package).and_return(true)
         allow(other_user).to receive(:has_local_permission?).with('change_package', package).and_return(false)
@@ -53,7 +53,7 @@ RSpec.describe CommentPolicy do
       it { is_expected.not_to permit(other_user, comment_on_package) }
     end
 
-    context 'with a comment of a Project' do
+    context 'with a comment on a Project' do
       before do
         allow(user).to receive(:has_local_permission?).with('change_project', project).and_return(true)
         allow(other_user).to receive(:has_local_permission?).with('change_project', project).and_return(false)
@@ -63,7 +63,7 @@ RSpec.describe CommentPolicy do
       it { is_expected.not_to permit(other_user, comment) }
     end
 
-    context 'with a comment of a Request' do
+    context 'with a comment on a Request' do
       before do
         allow(request).to receive(:is_target_maintainer?).with(user).and_return(true)
         allow(request).to receive(:is_target_maintainer?).with(other_user).and_return(false)
@@ -73,7 +73,7 @@ RSpec.describe CommentPolicy do
       it { is_expected.not_to permit(other_user, comment_on_request) }
     end
 
-    context 'with a comment of a Report' do
+    context 'with a comment on a Report' do
       let(:user_with_moderator_role) { create(:moderator) }
       let(:another_user_with_moderator_role) { create(:moderator) }
       let(:comment_on_report) { create(:comment_request, user: user_with_moderator_role) }

--- a/src/api/spec/policies/report_policy_spec.rb
+++ b/src/api/spec/policies/report_policy_spec.rb
@@ -67,6 +67,15 @@ RSpec.describe ReportPolicy, type: :policy do
 
         it { is_expected.not_to(permit(user, report)) }
       end
+
+      context "when trying to report a report's comment" do
+        let(:report_on_package_comment) { create(:report, user: user) }
+        let(:report_comment) { create(:comment_report, commentable: report_on_package_comment) }
+        let(:moderator) { create(:moderator) }
+        let(:report) { build(:report, user: moderator, reportable: report_comment) }
+
+        it { is_expected.not_to(permit(moderator, report)) }
+      end
     end
 
     context 'when the current user can not change the reportable' do


### PR DESCRIPTION
The new report show page now includes the possibility to add comments.

It's a private conversation between moderators/admins/staff/reporter, they all should be free to comment at any time, so we shouldn't allow reports' comments to be locked.

![Screenshot 2024-04-25 at 17-42-36 Open Build Service](https://github.com/openSUSE/open-build-service/assets/2581944/5b558c8b-5455-46e6-b932-9e5ab270942d)
