### PR TITLE
Avoid crashing when checking permissions to create a new status message

### DIFF
--- a/src/api/app/controllers/webui/status_messages_controller.rb
+++ b/src/api/app/controllers/webui/status_messages_controller.rb
@@ -71,6 +71,13 @@ class Webui::StatusMessagesController < Webui::WebuiController
 
   private
 
+  def require_staff
+    return if User.possibly_nobody.is_admin? || User.possibly_nobody.is_staff?
+
+    flash[:error] = 'Requires staff privileges'
+    redirect_back_or_to({ controller: 'main', action: 'index' })
+  end
+
   def set_status_message
     @status_message = StatusMessage.find(params[:id])
   end

--- a/src/api/app/controllers/webui/webui_controller.rb
+++ b/src/api/app/controllers/webui/webui_controller.rb
@@ -171,13 +171,6 @@ class Webui::WebuiController < ActionController::Base
     redirect_back_or_to({ controller: 'main', action: 'index' })
   end
 
-  def require_staff
-    return if User.session!.is_admin? || User.session!.is_staff?
-
-    flash[:error] = 'Requires staff privileges'
-    redirect_back_or_to({ controller: 'main', action: 'index' })
-  end
-
   # before filter to only show the frontpage to anonymous users
   def check_anonymous
     return if User.session.present?


### PR DESCRIPTION
We should flash back an error and redirecting the user to the main page instead of crashing.

Fixes #16187