### PR TITLE
Remove unused cache key section

### DIFF
--- a/src/api/app/helpers/webui/user_helper.rb
+++ b/src/api/app/helpers/webui/user_helper.rb
@@ -50,7 +50,7 @@ module Webui::UserHelper
     user = User.find_by_login(user) unless user.is_a?(User)
     return '' unless user
 
-    Rails.cache.fetch([user, 'realname_and_icon', opts, ::Configuration.first]) do
+    Rails.cache.fetch([user, 'realname_and_icon', opts]) do
       printed_name = if opts[:short]
                        user.login
                      else


### PR DESCRIPTION
When `::Configuration.first` is used, it results adding this string to the cache key: `/configurations/1`

Removing this part of the cache key prevents from doing a query to return something which doesn't change after an update of the configuration singleton record.

## Before

Logs after browsing http://localhost:3000/users :

```
  User Load (0.5ms)  SELECT `users`.`id`, `users`.`login`, `users`.`email`, `users`.`state`, `users`.`realname`, `users`.`owner_id`, `users`.`updated_at`, `users`.`ignore_auth_services` FROM `users` WHERE `users`.`login` != '_nobody_' ORDER BY users.login ASC LIMIT 50 OFFSET 0
  ↳ app/datatables/user_configuration_datatable.rb:22:in `map'
  CACHE Configuration Load (0.1ms)  SELECT `configurations`.* FROM `configurations` ORDER BY `configurations`.`id` ASC LIMIT 1
  ↳ app/helpers/webui/user_helper.rb:53:in `user_with_realname_and_icon'

# Multiple ocurrences of these CACHE lines...

  CACHE Configuration Load (0.0ms)  SELECT `configurations`.* FROM `configurations` ORDER BY `configurations`.`id` ASC LIMIT 1
  ↳ app/helpers/webui/user_helper.rb:53:in `user_with_realname_and_icon'
Completed 200 OK in 65ms (Views: 47.5ms | ActiveRecord: 3.3ms | Allocations: 23686)
```

## After

Logs after browsing http://localhost:3000/users :

```
  User Load (0.4ms)  SELECT `users`.`id`, `users`.`login`, `users`.`email`, `users`.`state`, `users`.`realname`, `users`.`owner_id`, `users`.`updated_at`, `users`.`ignore_auth_services` FROM `users` WHERE `users`.`login` != '_nobody_' ORDER BY users.login ASC LIMIT 50 OFFSET 0
  ↳ app/datatables/user_configuration_datatable.rb:22:in `map'
Completed 200 OK in 44ms (Views: 30.7ms | ActiveRecord: 2.4ms | Allocations: 17780)
```

## For reviewers

To take a look at what cache keys are used by memcached, add the `-vv` to the line of the `memcached` command in your `docker-compose.yml` file before starting up your development environment.

### Before the changes

```
<30    0x00 0x00 0x00 0x00
<30 GET users/1/realname_and_icon/no_icon=false/short=true/configurations/1
>30 Writing an error: Not found
>30 Writing bin response:
>30    0x00 0x00 0x00 0x00
```

### After the changes

```
<30    0x00 0x00 0x00 0x00
<30 GET users/1/realname_and_icon/no_icon=false/short=true
>30 Writing an error: Not found
>30 Writing bin response:
>30    0x00 0x00 0x00 0x00
```