### PR TITLE
Move configuration methods to class methods

### DIFF
--- a/src/api/app/components/sign_up_component.html.haml
+++ b/src/api/app/components/sign_up_component.html.haml
@@ -1,4 +1,4 @@
-- if proxy_auth_mode_enabled?
+- if ::Configuration.proxy_auth_mode_enabled?
   - if proxy_auth_register_page.blank?
     %p Sorry, signing up is currently disabled
   - else

--- a/src/api/app/components/sign_up_component.rb
+++ b/src/api/app/components/sign_up_component.rb
@@ -9,10 +9,6 @@ class SignUpComponent < ApplicationComponent
     @submit_btn_text = sanitize(create_page ? 'Create' : submit_btn_text)
   end
 
-  def proxy_auth_mode_enabled?
-    ::Configuration.proxy_auth_mode_enabled?
-  end
-
   def proxy_auth_register_page
     CONFIG['proxy_auth_register_page']
   end

--- a/src/api/app/helpers/webui/user_helper.rb
+++ b/src/api/app/helpers/webui/user_helper.rb
@@ -76,8 +76,8 @@ module Webui::UserHelper
     end
   end
 
-  def user_is_configurable(configuration, user)
-    configuration.ldap_enabled? && !user.ignore_auth_services?
+  def user_is_configurable(user)
+    Configuration.ldap_enabled? && !user.ignore_auth_services?
   end
 
   def activity_date_commits(projects)

--- a/src/api/app/models/concerns/configuration_constants.rb
+++ b/src/api/app/models/concerns/configuration_constants.rb
@@ -42,5 +42,6 @@ module ConfigurationConstants
   ON_OFF_OPTIONS = %i[anonymous default_access_disabled allow_user_to_create_home_project disallow_group_creation
                       change_password hide_private_options gravatar download_on_demand enforce_project_keys
                       cleanup_empty_projects disable_publish_for_branches].freeze
+
   PROXY_MODE_ENABLED_VALUES = %i[on ichain mellon].freeze
 end

--- a/src/api/app/views/webui/users/edit.html.haml
+++ b/src/api/app/views/webui/users/edit.html.haml
@@ -8,11 +8,11 @@
         = form.hidden_field(:login)
         .mb-3
           = form.label(:realname, 'Name:')
-          = form.text_field(:realname, disabled: user_is_configurable(@configuration, @displayed_user), class: 'form-control')
+          = form.text_field(:realname, disabled: user_is_configurable(@displayed_user), class: 'form-control')
         .mb-3
           = form.label(:email, 'Email:')
           %abbr.text-danger{ title: 'required' } *
-          = form.text_field(:email, required: true, email: true, disabled: user_is_configurable(@configuration, @displayed_user),
+          = form.text_field(:email, required: true, email: true, disabled: user_is_configurable(@displayed_user),
             class: 'form-control')
         .mb-3
           = form.collection_check_boxes(:role_ids, Role.global, :id, :title, {}) do |checkbox|

--- a/src/api/spec/models/configuration_spec.rb
+++ b/src/api/spec/models/configuration_spec.rb
@@ -19,16 +19,14 @@ RSpec.describe Configuration do
   end
 
   describe '#ldap_enabled?' do
-    let(:config) { Configuration.first }
-
     it 'returns true if config option `ldap_mode` is set to :on' do
       stub_const('CONFIG', CONFIG.merge('ldap_mode' => :on))
-      expect(config.ldap_enabled?).to be(true)
+      expect(described_class.ldap_enabled?).to be(true)
     end
 
     it 'returns false if config option `ldap_mode` is not set to :on' do
       stub_const('CONFIG', CONFIG.merge('ldap_mode' => :off))
-      expect(config.ldap_enabled?).to be(false)
+      expect(described_class.ldap_enabled?).to be(false)
     end
   end
 


### PR DESCRIPTION
We don't need to retrieve the values stored in the singleton record of the table `configurations` in the database for none of the `ldap_enabled?`, `proxy_auth_mode_enabled?` and `amqp_namespace` methods.

Moving each method to the class methods section prevents from performing unneeded database queries.

## For reviewers

### Before

Taking the `home:Admin` project page as an example, browsing http://localhost:3000/project/show/home:Admin and taking a look at the frontend log resulted in:
- 3 direct SQL queries to the database:
   ```
   Configuration Load (0.5ms)  SELECT `configurations`.* FROM `configurations` ORDER BY `configurations`.`id` ASC LIMIT 1
   ```
- 10 cache hits:
   ```
   CACHE Configuration Load (0.1ms)  SELECT `configurations`.* FROM `configurations` ORDER BY `configurations`.`id` ASC LIMIT 1
   ```

### After

Browsing http://localhost:3000/project/show/home:Admin resulted in:
- 3 direct SQL queries to the database:
   ```
   Configuration Load (0.5ms)  SELECT `configurations`.* FROM `configurations` ORDER BY `configurations`.`id` ASC LIMIT 1
   ```
- 7 cache hits (3 less than before):
   ```
   CACHE Configuration Load (0.1ms)  SELECT `configurations`.* FROM `configurations` ORDER BY `configurations`.`id` ASC LIMIT 1
   ```
