### PR TITLE
Handle `notification_id` query param and notifications toolbar gracefully

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -75,10 +75,7 @@ class Webui::PackageController < Webui::WebuiController
     @comments = @package.comments.includes(:user)
     @comment = Comment.new
 
-    if User.session && params[:notification_id]
-      @current_notification = Notification.find(params[:notification_id])
-      authorize @current_notification, :update?, policy_class: NotificationPolicy
-    end
+    @current_notification = handle_notification
 
     @services = @files.any? { |file| file['name'] == '_service' }
 
@@ -539,5 +536,15 @@ class Webui::PackageController < Webui::WebuiController
       end
     end
     true
+  end
+
+  def handle_notification
+    return unless User.session && params[:notification_id]
+
+    current_notification = Notification.find(params[:notification_id])
+
+    return unless NotificationPolicy.new(User.session, current_notification).update?
+
+    current_notification
   end
 end

--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -44,11 +44,7 @@ class Webui::ProjectController < Webui::WebuiController
     @has_patchinfo = @project.patchinfos.exists?
     @comments = @project.comments
     @comment = Comment.new
-
-    if User.session && params[:notification_id]
-      @current_notification = Notification.find(params[:notification_id])
-      authorize @current_notification, :update?, policy_class: NotificationPolicy
-    end
+    @current_notification = handle_notification
 
     respond_to do |format|
       format.html
@@ -473,5 +469,15 @@ class Webui::ProjectController < Webui::WebuiController
     @project = Project.get_by_name(params['project'])
   rescue Project::UnknownObjectError
     @project = nil
+  end
+
+  def handle_notification
+    return unless User.session && params[:notification_id]
+
+    current_notification = Notification.find(params[:notification_id])
+
+    return unless NotificationPolicy.new(User.session, current_notification).update?
+
+    current_notification
   end
 end

--- a/src/api/app/controllers/webui/reports_controller.rb
+++ b/src/api/app/controllers/webui/reports_controller.rb
@@ -8,7 +8,7 @@ class Webui::ReportsController < Webui::WebuiController
   def show
     authorize @report
 
-    handle_notification
+    @current_notification = handle_notification
   end
 
   def create
@@ -49,7 +49,10 @@ class Webui::ReportsController < Webui::WebuiController
   def handle_notification
     return unless User.session && params[:notification_id]
 
-    @current_notification = Notification.find(params[:notification_id])
-    authorize @current_notification, :update?, policy_class: NotificationPolicy
+    current_notification = Notification.find(params[:notification_id])
+
+    return unless NotificationPolicy.new(User.session, current_notification).update?
+
+    current_notification
   end
 end

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -50,7 +50,7 @@ class Webui::RequestController < Webui::WebuiController
       @comments = @bs_request.comments
       @comment = Comment.new
 
-      handle_notification
+      @current_notification = handle_notification
 
       @actions = @bs_request.webui_actions(filelimit: @diff_limit, tarlimit: @diff_limit, diff_to_superseded: @diff_to_superseded, diffs: false)
       @action = @actions.first
@@ -508,8 +508,11 @@ class Webui::RequestController < Webui::WebuiController
   def handle_notification
     return unless User.session && params[:notification_id]
 
-    @current_notification = Notification.find(params[:notification_id])
-    authorize @current_notification, :update?, policy_class: NotificationPolicy
+    current_notification = Notification.find(params[:notification_id])
+
+    return unless NotificationPolicy.new(User.session, current_notification).update?
+
+    current_notification
   end
 
   def prepare_request_data
@@ -544,7 +547,7 @@ class Webui::RequestController < Webui::WebuiController
     # Handling build results
     @staging_project = @bs_request.staging_project.name unless @bs_request.staging_project_id.nil?
 
-    handle_notification
+    @current_notification = handle_notification
   end
 
   def set_influxdb_data_request_actions

--- a/src/api/app/controllers/webui/users_controller.rb
+++ b/src/api/app/controllers/webui/users_controller.rb
@@ -32,7 +32,7 @@ class Webui::UsersController < Webui::WebuiController
     @activities_per_year = UserYearlyContribution.new(@displayed_user, @first_day).call
     @date = params[:date]
     @activities_per_day = UserDailyContribution.new(@displayed_user, @date).call
-    handle_notification
+    @current_notification = handle_notification
   end
 
   def new
@@ -204,8 +204,11 @@ class Webui::UsersController < Webui::WebuiController
   def handle_notification
     return unless User.session && params[:notification_id]
 
-    @current_notification = Notification.find(params[:notification_id])
-    authorize @current_notification, :update?, policy_class: NotificationPolicy
+    current_notification = Notification.find(params[:notification_id])
+
+    return unless NotificationPolicy.new(User.session, current_notification).update?
+
+    current_notification
   end
 
   def paged_comments


### PR DESCRIPTION
There is no need to block users from viewing content when
someone is sharing a link from his notifications with the
`notification_id` attached as a query param. The `notification_id`
query param is used to render the notification toolbar for an
authorized users. If someone without authorization is using the
same link, we should simply not render the toolbar, but still show
the content.