### PR TITLE
Get rid of unnecessary remove_foreign_key

### DIFF
--- a/src/api/db/migrate/20240513154336_remove_watched_projects.rb
+++ b/src/api/db/migrate/20240513154336_remove_watched_projects.rb
@@ -1,7 +1,5 @@
 class RemoveWatchedProjects < ActiveRecord::Migration[7.0]
   def up
-    remove_foreign_key 'watched_projects', 'users', name: 'watched_projects_ibfk_1'
-
     drop_table 'watched_projects', id: :integer, charset: 'utf8mb4', collation: 'utf8mb4_unicode_ci', options: 'ENGINE=InnoDB ROW_FORMAT=DYNAMIC', force: :cascade do |t|
       t.integer 'user_id', default: 0, null: false
       t.integer 'project_id', null: false


### PR DESCRIPTION
Removing the table implies removing the foreign key as well. There is no need to do it explicitly.

We had issues in deployment as the foreign key wasn't in the database for some reason.