### PR TITLE
 Introduces support for instantiating packages from remote project links 

### DIFF
--- a/src/api/app/models/concerns/project_links.rb
+++ b/src/api/app/models/concerns/project_links.rb
@@ -117,6 +117,6 @@ module ProjectLinks
   end
 
   def links_to_remote?
-    linking_to.where.not(linked_remote_project_name: nil).any?
+    expand_all_projects(allow_remote_projects: true).any?(String)
   end
 end


### PR DESCRIPTION
Instead of returning nil for packages that might come from an remote project link, check if they are known to the backend and return an in-memory, read only Package object.