### PR TITLE
Typo: relationship_deleted means "removed"

### DIFF
--- a/src/api/app/models/event/relationship_delete.rb
+++ b/src/api/app/models/event/relationship_delete.rb
@@ -8,7 +8,7 @@ module Event
     def subject
       object = payload[:project]
       object += "/#{payload[:package]}" if payload[:package]
-      "#{payload[:who]} added you as #{payload[:role]} on #{object}"
+      "#{payload[:who]} removed you as #{payload[:role]} on #{object}"
     end
   end
 end


### PR DESCRIPTION
https://github.com/openSUSE/open-build-service/pull/16166 conflicts with this: let the other one be prioritized, then this one will come after.

Typo: relationship_deleted means "removed"