### PR TITLE
Avoid querying the target package twice

### DIFF
--- a/src/api/app/models/bs_request_action_submit.rb
+++ b/src/api/app/models/bs_request_action_submit.rb
@@ -143,16 +143,18 @@ class BsRequestActionSubmit < BsRequestAction
     "Submit #{source_package}"
   end
 
+  def target_package_object
+    @target_package_object ||= Package.find_by_project_and_name(target_project, target_package)
+  end
+
   def creator_is_target_maintainer
     request_creator = User.find_by_login(bs_request.creator)
-    target_package_object = Package.find_by_project_and_name(target_project, target_package)
     request_creator.has_local_role?(Role.hashed['maintainer'], target_package_object)
   end
 
   # rubocop:disable Metrics/BlockNesting
   def forward
     forward_object = nil
-    target_package_object = Package.find_by_project_and_name(target_project, target_package)
 
     if target_package_object
       linkinfo = target_package_object.linkinfo


### PR DESCRIPTION
Both methods are used while rendering RequestDecisionComponent's template