### PR TITLE
Define a priority for responsive columns

### DIFF
--- a/src/api/app/assets/javascripts/webui/requests_table.js
+++ b/src/api/app/assets/javascripts/webui/requests_table.js
@@ -18,7 +18,7 @@ $(document).ready(function() {
         // We dont allow ordering by the request link.
         // Columns: created, source, target, requester, type, priority, request link.
         // First column has index 0.
-        { orderable: false, targets: [6] }
+        { orderable: false, targets: [6], responsivePriority: 1 }
       ],
       paging: true,
       pagingType: 'full',


### PR DESCRIPTION
Fix #16043.

For reference: https://datatables.net/reference/option/columns.responsivePriority

After the changes:

![Screenshot from 2024-04-26 17-11-10](https://github.com/openSUSE/open-build-service/assets/24919/ef753daa-d11a-4862-9da1-cb3bab6eb13a)

![Screenshot from 2024-04-26 17-11-28](https://github.com/openSUSE/open-build-service/assets/24919/8c5ea0d6-acc7-47fd-abe8-248d41d38529)
