### PR TITLE
Refactor Notification scopes

### DIFF
--- a/src/api/app/components/notification_action_bar_component.rb
+++ b/src/api/app/components/notification_action_bar_component.rb
@@ -1,18 +1,18 @@
 # frozen_string_literal: true
 
 class NotificationActionBarComponent < ApplicationComponent
-  attr_accessor :type, :update_path, :show_read_all_button
+  attr_accessor :state, :update_path, :show_read_all_button
 
-  def initialize(type:, update_path:, show_read_all_button: false)
+  def initialize(state:, update_path:, show_read_all_button: false)
     super
 
-    @type = type
+    @state = state
     @update_path = add_params(update_path)
     @show_read_all_button = show_read_all_button
   end
 
   def button_text(all: false)
-    text = type == 'read' ? 'Unread' : 'Read'
+    text = state == 'read' ? 'Unread' : 'Read'
     if all
       "Mark all as '#{text}'"
     else

--- a/src/api/app/components/notification_filter_component.html.haml
+++ b/src/api/app/components/notification_filter_component.html.haml
@@ -1,33 +1,33 @@
 .list-group.list-group-flush.my-2
   = render NotificationFilterLinkComponent.new(text: 'Unread', amount: @count['unread'],
-                                               filter_item: { type: 'unread' }, selected_filter: @selected_filter)
-  = render NotificationFilterLinkComponent.new(text: 'Read', filter_item: { type: 'read' },
+                                               filter_item: { state: 'unread' }, selected_filter: @selected_filter)
+  = render NotificationFilterLinkComponent.new(text: 'Read', filter_item: { state: 'read' },
                                                selected_filter: @selected_filter)
 .list-group.list-group-flush.mt-5.mb-2
   %h5.ms-3 Filter
   = render NotificationFilterLinkComponent.new(text: 'Comments', amount: @count['Comment'], icon: 'fas fa-comments',
-                                               filter_item: { type: 'comments' }, selected_filter: @selected_filter)
+                                               filter_item: { kind: 'comments' }, selected_filter: @selected_filter)
   = render NotificationFilterLinkComponent.new(text: 'Requests', amount: @count['BsRequest'], icon: 'fas fa-code-pull-request',
-                                               filter_item: { type: 'requests' }, selected_filter: @selected_filter)
+                                               filter_item: { kind: 'requests' }, selected_filter: @selected_filter)
   = render NotificationFilterLinkComponent.new(text: 'Incoming Requests', amount: @count['incoming_requests'], icon: 'fas fa-code-pull-request',
-                                               filter_item: { type: 'incoming_requests' }, selected_filter: @selected_filter)
+                                               filter_item: { kind: 'incoming_requests' }, selected_filter: @selected_filter)
   = render NotificationFilterLinkComponent.new(text: 'Outgoing Requests', amount: @count['outgoing_requests'], icon: 'fas fa-code-pull-request',
-                                               filter_item: { type: 'outgoing_requests' }, selected_filter: @selected_filter)
+                                               filter_item: { kind: 'outgoing_requests' }, selected_filter: @selected_filter)
   = render NotificationFilterLinkComponent.new(text: 'Roles Granted', amount: @count['relationships_created'], icon: 'fas fa-user-tag',
-                                               filter_item: { type: 'relationships_created' }, selected_filter: @selected_filter)
+                                               filter_item: { kind: 'relationships_created' }, selected_filter: @selected_filter)
   = render NotificationFilterLinkComponent.new(text: 'Roles Revoked', amount: @count['relationships_deleted'], icon: 'fas fa-user-tag',
-                                               filter_item: { type: 'relationships_deleted' }, selected_filter: @selected_filter)
+                                               filter_item: { kind: 'relationships_deleted' }, selected_filter: @selected_filter)
   = render NotificationFilterLinkComponent.new(text: 'Build Failures', amount: @count['build_failures'], icon: "fas fa-xmark text-danger",
-                                               filter_item: { type: 'build_failures' }, selected_filter: @selected_filter)
+                                               filter_item: { kind: 'build_failures' }, selected_filter: @selected_filter)
   - if ReportPolicy.new(@user, Report).notify?
     = render NotificationFilterLinkComponent.new(text: 'Reports', amount: @count['reports'], icon: 'fas fa-flag',
-                                                filter_item: { type: 'reports' }, selected_filter: @selected_filter,
+                                                filter_item: { kind: 'reports' }, selected_filter: @selected_filter,
                                                 )
   = render NotificationFilterLinkComponent.new(text: 'Workflow Runs', amount: @count['workflow_runs'], icon: 'fas fa-book-open',
-                                               filter_item: { type: 'workflow_runs' }, selected_filter: @selected_filter)
+                                               filter_item: { kind: 'workflow_runs' }, selected_filter: @selected_filter)
   - if Flipper.enabled?(:content_moderation, @user)
     = render NotificationFilterLinkComponent.new(text: 'Appealed Decisions', amount: @count['appealed_decisions'], icon: 'fas fa-hand',
-                                                 filter_item: { type: 'appealed_decisions' }, selected_filter: @selected_filter)
+                                                 filter_item: { kind: 'appealed_decisions' }, selected_filter: @selected_filter)
 
 - unless @projects_for_filter.empty?
   .list-group.list-group-flush.mt-5.mb-2

--- a/src/api/app/components/notification_filter_component.rb
+++ b/src/api/app/components/notification_filter_component.rb
@@ -14,8 +14,8 @@ class NotificationFilterComponent < ApplicationComponent
   def notifications_count
     notifications = User.session.notifications.for_web
     counted_notifications = notifications.unread.group(:notifiable_type).count
-    counted_notifications['incoming_requests'] = notifications.unread.for_incoming_requests.count
-    counted_notifications['outgoing_requests'] = notifications.unread.for_outgoing_requests.count
+    counted_notifications['incoming_requests'] = notifications.unread.for_incoming_requests(User.session!).count
+    counted_notifications['outgoing_requests'] = notifications.unread.for_outgoing_requests(User.session!).count
     counted_notifications['relationships_created'] = notifications.unread.for_relationships_created.count
     counted_notifications['relationships_deleted'] = notifications.unread.for_relationships_deleted.count
     counted_notifications['build_failures'] = notifications.unread.for_failed_builds.count

--- a/src/api/app/components/notification_filter_link_component.rb
+++ b/src/api/app/components/notification_filter_link_component.rb
@@ -24,10 +24,10 @@ class NotificationFilterLinkComponent < ApplicationComponent
       @filter_item[:project] == @selected_filter[:project]
     elsif @selected_filter[:group].present?
       @filter_item[:group] == @selected_filter[:group]
-    elsif @selected_filter[:type].present?
-      @filter_item[:type] == @selected_filter[:type]
+    elsif @selected_filter[:kind].present?
+      @filter_item[:kind] == @selected_filter[:kind]
     else
-      @filter_item[:type] == 'unread'
+      @filter_item[:state] == 'unread'
     end
   end
 

--- a/src/api/app/components/notification_mark_button_component.rb
+++ b/src/api/app/components/notification_mark_button_component.rb
@@ -19,7 +19,8 @@ class NotificationMarkButtonComponent < ApplicationComponent
   end
 
   def update_path
-    my_notifications_path(notification_ids: [@notification.id], type: @selected_filter[:type],
+    my_notifications_path(notification_ids: [@notification.id], kind: @selected_filter[:kind],
+                          state: @selected_filter[:state],
                           project: @selected_filter[:project], group: @selected_filter[:group],
                           page: @page, show_more: @show_more)
   end

--- a/src/api/app/controllers/concerns/webui/notifications_filter.rb
+++ b/src/api/app/controllers/concerns/webui/notifications_filter.rb
@@ -1,0 +1,33 @@
+module Webui::NotificationsFilter
+  extend ActiveSupport::Concern
+
+  # It's just a case...
+  # rubocop:disable Metrics/CyclomaticComplexity
+  def filter_notifications_by_type(notifications, filter_type)
+    case filter_type
+    when 'comments'
+      notifications.for_comments
+    when 'requests'
+      notifications.for_requests
+    when 'incoming_requests'
+      notifications.for_incoming_requests(User.session!)
+    when 'outgoing_requests'
+      notifications.for_outgoing_requests(User.session!)
+    when 'relationships_created'
+      notifications.for_relationships_created
+    when 'relationships_deleted'
+      notifications.for_relationships_deleted
+    when 'build_failures'
+      notifications.for_failed_builds
+    when 'reports'
+      notifications.for_reports
+    when 'workflow_runs'
+      notifications.for_workflow_runs
+    when 'appealed_decisions'
+      notifications.for_appealed_decisions
+    else # all
+      notifications
+    end
+  end
+  # rubocop:enable Metrics/CyclomaticComplexity
+end

--- a/src/api/app/controllers/webui/users/notifications_controller.rb
+++ b/src/api/app/controllers/webui/users/notifications_controller.rb
@@ -1,66 +1,76 @@
 class Webui::Users::NotificationsController < Webui::WebuiController
-  VALID_NOTIFICATION_TYPES = %w[read reviews comments requests unread incoming_requests outgoing_requests relationships_created relationships_deleted
-                                build_failures reports workflow_runs appealed_decisions].freeze
+  include Webui::NotificationsFilter
+
+  ALLOWED_FILTERS = %w[all comments requests incoming_requests outgoing_requests relationships_created relationships_deleted build_failures
+                       reports reviews workflow_runs appealed_decisions].freeze
+  ALLOWED_STATES = %w[unread read].freeze
 
   before_action :require_login
-  before_action :check_param_type, :check_param_project, only: :index
+  before_action :set_filter_type, :set_filter_state
+  before_action :set_notifications
+  before_action :set_notifications_to_be_updated, only: [:update]
+  before_action :set_show_read_all_button
+  before_action :set_selected_filter
+  before_action :paginate_notifications
 
   def index
-    @notifications = paginated_notifications
-    @show_read_all_button = show_read_all_button?
     @filtered_project = Project.find_by(name: params[:project])
-    @selected_filter = selected_filter
     @current_user = User.session
   end
 
   def update
-    notifications = if params[:update_all]
-                      fetch_notifications
-                    else
-                      fetch_notifications.where(id: params[:notification_ids])
-                    end
     # rubocop:disable Rails/SkipsModelValidations
-    read_count = notifications.where(delivered: false).update_all('delivered = !delivered')
-    unread_count = notifications.where(delivered: true).update_all('delivered = !delivered')
+    @read_count = Notification.where(id: @undelivered_notification_ids).update_all('delivered = !delivered')
+    @unread_count = Notification.where(id: @delivered_notification_ids).update_all('delivered = !delivered')
     # rubocop:enable Rails/SkipsModelValidations
-
-    if read_count.zero? && unread_count.zero?
-      flash.now[:error] = "Couldn't update the notifications"
-    else
-      send_notifications_information_rabbitmq(read_count, unread_count)
-    end
 
     respond_to do |format|
       format.html { redirect_to my_notifications_path }
       format.js do
         render partial: 'update', locals: {
-          notifications: paginated_notifications,
-          selected_filter: selected_filter,
-          show_read_all_button: show_read_all_button?,
+          notifications: @notifications,
+          selected_filter: @selected_filter,
+          show_read_all_button: @show_read_all_button,
           user: User.session
         }
       end
+      send_notifications_information_rabbitmq(@read_count, @unread_count)
     end
   end
 
   private
 
-  def selected_filter
-    { type: params[:type], project: params[:project], group: params[:group] }
+  def set_filter_type
+    @filter_type = params[:kind] || 'all'
+    raise FilterNotSupportedError if @filter_type.present? && ALLOWED_FILTERS.exclude?(@filter_type)
   end
 
-  def check_param_type
-    return if params[:type].nil? || VALID_NOTIFICATION_TYPES.include?(params[:type])
-
-    flash[:error] = 'Filter not valid.'
-    redirect_to my_notifications_path
+  def set_filter_state
+    @filter_state = params[:state] || 'unread'
+    raise FilterNotSupportedError if @filter_state.present? && ALLOWED_STATES.exclude?(@filter_state)
   end
 
-  def check_param_project
-    return unless params[:project] == ''
+  def set_notifications
+    @notifications = User.session!.notifications.for_web.includes(notifiable: [{ commentable: [{ comments: :user }, :project, :bs_request_actions] }, :bs_request_actions, :reviews])
+    @notifications = @notifications.for_project_name(params[:project]) if params[:project].present?
+    @notifications = @notifications.for_group_title(params[:group]) if params[:group].present?
+    @notifications = filter_notifications_by_type(@notifications, @filter_type)
+    @notifications = filter_notifications_by_state(@notifications, @filter_state)
+  end
 
-    flash[:error] = 'Filter not valid.'
-    redirect_to my_notifications_path
+  def set_notifications_to_be_updated
+    return unless params[:notification_ids]
+
+    @undelivered_notification_ids = @notifications.where(id: params[:notification_ids]).where(delivered: false).map(&:id)
+    @delivered_notification_ids = @notifications.where(id: params[:notification_ids]).where(delivered: true).map(&:id)
+  end
+
+  def set_show_read_all_button
+    @show_read_all_button = @notifications.count > Notification::MAX_PER_PAGE
+  end
+
+  def set_selected_filter
+    @selected_filter = { kind: @filter_type, state: @filter_state, project: params[:project], group: params[:group] }
   end
 
   def show_more(notifications)
@@ -69,30 +79,23 @@ class Webui::Users::NotificationsController < Webui::WebuiController
     notifications.page(params[:page]).per([total, Notification::MAX_PER_PAGE].min)
   end
 
-  def fetch_notifications
-    notifications = User.session!.notifications.for_web.includes(notifiable: [{ commentable: [{ comments: :user }, :project, :bs_request_actions] }, :bs_request_actions, :reviews])
-
-    if params[:project]
-      notifications.unread.for_project_name(params[:project])
-    elsif params[:group]
-      notifications.unread.for_group_title(params[:group])
+  def filter_notifications_by_state(notifications, filter_state)
+    case filter_state
+    when 'read'
+      notifications.read
     else
-      notifications.for_notifiable_type(params[:type])
+      notifications.unread
     end
-  end
-
-  def paginated_notifications
-    notifications = fetch_notifications
-    params[:page] = notifications.page(params[:page]).total_pages if notifications.page(params[:page]).out_of_range?
-    params[:show_more] ? show_more(notifications) : notifications.page(params[:page])
-  end
-
-  def show_read_all_button?
-    fetch_notifications.count > Notification::MAX_PER_PAGE
   end
 
   def send_notifications_information_rabbitmq(read_count, unread_count)
     RabbitmqBus.send_to_bus('metrics', "notification,action=read value=#{read_count}") if read_count.positive?
     RabbitmqBus.send_to_bus('metrics', "notification,action=unread value=#{unread_count}") if unread_count.positive?
+  end
+
+  def paginate_notifications
+    @notifications = @notifications.page(params[:page])
+    params[:page] = @notifications.total_pages if @notifications.out_of_range?
+    params[:show_more] ? show_more(@notifications) : @notifications
   end
 end

--- a/src/api/app/controllers/webui/users/notifications_controller.rb
+++ b/src/api/app/controllers/webui/users/notifications_controller.rb
@@ -94,8 +94,7 @@ class Webui::Users::NotificationsController < Webui::WebuiController
   end
 
   def paginate_notifications
-    @notifications = @notifications.page(params[:page])
+    @notifications = params[:show_more] ? show_more(@notifications) : @notifications.page(params[:page])
     params[:page] = @notifications.total_pages if @notifications.out_of_range?
-    params[:show_more] ? show_more(@notifications) : @notifications
   end
 end

--- a/src/api/app/helpers/webui/notification_helper.rb
+++ b/src/api/app/helpers/webui/notification_helper.rb
@@ -1,6 +1,6 @@
 module Webui::NotificationHelper
   def link_to_show_less_or_more
-    parameters = params.slice(:show_more, :type, :project).permit!
+    parameters = params.slice(:show_more, :state, :project).permit!
     less_or_more = parameters[:show_more] ? 'less' : 'more'
     parameters[:show_more] = parameters[:show_more] ? nil : '1'
     link_to("Show #{less_or_more}", my_notifications_path(parameters))
@@ -9,8 +9,8 @@ module Webui::NotificationHelper
   private
 
   def mark_as_read_or_unread_button(notification)
-    type = notification.unread? ? 'unread' : 'read'
-    update_path = my_notifications_path(notification_ids: [notification.id], type: type)
+    state = notification.unread? ? 'unread' : 'read'
+    update_path = my_notifications_path(notification_ids: [notification.id], state: state)
     title, icon = notification.unread? ? ['Mark as read', 'fa-check'] : ['Mark as unread', 'fa-undo']
     link_to(update_path, id: dom_id(notification, :update), method: :put,
                          class: 'btn btn-sm btn-outline-success', title: title) do

--- a/src/api/app/views/person/notifications/index.xml.builder
+++ b/src/api/app/views/person/notifications/index.xml.builder
@@ -1,7 +1,7 @@
 xml.notifications(count: @notifications_count) do
   if @notifications_count.positive?
-    xml.total_pages @notifications.total_pages
-    xml.current_page @notifications.current_page
+    xml.total_pages @paged_notifications.total_pages
+    xml.current_page @paged_notifications.current_page
   end
-  render partial: 'person/notifications/notification', collection: @notifications, locals: { builder: xml }
+  render partial: 'person/notifications/notification', collection: @paged_notifications, locals: { builder: xml }
 end

--- a/src/api/app/views/webui/users/notifications/_notifications_list.html.haml
+++ b/src/api/app/views/webui/users/notifications/_notifications_list.html.haml
@@ -2,7 +2,7 @@
   .card
     .card-body
       %p
-        - case selected_filter[:type]
+        - case selected_filter[:kind]
         - when 'reviews', 'comments', 'requests'
           There are no notifications for this filter
         - when 'read'
@@ -11,10 +11,11 @@
           There are no notifications, but there's a world of opportunities!
 - else
   :ruby
-    update_path = my_notifications_path(type: selected_filter[:type], project: selected_filter[:project], group: selected_filter[:group],
+    update_path = my_notifications_path(kind: selected_filter[:kind], state: selected_filter[:state],
+                                        project: selected_filter[:project], group: selected_filter[:group],
                                         page: params[:page], show_more: params[:show_more])
   = form_tag(update_path, method: :put, remote: true) do
-    = render(NotificationActionBarComponent.new(type: selected_filter[:type], update_path: update_path, show_read_all_button: show_read_all_button))
+    = render(NotificationActionBarComponent.new(type: selected_filter[:kind], update_path: update_path, show_read_all_button: show_read_all_button))
     .card
       .card-body
         .text-center

--- a/src/api/app/views/webui/users/notifications/_notifications_list.html.haml
+++ b/src/api/app/views/webui/users/notifications/_notifications_list.html.haml
@@ -15,7 +15,7 @@
                                         project: selected_filter[:project], group: selected_filter[:group],
                                         page: params[:page], show_more: params[:show_more])
   = form_tag(update_path, method: :put, remote: true) do
-    = render(NotificationActionBarComponent.new(type: selected_filter[:kind], update_path: update_path, show_read_all_button: show_read_all_button))
+    = render(NotificationActionBarComponent.new(state: selected_filter[:state], update_path: update_path, show_read_all_button: show_read_all_button))
     .card
       .card-body
         .text-center

--- a/src/api/app/views/webui/users/notifications/index.html.haml
+++ b/src/api/app/views/webui/users/notifications/index.html.haml
@@ -7,7 +7,7 @@
     .card.mb-3
       %strong.d-block.d-md-none.p-3{ data: { 'bs-toggle': 'collapse', 'bs-target': '#filters' },
                                   aria: { expanded: true, controls: 'filters' } }
-        Filtered by: #{params[:type]&.humanize || @filtered_project || 'Unread'}
+        Filtered by: #{params[:kind]&.humanize || @filtered_project || 'Unread'}
         %i.float-end.mt-1.fa.fa-chevron-down#notifications-dropdown-trigger
       .collapse#filters
         = render NotificationFilterComponent.new(selected_filter: @selected_filter,

--- a/src/api/spec/components/notification_action_bar_component_spec.rb
+++ b/src/api/spec/components/notification_action_bar_component_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe NotificationActionBarComponent, type: :component do
   context 'for unread notifications' do
     before do
       User.session = create(:user)
-      render_inline(described_class.new(type: 'unread', update_path: 'my/notifications', show_read_all_button: true))
+      render_inline(described_class.new(state: 'unread', update_path: 'my/notifications', show_read_all_button: true))
     end
 
     it do
@@ -25,7 +25,7 @@ RSpec.describe NotificationActionBarComponent, type: :component do
   context 'for read notifications' do
     before do
       User.session = create(:user)
-      render_inline(described_class.new(type: 'read', update_path: 'my/notifications?type=read', show_read_all_button: true))
+      render_inline(described_class.new(state: 'read', update_path: 'my/notifications?state=read', show_read_all_button: true))
     end
 
     it do
@@ -33,7 +33,7 @@ RSpec.describe NotificationActionBarComponent, type: :component do
     end
 
     it do
-      expect(rendered_content).to have_link(href: 'my/notifications?type=read&update_all=true')
+      expect(rendered_content).to have_link(href: 'my/notifications?state=read&update_all=true')
     end
 
     it do

--- a/src/api/spec/components/notification_filter_link_component_spec.rb
+++ b/src/api/spec/components/notification_filter_link_component_spec.rb
@@ -1,13 +1,14 @@
 RSpec.describe NotificationFilterLinkComponent, type: :component do
   context 'the filter item matches the selected filter and the amount is greater than 0' do
-    let(:link_selector) { 'a.active[href="/my/notifications?type=comments"]' }
+    let(:link_selector) { 'a.active[href="/my/notifications?kind=comments"]' }
 
     before do
-      render_inline(described_class.new(text: 'Comments', filter_item: { type: 'comments' },
-                                        selected_filter: { type: 'comments' }, amount: 20))
+      render_inline(described_class.new(text: 'Comments', filter_item: { kind: 'comments' },
+                                        selected_filter: { kind: 'comments', status: 'read' },
+                                        amount: 20))
     end
 
-    it 'displays a link with the active class and containing the amount of the type' do
+    it 'displays a link with the active class and containing the amount of the kind' do
       expect(rendered_content).to have_css(link_selector, text: 'Comments')
 
       expect(rendered_content).to have_css("#{link_selector} span", text: 20)
@@ -22,7 +23,7 @@ RSpec.describe NotificationFilterLinkComponent, type: :component do
                                         selected_filter: { project: 'home:Admin' }, amount: 0))
     end
 
-    it 'displays a link with the active class, but without the amount of the type' do
+    it 'displays a link with the active class, but without the amount of the kind' do
       expect(rendered_content).to have_css(link_selector, text: 'home:Admin')
 
       expect(rendered_content).to have_no_css("#{link_selector} span", text: 0)
@@ -34,10 +35,10 @@ RSpec.describe NotificationFilterLinkComponent, type: :component do
 
     before do
       render_inline(described_class.new(text: 'iron_maiden', filter_item: { group: 'iron_maiden' },
-                                        selected_filter: { type: 'requests' }, amount: 10))
+                                        selected_filter: { kind: 'requests' }, amount: 10))
     end
 
-    it 'displays a link without the active class, but containing the amount of the type' do
+    it 'displays a link without the active class, but containing the amount of the kind' do
       expect(rendered_content).to have_css(link_selector, text: 'iron_maiden')
 
       expect(rendered_content).to have_css("#{link_selector} span", text: 10)
@@ -49,7 +50,7 @@ RSpec.describe NotificationFilterLinkComponent, type: :component do
 
     before do
       render_inline(described_class.new(text: 'iron_maiden', filter_item: { group: 'iron_maiden' },
-                                        selected_filter: { type: 'requests' }, amount: 0))
+                                        selected_filter: { kind: 'requests' }, amount: 0))
     end
 
     it 'displays a link without the active class and the amount counter' do

--- a/src/api/spec/components/notification_mark_button_component_spec.rb
+++ b/src/api/spec/components/notification_mark_button_component_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe NotificationMarkButtonComponent, type: :component do
   context 'when the notification is read' do
     let(:notification) { create(:notification, delivered: true) }
-    let(:selected_filter) { {} }
+    let(:selected_filter) { { state: 'read' } }
 
     before do
       render_inline(described_class.new(notification, selected_filter))
@@ -10,11 +10,15 @@ RSpec.describe NotificationMarkButtonComponent, type: :component do
     it 'renders the link with an undo icon' do
       expect(rendered_content).to have_css("a#update_notification_#{notification.id}[title='Mark as \"Unread\"'] > i.fa-undo")
     end
+
+    it 'sets the update path with the right params' do
+      expect(rendered_content).to have_css("a#update_notification_#{notification.id}[href='/my/notifications?notification_ids%5B%5D=#{notification.id}&state=read']")
+    end
   end
 
   context 'when the notification is unread' do
     let(:notification) { create(:notification, delivered: false) }
-    let(:selected_filter) { {} }
+    let(:selected_filter) { { state: 'unread' } }
 
     before do
       render_inline(described_class.new(notification, selected_filter))
@@ -22,6 +26,10 @@ RSpec.describe NotificationMarkButtonComponent, type: :component do
 
     it 'renders the link with a check mark icon' do
       expect(rendered_content).to have_css("a#update_notification_#{notification.id}[title='Mark as \"Read\"'] > i.fa-check")
+    end
+
+    it 'sets the update path with the right params' do
+      expect(rendered_content).to have_css("a#update_notification_#{notification.id}[href='/my/notifications?notification_ids%5B%5D=#{notification.id}&state=unread']")
     end
   end
 end

--- a/src/api/spec/components/previews/notification_action_bar_component_preview.rb
+++ b/src/api/spec/components/previews/notification_action_bar_component_preview.rb
@@ -1,11 +1,11 @@
 class NotificationActionBarComponentPreview < ViewComponent::Preview
-  # Preview at http://HOST:PORT/rails/view_components/notification_action_bar_component/type_read
-  def type_read
-    render(NotificationActionBarComponent.new(type: 'read', update_path: 'my/notifications?type=read&update_all=true', show_read_all_button: true))
+  # Preview at http://HOST:PORT/rails/view_components/notification_action_bar_component/state_read
+  def state_read
+    render(NotificationActionBarComponent.new(state: 'read', update_path: 'my/notifications?state=read&update_all=true', show_read_all_button: true))
   end
 
-  # Preview at http://HOST:PORT/rails/view_components/notification_action_bar_component/type_unread
-  def type_unread
-    render(NotificationActionBarComponent.new(type: 'unread', update_path: 'my/notifications?type=unread&update_all=true', show_read_all_button: true))
+  # Preview at http://HOST:PORT/rails/view_components/notification_action_bar_component/state_unread
+  def state_unread
+    render(NotificationActionBarComponent.new(state: 'unread', update_path: 'my/notifications?state=unread&update_all=true', show_read_all_button: true))
   end
 end

--- a/src/api/spec/controllers/person/notifications_controller_spec.rb
+++ b/src/api/spec/controllers/person/notifications_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Person::NotificationsController do
     end
 
     context 'bad filter' do
-      let(:params) { { format: :xml, notifications_type: 'foobar' } }
+      let(:params) { { format: :xml, kind: 'foobar' } }
 
       it { expect(response).to have_http_status(:bad_request) }
     end
@@ -39,12 +39,12 @@ RSpec.describe Person::NotificationsController do
       it { expect(response).to have_http_status(:success) }
       it { expect(response.body).to include('<notifications count="2">') }
 
-      context 'filter by notifications_type' do
+      context 'filter by kind' do
         let!(:notifications) { create_list(:web_notification, 2, :request_state_change, subscriber: user, delivered: true) }
 
         before do
           login user
-          get :index, params: { format: :xml, notifications_type: 'read' }
+          get :index, params: { format: :xml, state: 'read' }
         end
 
         it { expect(response).to have_http_status(:success) }
@@ -92,7 +92,7 @@ RSpec.describe Person::NotificationsController do
         put :update, params: { format: :xml, id: notification.id }
       end
 
-      it { expect(response).to have_http_status(:forbidden) }
+      it { expect(response).to have_http_status(:not_found) }
     end
 
     context 'called by an authorized user' do

--- a/src/api/spec/controllers/webui/users/notifications_controller_spec.rb
+++ b/src/api/spec/controllers/webui/users/notifications_controller_spec.rb
@@ -51,21 +51,39 @@ RSpec.describe Webui::Users::NotificationsController do
     end
 
     context "when param type is 'read'" do
-      let(:params) { default_params.merge(type: 'read') }
+      let(:params) { default_params.merge(state: 'read') }
 
       before do
+        state_change_notification
+        read_notification
         subject
       end
 
       it_behaves_like 'returning success'
 
       it 'sets @notifications to all delivered notifications regardless of type' do
-        expect(assigns[:notifications]).to include(read_notification)
+        expect(assigns[:notifications]).to contain_exactly(read_notification)
+      end
+    end
+
+    context "when param type is 'unread'" do
+      let(:params) { default_params.merge(state: 'unread') }
+      let(:unread_notification) { create(:web_notification, :request_state_change, subscriber: user, delivered: false) }
+
+      before do
+        unread_notification
+        subject
+      end
+
+      it_behaves_like 'returning success'
+
+      it 'sets @notifications to all delivered notifications regardless of type' do
+        expect(assigns[:notifications]).to contain_exactly(unread_notification)
       end
     end
 
     context "when param type is 'build_failures'" do
-      let(:params) { default_params.merge(type: 'build_failures') }
+      let(:params) { default_params.merge(kind: 'build_failures') }
 
       before do
         subject
@@ -79,7 +97,7 @@ RSpec.describe Webui::Users::NotificationsController do
     end
 
     context "when param type is 'comments'" do
-      let(:params) { default_params.merge(type: 'comments') }
+      let(:params) { default_params.merge(kind: 'comments') }
 
       before do
         subject
@@ -95,7 +113,7 @@ RSpec.describe Webui::Users::NotificationsController do
     end
 
     context "when param type is 'requests'" do
-      let(:params) { default_params.merge(type: 'requests') }
+      let(:params) { default_params.merge(kind: 'requests') }
 
       before do
         subject
@@ -125,7 +143,7 @@ RSpec.describe Webui::Users::NotificationsController do
       let!(:request_created_notification) { create(:web_notification, :request_created, notifiable: maintained_request, subscriber: user) }
       let!(:review_wanted_notification) { review_notification }
 
-      let(:params) { default_params.merge(type: 'incoming_requests') }
+      let(:params) { default_params.merge(kind: 'incoming_requests') }
 
       before do
         subject
@@ -163,7 +181,7 @@ RSpec.describe Webui::Users::NotificationsController do
       let!(:state_change_to_declined_notification) { create(:web_notification, :request_state_change, notifiable: declined_bs_request, subscriber: user) }
       let(:request_created_notification) { create(:web_notification, :request_created, notifiable: maintained_request, subscriber: user) }
 
-      let(:params) { default_params.merge(type: 'outgoing_requests') }
+      let(:params) { default_params.merge(kind: 'outgoing_requests') }
 
       before do
         subject
@@ -183,19 +201,37 @@ RSpec.describe Webui::Users::NotificationsController do
 
   describe 'PUT #update' do
     context 'when a user marks one of their unread notifications as read' do
-      subject! do
+      subject do
         login user_to_log_in
         put :update, params: { notification_ids: [state_change_notification.id], user_login: user_to_log_in.login }, xhr: true
       end
 
+      let!(:another_unread_notification) { create(:web_notification, :request_state_change, subscriber: user_to_log_in, title: 'Another read notification') }
       let(:user_to_log_in) { user }
 
       it 'succeeds' do
+        subject
         expect(response).to have_http_status(:ok)
       end
 
       it 'sets the notification as delivered' do
+        subject
         expect(state_change_notification.reload.delivered).to be true
+      end
+
+      it {
+        subject
+        expect(assigns[:read_count]).to be 1
+      }
+
+      it {
+        subject
+        expect(assigns[:unread_count]).to be 0
+      }
+
+      it 'returns the updated list of read notifications' do
+        subject
+        expect(assigns[:notifications]).to contain_exactly(another_unread_notification)
       end
     end
 
@@ -210,16 +246,20 @@ RSpec.describe Webui::Users::NotificationsController do
       it "doesn't set the notification as read" do
         expect(state_change_notification.reload.delivered).to be false
       end
+
+      it { expect(assigns[:read_count]).to be 0 }
+      it { expect(assigns[:unread_count]).to be 0 }
     end
 
     context 'when a user marks one of their read notifications as unread' do
       subject! do
         login user_to_log_in
-        put :update, params: { notification_ids: [read_notification.id], type: 'read', user_login: user_to_log_in.login }, xhr: true
+        put :update, params: { notification_ids: [read_notification.id], state: 'read', user_login: user_to_log_in.login }, xhr: true
       end
 
       let(:user_to_log_in) { user }
-      let(:read_notification) { create(:web_notification, :request_state_change, subscriber: user_to_log_in, delivered: true) }
+      let(:read_notification) { create(:web_notification, :request_state_change, subscriber: user_to_log_in, delivered: true, title: 'Read notifications') }
+      let!(:another_read_notification) { create(:web_notification, :request_state_change, subscriber: user_to_log_in, delivered: true, title: 'Another read notification') }
 
       it 'succeeds' do
         expect(response).to have_http_status(:ok)
@@ -227,6 +267,13 @@ RSpec.describe Webui::Users::NotificationsController do
 
       it 'sets the notification as not delivered' do
         expect(read_notification.reload.delivered).to be false
+      end
+
+      it { expect(assigns[:read_count]).to be 0 }
+      it { expect(assigns[:unread_count]).to be 1 }
+
+      it 'returns the updated list of read notifications' do
+        expect(assigns[:notifications]).to contain_exactly(another_read_notification)
       end
     end
   end

--- a/src/api/spec/features/webui/users/notifications_spec.rb
+++ b/src/api/spec/features/webui/users/notifications_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe 'User notifications', :js do
     let(:another_notifiable) { another_notification_for_projects_comment.notifiable }
     let(:project) { notifiable.commentable.project }
 
-    shared_examples 'keeps the Comments filter' do
-      it 'keeps the filter' do
+    shared_examples 'keeping the Comments filter selected' do
+      it do
         wait_for_ajax
 
         find_by_id('notifications-dropdown-trigger').click if mobile?
@@ -52,7 +52,7 @@ RSpec.describe 'User notifications', :js do
           click_link("update_notification_#{notification_for_projects_comment.id}")
         end
 
-        it_behaves_like 'keeps the Comments filter'
+        it_behaves_like 'keeping the Comments filter selected'
       end
     end
 
@@ -71,7 +71,7 @@ RSpec.describe 'User notifications', :js do
         expect(page).to have_text('There are no notifications for this filter')
       end
 
-      it_behaves_like 'keeps the Comments filter'
+      it_behaves_like 'keeping the Comments filter selected'
     end
 
     context 'when clicking on the project filter' do

--- a/src/api/spec/helpers/webui/notification_helper_spec.rb
+++ b/src/api/spec/helpers/webui/notification_helper_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Webui::NotificationHelper do
       let(:notification) { create(:web_notification, delivered: false) }
 
       it { expect(link).to include(my_notifications_path(notification_ids: [notification.id])) }
-      it { expect(link).to include('type=unread') }
+      it { expect(link).to include('state=unread') }
       it { expect(link).to include('Mark as read') }
       it { expect(link).to include('fa-check fas') }
     end
@@ -15,7 +15,7 @@ RSpec.describe Webui::NotificationHelper do
       let(:notification) { create(:web_notification, delivered: true) }
 
       it { expect(link).to include(my_notifications_path(notification_ids: [notification.id])) }
-      it { expect(link).to include('type=read') }
+      it { expect(link).to include('state=read') }
       it { expect(link).to include('Mark as unread') }
       it { expect(link).to include('fa-undo fas') }
     end


### PR DESCRIPTION
This will be the foundation where we'll build a better https://github.com/openSUSE/open-build-service/pull/16101.

We decouple the read/unread status of a notification from it's
type (which notifiable it associated to).