### PR TITLE
Fix how we access payload in Event::Request

### DIFF
--- a/src/api/app/models/event/request.rb
+++ b/src/api/app/models/event/request.rb
@@ -105,7 +105,7 @@ module Event
     end
 
     def involves_hidden_project?
-      bs_request = BsRequest.find_by(number: payload[:number])
+      bs_request = BsRequest.find_by(number: payload['number'])
       return false unless bs_request
 
       bs_request.bs_request_actions.any?(&:involves_hidden_project?)


### PR DESCRIPTION
The payload hash uses strings as keys, not symbols.