### PR TITLE
[dist] Add OOMPolicy=continue to critical services

### DIFF
--- a/dist/systemd/obsdispatcher.service
+++ b/dist/systemd/obsdispatcher.service
@@ -4,6 +4,7 @@ Requires=obsrepserver.service
 After=network-online.target obssrcserver.service obsscheduler.service obsrepserver.service
 
 [Service]
+OOMPolicy=continue
 EnvironmentFile=/etc/sysconfig/obs-server
 ExecStart=/usr/lib/obs/server/bs_dispatch --logfile dispatcher.log
 ExecStop=/usr/lib/obs/server/bs_dispatch --stop

--- a/dist/systemd/obsdodup.service
+++ b/dist/systemd/obsdodup.service
@@ -4,6 +4,7 @@ After=network-online.target
 After=obsapisetup.service
 
 [Service]
+OOMPolicy=continue
 EnvironmentFile=/etc/sysconfig/obs-server
 ExecStart=/usr/lib/obs/server/bs_dodup --logfile dodup.log
 ExecStop=/usr/lib/obs/server/bs_dodup --stop

--- a/dist/systemd/obspublisher.service
+++ b/dist/systemd/obspublisher.service
@@ -3,6 +3,7 @@ Description=OBS repository publisher
 After=network-online.target
 
 [Service]
+OOMPolicy=continue
 EnvironmentFile=/etc/sysconfig/obs-server
 ExecStart=/usr/lib/obs/server/bs_publish --logfile publisher.log
 ExecStop=/usr/lib/obs/server/bs_publish --stop

--- a/dist/systemd/obsrepserver.service
+++ b/dist/systemd/obsrepserver.service
@@ -3,6 +3,7 @@ Description=OBS repository server
 After=network-online.target obsstoragesetup.service
 
 [Service]
+OOMPolicy=continue
 EnvironmentFile=/etc/sysconfig/obs-server
 ExecStart=/usr/lib/obs/server/bs_repserver --logfile rep_server.log
 ExecStop=/usr/lib/obs/server/bs_repserver --stop

--- a/dist/systemd/obsscheduler@.service
+++ b/dist/systemd/obsscheduler@.service
@@ -3,6 +3,7 @@ Description=OBS scheduler service for %I
 After=network-online.target obsstoragesetup.service
 
 [Service]
+OOMPolicy=continue
 EnvironmentFile=/etc/sysconfig/obs-server
 ExecStart=/usr/lib/obs/server/bs_sched %i
 ExecStop=/usr/lib/obs/server/bs_admin --shutdown-scheduler %i

--- a/dist/systemd/obsservice.service
+++ b/dist/systemd/obsservice.service
@@ -3,6 +3,7 @@ Description=OBS source service server
 After=network-online.target obsstoragesetup.service
 
 [Service]
+OOMPolicy=continue
 EnvironmentFile=/etc/sysconfig/obs-server
 ExecStart=/usr/lib/obs/server/bs_service --logfile src_service.log
 ExecStop=/usr/lib/obs/server/bs_service --stop

--- a/dist/systemd/obsservicedispatch.service
+++ b/dist/systemd/obsservicedispatch.service
@@ -3,6 +3,7 @@ Description=OBS source service dispatcher
 After=network-online.target obsstoragesetup.service obsservice.service
 
 [Service]
+OOMPolicy=continue
 EnvironmentFile=/etc/sysconfig/obs-server
 ExecStart=/usr/lib/obs/server/bs_servicedispatch --logfile servicedispatch.log
 ExecStop=/usr/lib/obs/server/bs_servicedispatch --stop

--- a/dist/systemd/obssigner.service
+++ b/dist/systemd/obssigner.service
@@ -3,6 +3,7 @@ Description=OBS signer service
 After=network-online.target obsapisetup.service obsstoragesetup.service signd.service
 
 [Service]
+OOMPolicy=continue
 EnvironmentFile=/etc/sysconfig/obs-server
 ExecStart=/usr/lib/obs/server/bs_signer --logfile signer.log
 ExecStop=/usr/lib/obs/server/bs_signer --stop

--- a/dist/systemd/obssrcserver.service
+++ b/dist/systemd/obssrcserver.service
@@ -3,6 +3,7 @@ Description=OBS source repository server
 After=network-online.target obsstoragesetup.service obsservice.service
 
 [Service]
+OOMPolicy=continue
 EnvironmentFile=/etc/sysconfig/obs-server
 ExecStart=/usr/lib/obs/server/bs_srcserver --logfile src_server.log
 ExecStop=/usr/lib/obs/server/bs_srcserver --stop

--- a/dist/systemd/obsworker@.service
+++ b/dist/systemd/obsworker@.service
@@ -3,6 +3,7 @@ Description=OBS worker for %i
 After=network-online.target
          
 [Service]
+OOMPolicy=continue
 EnvironmentFile=/etc/sysconfig/obs-server
 ExecStartPre=/bin/sh -c "/bin/systemctl set-environment HOSTNAME=`hostname`"
 ExecStartPre=/bin/mkdir -p /var/cache/build/root_%i


### PR DESCRIPTION
Enable restart of critical services when killed via systemd OOM.

Services where a downtime is considered less critical and be catched by monitoring remain to be stop for further analyses.

Verified on openSUSE 15.5 and newer.