### PR TITLE
Don't render markdown inside the user mention

### DIFF
--- a/src/api/lib/obsapi/markdown_renderer.rb
+++ b/src/api/lib/obsapi/markdown_renderer.rb
@@ -13,7 +13,7 @@ module OBSApi
       # request#12345 links
       fulldoc.gsub!(/(sr|req|request)#(\d+)/i) { |s| "[#{s}](#{request_show_url(number: Regexp.last_match(2))})" }
       # @user links
-      fulldoc.gsub!(/([^\w]|^)@(\b[-.\+\w]+\b)(?:\b|$)/) { "#{Regexp.last_match(1)}[@#{Regexp.last_match(2)}](#{user_url(Regexp.last_match(2))})" }
+      fulldoc.gsub!(/([^\w]|^)@(\b[-.\+\w]+\b)(?:\b|$)/) { "#{Regexp.last_match(1)}[@#{escape_markdown(Regexp.last_match(2))}](#{user_url(Regexp.last_match(2))})" }
       # bnc#12345 links
       IssueTracker.find_each do |t|
         fulldoc = t.get_markdown(fulldoc)
@@ -47,6 +47,12 @@ module OBSApi
       CodeRay.scan(code, language).div(css: :class)
     rescue ArgumentError
       CodeRay.scan(code, :plaintext).div(css: :class) unless language == :plaintext
+    end
+
+    private
+
+    def escape_markdown(text)
+      text.gsub(/([_*`~])/, '\\\\\1')
     end
   end
 end

--- a/src/api/spec/helpers/webui/markdown_helper_spec.rb
+++ b/src/api/spec/helpers/webui/markdown_helper_spec.rb
@@ -29,6 +29,12 @@ RSpec.describe Webui::MarkdownHelper do
       )
     end
 
+    it 'does not render markdown included in the user login' do
+      expect(render_as_markdown('@_testuser_')).to eq(
+        "<p><a href=\"https://unconfigured.openbuildservice.org/users/_testuser_\" rel=\"nofollow\">@_testuser_</a></p>\n"
+      )
+    end
+
     it 'does not crash due to invalid URIs' do
       expect(render_as_markdown("anbox[400000+22d000]\r\n(the number)")).to eq(
         "<p>anbox<a href=\"the%20number\" rel=\"nofollow\">400000+22d000</a></p>\n"


### PR DESCRIPTION
Fixes #13513

To verify:

1. Create a comment that includes a string that would be interpreted as markdown (ie. `_test_`) preceded with `@` to create a mention
2. It will correctly render the username inside of the mention