### PR TITLE
Add with_project param to source attributes api docs

### DIFF
--- a/src/api/public/apidocs/paths/source_project_name_attribute.yaml
+++ b/src/api/public/apidocs/paths/source_project_name_attribute.yaml
@@ -24,6 +24,14 @@ get:
         If the attribute doesn't contain any value and `with_default` is present,
         the default values will be displayed, if any.
       example: 1
+    - name: with_project
+      in: query
+      schema:
+        type: string
+      description: |
+        If the attribute doesn't contain any value and `with_project` is present,
+        it will use the project's values as fallback.
+      example: 1
   responses:
     '200':
       description: OK. The request has succeeded.


### PR DESCRIPTION
The `/source/{project_name}/_attribute` is missing a `with_project` attribute, as seen here https://github.com/openSUSE/open-build-service/issues/15664. See also #16217