### PR TITLE
Unify api notifications

### DIFF
--- a/src/api/app/components/notification_avatars_component.rb
+++ b/src/api/app/components/notification_avatars_component.rb
@@ -10,6 +10,7 @@ class NotificationAvatarsComponent < ApplicationComponent
   private
 
   # rubocop:disable Metrics/CyclomaticComplexity
+  # Moved to model
   def avatar_objects
     @avatar_objects ||= case @notification.notifiable_type
                         when 'Comment'
@@ -39,6 +40,7 @@ class NotificationAvatarsComponent < ApplicationComponent
     [0, avatar_objects.size - MAXIMUM_DISPLAYED_AVATARS].max
   end
 
+  # NOTE: moved to model
   def commenters
     comments = @notification.notifiable.commentable.comments
     comments.select { |comment| comment.updated_at >= @notification.unread_date }.map(&:user).uniq

--- a/src/api/app/components/notification_excerpt_component.rb
+++ b/src/api/app/components/notification_excerpt_component.rb
@@ -1,4 +1,5 @@
 class NotificationExcerptComponent < ApplicationComponent
+  # NOTE: moved to model
   TRUNCATION_LENGTH = 100
   TRUNCATION_ELLIPSIS_LENGTH = 3 # `...` is the default ellipsis for String#truncate
 
@@ -27,6 +28,7 @@ class NotificationExcerptComponent < ApplicationComponent
 
   private
 
+  # NOTE: moved to model
   def truncate_to_first_new_line(text)
     first_new_line_index = text.index("\n")
     truncation_index = !first_new_line_index.nil? && first_new_line_index < TRUNCATION_LENGTH ? first_new_line_index + TRUNCATION_ELLIPSIS_LENGTH : TRUNCATION_LENGTH

--- a/src/api/app/components/notification_notifiable_link_component.rb
+++ b/src/api/app/components/notification_notifiable_link_component.rb
@@ -78,6 +78,7 @@ class NotificationNotifiableLinkComponent < ApplicationComponent
       "Favored #{@notification.notifiable.reports.first.reportable&.class&.name} Report".squish
     when 'Event::AppealCreated'
       "Appealed the decision for a report of #{@notification.notifiable.decision.moderator.login}"
+    # NOTE: moved to model
     when 'Event::WorkflowRunFail'
       'Workflow Run'
     end

--- a/src/api/app/components/notification_notifiable_link_component.rb
+++ b/src/api/app/components/notification_notifiable_link_component.rb
@@ -57,14 +57,17 @@ class NotificationNotifiableLinkComponent < ApplicationComponent
     # TODO: Remove `Event::CreateReport` after all existing records are migrated to the new STI classes
     when 'Event::CreateReport', 'Event::ReportForUser'
       "Report for a #{@notification.event_payload['reportable_type']}"
+    # NOTE: moved to model
     when 'Event::ReportForComment'
       if Comment.exists?(@notification.event_payload['reportable_id'])
         'Report for a comment'
       else
         'Report for a deleted comment'
       end
+    # NOTE: moved to model
     when 'Event::ReportForProject', 'Event::ReportForPackage'
       @notification.event_type.constantize.notification_link_text(@notification.event_payload)
+    # NOTE: moved to model
     when 'Event::ReportForRequest'
       "Report for Request ##{@notification.notifiable.reportable.number}"
     when 'Event::ClearedDecision'

--- a/src/api/app/components/notification_notifiable_link_component.rb
+++ b/src/api/app/components/notification_notifiable_link_component.rb
@@ -26,6 +26,7 @@ class NotificationNotifiableLinkComponent < ApplicationComponent
     # NOTE: moved to model
     when 'Event::CommentForProject'
       'Comment on Project'
+    # NOTE: moved to model
     when 'Event::CommentForPackage'
       'Comment on Package'
     when 'Event::RelationshipCreate'

--- a/src/api/app/components/notification_notifiable_link_component.rb
+++ b/src/api/app/components/notification_notifiable_link_component.rb
@@ -23,6 +23,7 @@ class NotificationNotifiableLinkComponent < ApplicationComponent
       "#{helpers.request_type_of_action(@notification.notifiable)} Request ##{@notification.notifiable.number}"
     when 'Event::CommentForRequest'
       "Comment on #{helpers.request_type_of_action(bs_request)} Request ##{bs_request.number}"
+    # NOTE: moved to model
     when 'Event::CommentForProject'
       'Comment on Project'
     when 'Event::CommentForPackage'

--- a/src/api/app/components/notification_notifiable_link_component.rb
+++ b/src/api/app/components/notification_notifiable_link_component.rb
@@ -47,6 +47,7 @@ class NotificationNotifiableLinkComponent < ApplicationComponent
       else
         "Removed as #{role} of a project"
       end
+    # NOTE: moved to model
     when 'Event::BuildFail'
       project = @notification.event_payload['project']
       package = @notification.event_payload['package']

--- a/src/api/app/components/notification_notifiable_link_component.rb
+++ b/src/api/app/components/notification_notifiable_link_component.rb
@@ -21,6 +21,7 @@ class NotificationNotifiableLinkComponent < ApplicationComponent
     case @notification.event_type
     when 'Event::RequestStatechange', 'Event::RequestCreate', 'Event::ReviewWanted'
       "#{helpers.request_type_of_action(@notification.notifiable)} Request ##{@notification.notifiable.number}"
+    # NOTE: moved to model
     when 'Event::CommentForRequest'
       "Comment on #{helpers.request_type_of_action(bs_request)} Request ##{bs_request.number}"
     # NOTE: moved to model

--- a/src/api/app/components/notification_notifiable_link_component.rb
+++ b/src/api/app/components/notification_notifiable_link_component.rb
@@ -30,6 +30,7 @@ class NotificationNotifiableLinkComponent < ApplicationComponent
     # NOTE: moved to model
     when 'Event::CommentForPackage'
       'Comment on Package'
+    # NOTE: moved to model
     when 'Event::RelationshipCreate'
       role = @notification.event_payload['role']
       if @notification.event_payload['package']
@@ -37,6 +38,7 @@ class NotificationNotifiableLinkComponent < ApplicationComponent
       else
         "Added as #{role} of a project"
       end
+    # NOTE: moved to model
     when 'Event::RelationshipDelete'
       role = @notification.event_payload['role']
       if @notification.event_payload['package']

--- a/src/api/app/components/notification_notifiable_link_component.rb
+++ b/src/api/app/components/notification_notifiable_link_component.rb
@@ -82,6 +82,7 @@ class NotificationNotifiableLinkComponent < ApplicationComponent
       # https://trello.com/c/xrjOZGa7/45-ensure-all-reports-of-a-decision-point-to-the-same-reportable
       # This reportable won't be nil once we fix this: https://trello.com/c/vPDiLjIQ/66-prevent-the-creation-of-reports-without-reportable
       "Favored #{@notification.notifiable.reports.first.reportable&.class&.name} Report".squish
+    # NOTE: moved to model
     when 'Event::AppealCreated'
       "Appealed the decision for a report of #{@notification.notifiable.decision.moderator.login}"
     # NOTE: moved to model

--- a/src/api/app/components/notification_notifiable_link_component.rb
+++ b/src/api/app/components/notification_notifiable_link_component.rb
@@ -19,6 +19,7 @@ class NotificationNotifiableLinkComponent < ApplicationComponent
   # rubocop:disable Metrics/PerceivedComplexity
   def notifiable_link_text
     case @notification.event_type
+    # NOTE: moved to model
     when 'Event::RequestStatechange', 'Event::RequestCreate', 'Event::ReviewWanted'
       "#{helpers.request_type_of_action(@notification.notifiable)} Request ##{@notification.notifiable.number}"
     # NOTE: moved to model

--- a/src/api/app/components/notification_notifiable_link_component.rb
+++ b/src/api/app/components/notification_notifiable_link_component.rb
@@ -70,11 +70,13 @@ class NotificationNotifiableLinkComponent < ApplicationComponent
     # NOTE: moved to model
     when 'Event::ReportForRequest'
       "Report for Request ##{@notification.notifiable.reportable.number}"
+    # NOTE: moved to model
     when 'Event::ClearedDecision'
       # All reports should point to the same reportable. We will take care of that here:
       # https://trello.com/c/xrjOZGa7/45-ensure-all-reports-of-a-decision-point-to-the-same-reportable
       # This reportable won't be nil once we fix this: https://trello.com/c/vPDiLjIQ/66-prevent-the-creation-of-reports-without-reportable
       "Cleared #{@notification.notifiable.reports.first.reportable&.class&.name} Report".squish
+    # NOTE: moved to model
     when 'Event::FavoredDecision'
       # All reports should point to the same reportable. We will take care of that here:
       # https://trello.com/c/xrjOZGa7/45-ensure-all-reports-of-a-decision-point-to-the-same-reportable

--- a/src/api/app/models/notification.rb
+++ b/src/api/app/models/notification.rb
@@ -119,20 +119,12 @@ class Notification < ApplicationRecord
     end
   end
 
-  def first_action(bs_request)
-    bs_request.bs_request_actions.first
-  end
-
-  def number_of_bs_request_actions(bs_request)
-    bs_request.bs_request_actions.size
-  end
-
   # FIXME: Duplicated from RequestHelper
   # Returns strings like "Add Role", "Submit", etc.
   def request_type_of_action(bs_request)
-    return 'Multiple Actions' if number_of_bs_request_actions(bs_request) > 1
+    return 'Multiple Actions' if bs_request.bs_request_actions.size > 1
 
-    first_action(bs_request).type.titleize
+    bs_request.bs_request_actions.first.type.titleize
   end
 
   def commenters

--- a/src/api/app/models/notification.rb
+++ b/src/api/app/models/notification.rb
@@ -3,6 +3,9 @@ class Notification < ApplicationRecord
   MAX_RSS_ITEMS_PER_GROUP = 10
   MAX_PER_PAGE = 300
 
+  TRUNCATION_LENGTH = 100
+  TRUNCATION_ELLIPSIS_LENGTH = 3 # `...` is the default ellipsis for String#truncate
+
   belongs_to :subscriber, polymorphic: true, optional: true
   belongs_to :notifiable, polymorphic: true, optional: true
 
@@ -86,6 +89,12 @@ class Notification < ApplicationRecord
   def track_notification_delivered
     RabbitmqBus.send_to_bus('metrics',
                             "notification,action=#{delivered ? 'read' : 'unread'} value=1")
+  end
+
+  def truncate_to_first_new_line(text)
+    first_new_line_index = text.index("\n")
+    truncation_index = !first_new_line_index.nil? && first_new_line_index < TRUNCATION_LENGTH ? first_new_line_index + TRUNCATION_ELLIPSIS_LENGTH : TRUNCATION_LENGTH
+    text.truncate(truncation_index)
   end
 end
 

--- a/src/api/app/models/notification.rb
+++ b/src/api/app/models/notification.rb
@@ -127,6 +127,19 @@ class Notification < ApplicationRecord
     bs_request.bs_request_actions.first.type.titleize
   end
 
+
+  def request_source
+    return '' if bs_request.bs_request_actions.size > 1
+
+    [bs_request.bs_request_actions.first.source_project, bs_request.bs_request_actions.first.source_package].compact.join(' / ')
+  end
+
+  def request_target
+    return bs_request_action.target_project if bs_request.bs_request_actions.size > 1
+
+    [bs_request_action.target_project, bs_request_action.target_package].compact.join(' / ')
+  end
+
   def commenters
     comments = notifiable.commentable.comments
     comments.select { |comment| comment.updated_at >= unread_date }.map(&:user).uniq

--- a/src/api/app/models/notification.rb
+++ b/src/api/app/models/notification.rb
@@ -96,6 +96,24 @@ class Notification < ApplicationRecord
     truncation_index = !first_new_line_index.nil? && first_new_line_index < TRUNCATION_LENGTH ? first_new_line_index + TRUNCATION_ELLIPSIS_LENGTH : TRUNCATION_LENGTH
     text.truncate(truncation_index)
   end
+
+  def bs_request
+    return unless event_type == 'Event::CommentForRequest'
+
+    if notifiable.commentable.is_a?(BsRequestAction)
+      notifiable.commentable.bs_request
+    else
+      notifiable.commentable
+    end
+  end
+
+  # FIXME: Duplicated from RequestHelper
+  # Returns strings like "Add Role", "Submit", etc.
+  def request_type_of_action(bs_request)
+    return 'Multiple Actions' if bs_request.bs_request_actions.size > 1
+
+    bs_request.bs_request_actions.first.type.titleize
+  end
 end
 
 # == Schema Information

--- a/src/api/app/models/notification.rb
+++ b/src/api/app/models/notification.rb
@@ -110,21 +110,29 @@ class Notification < ApplicationRecord
   end
 
   def bs_request
-    return unless event_type == 'Event::CommentForRequest'
-
-    if notifiable.commentable.is_a?(BsRequestAction)
+    if notifiable_type == 'BsRequest'
+      notifiable
+    elsif notifiable.commentable.is_a?(BsRequestAction)
       notifiable.commentable.bs_request
     else
       notifiable.commentable
     end
   end
 
+  def first_action(bs_request)
+    bs_request.bs_request_actions.first
+  end
+
+  def number_of_bs_request_actions(bs_request)
+    bs_request.bs_request_actions.size
+  end
+
   # FIXME: Duplicated from RequestHelper
   # Returns strings like "Add Role", "Submit", etc.
   def request_type_of_action(bs_request)
-    return 'Multiple Actions' if bs_request.bs_request_actions.size > 1
+    return 'Multiple Actions' if number_of_bs_request_actions(bs_request) > 1
 
-    bs_request.bs_request_actions.first.type.titleize
+    first_action(bs_request).type.titleize
   end
 
   def commenters

--- a/src/api/app/models/notification.rb
+++ b/src/api/app/models/notification.rb
@@ -12,6 +12,8 @@ class Notification < ApplicationRecord
 
   serialize :event_payload, JSON
 
+  validates :type, presence: true, length: { maximum: 255 }
+
   after_create :track_notification_creation
 
   after_save :track_notification_delivered, if: :saved_change_to_delivered?

--- a/src/api/app/models/notification.rb
+++ b/src/api/app/models/notification.rb
@@ -77,6 +77,18 @@ class Notification < ApplicationRecord
     User.find_by(login: event_payload['accused']) if event_payload['accused']
   end
 
+  def summary
+    raise AbstractMethodCalled
+  end
+
+  def excerpt
+    raise AbstractMethodCalled
+  end
+
+  def involved_users
+    raise AbstractMethodCalled
+  end
+
   private
 
   def track_notification_creation

--- a/src/api/app/models/notification.rb
+++ b/src/api/app/models/notification.rb
@@ -114,6 +114,11 @@ class Notification < ApplicationRecord
 
     bs_request.bs_request_actions.first.type.titleize
   end
+
+  def commenters
+    comments = notifiable.commentable.comments
+    comments.select { |comment| comment.updated_at >= unread_date }.map(&:user).uniq
+  end
 end
 
 # == Schema Information

--- a/src/api/app/models/notification_appeal_created.rb
+++ b/src/api/app/models/notification_appeal_created.rb
@@ -11,6 +11,10 @@ class NotificationAppealCreated < Notification
   def involved_users
     [User.find(event_payload['appellant_id'])]
   end
+
+  def description
+    "'#{notifiable.appellant.login}' appealed the decision for the following reason:"
+  end
 end
 
 # == Schema Information

--- a/src/api/app/models/notification_appeal_created.rb
+++ b/src/api/app/models/notification_appeal_created.rb
@@ -1,0 +1,43 @@
+class NotificationAppealCreated < Notification
+  # TODO: rename to title after we remove the Notificiation#title column
+  def summary
+    "Appealed the decision for a report of #{notifiable.decision.moderator.login}"
+  end
+
+  def excerpt
+    reason
+  end
+end
+
+# == Schema Information
+#
+# Table name: notifications
+#
+#  id                         :bigint           not null, primary key
+#  bs_request_oldstate        :string(255)
+#  bs_request_state           :string(255)
+#  delivered                  :boolean          default(FALSE), indexed
+#  event_payload              :text(65535)      not null
+#  event_type                 :string(255)      not null, indexed
+#  last_seen_at               :datetime
+#  notifiable_type            :string(255)      indexed => [notifiable_id]
+#  rss                        :boolean          default(FALSE), indexed
+#  subscriber_type            :string(255)      indexed => [subscriber_id]
+#  subscription_receiver_role :string(255)      not null
+#  title                      :string(255)
+#  web                        :boolean          default(FALSE), indexed
+#  created_at                 :datetime         not null, indexed
+#  updated_at                 :datetime         not null
+#  notifiable_id              :integer          indexed => [notifiable_type]
+#  subscriber_id              :integer          indexed => [subscriber_type]
+#
+# Indexes
+#
+#  index_notifications_on_created_at                         (created_at)
+#  index_notifications_on_delivered                          (delivered)
+#  index_notifications_on_event_type                         (event_type)
+#  index_notifications_on_notifiable_type_and_notifiable_id  (notifiable_type,notifiable_id)
+#  index_notifications_on_rss                                (rss)
+#  index_notifications_on_subscriber_type_and_subscriber_id  (subscriber_type,subscriber_id)
+#  index_notifications_on_web                                (web)
+#

--- a/src/api/app/models/notification_appeal_created.rb
+++ b/src/api/app/models/notification_appeal_created.rb
@@ -7,6 +7,10 @@ class NotificationAppealCreated < Notification
   def excerpt
     reason
   end
+
+  def involved_users
+    [User.find(event_payload['appellant_id'])]
+  end
 end
 
 # == Schema Information

--- a/src/api/app/models/notification_build_fail.rb
+++ b/src/api/app/models/notification_build_fail.rb
@@ -1,0 +1,48 @@
+class NotificationBuildFail < Notification
+  # TODO: rename to title after we remove the Notificiation#title column
+  def summary
+    project = event_payload['project']
+    package = event_payload['package']
+    repository = event_payload['repository']
+    arch = event_payload['arch']
+
+    "Package #{package} on #{project} project failed to build against #{repository} / #{arch}"
+  end
+
+  def excerpt
+    ''
+  end
+end
+
+# == Schema Information
+#
+# Table name: notifications
+#
+#  id                         :bigint           not null, primary key
+#  bs_request_oldstate        :string(255)
+#  bs_request_state           :string(255)
+#  delivered                  :boolean          default(FALSE), indexed
+#  event_payload              :text(65535)      not null
+#  event_type                 :string(255)      not null, indexed
+#  last_seen_at               :datetime
+#  notifiable_type            :string(255)      indexed => [notifiable_id]
+#  rss                        :boolean          default(FALSE), indexed
+#  subscriber_type            :string(255)      indexed => [subscriber_id]
+#  subscription_receiver_role :string(255)      not null
+#  title                      :string(255)
+#  web                        :boolean          default(FALSE), indexed
+#  created_at                 :datetime         not null, indexed
+#  updated_at                 :datetime         not null
+#  notifiable_id              :integer          indexed => [notifiable_type]
+#  subscriber_id              :integer          indexed => [subscriber_type]
+#
+# Indexes
+#
+#  index_notifications_on_created_at                         (created_at)
+#  index_notifications_on_delivered                          (delivered)
+#  index_notifications_on_event_type                         (event_type)
+#  index_notifications_on_notifiable_type_and_notifiable_id  (notifiable_type,notifiable_id)
+#  index_notifications_on_rss                                (rss)
+#  index_notifications_on_subscriber_type_and_subscriber_id  (subscriber_type,subscriber_id)
+#  index_notifications_on_web                                (web)
+#

--- a/src/api/app/models/notification_build_fail.rb
+++ b/src/api/app/models/notification_build_fail.rb
@@ -16,6 +16,10 @@ class NotificationBuildFail < Notification
   def involved_users
     [User.find_by(login: event_payload['who'])]
   end
+
+  def description
+    "Build was triggered because of #{event_payload['reason']}"
+  end
 end
 
 # == Schema Information

--- a/src/api/app/models/notification_build_fail.rb
+++ b/src/api/app/models/notification_build_fail.rb
@@ -12,6 +12,10 @@ class NotificationBuildFail < Notification
   def excerpt
     ''
   end
+
+  def involved_users
+    [User.find_by(login: event_payload['who'])]
+  end
 end
 
 # == Schema Information

--- a/src/api/app/models/notification_cleared_decision.rb
+++ b/src/api/app/models/notification_cleared_decision.rb
@@ -14,6 +14,10 @@ class NotificationClearedDecision < Notification
   def involved_users
     [User.find(event_payload['moderator_id'])]
   end
+
+  def description
+    "'#{notifiable.moderator.login}' decided to clear the report. This is the reason:"
+  end
 end
 
 # == Schema Information

--- a/src/api/app/models/notification_cleared_decision.rb
+++ b/src/api/app/models/notification_cleared_decision.rb
@@ -1,0 +1,46 @@
+class NotificationClearedDecision < Notification
+  # TODO: rename to title after we remove the Notificiation#title column
+  def summary
+    # All reports should point to the same reportable. We will take care of that here:
+    # https://trello.com/c/xrjOZGa7/45-ensure-all-reports-of-a-decision-point-to-the-same-reportable
+    # This reportable won't be nil once we fix this: https://trello.com/c/vPDiLjIQ/66-prevent-the-creation-of-reports-without-reportable
+    "Cleared #{notifiable.reports.first.reportable&.class&.name} Report".squish
+  end
+
+  def excerpt
+    reason
+  end
+end
+
+# == Schema Information
+#
+# Table name: notifications
+#
+#  id                         :bigint           not null, primary key
+#  bs_request_oldstate        :string(255)
+#  bs_request_state           :string(255)
+#  delivered                  :boolean          default(FALSE), indexed
+#  event_payload              :text(65535)      not null
+#  event_type                 :string(255)      not null, indexed
+#  last_seen_at               :datetime
+#  notifiable_type            :string(255)      indexed => [notifiable_id]
+#  rss                        :boolean          default(FALSE), indexed
+#  subscriber_type            :string(255)      indexed => [subscriber_id]
+#  subscription_receiver_role :string(255)      not null
+#  title                      :string(255)
+#  web                        :boolean          default(FALSE), indexed
+#  created_at                 :datetime         not null, indexed
+#  updated_at                 :datetime         not null
+#  notifiable_id              :integer          indexed => [notifiable_type]
+#  subscriber_id              :integer          indexed => [subscriber_type]
+#
+# Indexes
+#
+#  index_notifications_on_created_at                         (created_at)
+#  index_notifications_on_delivered                          (delivered)
+#  index_notifications_on_event_type                         (event_type)
+#  index_notifications_on_notifiable_type_and_notifiable_id  (notifiable_type,notifiable_id)
+#  index_notifications_on_rss                                (rss)
+#  index_notifications_on_subscriber_type_and_subscriber_id  (subscriber_type,subscriber_id)
+#  index_notifications_on_web                                (web)
+#

--- a/src/api/app/models/notification_cleared_decision.rb
+++ b/src/api/app/models/notification_cleared_decision.rb
@@ -10,6 +10,10 @@ class NotificationClearedDecision < Notification
   def excerpt
     reason
   end
+
+  def involved_users
+    [User.find(event_payload['moderator_id'])]
+  end
 end
 
 # == Schema Information

--- a/src/api/app/models/notification_comment_for_package.rb
+++ b/src/api/app/models/notification_comment_for_package.rb
@@ -7,6 +7,10 @@ class NotificationCommentForPackage < Notification
   def excerpt
     truncate_to_first_new_line(notifiable.body) # comment body
   end
+
+  def involved_users
+    commenters
+  end
 end
 
 # == Schema Information

--- a/src/api/app/models/notification_comment_for_package.rb
+++ b/src/api/app/models/notification_comment_for_package.rb
@@ -1,0 +1,43 @@
+class NotificationCommentForPackage < Notification
+  # TODO: rename to title after we remove the Notificiation#title column
+  def summary
+    'Comment on Package'
+  end
+
+  def excerpt
+    truncate_to_first_new_line(notifiable.body) # comment body
+  end
+end
+
+# == Schema Information
+#
+# Table name: notifications
+#
+#  id                         :bigint           not null, primary key
+#  bs_request_oldstate        :string(255)
+#  bs_request_state           :string(255)
+#  delivered                  :boolean          default(FALSE), indexed
+#  event_payload              :text(65535)      not null
+#  event_type                 :string(255)      not null, indexed
+#  last_seen_at               :datetime
+#  notifiable_type            :string(255)      indexed => [notifiable_id]
+#  rss                        :boolean          default(FALSE), indexed
+#  subscriber_type            :string(255)      indexed => [subscriber_id]
+#  subscription_receiver_role :string(255)      not null
+#  title                      :string(255)
+#  web                        :boolean          default(FALSE), indexed
+#  created_at                 :datetime         not null, indexed
+#  updated_at                 :datetime         not null
+#  notifiable_id              :integer          indexed => [notifiable_type]
+#  subscriber_id              :integer          indexed => [subscriber_type]
+#
+# Indexes
+#
+#  index_notifications_on_created_at                         (created_at)
+#  index_notifications_on_delivered                          (delivered)
+#  index_notifications_on_event_type                         (event_type)
+#  index_notifications_on_notifiable_type_and_notifiable_id  (notifiable_type,notifiable_id)
+#  index_notifications_on_rss                                (rss)
+#  index_notifications_on_subscriber_type_and_subscriber_id  (subscriber_type,subscriber_id)
+#  index_notifications_on_web                                (web)
+#

--- a/src/api/app/models/notification_comment_for_package.rb
+++ b/src/api/app/models/notification_comment_for_package.rb
@@ -11,6 +11,11 @@ class NotificationCommentForPackage < Notification
   def involved_users
     commenters
   end
+
+  def description
+    commentable = notifiable.commentable
+    "#{commentable.project.name} / #{commentable.name}"
+  end
 end
 
 # == Schema Information

--- a/src/api/app/models/notification_comment_for_project.rb
+++ b/src/api/app/models/notification_comment_for_project.rb
@@ -7,6 +7,10 @@ class NotificationCommentForProject < Notification
   def excerpt
     truncate_to_first_new_line(notifiable.body) # comment body
   end
+
+  def involved_users
+    commenters
+  end
 end
 
 # == Schema Information

--- a/src/api/app/models/notification_comment_for_project.rb
+++ b/src/api/app/models/notification_comment_for_project.rb
@@ -11,6 +11,10 @@ class NotificationCommentForProject < Notification
   def involved_users
     commenters
   end
+
+  def description
+    notifiable.commentable.name
+  end
 end
 
 # == Schema Information

--- a/src/api/app/models/notification_comment_for_project.rb
+++ b/src/api/app/models/notification_comment_for_project.rb
@@ -1,0 +1,43 @@
+class NotificationCommentForProject < Notification
+  # TODO: rename to title after we remove the Notificiation#title column
+  def summary
+    'Comment on Project'
+  end
+
+  def excerpt
+    truncate_to_first_new_line(notifiable.body) # comment body
+  end
+end
+
+# == Schema Information
+#
+# Table name: notifications
+#
+#  id                         :bigint           not null, primary key
+#  bs_request_oldstate        :string(255)
+#  bs_request_state           :string(255)
+#  delivered                  :boolean          default(FALSE), indexed
+#  event_payload              :text(65535)      not null
+#  event_type                 :string(255)      not null, indexed
+#  last_seen_at               :datetime
+#  notifiable_type            :string(255)      indexed => [notifiable_id]
+#  rss                        :boolean          default(FALSE), indexed
+#  subscriber_type            :string(255)      indexed => [subscriber_id]
+#  subscription_receiver_role :string(255)      not null
+#  title                      :string(255)
+#  web                        :boolean          default(FALSE), indexed
+#  created_at                 :datetime         not null, indexed
+#  updated_at                 :datetime         not null
+#  notifiable_id              :integer          indexed => [notifiable_type]
+#  subscriber_id              :integer          indexed => [subscriber_type]
+#
+# Indexes
+#
+#  index_notifications_on_created_at                         (created_at)
+#  index_notifications_on_delivered                          (delivered)
+#  index_notifications_on_event_type                         (event_type)
+#  index_notifications_on_notifiable_type_and_notifiable_id  (notifiable_type,notifiable_id)
+#  index_notifications_on_rss                                (rss)
+#  index_notifications_on_subscriber_type_and_subscriber_id  (subscriber_type,subscriber_id)
+#  index_notifications_on_web                                (web)
+#

--- a/src/api/app/models/notification_comment_for_request.rb
+++ b/src/api/app/models/notification_comment_for_request.rb
@@ -1,0 +1,63 @@
+class NotificationCommentForRequest < Notification
+  # TODO: rename to title after we remove the Notificiation#title column
+  def summary
+    "Comment on #{request_type_of_action(bs_request)} Request ##{bs_request.number}"
+  end
+
+  def excerpt
+    truncate_to_first_new_line(notifiable.body) # comment body
+  end
+
+  private
+
+  def bs_request
+    return unless event_type == 'Event::CommentForRequest'
+
+    if notifiable.commentable.is_a?(BsRequestAction)
+      notifiable.commentable.bs_request
+    else
+      notifiable.commentable
+    end
+  end
+
+  # FIXME: Duplicated from RequestHelper
+  # Returns strings like "Add Role", "Submit", etc.
+  def request_type_of_action(bs_request)
+    return 'Multiple Actions' if bs_request.bs_request_actions.size > 1
+
+    bs_request.bs_request_actions.first.type.titleize
+  end
+end
+
+# == Schema Information
+#
+# Table name: notifications
+#
+#  id                         :bigint           not null, primary key
+#  bs_request_oldstate        :string(255)
+#  bs_request_state           :string(255)
+#  delivered                  :boolean          default(FALSE), indexed
+#  event_payload              :text(65535)      not null
+#  event_type                 :string(255)      not null, indexed
+#  last_seen_at               :datetime
+#  notifiable_type            :string(255)      indexed => [notifiable_id]
+#  rss                        :boolean          default(FALSE), indexed
+#  subscriber_type            :string(255)      indexed => [subscriber_id]
+#  subscription_receiver_role :string(255)      not null
+#  title                      :string(255)
+#  web                        :boolean          default(FALSE), indexed
+#  created_at                 :datetime         not null, indexed
+#  updated_at                 :datetime         not null
+#  notifiable_id              :integer          indexed => [notifiable_type]
+#  subscriber_id              :integer          indexed => [subscriber_type]
+#
+# Indexes
+#
+#  index_notifications_on_created_at                         (created_at)
+#  index_notifications_on_delivered                          (delivered)
+#  index_notifications_on_event_type                         (event_type)
+#  index_notifications_on_notifiable_type_and_notifiable_id  (notifiable_type,notifiable_id)
+#  index_notifications_on_rss                                (rss)
+#  index_notifications_on_subscriber_type_and_subscriber_id  (subscriber_type,subscriber_id)
+#  index_notifications_on_web                                (web)
+#

--- a/src/api/app/models/notification_comment_for_request.rb
+++ b/src/api/app/models/notification_comment_for_request.rb
@@ -7,6 +7,10 @@ class NotificationCommentForRequest < Notification
   def excerpt
     truncate_to_first_new_line(notifiable.body) # comment body
   end
+
+  def involved_users
+    commenters
+  end
 end
 
 # == Schema Information

--- a/src/api/app/models/notification_comment_for_request.rb
+++ b/src/api/app/models/notification_comment_for_request.rb
@@ -11,6 +11,10 @@ class NotificationCommentForRequest < Notification
   def involved_users
     commenters
   end
+
+  def description
+    "From #{request_source} to #{request_target}"
+  end
 end
 
 # == Schema Information

--- a/src/api/app/models/notification_comment_for_request.rb
+++ b/src/api/app/models/notification_comment_for_request.rb
@@ -7,26 +7,6 @@ class NotificationCommentForRequest < Notification
   def excerpt
     truncate_to_first_new_line(notifiable.body) # comment body
   end
-
-  private
-
-  def bs_request
-    return unless event_type == 'Event::CommentForRequest'
-
-    if notifiable.commentable.is_a?(BsRequestAction)
-      notifiable.commentable.bs_request
-    else
-      notifiable.commentable
-    end
-  end
-
-  # FIXME: Duplicated from RequestHelper
-  # Returns strings like "Add Role", "Submit", etc.
-  def request_type_of_action(bs_request)
-    return 'Multiple Actions' if bs_request.bs_request_actions.size > 1
-
-    bs_request.bs_request_actions.first.type.titleize
-  end
 end
 
 # == Schema Information

--- a/src/api/app/models/notification_favored_decision.rb
+++ b/src/api/app/models/notification_favored_decision.rb
@@ -10,6 +10,10 @@ class NotificationFavoredDecision < Notification
   def excerpt
     reason
   end
+
+  def involved_users
+    [User.find(event_payload['moderator_id'])]
+  end
 end
 
 # == Schema Information

--- a/src/api/app/models/notification_favored_decision.rb
+++ b/src/api/app/models/notification_favored_decision.rb
@@ -14,6 +14,10 @@ class NotificationFavoredDecision < Notification
   def involved_users
     [User.find(event_payload['moderator_id'])]
   end
+
+  def description
+    "'#{notifiable.moderator.login}' decided to favor the report. This is the reason:"
+  end
 end
 
 # == Schema Information

--- a/src/api/app/models/notification_favored_decision.rb
+++ b/src/api/app/models/notification_favored_decision.rb
@@ -1,0 +1,46 @@
+class NotificationFavoredDecision < Notification
+  # TODO: rename to title after we remove the Notificiation#title column
+  def summary
+    # All reports should point to the same reportable. We will take care of that here:
+    # https://trello.com/c/xrjOZGa7/45-ensure-all-reports-of-a-decision-point-to-the-same-reportable
+    # This reportable won't be nil once we fix this: https://trello.com/c/vPDiLjIQ/66-prevent-the-creation-of-reports-without-reportable
+    "Favored #{notifiable.reports.first.reportable&.class&.name} Report".squish
+  end
+
+  def excerpt
+    reason
+  end
+end
+
+# == Schema Information
+#
+# Table name: notifications
+#
+#  id                         :bigint           not null, primary key
+#  bs_request_oldstate        :string(255)
+#  bs_request_state           :string(255)
+#  delivered                  :boolean          default(FALSE), indexed
+#  event_payload              :text(65535)      not null
+#  event_type                 :string(255)      not null, indexed
+#  last_seen_at               :datetime
+#  notifiable_type            :string(255)      indexed => [notifiable_id]
+#  rss                        :boolean          default(FALSE), indexed
+#  subscriber_type            :string(255)      indexed => [subscriber_id]
+#  subscription_receiver_role :string(255)      not null
+#  title                      :string(255)
+#  web                        :boolean          default(FALSE), indexed
+#  created_at                 :datetime         not null, indexed
+#  updated_at                 :datetime         not null
+#  notifiable_id              :integer          indexed => [notifiable_type]
+#  subscriber_id              :integer          indexed => [subscriber_type]
+#
+# Indexes
+#
+#  index_notifications_on_created_at                         (created_at)
+#  index_notifications_on_delivered                          (delivered)
+#  index_notifications_on_event_type                         (event_type)
+#  index_notifications_on_notifiable_type_and_notifiable_id  (notifiable_type,notifiable_id)
+#  index_notifications_on_rss                                (rss)
+#  index_notifications_on_subscriber_type_and_subscriber_id  (subscriber_type,subscriber_id)
+#  index_notifications_on_web                                (web)
+#

--- a/src/api/app/models/notification_relationship_create.rb
+++ b/src/api/app/models/notification_relationship_create.rb
@@ -12,6 +12,10 @@ class NotificationRelationshipCreate < Notification
   def excerpt
     ''
   end
+
+  def involved_users
+    [User.find_by(login: event_payload['who'])]
+  end
 end
 
 # == Schema Information

--- a/src/api/app/models/notification_relationship_create.rb
+++ b/src/api/app/models/notification_relationship_create.rb
@@ -1,0 +1,48 @@
+class NotificationRelationshipCreate < Notification
+  # TODO: rename to title after we remove the Notificiation#title column
+  def summary
+    role = event_payload['role']
+    if event_payload['package']
+      "Added as #{role} of a package"
+    else
+      "Added as #{role} of a project"
+    end
+  end
+
+  def excerpt
+    ''
+  end
+end
+
+# == Schema Information
+#
+# Table name: notifications
+#
+#  id                         :bigint           not null, primary key
+#  bs_request_oldstate        :string(255)
+#  bs_request_state           :string(255)
+#  delivered                  :boolean          default(FALSE), indexed
+#  event_payload              :text(65535)      not null
+#  event_type                 :string(255)      not null, indexed
+#  last_seen_at               :datetime
+#  notifiable_type            :string(255)      indexed => [notifiable_id]
+#  rss                        :boolean          default(FALSE), indexed
+#  subscriber_type            :string(255)      indexed => [subscriber_id]
+#  subscription_receiver_role :string(255)      not null
+#  title                      :string(255)
+#  web                        :boolean          default(FALSE), indexed
+#  created_at                 :datetime         not null, indexed
+#  updated_at                 :datetime         not null
+#  notifiable_id              :integer          indexed => [notifiable_type]
+#  subscriber_id              :integer          indexed => [subscriber_type]
+#
+# Indexes
+#
+#  index_notifications_on_created_at                         (created_at)
+#  index_notifications_on_delivered                          (delivered)
+#  index_notifications_on_event_type                         (event_type)
+#  index_notifications_on_notifiable_type_and_notifiable_id  (notifiable_type,notifiable_id)
+#  index_notifications_on_rss                                (rss)
+#  index_notifications_on_subscriber_type_and_subscriber_id  (subscriber_type,subscriber_id)
+#  index_notifications_on_web                                (web)
+#

--- a/src/api/app/models/notification_relationship_delete.rb
+++ b/src/api/app/models/notification_relationship_delete.rb
@@ -1,0 +1,48 @@
+class NotificationRelationshipDelete < Notification
+  # TODO: rename to title after we remove the Notificiation#title column
+  def summary
+    role = event_payload['role']
+    if event_payload['package']
+      "Removed as #{role} of a package"
+    else
+      "Removed as #{role} of a project"
+    end
+  end
+
+  def excerpt
+    ''
+  end
+end
+
+# == Schema Information
+#
+# Table name: notifications
+#
+#  id                         :bigint           not null, primary key
+#  bs_request_oldstate        :string(255)
+#  bs_request_state           :string(255)
+#  delivered                  :boolean          default(FALSE), indexed
+#  event_payload              :text(65535)      not null
+#  event_type                 :string(255)      not null, indexed
+#  last_seen_at               :datetime
+#  notifiable_type            :string(255)      indexed => [notifiable_id]
+#  rss                        :boolean          default(FALSE), indexed
+#  subscriber_type            :string(255)      indexed => [subscriber_id]
+#  subscription_receiver_role :string(255)      not null
+#  title                      :string(255)
+#  web                        :boolean          default(FALSE), indexed
+#  created_at                 :datetime         not null, indexed
+#  updated_at                 :datetime         not null
+#  notifiable_id              :integer          indexed => [notifiable_type]
+#  subscriber_id              :integer          indexed => [subscriber_type]
+#
+# Indexes
+#
+#  index_notifications_on_created_at                         (created_at)
+#  index_notifications_on_delivered                          (delivered)
+#  index_notifications_on_event_type                         (event_type)
+#  index_notifications_on_notifiable_type_and_notifiable_id  (notifiable_type,notifiable_id)
+#  index_notifications_on_rss                                (rss)
+#  index_notifications_on_subscriber_type_and_subscriber_id  (subscriber_type,subscriber_id)
+#  index_notifications_on_web                                (web)
+#

--- a/src/api/app/models/notification_relationship_delete.rb
+++ b/src/api/app/models/notification_relationship_delete.rb
@@ -12,6 +12,10 @@ class NotificationRelationshipDelete < Notification
   def excerpt
     ''
   end
+
+  def involved_users
+    [User.find_by(login: event_payload['who'])]
+  end
 end
 
 # == Schema Information

--- a/src/api/app/models/notification_relationship_delete.rb
+++ b/src/api/app/models/notification_relationship_delete.rb
@@ -16,6 +16,13 @@ class NotificationRelationshipDelete < Notification
   def involved_users
     [User.find_by(login: event_payload['who'])]
   end
+
+  def description
+    target_object = [event_payload['project'], event_payload['package']].compact.join(' / ')
+    recipient = event_payload.fetch('group', 'you')
+
+    "#{event_payload['who']} removed #{recipient} as #{event_payload['role']} of #{target_object}"
+  end
 end
 
 # == Schema Information

--- a/src/api/app/models/notification_report_for_comment.rb
+++ b/src/api/app/models/notification_report_for_comment.rb
@@ -11,6 +11,10 @@ class NotificationReportForComment < Notification
   def excerpt
     reason
   end
+
+  def involved_users
+    [User.find_by(login: event_payload['reporter'])]
+  end
 end
 
 # == Schema Information

--- a/src/api/app/models/notification_report_for_comment.rb
+++ b/src/api/app/models/notification_report_for_comment.rb
@@ -15,6 +15,10 @@ class NotificationReportForComment < Notification
   def involved_users
     [User.find_by(login: event_payload['reporter'])]
   end
+
+  def description
+    "'#{notifiable.user.login}' created a report for a comment from #{event_payload['commenter']}. This is the reason:"
+  end
 end
 
 # == Schema Information

--- a/src/api/app/models/notification_report_for_comment.rb
+++ b/src/api/app/models/notification_report_for_comment.rb
@@ -1,0 +1,47 @@
+class NotificationReportForComment < Notification
+  # TODO: rename to title after we remove the Notificiation#title column
+  def summary
+    if Comment.exists?(event_payload['reportable_id'])
+      'Report for a comment'
+    else
+      'Report for a deleted comment'
+    end
+  end
+
+  def excerpt
+    reason
+  end
+end
+
+# == Schema Information
+#
+# Table name: notifications
+#
+#  id                         :bigint           not null, primary key
+#  bs_request_oldstate        :string(255)
+#  bs_request_state           :string(255)
+#  delivered                  :boolean          default(FALSE), indexed
+#  event_payload              :text(65535)      not null
+#  event_type                 :string(255)      not null, indexed
+#  last_seen_at               :datetime
+#  notifiable_type            :string(255)      indexed => [notifiable_id]
+#  rss                        :boolean          default(FALSE), indexed
+#  subscriber_type            :string(255)      indexed => [subscriber_id]
+#  subscription_receiver_role :string(255)      not null
+#  title                      :string(255)
+#  web                        :boolean          default(FALSE), indexed
+#  created_at                 :datetime         not null, indexed
+#  updated_at                 :datetime         not null
+#  notifiable_id              :integer          indexed => [notifiable_type]
+#  subscriber_id              :integer          indexed => [subscriber_type]
+#
+# Indexes
+#
+#  index_notifications_on_created_at                         (created_at)
+#  index_notifications_on_delivered                          (delivered)
+#  index_notifications_on_event_type                         (event_type)
+#  index_notifications_on_notifiable_type_and_notifiable_id  (notifiable_type,notifiable_id)
+#  index_notifications_on_rss                                (rss)
+#  index_notifications_on_subscriber_type_and_subscriber_id  (subscriber_type,subscriber_id)
+#  index_notifications_on_web                                (web)
+#

--- a/src/api/app/models/notification_report_for_package.rb
+++ b/src/api/app/models/notification_report_for_package.rb
@@ -1,0 +1,43 @@
+class NotificationReportForPackage < Notification
+  # TODO: rename to title after we remove the Notificiation#title column
+  def summary
+    event_type.constantize.notification_link_text(event_payload)
+  end
+
+  def excerpt
+    reason
+  end
+end
+
+# == Schema Information
+#
+# Table name: notifications
+#
+#  id                         :bigint           not null, primary key
+#  bs_request_oldstate        :string(255)
+#  bs_request_state           :string(255)
+#  delivered                  :boolean          default(FALSE), indexed
+#  event_payload              :text(65535)      not null
+#  event_type                 :string(255)      not null, indexed
+#  last_seen_at               :datetime
+#  notifiable_type            :string(255)      indexed => [notifiable_id]
+#  rss                        :boolean          default(FALSE), indexed
+#  subscriber_type            :string(255)      indexed => [subscriber_id]
+#  subscription_receiver_role :string(255)      not null
+#  title                      :string(255)
+#  web                        :boolean          default(FALSE), indexed
+#  created_at                 :datetime         not null, indexed
+#  updated_at                 :datetime         not null
+#  notifiable_id              :integer          indexed => [notifiable_type]
+#  subscriber_id              :integer          indexed => [subscriber_type]
+#
+# Indexes
+#
+#  index_notifications_on_created_at                         (created_at)
+#  index_notifications_on_delivered                          (delivered)
+#  index_notifications_on_event_type                         (event_type)
+#  index_notifications_on_notifiable_type_and_notifiable_id  (notifiable_type,notifiable_id)
+#  index_notifications_on_rss                                (rss)
+#  index_notifications_on_subscriber_type_and_subscriber_id  (subscriber_type,subscriber_id)
+#  index_notifications_on_web                                (web)
+#

--- a/src/api/app/models/notification_report_for_package.rb
+++ b/src/api/app/models/notification_report_for_package.rb
@@ -7,6 +7,10 @@ class NotificationReportForPackage < Notification
   def excerpt
     reason
   end
+
+  def involved_users
+    [User.find_by(login: event_payload['reporter'])]
+  end
 end
 
 # == Schema Information

--- a/src/api/app/models/notification_report_for_package.rb
+++ b/src/api/app/models/notification_report_for_package.rb
@@ -11,6 +11,10 @@ class NotificationReportForPackage < Notification
   def involved_users
     [User.find_by(login: event_payload['reporter'])]
   end
+
+  def description
+    "'#{notifiable.user.login}' created a report for a #{event_payload['reportable_type'].downcase}. This is the reason:"
+  end
 end
 
 # == Schema Information

--- a/src/api/app/models/notification_report_for_project.rb
+++ b/src/api/app/models/notification_report_for_project.rb
@@ -7,6 +7,10 @@ class NotificationReportForProject < Notification
   def excerpt
     reason
   end
+
+  def involved_users
+    [User.find_by(login: event_payload['reporter'])]
+  end
 end
 
 # == Schema Information

--- a/src/api/app/models/notification_report_for_project.rb
+++ b/src/api/app/models/notification_report_for_project.rb
@@ -11,6 +11,10 @@ class NotificationReportForProject < Notification
   def involved_users
     [User.find_by(login: event_payload['reporter'])]
   end
+
+  def description
+    "'#{notifiable.user.login}' created a report for a #{event_payload['reportable_type'].downcase}. This is the reason:"
+  end
 end
 
 # == Schema Information

--- a/src/api/app/models/notification_report_for_project.rb
+++ b/src/api/app/models/notification_report_for_project.rb
@@ -1,0 +1,43 @@
+class NotificationReportForProject < Notification
+  # TODO: rename to title after we remove the Notificiation#title column
+  def summary
+    event_type.constantize.notification_link_text(event_payload)
+  end
+
+  def excerpt
+    reason
+  end
+end
+
+# == Schema Information
+#
+# Table name: notifications
+#
+#  id                         :bigint           not null, primary key
+#  bs_request_oldstate        :string(255)
+#  bs_request_state           :string(255)
+#  delivered                  :boolean          default(FALSE), indexed
+#  event_payload              :text(65535)      not null
+#  event_type                 :string(255)      not null, indexed
+#  last_seen_at               :datetime
+#  notifiable_type            :string(255)      indexed => [notifiable_id]
+#  rss                        :boolean          default(FALSE), indexed
+#  subscriber_type            :string(255)      indexed => [subscriber_id]
+#  subscription_receiver_role :string(255)      not null
+#  title                      :string(255)
+#  web                        :boolean          default(FALSE), indexed
+#  created_at                 :datetime         not null, indexed
+#  updated_at                 :datetime         not null
+#  notifiable_id              :integer          indexed => [notifiable_type]
+#  subscriber_id              :integer          indexed => [subscriber_type]
+#
+# Indexes
+#
+#  index_notifications_on_created_at                         (created_at)
+#  index_notifications_on_delivered                          (delivered)
+#  index_notifications_on_event_type                         (event_type)
+#  index_notifications_on_notifiable_type_and_notifiable_id  (notifiable_type,notifiable_id)
+#  index_notifications_on_rss                                (rss)
+#  index_notifications_on_subscriber_type_and_subscriber_id  (subscriber_type,subscriber_id)
+#  index_notifications_on_web                                (web)
+#

--- a/src/api/app/models/notification_report_for_request.rb
+++ b/src/api/app/models/notification_report_for_request.rb
@@ -11,6 +11,10 @@ class NotificationReportForRequest < Notification
   def involved_users
     [User.find_by(login: event_payload['reporter'])]
   end
+
+  def description
+    "'#{notifiable.user.login}' created a report for a request. This is the reason:"
+  end
 end
 
 # == Schema Information

--- a/src/api/app/models/notification_report_for_request.rb
+++ b/src/api/app/models/notification_report_for_request.rb
@@ -1,0 +1,43 @@
+class NotificationReportForRequest < Notification
+  # TODO: rename to title after we remove the Notificiation#title column
+  def summary
+    "Report for Request ##{notifiable.reportable.number}"
+  end
+
+  def excerpt
+    reason
+  end
+end
+
+# == Schema Information
+#
+# Table name: notifications
+#
+#  id                         :bigint           not null, primary key
+#  bs_request_oldstate        :string(255)
+#  bs_request_state           :string(255)
+#  delivered                  :boolean          default(FALSE), indexed
+#  event_payload              :text(65535)      not null
+#  event_type                 :string(255)      not null, indexed
+#  last_seen_at               :datetime
+#  notifiable_type            :string(255)      indexed => [notifiable_id]
+#  rss                        :boolean          default(FALSE), indexed
+#  subscriber_type            :string(255)      indexed => [subscriber_id]
+#  subscription_receiver_role :string(255)      not null
+#  title                      :string(255)
+#  web                        :boolean          default(FALSE), indexed
+#  created_at                 :datetime         not null, indexed
+#  updated_at                 :datetime         not null
+#  notifiable_id              :integer          indexed => [notifiable_type]
+#  subscriber_id              :integer          indexed => [subscriber_type]
+#
+# Indexes
+#
+#  index_notifications_on_created_at                         (created_at)
+#  index_notifications_on_delivered                          (delivered)
+#  index_notifications_on_event_type                         (event_type)
+#  index_notifications_on_notifiable_type_and_notifiable_id  (notifiable_type,notifiable_id)
+#  index_notifications_on_rss                                (rss)
+#  index_notifications_on_subscriber_type_and_subscriber_id  (subscriber_type,subscriber_id)
+#  index_notifications_on_web                                (web)
+#

--- a/src/api/app/models/notification_report_for_request.rb
+++ b/src/api/app/models/notification_report_for_request.rb
@@ -7,6 +7,10 @@ class NotificationReportForRequest < Notification
   def excerpt
     reason
   end
+
+  def involved_users
+    [User.find_by(login: event_payload['reporter'])]
+  end
 end
 
 # == Schema Information

--- a/src/api/app/models/notification_report_for_user.rb
+++ b/src/api/app/models/notification_report_for_user.rb
@@ -7,6 +7,10 @@ class NotificationReportForUser < Notification
   def excerpt
     reason
   end
+
+  def involved_users
+    [User.find_by(login: event_payload['reporter'])]
+  end
 end
 
 # == Schema Information

--- a/src/api/app/models/notification_report_for_user.rb
+++ b/src/api/app/models/notification_report_for_user.rb
@@ -1,0 +1,43 @@
+class NotificationReportForUser < Notification
+  # TODO: rename to title after we remove the Notificiation#title column
+  def summary
+    "Report for a #{event_payload['reportable_type']}"
+  end
+
+  def excerpt
+    reason
+  end
+end
+
+# == Schema Information
+#
+# Table name: notifications
+#
+#  id                         :bigint           not null, primary key
+#  bs_request_oldstate        :string(255)
+#  bs_request_state           :string(255)
+#  delivered                  :boolean          default(FALSE), indexed
+#  event_payload              :text(65535)      not null
+#  event_type                 :string(255)      not null, indexed
+#  last_seen_at               :datetime
+#  notifiable_type            :string(255)      indexed => [notifiable_id]
+#  rss                        :boolean          default(FALSE), indexed
+#  subscriber_type            :string(255)      indexed => [subscriber_id]
+#  subscription_receiver_role :string(255)      not null
+#  title                      :string(255)
+#  web                        :boolean          default(FALSE), indexed
+#  created_at                 :datetime         not null, indexed
+#  updated_at                 :datetime         not null
+#  notifiable_id              :integer          indexed => [notifiable_type]
+#  subscriber_id              :integer          indexed => [subscriber_type]
+#
+# Indexes
+#
+#  index_notifications_on_created_at                         (created_at)
+#  index_notifications_on_delivered                          (delivered)
+#  index_notifications_on_event_type                         (event_type)
+#  index_notifications_on_notifiable_type_and_notifiable_id  (notifiable_type,notifiable_id)
+#  index_notifications_on_rss                                (rss)
+#  index_notifications_on_subscriber_type_and_subscriber_id  (subscriber_type,subscriber_id)
+#  index_notifications_on_web                                (web)
+#

--- a/src/api/app/models/notification_report_for_user.rb
+++ b/src/api/app/models/notification_report_for_user.rb
@@ -11,6 +11,10 @@ class NotificationReportForUser < Notification
   def involved_users
     [User.find_by(login: event_payload['reporter'])]
   end
+
+  def description
+    "'#{notifiable.user.login}' created a report for a #{event_payload['reportable_type'].downcase}. This is the reason:"
+  end
 end
 
 # == Schema Information

--- a/src/api/app/models/notification_request_create.rb
+++ b/src/api/app/models/notification_request_create.rb
@@ -7,6 +7,11 @@ class NotificationRequestCreate < Notification
   def excerpt
     notifiable.description.to_s
   end
+
+  def involved_users
+    reviews = notifiable.reviews
+    reviews.select(&:new?).map(&:reviewed_by) + User.where(login: notifiable.creator)
+  end
 end
 
 # == Schema Information

--- a/src/api/app/models/notification_request_create.rb
+++ b/src/api/app/models/notification_request_create.rb
@@ -1,0 +1,43 @@
+class NotificationRequestCreate < Notification
+  # TODO: rename to title after we remove the Notificiation#title column
+  def summary
+    "#{request_type_of_action(notifiable)} Request ##{notifiable.number}"
+  end
+
+  def excerpt
+    notifiable.description.to_s
+  end
+end
+
+# == Schema Information
+#
+# Table name: notifications
+#
+#  id                         :bigint           not null, primary key
+#  bs_request_oldstate        :string(255)
+#  bs_request_state           :string(255)
+#  delivered                  :boolean          default(FALSE), indexed
+#  event_payload              :text(65535)      not null
+#  event_type                 :string(255)      not null, indexed
+#  last_seen_at               :datetime
+#  notifiable_type            :string(255)      indexed => [notifiable_id]
+#  rss                        :boolean          default(FALSE), indexed
+#  subscriber_type            :string(255)      indexed => [subscriber_id]
+#  subscription_receiver_role :string(255)      not null
+#  title                      :string(255)
+#  web                        :boolean          default(FALSE), indexed
+#  created_at                 :datetime         not null, indexed
+#  updated_at                 :datetime         not null
+#  notifiable_id              :integer          indexed => [notifiable_type]
+#  subscriber_id              :integer          indexed => [subscriber_type]
+#
+# Indexes
+#
+#  index_notifications_on_created_at                         (created_at)
+#  index_notifications_on_delivered                          (delivered)
+#  index_notifications_on_event_type                         (event_type)
+#  index_notifications_on_notifiable_type_and_notifiable_id  (notifiable_type,notifiable_id)
+#  index_notifications_on_rss                                (rss)
+#  index_notifications_on_subscriber_type_and_subscriber_id  (subscriber_type,subscriber_id)
+#  index_notifications_on_web                                (web)
+#

--- a/src/api/app/models/notification_request_create.rb
+++ b/src/api/app/models/notification_request_create.rb
@@ -12,6 +12,10 @@ class NotificationRequestCreate < Notification
     reviews = notifiable.reviews
     reviews.select(&:new?).map(&:reviewed_by) + User.where(login: notifiable.creator)
   end
+
+  def description
+    "From #{request_source} to #{request_target}"
+  end
 end
 
 # == Schema Information

--- a/src/api/app/models/notification_request_statechange.rb
+++ b/src/api/app/models/notification_request_statechange.rb
@@ -12,6 +12,10 @@ class NotificationRequestStatechange < Notification
     reviews = notifiable.reviews
     reviews.select(&:new?).map(&:reviewed_by) + User.where(login: notifiable.creator)
   end
+
+  def description
+    "From #{request_source} to #{request_target}"
+  end
 end
 
 # == Schema Information

--- a/src/api/app/models/notification_request_statechange.rb
+++ b/src/api/app/models/notification_request_statechange.rb
@@ -1,0 +1,43 @@
+class NotificationRequestStatechange < Notification
+  # TODO: rename to title after we remove the Notificiation#title column
+  def summary
+    "#{request_type_of_action(notifiable)} Request ##{notifiable.number}"
+  end
+
+  def excerpt
+    notifiable.description.to_s
+  end
+end
+
+# == Schema Information
+#
+# Table name: notifications
+#
+#  id                         :bigint           not null, primary key
+#  bs_request_oldstate        :string(255)
+#  bs_request_state           :string(255)
+#  delivered                  :boolean          default(FALSE), indexed
+#  event_payload              :text(65535)      not null
+#  event_type                 :string(255)      not null, indexed
+#  last_seen_at               :datetime
+#  notifiable_type            :string(255)      indexed => [notifiable_id]
+#  rss                        :boolean          default(FALSE), indexed
+#  subscriber_type            :string(255)      indexed => [subscriber_id]
+#  subscription_receiver_role :string(255)      not null
+#  title                      :string(255)
+#  web                        :boolean          default(FALSE), indexed
+#  created_at                 :datetime         not null, indexed
+#  updated_at                 :datetime         not null
+#  notifiable_id              :integer          indexed => [notifiable_type]
+#  subscriber_id              :integer          indexed => [subscriber_type]
+#
+# Indexes
+#
+#  index_notifications_on_created_at                         (created_at)
+#  index_notifications_on_delivered                          (delivered)
+#  index_notifications_on_event_type                         (event_type)
+#  index_notifications_on_notifiable_type_and_notifiable_id  (notifiable_type,notifiable_id)
+#  index_notifications_on_rss                                (rss)
+#  index_notifications_on_subscriber_type_and_subscriber_id  (subscriber_type,subscriber_id)
+#  index_notifications_on_web                                (web)
+#

--- a/src/api/app/models/notification_request_statechange.rb
+++ b/src/api/app/models/notification_request_statechange.rb
@@ -7,6 +7,11 @@ class NotificationRequestStatechange < Notification
   def excerpt
     notifiable.description.to_s
   end
+
+  def involved_users
+    reviews = notifiable.reviews
+    reviews.select(&:new?).map(&:reviewed_by) + User.where(login: notifiable.creator)
+  end
 end
 
 # == Schema Information

--- a/src/api/app/models/notification_review_wanted.rb
+++ b/src/api/app/models/notification_review_wanted.rb
@@ -12,6 +12,10 @@ class NotificationReviewWanted < Notification
     reviews = notifiable.reviews
     reviews.select(&:new?).map(&:reviewed_by) + User.where(login: notifiable.creator)
   end
+
+  def description
+    "From #{request_source} to #{request_target}"
+  end
 end
 
 # == Schema Information

--- a/src/api/app/models/notification_review_wanted.rb
+++ b/src/api/app/models/notification_review_wanted.rb
@@ -1,0 +1,43 @@
+class NotificationReviewWanted < Notification
+  # TODO: rename to title after we remove the Notificiation#title column
+  def summary
+    "#{request_type_of_action(notifiable)} Request ##{notifiable.number}"
+  end
+
+  def excerpt
+    notifiable.description.to_s
+  end
+end
+
+# == Schema Information
+#
+# Table name: notifications
+#
+#  id                         :bigint           not null, primary key
+#  bs_request_oldstate        :string(255)
+#  bs_request_state           :string(255)
+#  delivered                  :boolean          default(FALSE), indexed
+#  event_payload              :text(65535)      not null
+#  event_type                 :string(255)      not null, indexed
+#  last_seen_at               :datetime
+#  notifiable_type            :string(255)      indexed => [notifiable_id]
+#  rss                        :boolean          default(FALSE), indexed
+#  subscriber_type            :string(255)      indexed => [subscriber_id]
+#  subscription_receiver_role :string(255)      not null
+#  title                      :string(255)
+#  web                        :boolean          default(FALSE), indexed
+#  created_at                 :datetime         not null, indexed
+#  updated_at                 :datetime         not null
+#  notifiable_id              :integer          indexed => [notifiable_type]
+#  subscriber_id              :integer          indexed => [subscriber_type]
+#
+# Indexes
+#
+#  index_notifications_on_created_at                         (created_at)
+#  index_notifications_on_delivered                          (delivered)
+#  index_notifications_on_event_type                         (event_type)
+#  index_notifications_on_notifiable_type_and_notifiable_id  (notifiable_type,notifiable_id)
+#  index_notifications_on_rss                                (rss)
+#  index_notifications_on_subscriber_type_and_subscriber_id  (subscriber_type,subscriber_id)
+#  index_notifications_on_web                                (web)
+#

--- a/src/api/app/models/notification_review_wanted.rb
+++ b/src/api/app/models/notification_review_wanted.rb
@@ -7,6 +7,11 @@ class NotificationReviewWanted < Notification
   def excerpt
     notifiable.description.to_s
   end
+
+  def involved_users
+    reviews = notifiable.reviews
+    reviews.select(&:new?).map(&:reviewed_by) + User.where(login: notifiable.creator)
+  end
 end
 
 # == Schema Information

--- a/src/api/app/models/notification_service_fail.rb
+++ b/src/api/app/models/notification_service_fail.rb
@@ -1,0 +1,44 @@
+# Only for email channel so far.
+class NotificationServiceFail < Notification
+  # TODO: rename to title after we remove the Notificiation#title column
+  def summary
+    'Package source service failed'
+  end
+
+  def excerpt
+    "Source service failure of #{event_payload['project']}/#{event_payload['package']}"
+  end
+end
+
+# == Schema Information
+#
+# Table name: notifications
+#
+#  id                         :bigint           not null, primary key
+#  bs_request_oldstate        :string(255)
+#  bs_request_state           :string(255)
+#  delivered                  :boolean          default(FALSE), indexed
+#  event_payload              :text(65535)      not null
+#  event_type                 :string(255)      not null, indexed
+#  last_seen_at               :datetime
+#  notifiable_type            :string(255)      indexed => [notifiable_id]
+#  rss                        :boolean          default(FALSE), indexed
+#  subscriber_type            :string(255)      indexed => [subscriber_id]
+#  subscription_receiver_role :string(255)      not null
+#  title                      :string(255)
+#  web                        :boolean          default(FALSE), indexed
+#  created_at                 :datetime         not null, indexed
+#  updated_at                 :datetime         not null
+#  notifiable_id              :integer          indexed => [notifiable_type]
+#  subscriber_id              :integer          indexed => [subscriber_type]
+#
+# Indexes
+#
+#  index_notifications_on_created_at                         (created_at)
+#  index_notifications_on_delivered                          (delivered)
+#  index_notifications_on_event_type                         (event_type)
+#  index_notifications_on_notifiable_type_and_notifiable_id  (notifiable_type,notifiable_id)
+#  index_notifications_on_rss                                (rss)
+#  index_notifications_on_subscriber_type_and_subscriber_id  (subscriber_type,subscriber_id)
+#  index_notifications_on_web                                (web)
+#

--- a/src/api/app/models/notification_service_fail.rb
+++ b/src/api/app/models/notification_service_fail.rb
@@ -8,6 +8,10 @@ class NotificationServiceFail < Notification
   def excerpt
     "Source service failure of #{event_payload['project']}/#{event_payload['package']}"
   end
+
+  def involved_users
+    []
+  end
 end
 
 # == Schema Information

--- a/src/api/app/models/notification_workflow_run_fail.rb
+++ b/src/api/app/models/notification_workflow_run_fail.rb
@@ -1,0 +1,43 @@
+class NotificationWorkflowRunFail < Notification
+  # TODO: rename to title after we remove the Notificiation#title column
+  def summary
+    'Workflow Run'
+  end
+
+  def excerpt
+    "In repository #{notifiable.repository_full_name}"
+  end
+end
+
+# == Schema Information
+#
+# Table name: notifications
+#
+#  id                         :bigint           not null, primary key
+#  bs_request_oldstate        :string(255)
+#  bs_request_state           :string(255)
+#  delivered                  :boolean          default(FALSE), indexed
+#  event_payload              :text(65535)      not null
+#  event_type                 :string(255)      not null, indexed
+#  last_seen_at               :datetime
+#  notifiable_type            :string(255)      indexed => [notifiable_id]
+#  rss                        :boolean          default(FALSE), indexed
+#  subscriber_type            :string(255)      indexed => [subscriber_id]
+#  subscription_receiver_role :string(255)      not null
+#  title                      :string(255)
+#  web                        :boolean          default(FALSE), indexed
+#  created_at                 :datetime         not null, indexed
+#  updated_at                 :datetime         not null
+#  notifiable_id              :integer          indexed => [notifiable_type]
+#  subscriber_id              :integer          indexed => [subscriber_type]
+#
+# Indexes
+#
+#  index_notifications_on_created_at                         (created_at)
+#  index_notifications_on_delivered                          (delivered)
+#  index_notifications_on_event_type                         (event_type)
+#  index_notifications_on_notifiable_type_and_notifiable_id  (notifiable_type,notifiable_id)
+#  index_notifications_on_rss                                (rss)
+#  index_notifications_on_subscriber_type_and_subscriber_id  (subscriber_type,subscriber_id)
+#  index_notifications_on_web                                (web)
+#

--- a/src/api/app/models/notification_workflow_run_fail.rb
+++ b/src/api/app/models/notification_workflow_run_fail.rb
@@ -7,6 +7,10 @@ class NotificationWorkflowRunFail < Notification
   def excerpt
     "In repository #{notifiable.repository_full_name}"
   end
+
+  def involved_users
+    [Token.find(event_payload['token_id'])&.executor].compact
+  end
 end
 
 # == Schema Information

--- a/src/api/db/data/20240524152040_backfill_notifications_type.rb
+++ b/src/api/db/data/20240524152040_backfill_notifications_type.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class BackfillNotificationsType < ActiveRecord::Migration[7.0]
+  def up
+    Notification.find_in_batches do |batch|
+      batch.each do |notification|
+        new_type = "Notification#{notification.event_type.delete_prefix('Event::')}"
+        notification.update!(type: new_type)
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/src/api/db/data_schema.rb
+++ b/src/api/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20240507120255)
+DataMigrate::Data.define(version: 20240524152040)

--- a/src/api/db/migrate/20240524151051_add_type_to_notifications.rb
+++ b/src/api/db/migrate/20240524151051_add_type_to_notifications.rb
@@ -1,0 +1,5 @@
+class AddTypeToNotifications < ActiveRecord::Migration[7.0]
+  def change
+    add_column :notifications, :type, :string, default: 'NotificationCommentForProject', null: false
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_05_16_133632) do
+ActiveRecord::Schema[7.0].define(version: 2024_05_24_151051) do
   create_table "active_storage_attachments", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -779,6 +779,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_16_133632) do
     t.boolean "rss", default: false
     t.boolean "web", default: false
     t.datetime "last_seen_at", precision: nil
+    t.string "type", null: false
     t.index ["created_at"], name: "index_notifications_on_created_at"
     t.index ["delivered"], name: "index_notifications_on_delivered"
     t.index ["event_type"], name: "index_notifications_on_event_type"

--- a/src/api/spec/factories/notification.rb
+++ b/src/api/spec/factories/notification.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     subscription_receiver_role { 'owner' }
     title { Faker::Lorem.sentence }
     delivered { false }
+    type { 'NotificationRequestStatechange' }
 
     transient do
       originator { nil } # User login
@@ -27,60 +28,72 @@ FactoryBot.define do
       event_type { 'Event::RequestStatechange' }
       notifiable factory: [:bs_request_with_submit_action]
       bs_request_oldstate { :new }
+      type { 'NotificationRequestStatechange' }
     end
 
     trait :request_created do
       event_type { 'Event::RequestCreate' }
       notifiable factory: [:bs_request_with_submit_action]
+      type { 'NotificationRequestCreate' }
     end
 
     trait :review_wanted do
       event_type { 'Event::ReviewWanted' }
       notifiable factory: [:bs_request_with_submit_action]
+      type { 'NotificationReviewWanted' }
     end
 
     trait :comment_for_project do
       event_type { 'Event::CommentForProject' }
       notifiable factory: [:comment_project]
+      type { 'NotificationCommentForProject' }
     end
 
     trait :comment_for_package do
       event_type { 'Event::CommentForPackage' }
       notifiable factory: [:comment_package]
+      type { 'NotificationCommentForPackage' }
     end
 
     trait :comment_for_request do
       event_type { 'Event::CommentForRequest' }
       notifiable factory: [:comment_request]
+      type { 'NotificationCommentForRequest' }
     end
 
     trait :relationship_create_for_project do
       event_type { 'Event::RelationshipCreate' }
       notifiable factory: [:project]
+      type { 'NotificationRelationshipCreate' }
     end
 
     trait :relationship_delete_for_project do
       event_type { 'Event::RelationshipDelete' }
       notifiable factory: [:project]
+      type { 'NotificationRelationshipDelete' }
     end
     trait :relationship_create_for_package do
       event_type { 'Event::RelationshipCreate' }
       notifiable factory: [:package]
+      type { 'NotificationRelationshipCreate' }
     end
 
     trait :relationship_delete_for_package do
       event_type { 'Event::RelationshipDelete' }
       notifiable factory: [:package]
+      type { 'NotificationRelationshipDelete' }
     end
 
     trait :build_failure do
       event_type { 'Event::BuildFail' }
       notifiable factory: [:package]
+      type { 'NotificationBuildFail' }
     end
 
     trait :create_report do
       event_type { 'Event::CreateReport' }
       notifiable factory: [:report]
+      type { 'NotificationCreateReport' }
 
       transient do
         reason { nil }
@@ -95,6 +108,7 @@ FactoryBot.define do
     trait :cleared_decision do
       event_type { 'Event::ClearedDecision' }
       notifiable { association(:decision_cleared) }
+      type { 'NotificationClearedDecision' }
 
       after(:build) do |notification|
         notification.event_payload['reportable_type'] ||= notification.notifiable.reports.first.reportable.class.to_s
@@ -104,6 +118,7 @@ FactoryBot.define do
     trait :favored_decision do
       event_type { 'Event::FavoredDecision' }
       notifiable { association(:decision_favored) }
+      type { 'NotificationFavoredDecision' }
 
       after(:build) do |notification|
         notification.event_payload['reportable_type'] ||= notification.notifiable.reports.first.reportable.class.to_s


### PR DESCRIPTION
First step to introduce STI in notifications. One for each kind of notification we have in [this huge case](https://github.com/openSUSE/open-build-service/blob/b51a9aa6e069226e5700ce486a2b7db9df331c47/src/api/app/components/notification_notifiable_link_component.rb#L20).

Notification
|_ NotificationCommentForProject
|_ NotificationRelationshipCreate
|_ ...