### PR TITLE
Introduce new names of project receiver roles

### DIFF
--- a/src/api/app/models/event/base.rb
+++ b/src/api/app/models/event/base.rb
@@ -253,7 +253,12 @@ module Event
       ret
     end
 
+    # TODO: Remove this method on a following step of the renaming.
     def watchers
+      project_watchers
+    end
+
+    def project_watchers
       project = ::Project.find_by_name(payload['project'])
       return [] if project.blank?
 

--- a/src/api/app/models/event/build_fail.rb
+++ b/src/api/app/models/event/build_fail.rb
@@ -4,7 +4,8 @@ module Event
 
     self.message_bus_routing_key = 'package.build_fail'
     self.description = 'Package has failed to build'
-    receiver_roles :maintainer, :bugowner, :reader, :watcher, :package_watcher, :request_watcher
+    # TODO: Remove the ':watcher' receiver role on a following step of the renaming.
+    receiver_roles :maintainer, :bugowner, :reader, :watcher, :project_watcher, :package_watcher, :request_watcher
 
     create_jobs :report_to_scm_job
 

--- a/src/api/app/models/event/comment_for_package.rb
+++ b/src/api/app/models/event/comment_for_package.rb
@@ -3,7 +3,8 @@ module Event
     include CommentEvent
     self.message_bus_routing_key = 'package.comment'
     self.description = 'New comment for package created'
-    receiver_roles :maintainer, :bugowner, :watcher, :package_watcher
+    # TODO: Remove the ':watcher' receiver role on a following step of the renaming.
+    receiver_roles :maintainer, :bugowner, :watcher, :project_watcher, :package_watcher
     payload_keys :project, :package, :sender
 
     def subject

--- a/src/api/app/models/event/comment_for_project.rb
+++ b/src/api/app/models/event/comment_for_project.rb
@@ -4,7 +4,8 @@ module Event
     self.message_bus_routing_key = 'project.comment'
     self.description = 'New comment for project created'
     payload_keys :project
-    receiver_roles :maintainer, :bugowner, :watcher
+    # TODO: Remove the ':watcher' receiver role on a following step of the renaming.
+    receiver_roles :maintainer, :bugowner, :watcher, :project_watcher
 
     def subject
       "New comment in project #{payload['project']} by #{payload['commenter']}"

--- a/src/api/app/models/event/comment_for_request.rb
+++ b/src/api/app/models/event/comment_for_request.rb
@@ -4,7 +4,8 @@ module Event
     self.message_bus_routing_key = 'request.comment'
     self.description = 'New comment for request created'
     payload_keys :request_number, :diff_ref
-    receiver_roles :source_maintainer, :target_maintainer, :creator, :reviewer, :source_watcher, :target_watcher,
+    # TODO: Remove the ':source_watcher' and the ':target_watcher' receiver roles on a following step of the renaming.
+    receiver_roles :source_maintainer, :target_maintainer, :creator, :reviewer, :source_watcher, :target_watcher, :source_project_watcher, :target_project_watcher,
                    :source_package_watcher, :target_package_watcher, :request_watcher
 
     def subject

--- a/src/api/app/models/event/request.rb
+++ b/src/api/app/models/event/request.rb
@@ -84,11 +84,21 @@ module Event
       action_maintainers('sourceproject', 'sourcepackage')
     end
 
+    # TODO: Remove this method on a following step of the renaming.
     def source_watchers
+      source_project_watchers
+    end
+
+    def source_project_watchers
       source_or_target_project_watchers(project_type: 'sourceproject')
     end
 
+    # TODO: Remove this method on a following step of the renaming.
     def target_watchers
+      target_project_watchers
+    end
+
+    def target_project_watchers
       source_or_target_project_watchers(project_type: 'targetproject')
     end
 

--- a/src/api/app/models/event/request_create.rb
+++ b/src/api/app/models/event/request_create.rb
@@ -2,7 +2,8 @@ module Event
   class RequestCreate < Request
     self.message_bus_routing_key = 'request.create'
     self.description = 'Request created'
-    receiver_roles :source_maintainer, :target_maintainer, :source_watcher, :target_watcher,
+    # TODO: Remove the ':source_watcher' and the ':target_watcher' receiver roles on a following step of the renaming.
+    receiver_roles :source_maintainer, :target_maintainer, :source_watcher, :target_watcher, :source_project_watcher, :target_project_watcher,
                    :source_package_watcher, :target_package_watcher
 
     def custom_headers

--- a/src/api/app/models/event/request_statechange.rb
+++ b/src/api/app/models/event/request_statechange.rb
@@ -3,7 +3,8 @@ module Event
     self.message_bus_routing_key = 'request.state_change'
     self.description = 'Request state was changed'
     payload_keys :oldstate, :duration
-    receiver_roles :source_maintainer, :target_maintainer, :creator, :reviewer, :source_watcher, :target_watcher,
+    # TODO: Remove the ':source_watcher' and the ':target_watcher' receiver roles on a following step of the renaming.
+    receiver_roles :source_maintainer, :target_maintainer, :creator, :reviewer, :source_watcher, :target_watcher, :source_project_watcher, :target_project_watcher,
                    :source_package_watcher, :target_package_watcher, :request_watcher
 
     create_jobs :report_to_scm_job

--- a/src/api/app/models/event/review_changed.rb
+++ b/src/api/app/models/event/review_changed.rb
@@ -3,7 +3,8 @@ module Event
     self.message_bus_routing_key = 'request.review_changed'
     self.description = 'Request was reviewed'
     payload_keys :reviewers, :by_user, :by_group, :by_project, :by_package
-    receiver_roles :source_maintainer, :target_maintainer, :creator, :source_watcher, :target_watcher
+    # TODO: Remove the ':source_watcher' and the ':target_watcher' receiver roles on a following step of the renaming.
+    receiver_roles :source_maintainer, :target_maintainer, :creator, :source_watcher, :target_watcher, :source_project_watcher, :target_project_watcher
 
     def subject
       "Request #{payload['number']} was reviewed (#{actions_summary})"

--- a/src/api/app/models/event_subscription.rb
+++ b/src/api/app/models/event_subscription.rb
@@ -1,5 +1,4 @@
 class EventSubscription < ApplicationRecord
-  # TODO: remove watcher, source_watcher and target_watcher as soon as the renaming steps and migration are finished.
   RECEIVER_ROLE_TEXTS = {
     maintainer: 'Maintainer',
     bugowner: 'Bugowner',
@@ -9,9 +8,12 @@ class EventSubscription < ApplicationRecord
     reviewer: 'Reviewer',
     commenter: 'Commenter or mentioned user',
     creator: 'Creator',
-    watcher: 'Watching the project',
-    source_watcher: 'Watching the source project',
-    target_watcher: 'Watching the target project',
+    watcher: 'Watching the project',                       # TODO: remove on a following step of the renaming.
+    project_watcher: 'Watching the project',
+    source_watcher: 'Watching the source project',         # TODO: remove on a following step of the renaming.
+    source_project_watcher: 'Watching the source project',
+    target_watcher: 'Watching the target project',         # TODO: remove on a following step of the renaming.
+    target_project_watcher: 'Watching the target project',
     any_role: 'Any role',
     package_watcher: 'Watching the package',
     source_package_watcher: 'Watching the source package',
@@ -45,7 +47,8 @@ class EventSubscription < ApplicationRecord
 
   validates :receiver_role, inclusion: {
     in: %i[maintainer bugowner reader source_maintainer target_maintainer
-           reviewer commenter creator watcher source_watcher target_watcher
+           reviewer commenter creator
+           project_watcher source_project_watcher target_project_watcher
            package_watcher target_package_watcher source_package_watcher request_watcher any_role
            moderator reporter offender token_executor]
   }

--- a/src/api/app/models/event_subscription/for_event_form.rb
+++ b/src/api/app/models/event_subscription/for_event_form.rb
@@ -1,5 +1,8 @@
 class EventSubscription
   class ForEventForm
+    # TODO: Remove this line on a following step of the renaming.
+    OBSOLETE_RECEIVER_ROLES = %i[watcher source_watcher target_watcher].freeze
+
     attr_reader :event_class, :subscriber, :roles
 
     def initialize(event, subscriber)
@@ -9,7 +12,9 @@ class EventSubscription
     end
 
     def call
-      @roles = event_class.receiver_roles.map { |role| EventSubscription::ForRoleForm.new(role, event_class, subscriber).call }
+      @roles = event_class.receiver_roles
+                          .reject { |role| OBSOLETE_RECEIVER_ROLES.include?(role) } # TODO: Remove this line on a following step of the renaming.
+                          .map { |role| EventSubscription::ForRoleForm.new(role, event_class, subscriber).call }
       self
     end
   end

--- a/src/api/db/data/20240507120255_rename_project_receiver_roles_in_event_subscriptions.rb
+++ b/src/api/db/data/20240507120255_rename_project_receiver_roles_in_event_subscriptions.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class RenameProjectReceiverRolesInEventSubscriptions < ActiveRecord::Migration[7.0]
+  # rubocop:disable Rails/SkipsModelValidations
+  def up
+    EventSubscription.where(receiver_role: 'watcher').in_batches do |relation|
+      relation.update_all receiver_role: 'project_watcher'
+      sleep(0.01) # throttle
+    end
+    EventSubscription.where(receiver_role: 'source_watcher').in_batches do |relation|
+      relation.update_all receiver_role: 'source_project_watcher'
+      sleep(0.01) # throttle
+    end
+    EventSubscription.where(receiver_role: 'target_watcher').in_batches do |relation|
+      relation.update_all receiver_role: 'target_project_watcher'
+      sleep(0.01) # throttle
+    end
+  end
+
+  def down
+    EventSubscription.where(receiver_role: 'target_project_watcher').in_batches do |relation|
+      relation.update_all receiver_role: 'target_project_watcher'
+      sleep(0.01) # throttle
+    end
+    EventSubscription.where(receiver_role: 'source_project_watcher').in_batches do |relation|
+      relation.update_all receiver_role: 'project_watcher'
+      sleep(0.01) # throttle
+    end
+    EventSubscription.where(receiver_role: 'project_watcher').in_batches do |relation|
+      relation.update_all receiver_role: 'watcher'
+      sleep(0.01) # throttle
+    end
+  end
+  # rubocop:enable Rails/SkipsModelValidations
+end

--- a/src/api/db/data_schema.rb
+++ b/src/api/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20240419092811)
+DataMigrate::Data.define(version: 20240507120255)

--- a/src/api/spec/db/data/generate_web_notifications_spec.rb
+++ b/src/api/spec/db/data/generate_web_notifications_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe GenerateWebNotifications, type: :migration do
     let!(:event_subscription_3) { create(:event_subscription_comment_for_project, user: owner, receiver_role: 'bugowner') }
     let!(:disabled_event_for_web_and_rss) { create(:event_subscription, eventtype: 'Event::BuildFail', user: owner, receiver_role: 'maintainer') }
     let!(:default_subscription) { create(:event_subscription_comment_for_project_without_subscriber, receiver_role: 'bugowner') }
-    let!(:default_subscription_1) { create(:event_subscription_comment_for_project_without_subscriber, receiver_role: 'watcher') }
+    let!(:default_subscription_1) { create(:event_subscription_comment_for_project_without_subscriber, receiver_role: 'project_watcher') }
     let!(:default_subscription_2) do
       create(:event_subscription_comment_for_project_without_subscriber,
              receiver_role: 'maintainer',

--- a/src/api/spec/features/webui/subscriptions_spec.rb
+++ b/src/api/spec/features/webui/subscriptions_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Subscriptions', :js do
 
       expect(page).to have_content(title)
       notification_field = find('.card-body h5', text: 'Package has failed to build').sibling('.list-group')
-      %w[maintainer bugowner reader watcher].each do |role|
+      %w[maintainer bugowner reader project_watcher].each do |role|
         subscription_by_role = notification_field.find(".#{role}")
         subscription_by_role.check('email')
         expect(page).to have_css('#flash', text: 'Notifications settings updated')
@@ -18,7 +18,7 @@ RSpec.describe 'Subscriptions', :js do
       visit path
 
       notification_field = find('.card-body h5', text: 'Package has failed to build').sibling('.list-group')
-      %w[maintainer bugowner reader watcher].each do |role|
+      %w[maintainer bugowner reader project_watcher].each do |role|
         subscription_by_role = notification_field.find(".#{role}")
         expect(subscription_by_role.find_field('email', visible: false)).to be_checked
       end

--- a/src/api/spec/models/event/base_spec.rb
+++ b/src/api/spec/models/event/base_spec.rb
@@ -89,8 +89,8 @@ RSpec.describe Event::Base do
     end
   end
 
-  describe '#watchers' do
-    subject { event.watchers }
+  describe '#project_watchers' do
+    subject { event.project_watchers }
 
     let(:project) { create(:project, name: 'openSUSE') }
     let(:event) { Event::CommentForProject.create(project: project.name) }

--- a/src/api/spec/models/event_subscription/find_for_event_spec.rb
+++ b/src/api/spec/models/event_subscription/find_for_event_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe EventSubscription::FindForEvent do
         create(
           :event_subscription,
           eventtype: 'Event::RequestCreate',
-          receiver_role: 'source_watcher',
+          receiver_role: 'source_project_watcher',
           user: nil,
           group: nil,
           channel: :instant_email
@@ -158,7 +158,7 @@ RSpec.describe EventSubscription::FindForEvent do
         let!(:comment) { create(:comment_project, commentable: project) }
 
         let!(:default_subscription) do
-          create(:event_subscription_comment_for_project, receiver_role: 'watcher', user: nil, group: nil)
+          create(:event_subscription_comment_for_project, receiver_role: 'project_watcher', user: nil, group: nil)
         end
 
         before do

--- a/src/api/spec/models/event_subscription/for_event_form_spec.rb
+++ b/src/api/spec/models/event_subscription/for_event_form_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe EventSubscription::ForEventForm do
     context 'for Event::CommentForProject' do
       let(:event_class) { Event::CommentForProject }
       let(:expected_receiver_roles) do
-        event_class.receiver_roles
+        %i[bugowner commenter maintainer project_watcher]
       end
 
       it { expect(subject.event_class).to eq(event_class) }
@@ -21,7 +21,7 @@ RSpec.describe EventSubscription::ForEventForm do
     context 'for Event::CommentForRequest' do
       let(:event_class) { Event::CommentForRequest }
       let(:expected_receiver_roles) do
-        event_class.receiver_roles
+        %i[commenter creator request_watcher reviewer source_maintainer source_package_watcher source_project_watcher target_maintainer target_package_watcher target_project_watcher]
       end
 
       it { expect(subject.event_class).to eq(event_class) }


### PR DESCRIPTION
This is the first step for renaming the following receiver roles:

- `watcher` to `project_watcher`
- `source_watcher` to `source_project_watcher`
- `target_watcher` to `target_project_watcher`