### PR TITLE
[backend] allow to specify an embargo in _patchinfo

### DIFF
--- a/docs/api/api/patchinfo.rng
+++ b/docs/api/api/patchinfo.rng
@@ -90,6 +90,11 @@
           </element>
         </optional>
         <optional>
+          <element name="embargo_date">
+            <text/>
+          </element>
+        </optional>
+        <optional>
           <element name="reboot_needed"> 
             <empty/>
           </element>

--- a/src/backend/BSSched/BuildJob/Patchinfo.pm
+++ b/src/backend/BSSched/BuildJob/Patchinfo.pm
@@ -622,6 +622,7 @@ sub build {
         'filename' => $bin,
         'src' => "$d->{'arch'}/$bin",   # as hopefully written by the publisher
       };
+      $upd->{'embargo_date'} = $patchinfo->{'embargo_date'} if exists $patchinfo->{'embargo_date'};
       $upd->{'reboot_suggested'} = 'True' if exists $patchinfo->{'reboot_needed'};
       $upd->{'relogin_suggested'} = 'True' if exists $patchinfo->{'relogin_needed'};
       $upd->{'restart_suggested'} = 'True' if exists $patchinfo->{'zypp_restart_needed'};

--- a/src/backend/BSXML.pm
+++ b/src/backend/BSXML.pm
@@ -269,6 +269,7 @@ our $patchinfo = [
             'retracted',
             'stopped',
             'seperate_build_arch', # for builds on each scheduler arch
+	    'embargo_date',
             'zypp_restart_needed',
             'reboot_needed',
             'relogin_needed',
@@ -1643,6 +1644,7 @@ our $updateinfoitem = [
 		    'src',
 		    'supportstatus',	# extension
 		    'superseded_by',    # extension
+		    'embargo_date',     # extension
 		    [],
 		    'filename',
 		  [ 'sum' =>	# obsolete?

--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -684,8 +684,9 @@ sub createrepo_rpmmd {
       delete $up->{'patchinforef'};
       for my $cl (@{($up->{'pkglist'} || {})->{'collection'} || []}) {
 	for my $pkg (@{$cl->{'package'} || []}) {
-  	  delete $pkg->{'supportstatus'};
-  	  delete $pkg->{'superseded_by'};
+          delete $pkg->{'embargo_date'};
+          delete $pkg->{'supportstatus'};
+          delete $pkg->{'superseded_by'};
         }
       }
     }


### PR DESCRIPTION
We allow to specify an embargo date in a _patchinfo. This gets also tansfered to internal updateinfo.xml files, but gets stripped at publish time.

It is up to tooling like product-composer to deal with the data.