### PR TITLE
Introduce cache for singleton record of Configuration

### DIFF
--- a/src/api/app/controllers/configurations_controller.rb
+++ b/src/api/app/controllers/configurations_controller.rb
@@ -13,7 +13,7 @@ class ConfigurationsController < ApplicationController
   # GET /configuration.xml
   # GET /configuration.json
   def show
-    @configuration = ::Configuration.first
+    @configuration = ::Configuration.fetch
 
     respond_to do |format|
       format.xml  { render xml: @configuration.render_xml }
@@ -24,7 +24,7 @@ class ConfigurationsController < ApplicationController
   # PUT /configuration
   # PUT /configuration.xml
   def update
-    @configuration = ::Configuration.first
+    @configuration = ::Configuration.fetch
 
     xml = Xmlhash.parse(request.raw_post) || {}
     attribs = {}

--- a/src/api/app/controllers/public_controller.rb
+++ b/src/api/app/controllers/public_controller.rb
@@ -28,7 +28,7 @@ class PublicController < ApplicationController
   # GET /public/configuration.xml
   # GET /public/configuration.json
   def configuration_show
-    @configuration = ::Configuration.first
+    @configuration = ::Configuration.fetch
 
     respond_to do |format|
       format.xml  { render xml: @configuration.render_xml }

--- a/src/api/app/controllers/webui/code_of_conduct_controller.rb
+++ b/src/api/app/controllers/webui/code_of_conduct_controller.rb
@@ -1,6 +1,6 @@
 class Webui::CodeOfConductController < Webui::WebuiController
   def index
-    @code_of_conduct = ::Configuration.first.code_of_conduct
+    @code_of_conduct = ::Configuration.code_of_conduct
 
     raise ActiveRecord::RecordNotFound, 'Not Found' if @code_of_conduct.blank?
   end

--- a/src/api/app/controllers/webui/feeds_controller.rb
+++ b/src/api/app/controllers/webui/feeds_controller.rb
@@ -26,7 +26,7 @@ class Webui::FeedsController < Webui::WebuiController
   def notifications
     @user = User.find_by!(rss_secret: params[:secret])
     @host = ::Configuration.obs_url
-    @configuration = ::Configuration.first
+    @configuration = ::Configuration.fetch
     @notifications = @user.combined_rss_feed_items
   end
 

--- a/src/api/app/controllers/webui/webui_controller.rb
+++ b/src/api/app/controllers/webui/webui_controller.rb
@@ -160,7 +160,7 @@ class Webui::WebuiController < ActionController::Base
   end
 
   def require_configuration
-    @configuration = ::Configuration.first
+    @configuration = ::Configuration.fetch
   end
 
   # Before filter to check if current user is administrator

--- a/src/api/app/mailers/admin_mailer.rb
+++ b/src/api/app/mailers/admin_mailer.rb
@@ -5,7 +5,7 @@ class AdminMailer < ActionMailer::Base
     @host = ::Configuration.obs_url
     return unless @host
 
-    @configuration = ::Configuration.first
+    @configuration = ::Configuration.fetch
 
     headers['Precedence'] = 'bulk'
     headers['X-Mailer'] = 'OBS Administrator Notification'

--- a/src/api/app/mailers/event_mailer.rb
+++ b/src/api/app/mailers/event_mailer.rb
@@ -24,7 +24,7 @@ class EventMailer < ActionMailer::Base
   private
 
   def set_configuration
-    @configuration = ::Configuration.first
+    @configuration = ::Configuration.fetch
 
     # FIXME: This if for the view. Use action_mailer.default_url_options instead
     # https://guides.rubyonrails.org/action_mailer_basics.html#generating-urls-in-action-mailer-views

--- a/src/api/app/models/configuration.rb
+++ b/src/api/app/models/configuration.rb
@@ -27,7 +27,9 @@ class Configuration < ApplicationRecord
     # Simple singleton implementation: Try to respond with the
     # the data from the first instance
     def method_missing(method_name, ...)
-      if Configuration.new.methods.include?(method_name)
+      if Configuration.column_names.include?(method_name.to_s)
+        fetch.send(method_name, ...)
+      elsif Configuration.new.methods.include?(method_name)
         first.send(method_name, ...)
       else
         super

--- a/src/api/app/models/configuration.rb
+++ b/src/api/app/models/configuration.rb
@@ -11,6 +11,12 @@ class Configuration < ApplicationRecord
   validates :description, :code_of_conduct, length: { maximum: 65_535 }
 
   class << self
+    def fetch
+      Rails.cache.fetch(first.cache_key_with_version) do
+        first
+      end
+    end
+
     def map_value(key, value)
       # make them boolean
       return value.in?([:on, ':on', 'on', 'true', true]) if key.in?(::Configuration::ON_OFF_OPTIONS)

--- a/src/api/app/models/project/remote_url.rb
+++ b/src/api/app/models/project/remote_url.rb
@@ -4,9 +4,9 @@ class Project::RemoteURL
   def self.load(remote_project, path)
     uri = URI.parse(remote_project.remoteurl + path)
     # prefer environment variables if set
-    ENV['http_proxy'] = Configuration.first.http_proxy if ENV['http_proxy'].blank?
-    ENV['https_proxy'] = Configuration.first.http_proxy if ENV['https_proxy'].blank?
-    ENV['no_proxy'] = Configuration.first.no_proxy if ENV['no_proxy'].blank?
+    ENV['http_proxy'] = Configuration.http_proxy if ENV['http_proxy'].blank?
+    ENV['https_proxy'] = Configuration.http_proxy if ENV['https_proxy'].blank?
+    ENV['no_proxy'] = Configuration.no_proxy if ENV['no_proxy'].blank?
     begin
       uri.open.read
     rescue OpenURI::HTTPError, SocketError, Errno::EINTR, Errno::EPIPE, Net::HTTPBadResponse, IOError, Errno::ENETUNREACH,

--- a/src/api/app/policies/webui/user_policy.rb
+++ b/src/api/app/policies/webui/user_policy.rb
@@ -12,7 +12,7 @@ class Webui::UserPolicy < ApplicationPolicy
   end
 
   def update?
-    configuration = ::Configuration.first
+    configuration = ::Configuration.fetch
 
     return false unless configuration.accounts_editable?(record)
     return true if user.is_admin? || user == record

--- a/src/api/spec/factories/users.rb
+++ b/src/api/spec/factories/users.rb
@@ -28,8 +28,11 @@ FactoryBot.define do
         # rubocop:disable Rails/SkipsModelValidations
         # Avoid triggering the callbacks to propagate the change to the backend
         Configuration.update_column(:allow_user_to_create_home_project, false)
+        # But call touch to force a cache update
+        Configuration.touch
         user.save!
         Configuration.update_column(:allow_user_to_create_home_project, true)
+        Configuration.touch
         # rubocop:enable Rails/SkipsModelValidations
       end
     end

--- a/src/api/spec/models/user_spec.rb
+++ b/src/api/spec/models/user_spec.rb
@@ -153,6 +153,10 @@ RSpec.describe User do
   end
 
   describe "methods used in the User's dashboard" do
+    before do
+      unfreeze_time
+    end
+
     let(:project) { create(:project, name: 'project_a') }
 
     it 'has involved packages' do

--- a/src/api/spec/policies/webui/user_policy_spec.rb
+++ b/src/api/spec/policies/webui/user_policy_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Webui::UserPolicy do
 
     before do
       allow(configuration).to receive(:accounts_editable?).and_return(true)
-      allow(Configuration).to receive(:first).and_return(configuration)
+      allow(Configuration).to receive(:fetch).and_return(configuration)
     end
 
     context 'for a user with moderator role' do
@@ -65,7 +65,7 @@ RSpec.describe Webui::UserPolicy do
 
     before do
       allow(configuration).to receive(:accounts_editable?).and_return(false)
-      allow(Configuration).to receive(:first).and_return(configuration)
+      allow(Configuration).to receive(:fetch).and_return(configuration)
     end
 
     context 'for a user with moderator role' do


### PR DESCRIPTION
Instead of querying the database every time a configuration parameter is read, we make all methods of the Configuration class to pass internally through a new `fetch` method which retrieves the Configuration singleton record from the cache.

Follow up to #16123.