### PR TITLE
 Extend types used to filter notifications with the API

### DIFF
--- a/src/api/app/controllers/person/notifications_controller.rb
+++ b/src/api/app/controllers/person/notifications_controller.rb
@@ -3,7 +3,8 @@ module Person
     include Person::Errors
 
     MAX_PER_PAGE = 300
-    ALLOWED_FILTERS = %w[requests unread incoming_requests outgoing_requests read].freeze
+    ALLOWED_FILTERS = %w[read comments requests unread incoming_requests outgoing_requests relationships_created relationships_deleted
+                         build_failures reports workflow_runs appealed_decisions].freeze
 
     before_action :check_filter_type, except: [:update]
 

--- a/src/api/public/apidocs/paths/my_notifications.yaml
+++ b/src/api/public/apidocs/paths/my_notifications.yaml
@@ -24,7 +24,7 @@ get:
       name: notifications_type
       schema:
         type: string
-        enum: ['requests', 'unread', 'incoming_requests', 'outgoing_requests', 'read']
+        enum: ['read', 'comments', 'requests', 'unread', 'incoming_requests', 'outgoing_requests', 'relationships_created', 'relationships_deleted', 'build_failures', 'reports', 'workflow_runs', 'appealed_decisions']
   responses:
     '200':
       description: OK. The request has succeeded.


### PR DESCRIPTION
Make it possible to use the same filter values defined in the Web-UI for the API.

Related to #16135.

## Before

http://localhost:3000/my/notifications?notifications_type=relationships_created

```
<status code="bad_request">
  <summary>Filter not supported</summary>
</status>
```

## After

```
<notifications count="1">
  <total_pages>1</total_pages>
  <current_page>1</current_page>
  <notification id="18">
    <title>Build Service Notification</title>
    <event_type>relationship_create</event_type>
    <comment/>
    <description/>
    <state/>
    <when/>
    <who>Iggy</who>
    <request_number/>
  </notification>
</notifications>
```
