### PR TITLE
[backend] bs_publish: fix mapslepool for product composer

### DIFF
--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -1899,6 +1899,8 @@ sub mapslepool {
     $p =~ s/-Build[\d\.]*\d//;
   } elsif ($bin =~ /.*-Media1?(\.license|)$/) {
     $p = "$name$1";
+  } elsif ($bin =~ /.*[_-](?:$binarchs)?(\.license|)$/) {
+    $p = "$name$1";
   } elsif ($bin =~ /-Media3$/ || $bin =~ /-Debug$/) {
     $p = "${name}_debug";
   } elsif ($bin =~ /-Source$/) {


### PR DESCRIPTION
mapslepool missed main repository, we match now for a suffix of any binary architecture.