### PR TITLE
Add missing indexes in table notifications

### DIFF
--- a/src/api/db/migrate/20240516133632_add_missing_indexes_to_notifications.rb
+++ b/src/api/db/migrate/20240516133632_add_missing_indexes_to_notifications.rb
@@ -1,0 +1,9 @@
+class AddMissingIndexesToNotifications < ActiveRecord::Migration[7.0]
+  def change
+    add_index(:notifications, :created_at)
+    add_index(:notifications, :delivered)
+    add_index(:notifications, :event_type)
+    add_index(:notifications, :rss)
+    add_index(:notifications, :web)
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_05_13_154336) do
+ActiveRecord::Schema[7.0].define(version: 2024_05_16_133632) do
   create_table "active_storage_attachments", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -779,8 +779,13 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_13_154336) do
     t.boolean "rss", default: false
     t.boolean "web", default: false
     t.datetime "last_seen_at", precision: nil
+    t.index ["created_at"], name: "index_notifications_on_created_at"
+    t.index ["delivered"], name: "index_notifications_on_delivered"
+    t.index ["event_type"], name: "index_notifications_on_event_type"
     t.index ["notifiable_type", "notifiable_id"], name: "index_notifications_on_notifiable_type_and_notifiable_id"
+    t.index ["rss"], name: "index_notifications_on_rss"
     t.index ["subscriber_type", "subscriber_id"], name: "index_notifications_on_subscriber_type_and_subscriber_id"
+    t.index ["web"], name: "index_notifications_on_web"
   end
 
   create_table "notified_projects", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|


### PR DESCRIPTION
They will improve the several queries performed when browsing the notifications page.

I realized these indexes were missing after reviewing #16143.