### PR TITLE
Be backwards compatible with event_payload

### DIFF
--- a/src/api/app/models/notification.rb
+++ b/src/api/app/models/notification.rb
@@ -68,8 +68,9 @@ class Notification < ApplicationRecord
     last_seen_at || created_at
   end
 
+  # FIXME: user_login is the old name in the Notification.event_payload. We should drop this in 365 days...
   def accused
-    User.find_by(login: event_payload['accused']) if event_payload['accused']
+    User.find_by(login: event_payload['accused']) || User.find_by(login: event_payload['user_login'])
   end
 
   private


### PR DESCRIPTION
Notifications about old events stay around for 365 days...

Fixes #16207.