### PR TITLE
Fix undefined local variable or method `project`

### DIFF
--- a/src/api/app/models/concerns/has_attributes.rb
+++ b/src/api/app/models/concerns/has_attributes.rb
@@ -69,8 +69,9 @@ module HasAttributes
     builder.attributes do |xml|
       render_main_attributes(xml, opts)
 
-      # show project values as fallback ?
-      project.render_main_attributes(xml, opts) if opts[:with_project]
+      next unless is_a?(Package) && opts[:with_project]
+
+      project.render_main_attributes(xml, opts)
     end
     builder.doc.to_xml(indent: 2, encoding: 'UTF-8',
                        save_with: Nokogiri::XML::Node::SaveOptions::NO_DECLARATION |


### PR DESCRIPTION
The `project` method is only valid when the object is a package, if not, we can ask for `render_main_attributes` directly.

Fixes #15664