### PR TITLE
[backend] bs_regpush: rename --old-list-output option and add --listf…

### DIFF
--- a/src/backend/BSPublisher/Container.pm
+++ b/src/backend/BSPublisher/Container.pm
@@ -410,7 +410,7 @@ sub query_repostate {
   push @opts, '--cosign' if $tags;
   push @opts, '--no-cosign-info' if $registry->{'cosign_nocheck'};
   push @opts, '-F', $tagsfile if $tagsfile;
-  push @opts, '--old-listfile', "$registrystate/$repository:oldlist" if $registrystate && -s "$registrystate/$repository/:oldlist";
+  push @opts, '--old-listfile', "$registrystate/$repository/:oldlist" if $registrystate && -s "$registrystate/$repository/:oldlist";
   my @cmd = ("$INC[0]/bs_regpush", '--dest-creds', '-', @opts, $registryserver, $repository);
   my $now = time();
   my $result = BSPublisher::Util::qsystem('echo', "$registry->{user}:$registry->{password}\n", 'stdout', $tempfile, @cmd);
@@ -428,7 +428,7 @@ sub query_repostate {
       }
     }
     close($fd);
-    printf "query took %d seconds, found %d tags\n", time() - $now, scalar(keys %$repostate);
+    printf "query of %s took %d seconds, found %d tags\n", $repository, time() - $now, scalar(keys %$repostate);
     if ($registrystate) {
       mkdir_p("$registrystate/$repository");
       rename($tempfile, "$registrystate/$repository/:oldlist")
@@ -468,10 +468,12 @@ sub create_manifestinfo {
 }
 
 sub compare_to_repostate {
-  my ($registry, $repostate, $repository, $containerinfos, $tags, $multiarch, $oci, $cosigncookie, $cosign_attestation) = @_;
+  my ($registry, $repostate, $repository, $containerinfos, $tags, $multiarch, $oci, $cosign) = @_;
   my %expected;
   my $containerdigests = '';
   my $info;
+  my $cosigncookie = ($cosign || {})->{'cookie'};
+  my $cosign_attestation = ($cosign || {})->{'attestation'};
   my $cosign_expect = $cosigncookie && !$registry->{'cosign_nocheck'} ? "cosigncookie=$cosigncookie" : '-';
   my $manifestinfodir;
   if ($registry->{'manifestinfos'} && "/$repository/" !~ /\/[\.\/]/) {
@@ -538,7 +540,7 @@ sub compare_to_repostate {
 =cut
 
 sub upload_to_registry {
-  my ($registry, $projid, $repoid, $repository, $containerinfos, $tags, $data, $repostate) = @_;
+  my ($registry, $projid, $repoid, $repository, $containerinfos, $tags, $data, $repostate, $cosign) = @_;
 
   return '' unless @{$containerinfos || []} && @{$tags || []};
   
@@ -563,23 +565,9 @@ sub upload_to_registry {
   $gun =~ s/^https?:\/\///;
   $gun .= "/$repository";
 
-  my $cosign = $registry->{'cosign'};
-  $cosign = $cosign->($repository, $projid) if $cosign && ref($cosign) eq 'CODE';
-  my $cosign_attestation = $cosign;
-  if (defined $registry->{'cosign_attestation'}) {
-    $cosign_attestation = $registry->{'cosign_attestation'};
-    $cosign_attestation = $cosign_attestation->($repository, $projid) if $cosign_attestation && ref($cosign_attestation) eq 'CODE';
-  }
-  
-  my $cosigncookie;
-  if (defined($pubkey) && $cosign) {
-    my $creator = 'OBS';
-    $cosigncookie = BSConSign::create_cosign_cookie($pubkey, $gun, $creator);
-  }
-
   # check if the registry is up-to-date
   if ($repostate) {
-    my $containerdigests = compare_to_repostate($registry, $repostate, $repository, $containerinfos, $tags, $multiarch, $oci, $cosigncookie, $cosign_attestation);
+    my $containerdigests = compare_to_repostate($registry, $repostate, $repository, $containerinfos, $tags, $multiarch, $oci, $cosign);
     return $containerdigests if defined $containerdigests;
   }
 
@@ -619,7 +607,7 @@ sub upload_to_registry {
       push @tempfiles, $tmpfile;
     }
     # copy provenance file into blobdir
-    if ($wrote_containerinfo && $cosign_attestation) {
+    if ($wrote_containerinfo && $cosign && $cosign->{'attestation'}) {
       if ($containerinfo->{'slsa_provenance'}) {
 	my $provenancefile = $wrote_containerinfo;
 	die unless $provenancefile =~ s/\.[^\.]+$/.slsa_provenance.json/;
@@ -662,7 +650,7 @@ sub upload_to_registry {
   push @opts, '-m' if $multiarch;
   push @opts, '--oci' if $oci;
   push @opts, '-B', $blobdir if $blobdir;
-  if ($cosigncookie) {
+  if ($cosign && $cosign->{'cookie'}) {
     my @signargs;
     push @signargs, '--project', $projid if $BSConfig::sign_project;
     push @signargs, @{$signargs || []};
@@ -671,7 +659,7 @@ sub upload_to_registry {
     mkdir_p($uploaddir);
     unlink($pubkeyfile);
     writestr($pubkeyfile, undef, $pubkey);
-    push @opts, '--cosign', '--cosigncookie', $cosigncookie;
+    push @opts, '--cosign', '--cosigncookie', $cosign->{'cookie'};
     push @opts, '-p', $pubkeyfile, '-G', $gun, @signargs;
     push @opts, '--rekor', $registry->{'rekorserver'} if $registry->{'rekorserver'};
     push @opts, '--slsaprovenance' if $do_slsaprovenance;
@@ -850,6 +838,7 @@ sub do_local_uploads {
 
   my %todo;
   my @tempfiles;
+  my $now = time();
   for my $tag (sort keys %{$uptags || {}}) {
     my $archs = $uptags->{$tag};
     for my $arch (sort keys %{$archs || {}}) {
@@ -882,6 +871,7 @@ sub do_local_uploads {
   };
   unlink($_) for @tempfiles;
   die($@) if $@;
+  printf "local updating of %s took %d seconds\n", $repository, time() - $now;
 }
 
 =head2 do_remote_uploads - sync containers to a repository in a remote registry
@@ -897,6 +887,7 @@ sub do_remote_uploads {
     delete_obsolete_tags_from_registry($registry, $repository, $containerdigests);
     return;
   }
+
   # find common containerinfos so that we can push multiple tags in one go
   my %todo;
   my %todo_p;
@@ -907,31 +898,48 @@ sub do_remote_uploads {
     push @{$todo{$joinp}}, $tag;
     $todo_p{$joinp} = \@p;
   }
-  my $pullserver = $registry->{server};
-  $pullserver =~ s/https?:\/\///;
-  $pullserver =~ s/\/?$/\//;
-  $pullserver = '' if $pullserver =~ /docker.io\/$/;
+
+  my $gun = $registry->{'notary_gunprefix'} || $registry->{'server'};
+  $gun =~ s/^https?:\/\///;
+  $gun .= "/$repository";
+
+  # check if we should do cosign and generate a cookie
+  my $cosign;
+  if (defined($data->{'pubkey'}) && $registry->{'cosign'} && %todo) {
+    $cosign = $registry->{'cosign'};
+    $cosign = $cosign->($repository, $projid) if $cosign && ref($cosign) eq 'CODE';
+    $cosign = $cosign ? {} : undef;
+  }
+  if ($cosign) {
+    my $creator = 'OBS';
+    $cosign->{'cookie'} = BSConSign::create_cosign_cookie($data->{'pubkey'}, $gun, $creator);
+    my $cosign_attestation = defined($registry->{'cosign_attestation'}) ? $registry->{'cosign_attestation'} : 1;
+    $cosign_attestation = $cosign_attestation->($repository, $projid) if $cosign_attestation && ref($cosign_attestation) eq 'CODE';
+    $cosign->{'attestation'} = 1 if $cosign_attestation;
+  }
+
   # query the current state
   my $repostate;
   my $querytags;
   $querytags = [ sort keys %$uptags ] if $registry->{'nodelete'};
   $repostate = eval { query_repostate($registry, $repository, $querytags) } if 1;
+
   # now do the uploads for the tag groups
+  my $now = time();
   my $containerdigests = '';
   for my $joinp (sort keys %todo) {
     my @tags = @{$todo{$joinp}};
     my @containerinfos = map {$containers->{$_}} @{$todo_p{$joinp}};
-    my $digests = upload_to_registry($registry, $projid, $repoid, $repository, \@containerinfos, \@tags, $data, $repostate);
+    my $digests = upload_to_registry($registry, $projid, $repoid, $repository, \@containerinfos, \@tags, $data, $repostate, $cosign);
     $containerdigests .= $digests;
   }
-  my $gun = $registry->{'notary_gunprefix'} || $registry->{'server'};
-  $gun =~ s/^https?:\/\///;
-  $gun = '' if $gun eq 'local:';
   if (($data->{'artifacthubdata'} || {})->{"$gun/$repository"} && !$uptags->{'artifacthub.io'}) {
     my $containerinfo = { 'type' => 'artifacthub', 'artifacthubdata' => $data->{'artifacthubdata'}->{"$gun/$repository"} };
     my $digests = upload_to_registry($registry, $projid, $repoid, $repository, [ $containerinfo ], [ 'artifacthub.io' ], $data, $repostate);
     $containerdigests .= $digests;
   }
+  printf "syncing of %s took %d seconds\n", $repository, time() - $now;
+
   # all is pushed, now clean the rest
   add_notary_upload($notary_uploads, $registry, $repository, $containerdigests);
   delete_obsolete_tags_from_registry($registry, $repository, $containerdigests, $repostate);

--- a/src/backend/BSPublisher/Container.pm
+++ b/src/backend/BSPublisher/Container.pm
@@ -410,7 +410,7 @@ sub query_repostate {
   push @opts, '--cosign' if $tags;
   push @opts, '--no-cosign-info' if $registry->{'cosign_nocheck'};
   push @opts, '-F', $tagsfile if $tagsfile;
-  push @opts, '--old-list-output', "$registrystate/$repository:oldlist" if $registrystate && -s "$registrystate/$repository/:oldlist";
+  push @opts, '--old-listfile', "$registrystate/$repository:oldlist" if $registrystate && -s "$registrystate/$repository/:oldlist";
   my @cmd = ("$INC[0]/bs_regpush", '--dest-creds', '-', @opts, $registryserver, $repository);
   my $now = time();
   my $result = BSPublisher::Util::qsystem('echo', "$registry->{user}:$registry->{password}\n", 'stdout', $tempfile, @cmd);
@@ -421,8 +421,8 @@ sub query_repostate {
     $repostate = {};
     while (<$fd>) {
       my @s = split(' ', $_);
-      if (@s == 4 && $s[0] =~ /\.(?:sig|att)$/ && $s[3] =~ /^cosigncookie=/) {
-        $repostate->{$s[0]} = $s[3];
+      if (@s >= 4 && $s[0] =~ /\.(?:sig|att)$/ && $s[-1] =~ /^cosigncookie=/) {
+        $repostate->{$s[0]} = $s[-1];
       } elsif (@s >= 2) {
         $repostate->{$s[0]} = $s[1];
       }

--- a/src/backend/BSPublisher/Container.pm
+++ b/src/backend/BSPublisher/Container.pm
@@ -710,7 +710,9 @@ sub delete_obsolete_tags_from_registry {
       push @keep, $4;
     }
     my %keep = map {$_ => 1} @keep;
-    return unless grep {!$keep{$_}} keys %$repostate;
+    my @obsoletetags = grep {!$keep{$_}} keys %$repostate;
+    return unless @obsoletetags;
+    print "obsolete tags: @obsoletetags\n";
   }
   mkdir_p($uploaddir);
   my $containerdigestfile = "$uploaddir/publisher.$$.containerdigests";

--- a/src/backend/BSPublisher/Container.pm
+++ b/src/backend/BSPublisher/Container.pm
@@ -940,11 +940,12 @@ sub do_remote_uploads {
     my $digests = upload_to_registry($registry, $projid, $repoid, $repository, [ $containerinfo ], [ 'artifacthub.io' ], $data, $repostate);
     $containerdigests .= $digests;
   }
-  printf "syncing of %s took %d seconds\n", $repository, time() - $now;
 
   # all is pushed, now clean the rest
   add_notary_upload($notary_uploads, $registry, $repository, $containerdigests);
   delete_obsolete_tags_from_registry($registry, $repository, $containerdigests, $repostate);
+
+  printf "syncing of %s took %d seconds\n", $repository, time() - $now;
 }
 
 1;

--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -2012,7 +2012,7 @@ sub linkintoblobdir {
 }
 
 sub readcontainermetafiles {
-  my ($containerinfo, $dir, $containerinfofile, $blobdirref) = @_;
+  my ($containerinfo, $dir, $containerinfofile, $blobdirref, $cache) = @_;
   return unless $containerinfo;
   my $prefix = "$dir/$containerinfofile";
   return unless $prefix =~ s/\.containerinfo$//;
@@ -2026,7 +2026,14 @@ sub readcontainermetafiles {
   if (-e "$prefix.cdx.json") {
     $containerinfo->{'cyclonedx_file'} = linkintoblobdir("$prefix.cdx.json", $blobdirref);
   }
-  my @intoto = grep {/^\Q$prefix\E\.[^\.]+\.intoto.json$/} map {"$dir/$_"} sort(ls($dir));
+  my @intoto;
+  if ($cache && $cache->{'intoto_files'}) {
+    @intoto = @{$cache->{'intoto_files'}};
+  } else {
+    @intoto = map {"$dir/$_"} grep {/\.intoto\.json$/} sort(ls($dir));
+    $cache->{'intoto_files'} = [ @intoto ] if $cache;
+  }
+  @intoto = grep {/^\Q$prefix\E\.[^\.]+\.intoto\.json$/} @intoto;
   push @{$containerinfo->{'intoto_files'}}, map {linkintoblobdir($_, $blobdirref)} @intoto;
   $prefix =~ s/\.docker$// unless -e "$prefix.packages";
   if (-e "$prefix.packages") {
@@ -2278,6 +2285,7 @@ sub publish {
       push @chksumfiles, "$r/.checksums";
     }
 
+    my $readcontainermetafiles_cache = {};
     for my $rbin (sort(ls($r))) {
       next if $rbin eq '.newchecksums' || $rbin eq '.newchecksums.new' || $rbin eq '.checksums' || $rbin eq '.checksums.new' || $rbin eq '.archsync' || $rbin eq '.archsync.new';
       my $bin = $rbin;
@@ -2418,7 +2426,7 @@ sub publish {
 	  } elsif ($bin =~ /(.*)\.containerinfo$/) {
             $kiwimedium{$p} = "$arch/$1" if -e "$r/$1.packages";
 	  }
-          readcontainermetafiles($containerinfo, $r, $bin, \$blobdir);
+          readcontainermetafiles($containerinfo, $r, $bin, \$blobdir, $readcontainermetafiles_cache);
 	  next;
 	} elsif ($bin =~ /((.*-Build\d.*?)(?:\.docker)?)\.(?:tbz|tgz|tar|tar\.gz|tar\.bz2|tar\.xz)(\.sha256(?:\.asc)?)?$/) {
           # kiwi image case
@@ -2437,7 +2445,7 @@ sub publish {
 	      $containerinfo->{'publishfile'} = "$extrep/$p";
 	      undef $containerinfo if $3;
 	    }
-            readcontainermetafiles($containerinfo, $r, "$1.containerinfo", \$blobdir) if $containerinfo;
+            readcontainermetafiles($containerinfo, $r, "$1.containerinfo", \$blobdir, $readcontainermetafiles_cache) if $containerinfo;
 	  } else {
 	    $p = mapsleimage($sleimagedata, "$reporoot/$prp/$arch/:repo", $rbin, $p) if $sleimagedata;
 	  }
@@ -2458,7 +2466,7 @@ sub publish {
 	      $containerinfo->{'publishfile'} = "$extrep/$p";
 	      undef $containerinfo if $2;
 	    }
-            readcontainermetafiles($containerinfo, $r, "$1.containerinfo", \$blobdir) if $containerinfo;
+            readcontainermetafiles($containerinfo, $r, "$1.containerinfo", \$blobdir, $readcontainermetafiles_cache) if $containerinfo;
 	  }
 	  next if $bin =~ /-(?:appstream|desktopfiles|polkitactions|mimetypes)\.tar/;
         } elsif ($bin =~ /\.(?:tgz|zip)?(?:\.sha256(?:\.asc)?)?$/) {

--- a/src/backend/bs_regpush
+++ b/src/backend/bs_regpush
@@ -48,6 +48,7 @@ my $dest_creds;
 my $use_image_tags;
 my $multiarch;
 my $digestfile;
+my $listfile;
 my $writeinfofile;
 my $delete_mode;
 my $delete_except_mode;
@@ -57,7 +58,7 @@ my $no_info;
 my @tags;
 my $blobdir;
 my $oci;
-my $old_list_output;
+my $old_listfile;
 
 my $cosign;
 my $cosigncookie;
@@ -87,6 +88,16 @@ sub send_layer {
   return $chunk;
 }
 
+sub contenttype2manitype {
+  my ($ct) = @_;
+  return 'v1image' unless $ct;
+  return 'list' if $ct eq $BSContar::mt_docker_manifestlist;
+  return 'image' if $ct eq $BSContar::mt_docker_manifest;
+  return 'ociimage' if $ct eq $BSContar::mt_oci_manifest;
+  return 'ocilist' if $ct eq $BSContar::mt_oci_index;
+  return 'unknown';
+}
+  
 sub blob_exists {
   my ($blobid, $size) = @_;
   my $replyheaders;
@@ -220,13 +231,12 @@ sub manifest_upload {
   my $maniid = BSContar::blobid($manifest);
   return $maniid if manifest_exists($manifest, $tag, $content_type);
   $content_type ||= $BSContar::mt_docker_manifest;
-  my $fat = '';
-  $fat = 'fat ' if $content_type eq $BSContar::mt_docker_manifestlist || $content_type eq $BSContar::mt_oci_index;
+  my $mtype = contenttype2manitype($content_type);
   if (!$quiet) {
     if (defined($tag)) {
-      print "uploading ${fat}manifest $maniid for tag '$tag'... ";
+      print "uploading $mtype manifest $maniid for tag '$tag'... ";
     } else {
-      print "uploading ${fat}manifest $maniid... ";
+      print "uploading $mtype manifest $maniid... ";
     }
   }
   $tag = $maniid unless defined $tag;
@@ -247,8 +257,8 @@ sub manifest_upload {
   return $maniid;
 }
 
-sub manifest_append {
-  my ($manifest, $tag) = @_;
+sub manifest_append_digestfile  {
+  my ($manifest, $tag, $content_type) = @_;
   my $maniid = BSContar::blobid($manifest);
   my $str = "$maniid ".length($manifest).(defined($tag) ? " $tag" : '')."\n";
   if ($digestfile ne '-') {
@@ -258,16 +268,31 @@ sub manifest_append {
   }
 }
 
+sub manifest_append_listfile {
+  my ($manifest, $tag, $content_type, $extra) = @_;
+  my $mtype = contenttype2manitype($content_type || $BSContar::mt_docker_manifest);
+  my $maniid = BSContar::blobid($manifest);
+  $tag = '-' unless defined $tag;
+  my $str = sprintf "%-20s %s %s%s\n", $tag, $maniid, $mtype, $extra ne '' ? " $extra" : '';
+  if ($listfile ne '-') {
+    BSUtil::appendstr($listfile, $str);
+  } else {
+    print $str;
+  }
+}
+
 sub manifest_upload_tags {
   my ($manifest, $tags, $content_type) = @_;
   if (!@{$tags || []}) {
     manifest_upload($manifest, undef, $content_type);
-    manifest_append($manifest, undef) if defined $digestfile;
+    manifest_append_digestfile($manifest, undef, $content_type) if defined $digestfile;
+    manifest_append_listfile($manifest, undef, $content_type) if defined $listfile;
     return;
   }
   for my $tag (BSUtil::unify(@$tags)) {
     manifest_upload($manifest, $tag, $content_type);
-    manifest_append($manifest, $tag) if defined $digestfile;
+    manifest_append_digestfile($manifest, $tag, $content_type) if defined $digestfile;
+    manifest_append_listfile($manifest, $tag, $content_type) if defined $listfile;
   }
 }
 
@@ -285,7 +310,10 @@ sub cosign_upload {
   }
   my $mani = BSContar::create_dist_manifest_data($config_data, \@layer_data, $oci);
   my $mani_json = BSContar::create_dist_manifest($mani);
-  return manifest_upload($mani_json, $tag, $mani->{'mediaType'});
+  manifest_upload($mani_json, $tag, $mani->{'mediaType'});
+  my $extra = '';
+  $extra = manifest2extrainfo($mani, $tag) if $tag =~ /^[a-z0-9]+-[a-f0-9]+\.(?:sig|att)$/;
+  manifest_append_listfile($mani_json, $tag, $mani->{'mediaType'}, $extra) if defined $listfile;
 }
 
 sub get_all_tags {
@@ -414,6 +442,26 @@ sub delete_tag {
   }
 }
 
+sub manifest2extrainfo {
+  my ($mani, $tag) = @_;
+  my $extra = '';
+  if ($tag =~ /^[a-z0-9]+-[a-f0-9]+\.sig$/ && $mani && $mani->{'mediaType'} && $mani->{'mediaType'} eq $BSContar::mt_oci_manifest) {
+    if (@{$mani->{'layers'} || []} == 1 && $mani->{'layers'}->[0]->{'mediaType'} eq 'application/vnd.dev.cosign.simplesigning.v1+json') {
+      my $annotations = $mani->{'layers'}->[0]->{'annotations'} || {};
+      my $cookie = $annotations->{$cosign_cookie_name};
+      $extra = "cosigncookie=$cookie" if $cookie;
+    }
+  }
+  if ($tag =~ /^[a-z0-9]+-[a-f0-9]+\.att$/ && $mani && $mani->{'mediaType'} && $mani->{'mediaType'} eq $BSContar::mt_oci_manifest) {
+    if (@{$mani->{'layers'} || []} >= 1 && $mani->{'layers'}->[0]->{'mediaType'} eq 'application/vnd.dsse.envelope.v1+json') {
+      my $annotations = $mani->{'layers'}->[0]->{'annotations'} || {};
+      my $cookie = $annotations->{$cosign_cookie_name};
+      $extra = "cosigncookie=$cookie" if $cookie;
+    }
+  }
+  return $extra;
+}
+
 sub list_tag {
   my ($tag, $maniids, $old_data) = @_;
 
@@ -426,26 +474,15 @@ sub list_tag {
   my ($mani, $maniid) = eval { get_manifest_for_tag($tag, $ifnonematch) };
   if ($@) {
     if ($ifnonematch && $@ =~ /^304/) {
+      $tag = '-' if $tag eq $old_data->[0];
       printf "%-20s %s %s\n", $tag, $old_data->[0], $old_data->[1];
       return;
     }
     die($@);
   }
+  $tag = '-' if $maniid && $tag eq $maniid;
   my $extra = '';
-  if ($tag =~ /^[a-z0-9]+-[a-f0-9]+\.sig$/ && $mani && $mani->{'mediaType'} && $mani->{'mediaType'} eq $BSContar::mt_oci_manifest) {
-    if (@{$mani->{'layers'} || []} == 1 && $mani->{'layers'}->[0]->{'mediaType'} eq 'application/vnd.dev.cosign.simplesigning.v1+json') {
-      my $annotations = $mani->{'layers'}->[0]->{'annotations'} || {};
-      my $cookie = $annotations->{$cosign_cookie_name};
-      $extra = " cosigncookie=$cookie" if $cookie;
-    }
-  }
-  if ($tag =~ /^[a-z0-9]+-[a-f0-9]+\.att$/ && $mani && $mani->{'mediaType'} && $mani->{'mediaType'} eq $BSContar::mt_oci_manifest) {
-    if (@{$mani->{'layers'} || []} >= 1 && $mani->{'layers'}->[0]->{'mediaType'} eq 'application/vnd.dsse.envelope.v1+json') {
-      my $annotations = $mani->{'layers'}->[0]->{'annotations'} || {};
-      my $cookie = $annotations->{$cosign_cookie_name};
-      $extra = " cosigncookie=$cookie" if $cookie;
-    }
-  }
+  $extra = manifest2extrainfo($mani, $tag) if $tag =~ /^[a-z0-9]+-[a-f0-9]+\.(?:sig|att)$/;
   if ($mani && $maniids && $tag !~ /^[a-z0-9]+-[a-f0-9]+\.(?:sig|att)$/) {
     $maniids->{$maniid} = 1;
     if ($mani->{'mediaType'} eq $BSContar::mt_docker_manifestlist || $mani->{'mediaType'} eq $BSContar::mt_oci_index) {
@@ -454,29 +491,22 @@ sub list_tag {
   }
   if (!$mani) {
     printf "%-20s -\n", $tag;
-  } elsif (!$mani->{'mediaType'}) {
-    printf "%-20s %s %s\n", $tag, $maniid, 'v1image';
-  } elsif ($mani->{'mediaType'} eq $BSContar::mt_docker_manifestlist) {
-    printf "%-20s %s %s\n", $tag, $maniid, 'list';
-  } elsif ($mani->{'mediaType'} eq $BSContar::mt_docker_manifest) {
-    printf "%-20s %s %s%s\n", $tag, $maniid, 'image', $extra;
-  } elsif ($mani->{'mediaType'} eq $BSContar::mt_oci_manifest) {
-    printf "%-20s %s %s%s\n", $tag, $maniid, 'ociimage', $extra;
-  } elsif ($mani->{'mediaType'} eq $BSContar::mt_oci_index) {
-    printf "%-20s %s %s\n", $tag, $maniid, 'ocilist';
   } else {
-    printf "%-20s %s %s\n", $tag, $maniid, 'unknown';
+    my $mtype = contenttype2manitype($mani->{'mediaType'});
+    printf "%-20s %s %s%s\n", $tag, $maniid, $mtype, $extra ne '' ? " $extra" : '';
   }
 }
 
-sub read_old_list_output {
+sub read_old_listfile {
   local *F;
-  open(F, '<', $old_list_output) || die("$old_list_output: $!\n");
+  open(F, '<', $old_listfile) || die("$old_listfile: $!\n");
   my $old = {} ;
   while (<F>) {
     chomp;
+    next if /^#/ || /^\s*$/;
     my @s = split(' ', $_, 3);
-    $old->{$s[0]} = [ $s[1], $s[2] ];
+    my $tag = shift @s;
+    $old->{$tag} = \@s if @s && $tag ne '-';
   }
   close F;
   return $old;
@@ -598,9 +628,10 @@ while (@ARGV) {
   } elsif ($ARGV[0] eq '-t') {
     push @tags, $ARGV[1];
     splice(@ARGV, 0, 2);
-  } elsif ($ARGV[0] eq '-F') {
-    $digestfile = $ARGV[1];
-    splice(@ARGV, 0, 2);
+  } elsif ($ARGV[0] eq '-F' || $ARGV[0] eq '--digestfile') {
+    (undef, $digestfile) = splice(@ARGV, 0, 2);
+  } elsif ($ARGV[0] eq '--listfile') {
+    (undef, $listfile) = splice(@ARGV, 0, 2);
   } elsif ($ARGV[0] eq '--write-info') {
     (undef, $writeinfofile) = splice(@ARGV, 0, 2);
   } elsif ($ARGV[0] eq '-D') {
@@ -615,8 +646,8 @@ while (@ARGV) {
   } elsif ($ARGV[0] eq '--no-cosign-info') {
     $no_cosign_info = 1;
     shift @ARGV;
-  } elsif ($ARGV[0] eq '--old-list-output') {
-    (undef, $old_list_output) = splice(@ARGV, 0, 2);
+  } elsif ($ARGV[0] eq '--old-listfile') {
+    (undef, $old_listfile) = splice(@ARGV, 0, 2);
   } elsif ($ARGV[0] eq '-X') {
     $delete_except_mode = 1;
     shift @ARGV;
@@ -646,7 +677,7 @@ while (@ARGV) {
   } elsif ($ARGV[0] eq '--dest-creds') {
     $dest_creds = BSBearer::get_credentials($ARGV[1]);
     splice(@ARGV, 0, 2);
-  } elsif ($ARGV[0] eq '-P' || $ARGV[0] eq '--project' || $ARGV[0] eq '-u' || $ARGV[0] eq '--signtype' ||  $ARGV[0] eq '-h') {
+  } elsif ($ARGV[0] eq '-P' || $ARGV[0] eq '--project' || $ARGV[0] eq '-u' || $ARGV[0] eq '--signtype' || $ARGV[0] eq '-h') {
     my @signopts = splice(@ARGV, 0, 2);
     push @signcmd, @signopts unless $signopts[0] eq '-h';
   } else {
@@ -665,7 +696,7 @@ if ($list_mode) {
     }
   } elsif (@ARGV == 2) {
     my $old_data = {};
-    $old_data = read_old_list_output() if $old_list_output;
+    $old_data = read_old_listfile() if $old_listfile;
     $keepalive = {};
     my %tags = map {$_ => 1} @tags;
     $tags{$_} = 1 for tags_from_digestfile();


### PR DESCRIPTION
…ile option

The listfile is in the format of the list mode, i.e. it contains the tag, digest, type, and extra info.

The plan is to replace the digestfile with the listfile in the future. For this to happen we would need to add the manifest size as additional output.