### PR TITLE
Do not call `link_to_reportable` if reportable does not exist

### DIFF
--- a/src/api/app/views/webui/reports/show.html.haml
+++ b/src/api/app/views/webui/reports/show.html.haml
@@ -8,8 +8,9 @@
     %p
       Created by
       = render UserAvatarComponent.new(@report.user.login)
-      on
-      = link_to_reportables(report_id: @report.id, reportable_type: @report.reportable_type, host: '')
+      - if @report.reportable.present?
+        on
+        = link_to_reportables(report_id: @report.id, reportable_type: @report.reportable_type, host: '')
     %h5 Description
     %p
       = @report.reason


### PR DESCRIPTION
We call the `link_to_reportables` helper on the report show view. This throws an `nil` exception when the reportable is deleted, since the `reportable_type` gets nullified as well. `link_to_reportable` works in on the email notification since the `reportable_type` is still available from the event payload, but we cannot retrieve it from the report record.

Fixes #16062