### PR TITLE
Mark as read when button specified mark as read

### DIFF
--- a/src/api/app/assets/javascripts/webui/notification.js
+++ b/src/api/app/assets/javascripts/webui/notification.js
@@ -14,10 +14,12 @@ function setCheckboxCounterAndSubmitButton() {
   });
 
   if(amountBoxesChecked <= 0) {
-    $('#done-button').prop('disabled', true);
+    $('#read-button').prop('disabled', true);
+    $('#unread-button').prop('disabled', true);
     $('#select-all-label').text('Select All');
   } else {
-    $('#done-button').prop('disabled', false);
+    $('#read-button').prop('disabled', false);
+    $('#unread-button').prop('disabled', false);
     $('#select-all-label').text(amountBoxesChecked + ' selected');
   }
 }

--- a/src/api/app/components/notification_action_bar_component.html.haml
+++ b/src/api/app/components/notification_action_bar_component.html.haml
@@ -5,9 +5,12 @@
         = check_box_tag('select-all-notifications', 1, false, class: 'form-check-input')
         %label.form-check-label.align-middle.me-4#select-all-label{ for: 'select-all-notifications' } Select All
       .me-auto
-        = button_tag(type: 'submit', class: 'btn btn-sm btn-outline-success px-3', id: 'done-button', disabled: 'disabled',
-                     'data-disable-with': disable_with_content) do
-          = button_text
+        - if state != 'read'
+          = button_tag("Mark selected as 'Read'", type: 'submit', class: 'btn btn-sm btn-outline-success px-3', id: 'read-button',
+                       disabled: 'disabled', 'data-disable-with': disable_with_content, value: 'read')
+        - if state != 'unread'
+          = button_tag("Mark selected as 'Unread'", type: 'submit', class: 'btn btn-sm btn-outline-success px-3', id: 'unread-button',
+                       disabled: 'disabled', 'data-disable-with': disable_with_content, value: 'unread')
       - if @show_read_all_button
         .ms-4
           = link_to(button_text(all: true), @update_path, method: :put, remote: true,

--- a/src/api/app/components/notification_mark_button_component.rb
+++ b/src/api/app/components/notification_mark_button_component.rb
@@ -21,6 +21,7 @@ class NotificationMarkButtonComponent < ApplicationComponent
   def update_path
     my_notifications_path(notification_ids: [@notification.id], kind: @selected_filter[:kind],
                           state: @selected_filter[:state],
+                          button: @notification.unread? ? 'read' : 'unread',
                           project: @selected_filter[:project], group: @selected_filter[:group],
                           page: @page, show_more: @show_more)
   end

--- a/src/api/app/controllers/webui/users/notifications_controller.rb
+++ b/src/api/app/controllers/webui/users/notifications_controller.rb
@@ -18,17 +18,13 @@ class Webui::Users::NotificationsController < Webui::WebuiController
   end
 
   def update
-    if %w[all unread].include?(@filter_state)
-      # rubocop:disable Rails/SkipsModelValidations
-      @read_count = Notification.where(id: @undelivered_notification_ids).update_all('delivered = !delivered')
-      # rubocop:enable Rails/SkipsModelValidations
-      @unread_count = 0
-    else
-      # rubocop:disable Rails/SkipsModelValidations
-      @unread_count = Notification.where(id: @delivered_notification_ids).update_all('delivered = !delivered')
-      # rubocop:enable Rails/SkipsModelValidations
-      @read_count = 0
-    end
+    # If we filter by "read", we want to "unread" the notifications, ie. undeliver them.
+    # In any other case, we display `Mark as "read"`, indicating we want to make all
+    # the selected notifications be delivered.
+    delivered = params[:state] == 'read'
+    # rubocop:disable Rails/SkipsModelValidations
+    @count = @notifications.where(id: @notification_ids).where(delivered: delivered).update_all(delivered: !delivered)
+    # rubocop:enable Rails/SkipsModelValidations
 
     respond_to do |format|
       format.html { redirect_to my_notifications_path }
@@ -41,7 +37,7 @@ class Webui::Users::NotificationsController < Webui::WebuiController
           user: User.session
         }
       end
-      send_notifications_information_rabbitmq(@read_count, @unread_count)
+      send_notifications_information_rabbitmq(!delivered, @count)
     end
   end
 
@@ -74,16 +70,10 @@ class Webui::Users::NotificationsController < Webui::WebuiController
   end
 
   def set_notifications_to_be_updated
-    if params[:notification_ids]
-      @undelivered_notification_ids = @notifications.where(id: params[:notification_ids]).where(delivered: false).map(&:id)
-      @delivered_notification_ids = @notifications.where(id: params[:notification_ids]).where(delivered: true).map(&:id)
-    elsif params[:update_all]
-      @undelivered_notification_ids = @notifications.where(delivered: false).map(&:id)
-      @delivered_notification_ids = @notifications.where(delivered: true).map(&:id)
-    else
-      @undelivered_notification_ids = []
-      @delivered_notification_ids = []
-    end
+    return @notification_ids = @notifications.map(&:id) if params[:update_all]
+    return unless params[:notification_ids]
+
+    @notification_ids = @notifications.where(id: params[:notification_ids]).map(&:id)
   end
 
   def set_show_read_all_button
@@ -101,9 +91,9 @@ class Webui::Users::NotificationsController < Webui::WebuiController
     notifications.page(params[:page]).per([total, Notification::MAX_PER_PAGE].min)
   end
 
-  def send_notifications_information_rabbitmq(read_count, unread_count)
-    RabbitmqBus.send_to_bus('metrics', "notification,action=read value=#{read_count}") if read_count.positive?
-    RabbitmqBus.send_to_bus('metrics', "notification,action=unread value=#{unread_count}") if unread_count.positive?
+  def send_notifications_information_rabbitmq(delivered, count)
+    action = delivered ? 'read' : 'unread'
+    RabbitmqBus.send_to_bus('metrics', "notification,action=#{action} value=#{count}") if count.positive?
   end
 
   def paginate_notifications

--- a/src/api/app/controllers/webui/users/notifications_controller.rb
+++ b/src/api/app/controllers/webui/users/notifications_controller.rb
@@ -18,12 +18,10 @@ class Webui::Users::NotificationsController < Webui::WebuiController
   end
 
   def update
-    # If we filter by "read", we want to "unread" the notifications, ie. undeliver them.
-    # In any other case, we display `Mark as "read"`, indicating we want to make all
-    # the selected notifications be delivered.
-    delivered = params[:state] == 'read'
+    # The button value specifies whether we selected read or unread
+    deliver = params[:button] == 'read'
     # rubocop:disable Rails/SkipsModelValidations
-    @count = @notifications.where(id: @notification_ids).where(delivered: delivered).update_all(delivered: !delivered)
+    @count = @notifications.where(id: @notification_ids, delivered: !deliver).update_all(delivered: deliver)
     # rubocop:enable Rails/SkipsModelValidations
 
     respond_to do |format|
@@ -37,7 +35,7 @@ class Webui::Users::NotificationsController < Webui::WebuiController
           user: User.session
         }
       end
-      send_notifications_information_rabbitmq(!delivered, @count)
+      send_notifications_information_rabbitmq(deliver, @count)
     end
   end
 

--- a/src/api/spec/components/notification_mark_button_component_spec.rb
+++ b/src/api/spec/components/notification_mark_button_component_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe NotificationMarkButtonComponent, type: :component do
     end
 
     it 'sets the update path with the right params' do
-      expect(rendered_content).to have_css("a#update_notification_#{notification.id}[href='/my/notifications?notification_ids%5B%5D=#{notification.id}&state=read']")
+      expect(rendered_content).to have_css("a#update_notification_#{notification.id}[href='/my/notifications?button=unread&notification_ids%5B%5D=#{notification.id}&state=read']")
     end
   end
 
@@ -29,7 +29,7 @@ RSpec.describe NotificationMarkButtonComponent, type: :component do
     end
 
     it 'sets the update path with the right params' do
-      expect(rendered_content).to have_css("a#update_notification_#{notification.id}[href='/my/notifications?notification_ids%5B%5D=#{notification.id}&state=unread']")
+      expect(rendered_content).to have_css("a#update_notification_#{notification.id}[href='/my/notifications?button=read&notification_ids%5B%5D=#{notification.id}&state=unread']")
     end
   end
 end

--- a/src/api/spec/controllers/webui/users/notifications_controller_spec.rb
+++ b/src/api/spec/controllers/webui/users/notifications_controller_spec.rb
@@ -221,12 +221,7 @@ RSpec.describe Webui::Users::NotificationsController do
 
       it {
         subject
-        expect(assigns[:read_count]).to be 1
-      }
-
-      it {
-        subject
-        expect(assigns[:unread_count]).to be 0
+        expect(assigns[:count]).to be 1
       }
 
       it 'returns the updated list of read notifications' do
@@ -247,8 +242,7 @@ RSpec.describe Webui::Users::NotificationsController do
         expect(state_change_notification.reload.delivered).to be false
       end
 
-      it { expect(assigns[:read_count]).to be 0 }
-      it { expect(assigns[:unread_count]).to be 0 }
+      it { expect(assigns[:count]).to be 0 }
     end
 
     context 'when a user marks one of their read notifications as unread' do
@@ -269,8 +263,7 @@ RSpec.describe Webui::Users::NotificationsController do
         expect(read_notification.reload.delivered).to be false
       end
 
-      it { expect(assigns[:read_count]).to be 0 }
-      it { expect(assigns[:unread_count]).to be 1 }
+      it { expect(assigns[:count]).to be 1 }
 
       it 'returns the updated list of read notifications' do
         expect(assigns[:notifications]).to contain_exactly(another_read_notification)

--- a/src/api/spec/controllers/webui/users/notifications_controller_spec.rb
+++ b/src/api/spec/controllers/webui/users/notifications_controller_spec.rb
@@ -203,7 +203,7 @@ RSpec.describe Webui::Users::NotificationsController do
     context 'when a user marks one of their unread notifications as read' do
       subject do
         login user_to_log_in
-        put :update, params: { notification_ids: [state_change_notification.id], user_login: user_to_log_in.login }, xhr: true
+        put :update, params: { notification_ids: [state_change_notification.id], user_login: user_to_log_in.login, button: 'read' }, xhr: true
       end
 
       let!(:another_unread_notification) { create(:web_notification, :request_state_change, subscriber: user_to_log_in, title: 'Another read notification') }
@@ -233,7 +233,7 @@ RSpec.describe Webui::Users::NotificationsController do
     context 'when a user tries to mark other user notifications as read' do
       subject! do
         login user_to_log_in
-        put :update, params: { notification_ids: [state_change_notification.id], user_login: user_to_log_in.login }, xhr: true
+        put :update, params: { notification_ids: [state_change_notification.id], user_login: user_to_log_in.login, button: 'read' }, xhr: true
       end
 
       let(:user_to_log_in) { other_user }
@@ -248,7 +248,7 @@ RSpec.describe Webui::Users::NotificationsController do
     context 'when a user marks one of their read notifications as unread' do
       subject! do
         login user_to_log_in
-        put :update, params: { notification_ids: [read_notification.id], state: 'read', user_login: user_to_log_in.login }, xhr: true
+        put :update, params: { notification_ids: [read_notification.id], state: 'read', user_login: user_to_log_in.login, button: 'unread' }, xhr: true
       end
 
       let(:user_to_log_in) { user }

--- a/src/api/spec/features/webui/users/notifications_spec.rb
+++ b/src/api/spec/features/webui/users/notifications_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe 'User notifications', :js do
         click_button('filter-button') # apply the filters
         toggle_checkbox("notification_ids_#{notification_for_projects_comment.id}")
         toggle_checkbox("notification_ids_#{another_notification_for_projects_comment.id}")
-        click_button('done-button')
+        click_button('read-button')
       end
 
       it 'marks all comment notification as read' do


### PR DESCRIPTION
Matches the action performed in the controller to the button text as specified in:
https://github.com/openSUSE/open-build-service/blob/1abe6b4d4c4b1deda44541966ca2eaaeda86a6b4/src/api/app/components/notification_action_bar_component.rb#L15

This way there is no ambiguity about the action that the user is trying to perform vs what's done in the controller code