### PR TITLE
Improve rendering of notifications API

### DIFF
--- a/src/api/app/views/person/notifications/_notification.xml.builder
+++ b/src/api/app/views/person/notifications/_notification.xml.builder
@@ -1,10 +1,10 @@
 builder.notification(id: notification.id) do
   builder.title notification.title
   builder.event_type notification.event_type.split('::').last.underscore
-  builder.comment_ notification.event_payload['comment']
-  builder.description notification.event_payload['description']
-  builder.state notification.event_payload['state']
-  builder.when notification.event_payload['when']
-  builder.who notification.event_payload['who']
-  builder.request_number notification.event_payload['number']
+  builder.comment_ notification.event_payload['comment'] if notification.event_payload['comment']
+  builder.description notification.event_payload['description'] if notification.event_payload['description']
+  builder.state notification.event_payload['state'] if notification.event_payload['state']
+  builder.when notification.event_payload['when'] if notification.event_payload['when']
+  builder.who notification.event_payload['who'] if notification.event_payload['who']
+  builder.request_number notification.event_payload['number'] if notification.event_payload['number']
 end


### PR DESCRIPTION
We still have to decide a format of a notification rendered by the API, in XML. But still this change prevents from showing empty XML elements.

Related to #16135.

## Before

http://localhost:3000/my/notifications

```
[...]
  <notification id="18">
    <title>Build Service Notification</title>
    <event_type>relationship_create</event_type>
    <comment/>
    <description/>
    <state/>
    <when/>
    <who>Iggy</who>
    <request_number/>
  </notification>
  <notification id="14">
    <title>Build Service Notification</title>
    <event_type>report_for_comment</event_type>
    <comment/>
    <description/>
    <state/>
    <when/>
    <who/>
    <request_number/>
  </notification>
  <notification id="15">
    <title>Workflow run failed on Pull request</title>
    <event_type>workflow_run_fail</event_type>
    <comment/>
    <description/>
    <state/>
    <when/>
    <who/>
    <request_number/>
  </notification>
[...]
```

## After

```
[...]
  <notification id="18">
    <title>Build Service Notification</title>
    <event_type>relationship_create</event_type>
    <who>Iggy</who>
  </notification>
  <notification id="14">
    <title>Build Service Notification</title>
    <event_type>report_for_comment</event_type>
  </notification>
  <notification id="15">
    <title>Workflow run failed on Pull request</title>
    <event_type>workflow_run_fail</event_type>
  </notification>
[...]
```