### PR TITLE
Drop `find_for` BsRequest scope

### DIFF
--- a/src/api/app/controllers/request_controller.rb
+++ b/src/api/app/controllers/request_controller.rb
@@ -36,7 +36,7 @@ class RequestController < ApplicationController
     params[:review_states] = params[:reviewstates].split(',') if params[:reviewstates]
     params[:ids] = params[:ids].split(',').map(&:to_i) if params[:ids]
 
-    rel = BsRequest.find_for(params)
+    rel = BsRequest::FindFor::Query.new(params).all
     rel = BsRequest.where(id: rel.select(:id)).preload([{ bs_request_actions: :bs_request_action_accept_info, reviews: { history_elements: :user } }])
     rel = rel.limit(params[:limit].to_i) if params[:limit].to_i.positive?
     rel = rel.offset(params[:offset].to_i) if params[:offset].to_i.positive?

--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -455,10 +455,10 @@ class Webui::ProjectController < Webui::WebuiController
     @is_incident_project = @project.is_maintenance_incident?
     return unless @is_incident_project
 
-    @open_release_requests = BsRequest.find_for(project: @project.name,
-                                                states: %w[new review],
-                                                types: ['maintenance_release'],
-                                                roles: ['source']).pluck(:number)
+    @open_release_requests = BsRequest::FindFor::Query.new(project: @project.name,
+                                                           states: %w[new review],
+                                                           types: ['maintenance_release'],
+                                                           roles: ['source']).all.pluck(:number) # rubocop:disable Rails/RedundantActiveRecordAllMethod
   end
 
   def valid_target_name?(name)

--- a/src/api/app/models/bs_request/data_table/find_for_package_query.rb
+++ b/src/api/app/models/bs_request/data_table/find_for_package_query.rb
@@ -27,15 +27,11 @@ class BsRequest
       private
 
       def request_query
-        BsRequest.find_for(
-          @params.merge(project: @project.name, package: @package.name)
-        )
+        BsRequest::FindFor::Query.new(@params.merge(project: @project.name, package: @package.name)).all
       end
 
       def request_query_without_search
-        BsRequest.find_for(
-          @params.except(:search).merge(project: @project.name, package: @package.name)
-        )
+        BsRequest::FindFor::Query.new(@params.except(:search).merge(project: @project.name, package: @package.name)).all
       end
     end
   end

--- a/src/api/app/models/bs_request/data_table/find_for_project_query.rb
+++ b/src/api/app/models/bs_request/data_table/find_for_project_query.rb
@@ -26,15 +26,11 @@ class BsRequest
       private
 
       def request_query
-        BsRequest.find_for(
-          @params.merge(project: @project.name)
-        )
+        BsRequest::FindFor::Query.new(@params.merge(project: @project.name)).all
       end
 
       def request_query_without_search
-        BsRequest.find_for(
-          @params.except(:search).merge(project: @project.name)
-        )
+        BsRequest::FindFor::Query.new(@params.except(:search).merge(project: @project.name)).all
       end
     end
   end

--- a/src/api/app/models/group.rb
+++ b/src/api/app/models/group.rb
@@ -161,21 +161,21 @@ class Group < ApplicationRecord
   end
 
   def involved_reviews(search = nil)
-    BsRequest.find_for(
+    BsRequest::FindFor::Query.new(
       group: title,
       roles: [:reviewer],
       review_states: [:new],
       states: [:review],
       search: search
-    )
+    ).all
   end
 
   def incoming_requests(search = nil)
-    BsRequest.find_for(group: title, states: [:new], roles: [:maintainer], search: search)
+    BsRequest::FindFor::Query.new(group: title, states: [:new], roles: [:maintainer], search: search).all
   end
 
   def requests(search = nil)
-    BsRequest.find_for(group: title, search: search)
+    BsRequest::FindFor::Query.new(group: title, search: search).all
   end
 
   def all_requests_count


### PR DESCRIPTION
This is the first step of a series of refactorings where queries to BsRequest will be improved and more fine grained.