### PR TITLE
Missing event subject

### DIFF
--- a/src/api/app/models/event/build.rb
+++ b/src/api/app/models/event/build.rb
@@ -5,6 +5,10 @@ module Event
     payload_keys :project, :package, :sender, :repository, :arch, :release, :readytime, :srcmd5,
                  :rev, :reason, :bcnt, :verifymd5, :hostarch, :starttime, :endtime, :workerid, :versrel, :previouslyfailed, :successive_failcount, :buildtype
 
+    def subject
+      raise AbstractMethodCalled
+    end
+
     def custom_headers
       mid = my_message_id
       h = super

--- a/src/api/app/models/event/comment_event.rb
+++ b/src/api/app/models/event/comment_event.rb
@@ -8,6 +8,10 @@ module Event
       end
     end
 
+    def subject
+      raise AbstractMethodCalled
+    end
+
     def expanded_payload
       p = payload.dup
       p['commenter'] = User.find_by(login: p['commenter']) || User.find(p['commenter'])

--- a/src/api/app/models/event/relationship.rb
+++ b/src/api/app/models/event/relationship.rb
@@ -4,6 +4,10 @@ module Event
     payload_keys :description, :who, :user, :group, :project, :package, :role, :notifiable_id
     shortenable_key :description
 
+    def subject
+      raise AbstractMethodCalled
+    end
+
     def parameters_for_notification
       super.merge({ notifiable_type: notifiable_type, notifiable_id: notifiable_id })
     end

--- a/src/api/app/models/event/relationship_create.rb
+++ b/src/api/app/models/event/relationship_create.rb
@@ -4,6 +4,12 @@ module Event
     self.description = 'Relationship created'
 
     receiver_roles :any_role
+
+    def subject
+      object = payload[:project]
+      object += "/#{payload[:package]}" if payload[:package]
+      "#{payload[:who]} added you as #{payload[:role]} on #{object}"
+    end
   end
 end
 

--- a/src/api/app/models/event/relationship_delete.rb
+++ b/src/api/app/models/event/relationship_delete.rb
@@ -4,6 +4,12 @@ module Event
     self.description = 'Relationship deleted'
 
     receiver_roles :any_role
+
+    def subject
+      object = payload[:project]
+      object += "/#{payload[:package]}" if payload[:package]
+      "#{payload[:who]} added you as #{payload[:role]} on #{object}"
+    end
   end
 end
 

--- a/src/api/app/models/event/report.rb
+++ b/src/api/app/models/event/report.rb
@@ -5,6 +5,10 @@ module Event
 
     payload_keys :id, :user_id, :reportable_id, :reportable_type, :reason, :category
 
+    def subject
+      raise AbstractMethodCalled
+    end
+
     def parameters_for_notification
       super.merge(notifiable_type: 'Report')
     end

--- a/src/api/app/models/event/report_for_comment.rb
+++ b/src/api/app/models/event/report_for_comment.rb
@@ -3,6 +3,10 @@ module Event
     self.description = 'Report for a comment created'
     payload_keys :commentable_type, :bs_request_number, :bs_request_action_id,
                  :project_name, :package_name, :commenter
+
+    def subject
+      "Comment by #{payload[:commenter]} reported"
+    end
   end
 end
 

--- a/src/api/app/models/event/report_for_package.rb
+++ b/src/api/app/models/event/report_for_package.rb
@@ -3,6 +3,10 @@ module Event
     self.description = 'Report for a package created'
     payload_keys :package_name, :project_name
 
+    def subject
+      "Package #{payload[:project_name]}/#{payload[:package_name]} reported"
+    end
+
     def self.notification_link_path(notification)
       return unless Package.exists_by_project_and_name(notification.event_payload['project_name'], notification.event_payload['package_name'])
 

--- a/src/api/app/models/event/report_for_project.rb
+++ b/src/api/app/models/event/report_for_project.rb
@@ -3,6 +3,10 @@ module Event
     self.description = 'Report for a project created'
     payload_keys :project_name
 
+    def subject
+      "Project #{payload[:project_name]} reported"
+    end
+
     def self.notification_link_path(notification)
       Rails.application.routes.url_helpers.project_show_path(notification.event_payload['project_name'], notification_id: notification.id) if Project.exists_by_name(notification.event_payload['project_name'])
     end

--- a/src/api/app/models/event/report_for_request.rb
+++ b/src/api/app/models/event/report_for_request.rb
@@ -2,6 +2,10 @@ module Event
   class ReportForRequest < Report
     self.description = 'Report for a request created'
     payload_keys :bs_request_number
+
+    def subject
+      "Request #{payload[:bs_request_number]} reported"
+    end
   end
 end
 

--- a/src/api/app/models/event/report_for_user.rb
+++ b/src/api/app/models/event/report_for_user.rb
@@ -2,6 +2,10 @@ module Event
   class ReportForUser < Report
     self.description = 'Report for a user created'
     payload_keys :user_login
+
+    def subject
+      "User #{payload[:user_login]} reported"
+    end
   end
 end
 

--- a/src/api/app/models/event/request.rb
+++ b/src/api/app/models/event/request.rb
@@ -7,6 +7,10 @@ module Event
 
     DIFF_LIMIT = 120
 
+    def subject
+      raise AbstractMethodCalled
+    end
+
     def self.message_number(number)
       "<obs-request-#{number}@#{URI.parse(Configuration.obs_url).host.downcase}>"
     end


### PR DESCRIPTION
Every subscribable `Event` has its own `subject` (for RSS and Email) implementation.