### PR TITLE
Make clicking on "Cancel" button not to delete a Staging Workflow

### DIFF
--- a/src/api/app/views/webui/staging/workflows/_delete.html.haml
+++ b/src/api/app/views/webui/staging/workflows/_delete.html.haml
@@ -18,7 +18,7 @@
           %br
           .modal-footer
             %i.fas.fa-spinner.fa-spin.delete-spinner.d-none
-            %button.btn.btn-sm.btn-outline-secondary.px-4{ data: { 'bs-dismiss': 'modal' } }
+            %button.btn.btn-sm.btn-outline-secondary.px-4{ data: { 'bs-dismiss': 'modal' }, type: 'button' }
               Cancel
             = f.submit('Delete', class: 'btn btn-sm btn-danger px-4')
 


### PR DESCRIPTION
Found while working on #16205.

Currently, cliking on "Cancel" button on the modal for deleting a Staging Workflow not only closes the modal, but also triggers a delete of the Staging Workflow. Clicking on the "Cancel" button should only close the modal.

Fix this behaviour adding a missing `type` attribute in the `button` HTML element.