### PR TITLE
[backend] catch errors in the publish filter

### DIFF
--- a/src/backend/BSSched/PublishRepo.pm
+++ b/src/backend/BSSched/PublishRepo.pm
@@ -183,7 +183,12 @@ sub prpfinished {
   $filter = $bconf->{'publishfilter'} if $bconf;
   undef $filter if $filter && !@$filter;
   $filter ||= $default_publishfilter;
-  $filter = compile_publishfilter($filter);
+  eval { $filter = compile_publishfilter($filter) };
+  if ($@) {
+    my $err = $@;
+    chomp $err;
+    return "invalid publish filter: $err";
+  }
 
   my $seen_binary;
   my $singleexport;


### PR DESCRIPTION
We do not want to crash the scheduler, but return a meaningful error.