### PR TITLE
Display a nicer icon for closed requests

### DIFF
--- a/src/api/app/assets/stylesheets/webui/requests.scss
+++ b/src/api/app/assets/stylesheets/webui/requests.scss
@@ -80,3 +80,15 @@
     order: 2;
   }
 }
+
+.fa-custom-pr-closed {
+  position: relative;
+  .fa-code-pull-request {
+    clip-path: polygon(0 0, 30% 0, 30% 50%, 100% 50%, 100% 100%, 0 100%);
+  }
+  .fa-times {
+    position: absolute;
+    top: 25%;
+    right: -10%;
+  }
+}

--- a/src/api/app/components/bs_request_state_badge_component.rb
+++ b/src/api/app/components/bs_request_state_badge_component.rb
@@ -54,10 +54,10 @@ class BsRequestStateBadgeComponent < ApplicationComponent
     if %i[declined revoked].include?(state)
       content_tag(
         :span,
-        tag.i(class: "fas fa-#{decode_state_icon}").concat(
-          tag.i(class: 'fas fa-slash fa-stack-1x fa-stack-slash top-icon')
+        tag.i(class: 'fas fa-code-pull-request').concat(
+          tag.i(class: 'fas fa-times fa-xs')
         ),
-        class: 'position-relative me-1'
+        class: 'fa-custom-pr-closed me-1'
       )
     else
       tag.i(class: "fas fa-#{decode_state_icon} me-1")


### PR DESCRIPTION
Applies to both declined and revoked requests. Pictured below are declined requests

|Before|After|
|:---|:---|
|![Screenshot from 2024-05-22 11-48-57](https://github.com/openSUSE/open-build-service/assets/114928900/d015f293-4ee1-435d-8c24-f9531ddc1d88)|![Screenshot from 2024-05-22 11-48-02](https://github.com/openSUSE/open-build-service/assets/114928900/c7401d7e-bf49-4e02-b6ca-c17f28a4e21b)|
|![Screenshot from 2024-05-22 11-49-12](https://github.com/openSUSE/open-build-service/assets/114928900/569c470f-582c-4dab-a77c-5b6d77d16a62)|![Screenshot from 2024-05-22 11-49-26](https://github.com/openSUSE/open-build-service/assets/114928900/f48f201a-de58-4408-bd21-49a441926cf0)|

This is meant to replicate the feel of https://fontawesome.com/icons/code-pull-request-closed, which we can't use since it's a pro icon