### PR TITLE
Fix setting the managers group of a Staging Workflow from the Web UI

### DIFF
--- a/src/api/app/views/webui/staging/workflows/_staging_managers_group.html.haml
+++ b/src/api/app/views/webui/staging/workflows/_staging_managers_group.html.haml
@@ -2,7 +2,7 @@
 .modal.fade#staging-managers-group-modal{ tabindex: -1, role: 'dialog', aria: { labelledby: 'staging-managers-group-modal-label', hidden: true } }
   .modal-dialog.modal-dialog-centered{ role: 'document' }
     .modal-content
-      = form_tag(staging_workflow_path(staging_workflow), method: :put) do
+      = form_with(url: staging_workflow_path, method: :put) do
         .modal-header
           %h5.modal-title#staging-managers-group-modal-label Assign other group
         .modal-body


### PR DESCRIPTION
Before, the id of the staging workflow was passed in the `action` attribute of the form.

Pass the correct url to the form, so the update path could be reached and the managers group updated.

Fixes #16205, the remaining Web UI part.