### PR TITLE
Invalidate configuration cache after update

### DIFF
--- a/src/api/spec/factories/users.rb
+++ b/src/api/spec/factories/users.rb
@@ -28,11 +28,11 @@ FactoryBot.define do
         # rubocop:disable Rails/SkipsModelValidations
         # Avoid triggering the callbacks to propagate the change to the backend
         Configuration.update_column(:allow_user_to_create_home_project, false)
-        # But call touch to force a cache update
-        Configuration.touch
+        # But invalidate the cache
+        Configuration.invalidate_cache
         user.save!
         Configuration.update_column(:allow_user_to_create_home_project, true)
-        Configuration.touch
+        Configuration.invalidate_cache
         # rubocop:enable Rails/SkipsModelValidations
       end
     end


### PR DESCRIPTION
Prevent from performing a query to the database to check for an update on the configuration singleton record.