### PR TITLE
Sort notifications in descending order again

### DIFF
--- a/src/api/app/controllers/webui/users/notifications_controller.rb
+++ b/src/api/app/controllers/webui/users/notifications_controller.rb
@@ -73,7 +73,7 @@ class Webui::Users::NotificationsController < Webui::WebuiController
   end
 
   def fetch_notifications
-    notifications = policy_scope(Notification).for_web.includes(notifiable: [{ commentable: [{ comments: :user }, :project, :bs_request_actions] }, :bs_request_actions, :reviews])
+    notifications = policy_scope(Notification).for_web.includes(notifiable: [{ commentable: [{ comments: :user }, :project, :bs_request_actions] }, :bs_request_actions, :reviews]).order(created_at: :desc)
 
     if params[:project]
       notifications.unread.for_project_name(params[:project])


### PR DESCRIPTION
After the latest changes related to notifications, the oldest notifications were displayed at the top of the list. It's time to make it descending again.