### PR TITLE
Drop obsolete watcher receiver roles

### DIFF
--- a/src/api/app/models/event/base.rb
+++ b/src/api/app/models/event/base.rb
@@ -253,11 +253,6 @@ module Event
       ret
     end
 
-    # TODO: Remove this method on a following step of the renaming.
-    def watchers
-      project_watchers
-    end
-
     def project_watchers
       project = ::Project.find_by_name(payload['project'])
       return [] if project.blank?

--- a/src/api/app/models/event/build_fail.rb
+++ b/src/api/app/models/event/build_fail.rb
@@ -4,8 +4,7 @@ module Event
 
     self.message_bus_routing_key = 'package.build_fail'
     self.description = 'Package has failed to build'
-    # TODO: Remove the ':watcher' receiver role on a following step of the renaming.
-    receiver_roles :maintainer, :bugowner, :reader, :watcher, :project_watcher, :package_watcher, :request_watcher
+    receiver_roles :maintainer, :bugowner, :reader, :project_watcher, :package_watcher, :request_watcher
 
     create_jobs :report_to_scm_job
 

--- a/src/api/app/models/event/comment_for_package.rb
+++ b/src/api/app/models/event/comment_for_package.rb
@@ -3,8 +3,7 @@ module Event
     include CommentEvent
     self.message_bus_routing_key = 'package.comment'
     self.description = 'New comment for package created'
-    # TODO: Remove the ':watcher' receiver role on a following step of the renaming.
-    receiver_roles :maintainer, :bugowner, :watcher, :project_watcher, :package_watcher
+    receiver_roles :maintainer, :bugowner, :project_watcher, :package_watcher
     payload_keys :project, :package, :sender
 
     def subject

--- a/src/api/app/models/event/comment_for_project.rb
+++ b/src/api/app/models/event/comment_for_project.rb
@@ -4,8 +4,7 @@ module Event
     self.message_bus_routing_key = 'project.comment'
     self.description = 'New comment for project created'
     payload_keys :project
-    # TODO: Remove the ':watcher' receiver role on a following step of the renaming.
-    receiver_roles :maintainer, :bugowner, :watcher, :project_watcher
+    receiver_roles :maintainer, :bugowner, :project_watcher
 
     def subject
       "New comment in project #{payload['project']} by #{payload['commenter']}"

--- a/src/api/app/models/event/comment_for_request.rb
+++ b/src/api/app/models/event/comment_for_request.rb
@@ -4,8 +4,7 @@ module Event
     self.message_bus_routing_key = 'request.comment'
     self.description = 'New comment for request created'
     payload_keys :request_number, :diff_ref
-    # TODO: Remove the ':source_watcher' and the ':target_watcher' receiver roles on a following step of the renaming.
-    receiver_roles :source_maintainer, :target_maintainer, :creator, :reviewer, :source_watcher, :target_watcher, :source_project_watcher, :target_project_watcher,
+    receiver_roles :source_maintainer, :target_maintainer, :creator, :reviewer, :source_project_watcher, :target_project_watcher,
                    :source_package_watcher, :target_package_watcher, :request_watcher
 
     def subject

--- a/src/api/app/models/event/request.rb
+++ b/src/api/app/models/event/request.rb
@@ -84,18 +84,8 @@ module Event
       action_maintainers('sourceproject', 'sourcepackage')
     end
 
-    # TODO: Remove this method on a following step of the renaming.
-    def source_watchers
-      source_project_watchers
-    end
-
     def source_project_watchers
       source_or_target_project_watchers(project_type: 'sourceproject')
-    end
-
-    # TODO: Remove this method on a following step of the renaming.
-    def target_watchers
-      target_project_watchers
     end
 
     def target_project_watchers

--- a/src/api/app/models/event/request_create.rb
+++ b/src/api/app/models/event/request_create.rb
@@ -2,8 +2,7 @@ module Event
   class RequestCreate < Request
     self.message_bus_routing_key = 'request.create'
     self.description = 'Request created'
-    # TODO: Remove the ':source_watcher' and the ':target_watcher' receiver roles on a following step of the renaming.
-    receiver_roles :source_maintainer, :target_maintainer, :source_watcher, :target_watcher, :source_project_watcher, :target_project_watcher,
+    receiver_roles :source_maintainer, :target_maintainer, :source_project_watcher, :target_project_watcher,
                    :source_package_watcher, :target_package_watcher
 
     def custom_headers

--- a/src/api/app/models/event/request_statechange.rb
+++ b/src/api/app/models/event/request_statechange.rb
@@ -3,8 +3,7 @@ module Event
     self.message_bus_routing_key = 'request.state_change'
     self.description = 'Request state was changed'
     payload_keys :oldstate, :duration
-    # TODO: Remove the ':source_watcher' and the ':target_watcher' receiver roles on a following step of the renaming.
-    receiver_roles :source_maintainer, :target_maintainer, :creator, :reviewer, :source_watcher, :target_watcher, :source_project_watcher, :target_project_watcher,
+    receiver_roles :source_maintainer, :target_maintainer, :creator, :reviewer, :source_project_watcher, :target_project_watcher,
                    :source_package_watcher, :target_package_watcher, :request_watcher
 
     create_jobs :report_to_scm_job

--- a/src/api/app/models/event/review_changed.rb
+++ b/src/api/app/models/event/review_changed.rb
@@ -3,8 +3,7 @@ module Event
     self.message_bus_routing_key = 'request.review_changed'
     self.description = 'Request was reviewed'
     payload_keys :reviewers, :by_user, :by_group, :by_project, :by_package
-    # TODO: Remove the ':source_watcher' and the ':target_watcher' receiver roles on a following step of the renaming.
-    receiver_roles :source_maintainer, :target_maintainer, :creator, :source_watcher, :target_watcher, :source_project_watcher, :target_project_watcher
+    receiver_roles :source_maintainer, :target_maintainer, :creator, :source_project_watcher, :target_project_watcher
 
     def subject
       "Request #{payload['number']} was reviewed (#{actions_summary})"

--- a/src/api/app/models/event_subscription.rb
+++ b/src/api/app/models/event_subscription.rb
@@ -8,11 +8,8 @@ class EventSubscription < ApplicationRecord
     reviewer: 'Reviewer',
     commenter: 'Commenter or mentioned user',
     creator: 'Creator',
-    watcher: 'Watching the project',                       # TODO: remove on a following step of the renaming.
     project_watcher: 'Watching the project',
-    source_watcher: 'Watching the source project',         # TODO: remove on a following step of the renaming.
     source_project_watcher: 'Watching the source project',
-    target_watcher: 'Watching the target project',         # TODO: remove on a following step of the renaming.
     target_project_watcher: 'Watching the target project',
     any_role: 'Any role',
     package_watcher: 'Watching the package',

--- a/src/api/app/models/event_subscription/for_event_form.rb
+++ b/src/api/app/models/event_subscription/for_event_form.rb
@@ -1,8 +1,5 @@
 class EventSubscription
   class ForEventForm
-    # TODO: Remove this line on a following step of the renaming.
-    OBSOLETE_RECEIVER_ROLES = %i[watcher source_watcher target_watcher].freeze
-
     attr_reader :event_class, :subscriber, :roles
 
     def initialize(event, subscriber)
@@ -12,9 +9,7 @@ class EventSubscription
     end
 
     def call
-      @roles = event_class.receiver_roles
-                          .reject { |role| OBSOLETE_RECEIVER_ROLES.include?(role) } # TODO: Remove this line on a following step of the renaming.
-                          .map { |role| EventSubscription::ForRoleForm.new(role, event_class, subscriber).call }
+      @roles = event_class.receiver_roles.map { |role| EventSubscription::ForRoleForm.new(role, event_class, subscriber).call }
       self
     end
   end


### PR DESCRIPTION
This is the second and last step for renaming the following receiver roles:

- `watcher` to `project_watcher`
- `source_watcher` to `source_project_watcher`
- `target_watcher` to `target_project_watcher`