### PR TITLE
Add preview testing for AccordionReviewsComponent

### DIFF
--- a/src/api/spec/components/accordion_reviews_component_spec.rb
+++ b/src/api/spec/components/accordion_reviews_component_spec.rb
@@ -1,0 +1,30 @@
+RSpec.describe AccordionReviewsComponent, type: :component do
+  context 'when testing the preview' do
+    let(:user) { create(:confirmed_user, :with_home) }
+    let!(:opened_review) { create(:review, by_user: user) }
+    let!(:accepted_review) { create(:review, by_user: user, state: :accepted) }
+    let!(:declined_review) { create(:review, by_user: user, state: :declined) }
+    let(:source_prj) { create(:project) }
+    let(:source_pkg) { create(:package, project: source_prj) }
+    let(:target_prj) { user.home_project }
+    let(:target_pkg) { create(:package, project: target_prj) }
+    let(:action_attributes) do
+      {
+        type: 'submit',
+        source_package: source_pkg,
+        source_project: source_prj,
+        target_project: target_prj,
+        target_package: target_pkg
+      }
+    end
+
+    before do
+      create(:bs_request, action_attributes.merge(creator: user))
+      user.run_as { render_preview(:preview) }
+    end
+
+    it { expect(rendered_content).to have_text('Accepted Review') }
+    it { expect(rendered_content).to have_text('Pending Review') }
+    it { expect(rendered_content).to have_text('Declined Review') }
+  end
+end

--- a/src/api/spec/components/previews/accordion_reviews_component_preview.rb
+++ b/src/api/spec/components/previews/accordion_reviews_component_preview.rb
@@ -4,6 +4,8 @@ class AccordionReviewsComponentPreview < ViewComponent::Preview
     pending_reviews = Review.opened.take(3)
     accepted_reviews = Review.accepted.take(2)
     declined_review = Review.declined.take(1)
-    render(AccordionReviewsComponent.new(pending_reviews + accepted_reviews + declined_review, :review, can_handle_request: true))
+    request_reviews = accepted_reviews + pending_reviews + declined_review
+    bs_request = BsRequest.last || FactoryBot.create(:bs_request_with_submit_action)
+    render(AccordionReviewsComponent.new(request_reviews, bs_request))
   end
 end


### PR DESCRIPTION
The preview for AccordionReviewsComponent was broken. 
This PR fixes the preview and adds it to the test coverage to ensure it keeps from breaking again. 