### PR TITLE
Remove watched_projects table

### DIFF
--- a/src/api/.rubocop.yml
+++ b/src/api/.rubocop.yml
@@ -279,6 +279,7 @@ Rails:
 
 Rails/CreateTableWithTimestamps:
   Exclude:
+    - 'db/migrate/20171030143054_create_kiwi_preference_types.rb'
     - 'db/migrate/20240513154336_remove_watched_projects.rb'
 
 # Actually is not possible to enable this cop because we have several overwritten methods.

--- a/src/api/.rubocop.yml
+++ b/src/api/.rubocop.yml
@@ -277,6 +277,10 @@ Metrics/BlockLength:
 Rails:
   Enabled: true
 
+Rails/CreateTableWithTimestamps:
+  Exclude:
+    - 'db/migrate/20240513154336_remove_watched_projects.rb'
+
 # Actually is not possible to enable this cop because we have several overwritten methods.
 Rails/DynamicFindBy:
   Enabled: false

--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -812,13 +812,6 @@ Rails/ApplicationMailer:
     - 'app/mailers/admin_mailer.rb'
     - 'app/mailers/event_mailer.rb'
 
-# Offense count: 1
-# Configuration parameters: Include.
-# Include: db/**/*.rb
-Rails/CreateTableWithTimestamps:
-  Exclude:
-    - 'db/migrate/20171030143054_create_kiwi_preference_types.rb'
-
 # Offense count: 70
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: EnforcedStyle.

--- a/src/api/db/migrate/20240513154336_remove_watched_projects.rb
+++ b/src/api/db/migrate/20240513154336_remove_watched_projects.rb
@@ -1,0 +1,21 @@
+class RemoveWatchedProjects < ActiveRecord::Migration[7.0]
+  def up
+    remove_foreign_key 'watched_projects', 'users', name: 'watched_projects_ibfk_1'
+
+    drop_table 'watched_projects', id: :integer, charset: 'utf8mb4', collation: 'utf8mb4_unicode_ci', options: 'ENGINE=InnoDB ROW_FORMAT=DYNAMIC', force: :cascade do |t|
+      t.integer 'user_id', default: 0, null: false
+      t.integer 'project_id', null: false
+      t.index ['user_id'], name: 'watched_projects_users_fk_1'
+    end
+  end
+
+  def down
+    create_table 'watched_projects', id: :integer, charset: 'utf8mb4', collation: 'utf8mb4_unicode_ci', options: 'ENGINE=InnoDB ROW_FORMAT=DYNAMIC', force: :cascade do |t|
+      t.integer 'user_id', default: 0, null: false
+      t.integer 'project_id', null: false
+      t.index ['user_id'], name: 'watched_projects_users_fk_1'
+    end
+
+    add_foreign_key 'watched_projects', 'users', name: 'watched_projects_ibfk_1'
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_04_25_122946) do
+ActiveRecord::Schema[7.0].define(version: 2024_05_13_154336) do
   create_table "active_storage_attachments", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -1199,12 +1199,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_25_122946) do
     t.index ["watchable_type", "watchable_id"], name: "index_watched_items_on_watchable"
   end
 
-  create_table "watched_projects", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
-    t.integer "user_id", default: 0, null: false
-    t.integer "project_id", null: false
-    t.index ["user_id"], name: "watched_projects_users_fk_1"
-  end
-
   create_table "workflow_artifacts_per_steps", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "workflow_run_id", null: false
     t.string "step"
@@ -1353,5 +1347,4 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_25_122946) do
   add_foreign_key "status_checks", "status_reports", column: "status_reports_id"
   add_foreign_key "tokens", "packages", name: "tokens_ibfk_2"
   add_foreign_key "tokens", "users", column: "executor_id", name: "tokens_ibfk_1"
-  add_foreign_key "watched_projects", "users", name: "watched_projects_ibfk_1"
 end


### PR DESCRIPTION
Since a while, we are using watched_items table to store the Watchlist. It is safe to remove the watched_projects table already.