### PR TITLE
Fix N+1 queries fetching all projects

### DIFF
--- a/src/api/app/datatables/project_datatable.rb
+++ b/src/api/app/datatables/project_datatable.rb
@@ -30,10 +30,9 @@ class ProjectDatatable < Datatable
   # rubocop:enable Naming/AccessorMethodName
 
   def data
-    records.map do |record|
+    records.left_outer_joins(quality_attribs: :values).select('projects.*', 'attrib_values.value AS attrib_value').map do |record|
       {
-        name: link_to(record.name, project_show_path(record)) +
-          safe_join(record.categories.map { |q| category_badge(q) }),
+        name: link_to(record.name, project_show_path(record)) + category_badge(record.attrib_value),
         title: record.title
       }
     end

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -47,6 +47,9 @@ class Project < ApplicationRecord
   has_many :package_kinds, through: :packages
   has_many :issues, through: :packages
   has_many :attribs, dependent: :destroy
+  has_many :quality_attribs, lambda {
+    where(attrib_type_id: AttribType.joins(:attrib_namespace).where(attrib_namespace: { name: 'OBS' }, attrib_types: { name: 'QualityCategory' }))
+  }, class_name: 'Attrib'
 
   has_many :repositories, dependent: :destroy, foreign_key: :db_project_id
   has_many :release_targets, through: :repositories


### PR DESCRIPTION
Craft with a scope the join condition of projects and values. This prevent N+1 queries.

Also, remove the loop to render more than one value for the OBS:QualityCategory attribute. This attribute can only keep one value.

## Before

The last query (`SELECT attrib_values.* FROM attrib_values INNER JOIN...`) is repeated 25 times.

```
Project Load (0.7ms)  SELECT `projects`.* FROM `projects` WHERE `projects`.`id` != 0 AND NOT (name rlike '^home:.+') ORDER BY projects.name ASC LIMIT 25 OFFSET 0
↳ app/datatables/project_datatable.rb:33:in `map'
AttribValue Load (0.5ms)  SELECT `attrib_values`.* FROM `attrib_values` INNER JOIN `attribs` ON `attribs`.`id` = `attrib_values`.`attrib_id` INNER JOIN `attrib_types` ON `attrib_types`.`id` = `attribs`.`attrib_type_id` INNER JOIN `attrib_namespaces` ON `attrib_namespaces`.`id` = `attrib_types`.`attrib_namespace_id` WHERE `attribs`.`project_id` = 10 AND `attrib_types`.`name` = 'QualityCategory' AND `attrib_namespaces`.`name` = 'OBS'
↳ app/queries/obs_quality_categories_finder.rb:8:in `map'
AttribValue Load (0.9ms)  SELECT `attrib_values`.* FROM `attrib_values` INNER JOIN `attribs` ON `attribs`.`id` = `attrib_values`.`attrib_id` INNER JOIN `attrib_types` ON `attrib_types`.`id` = `attribs`.`attrib_type_id` INNER JOIN `attrib_namespaces` ON `attrib_namespaces`.`id` = `attrib_types`.`attrib_namespace_id` WHERE `attribs`.`project_id` = 1 AND `attrib_types`.`name` = 'QualityCategory' AND `attrib_namespaces`.`name` = 'OBS'
↳ app/queries/obs_quality_categories_finder.rb:8:in `map'
[...]
AttribValue Load (0.8ms)  SELECT `attrib_values`.* FROM `attrib_values` INNER JOIN `attribs` ON `attribs`.`id` = `attrib_values`.`attrib_id` INNER JOIN `attrib_types` ON `attrib_types`.`id` = `attribs`.`attrib_type_id` INNER JOIN `attrib_namespaces` ON `attrib_namespaces`.`id` = `attrib_types`.`attrib_namespace_id` WHERE `attribs`.`project_id` = 1 AND `attrib_types`.`name` = 'QualityCategory' AND `attrib_namespaces`.`name` = 'OBS'
↳ app/queries/obs_quality_categories_finder.rb:8:in `map'
```

## After

```
Project Load (2.2ms)  SELECT projects.*, attrib_values.value AS attrib_value FROM `projects` LEFT OUTER JOIN attribs ON (attribs.project_id = projects.id AND attribs.attrib_type_id = 15) LEFT OUTER JOIN attrib_values ON attribs.id = attrib_values.attrib_id WHERE `projects`.`id` != 0 AND NOT (name rlike '^home:.+') ORDER BY projects.name ASC LIMIT 25 OFFSET 0
↳ app/datatables/project_datatable.rb:36:in `map'
```

## For reviewers

- Access http://localhost:3000/project in your local development environment
- See logs.