### PR TITLE
Remove kind column from the decisions table

### DIFF
--- a/src/api/app/models/decision.rb
+++ b/src/api/app/models/decision.rb
@@ -10,8 +10,6 @@ class Decision < ApplicationRecord
 
   after_create :track_decision
 
-  self.ignored_columns += ['kind']
-
   def description
     'The moderator decided on the report'
   end

--- a/src/api/app/models/decision.rb
+++ b/src/api/app/models/decision.rb
@@ -60,9 +60,8 @@ end
 # Table name: decisions
 #
 #  id           :bigint           not null, primary key
-#  kind         :integer          default("cleared")
 #  reason       :text(65535)      not null
-#  type         :string(255)      not null, default("DecisionCleared")
+#  type         :string(255)      default("DecisionCleared"), not null
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
 #  moderator_id :integer          not null, indexed

--- a/src/api/app/models/decision_cleared.rb
+++ b/src/api/app/models/decision_cleared.rb
@@ -21,9 +21,8 @@ end
 # Table name: decisions
 #
 #  id           :bigint           not null, primary key
-#  kind         :integer          default("cleared")
 #  reason       :text(65535)      not null
-#  type         :string(255)      not null, default("DecisionCleared")
+#  type         :string(255)      default("DecisionCleared"), not null
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
 #  moderator_id :integer          not null, indexed

--- a/src/api/app/models/decision_favored.rb
+++ b/src/api/app/models/decision_favored.rb
@@ -21,9 +21,8 @@ end
 # Table name: decisions
 #
 #  id           :bigint           not null, primary key
-#  kind         :integer          default("cleared")
 #  reason       :text(65535)      not null
-#  type         :string(255)      not null, default("DecisionCleared")
+#  type         :string(255)      default("DecisionCleared"), not null
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
 #  moderator_id :integer          not null, indexed

--- a/src/api/app/models/decision_favored_with_comment_moderation.rb
+++ b/src/api/app/models/decision_favored_with_comment_moderation.rb
@@ -37,9 +37,8 @@ end
 # Table name: decisions
 #
 #  id           :bigint           not null, primary key
-#  kind         :integer          default("cleared")
 #  reason       :text(65535)      not null
-#  type         :string(255)      not null, default("DecisionCleared")
+#  type         :string(255)      default("DecisionCleared"), not null
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
 #  moderator_id :integer          not null, indexed

--- a/src/api/app/models/decision_favored_with_delete_request.rb
+++ b/src/api/app/models/decision_favored_with_delete_request.rb
@@ -39,3 +39,23 @@ class DecisionFavoredWithDeleteRequest < Decision
     Event::FavoredDecision.create(event_parameters)
   end
 end
+
+# == Schema Information
+#
+# Table name: decisions
+#
+#  id           :bigint           not null, primary key
+#  reason       :text(65535)      not null
+#  type         :string(255)      default("DecisionCleared"), not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  moderator_id :integer          not null, indexed
+#
+# Indexes
+#
+#  index_decisions_on_moderator_id  (moderator_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (moderator_id => users.id)
+#

--- a/src/api/app/models/decision_favored_with_user_deletion.rb
+++ b/src/api/app/models/decision_favored_with_user_deletion.rb
@@ -42,9 +42,8 @@ end
 # Table name: decisions
 #
 #  id           :bigint           not null, primary key
-#  kind         :integer          default("cleared")
 #  reason       :text(65535)      not null
-#  type         :string(255)      not null, default("DecisionCleared")
+#  type         :string(255)      default("DecisionCleared"), not null
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
 #  moderator_id :integer          not null, indexed

--- a/src/api/db/data/20240417122944_set_the_decision_type_from_decision_kind.rb
+++ b/src/api/db/data/20240417122944_set_the_decision_type_from_decision_kind.rb
@@ -2,6 +2,8 @@
 
 class SetTheDecisionTypeFromDecisionKind < ActiveRecord::Migration[7.0]
   def up
+    return unless Decision.columns.any? { |c| c.name == 'kind' }
+
     Decision.in_batches do |batch|
       batch.each do |decision|
         decision.type = decision.favor? ? 'DecisionFavored' : 'DecisionCleared'

--- a/src/api/db/migrate/20240425084914_remove_kind_from_decision.rb
+++ b/src/api/db/migrate/20240425084914_remove_kind_from_decision.rb
@@ -1,0 +1,5 @@
+class RemoveKindFromDecision < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured { remove_column :decisions, :kind, :integer }
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_04_24_141833) do
+ActiveRecord::Schema[7.0].define(version: 2024_04_25_084914) do
   create_table "appeals", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.text "reason", null: false
     t.integer "appellant_id", null: false
@@ -406,7 +406,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_24_141833) do
   create_table "decisions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "moderator_id", null: false
     t.text "reason", null: false
-    t.integer "kind", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "type", default: "DecisionCleared", null: false


### PR DESCRIPTION
Gets rid of the kind column from this table. Follows the strong migrations guidelines