### PR TITLE
Regenerate the Rubocop TODOs on depfu PRs

### DIFF
--- a/.github/workflows/regenerate_rubocop_todos.yml
+++ b/.github/workflows/regenerate_rubocop_todos.yml
@@ -22,7 +22,8 @@ jobs:
       - name: Run rubocop
         run: |
           cd src/api
-          bundler exec rubocop --regenerate-todo
+          bin/rake dev:lint:rubocop:auto_gen_config:rails
+          bin/rake dev:lint:rubocop:auto_gen_config:root
       - name: Commit to the repository
         run: |
           git config --global user.name 'Rubocop TODOs'


### PR DESCRIPTION
This creates a commit with a regenerated TODOs file from Rubocop whenever depfu pushes into a `depfu/update/srcapi/rubocop-*` branch. Fixes #5009 