### PR TITLE
Apply notification filters onclick

### DIFF
--- a/src/api/app/views/webui/users/notifications/_notification_filter.html.haml
+++ b/src/api/app/views/webui/users/notifications/_notification_filter.html.haml
@@ -1,5 +1,5 @@
 -# haml-lint:disable ViewLength
-= form_for(:notification, url: my_notifications_path, method: :get) do |form|
+= form_for(:notification, url: my_notifications_path, method: :get, id: 'notifications-filter-form') do |form|
   .list-group.list-group-flush.mt-3.mb-2
     %h6.px-3.py-2
       %b State
@@ -100,9 +100,20 @@
 
   .text-center.mt-4.mb-4
     = link_to('Clear', my_notifications_path, class: 'btn btn-light border')
-    %button.btn.btn-info#filter-button{ type: :submit }
-      Apply
 
 :javascript
   collectMultiSelects()
+
+  function submitNotificationFilters() {
+    $('#notifications-list').hide();
+    $('#notifications-list-loading').toggleClass('d-none');
+    $('#notifications-filter-form').submit();
+  }
+  let submitFiltersTimeout;
+
+  $(document).on('change', '#filters input', function() {
+    clearTimeout(submitFiltersTimeout);
+    submitFiltersTimeout = setTimeout(submitNotificationFilters, 1500);
+  });
+
 -# haml-lint:enable ViewLength

--- a/src/api/app/views/webui/users/notifications/_notification_filter.html.haml
+++ b/src/api/app/views/webui/users/notifications/_notification_filter.html.haml
@@ -105,13 +105,13 @@
   collectMultiSelects()
 
   function submitNotificationFilters() {
-    $('#notifications-list').hide();
-    $('#notifications-list-loading').toggleClass('d-none');
     $('#notifications-filter-form').submit();
   }
   let submitFiltersTimeout;
 
   $(document).on('change', '#filters input', function() {
+    $('#notifications-list').hide();
+    $('#notifications-list-loading').removeClass('d-none');
     clearTimeout(submitFiltersTimeout);
     submitFiltersTimeout = setTimeout(submitNotificationFilters, 1500);
   });

--- a/src/api/app/views/webui/users/notifications/index.html.haml
+++ b/src/api/app/views/webui/users/notifications/index.html.haml
@@ -15,6 +15,8 @@
                                                            projects_for_filter: @projects_for_filter,
                                                            groups_for_filter: @groups_for_filter }
 
+  .col-md-8.col-lg-9.px-0.px-md-3.d-none#notifications-list-loading
+    = render partial: 'webui/shared/loading', locals: { text: 'Loading...', wrapper_css: ['loading'] }
   .col-md-8.col-lg-9.px-0.px-md-3#notifications-list
     = render partial: 'notifications_list', locals: { notifications: @notifications,
                                                       selected_filter: @selected_filter,

--- a/src/api/spec/features/webui/users/notifications_spec.rb
+++ b/src/api/spec/features/webui/users/notifications_spec.rb
@@ -41,8 +41,7 @@ RSpec.describe 'User notifications', :js do
 
     context 'when marking multiple comment notifications as read' do
       before do
-        find_by_id('notifications-dropdown-trigger').click if mobile? # open the filter dropdown
-        within('#filters') { check('Comments') }
+        visit my_notifications_path({ kind: 'comments' })
         toggle_checkbox("notification_ids_#{notification_for_projects_comment.id}")
         toggle_checkbox("notification_ids_#{another_notification_for_projects_comment.id}")
         click_button('read-button')

--- a/src/api/spec/features/webui/users/notifications_spec.rb
+++ b/src/api/spec/features/webui/users/notifications_spec.rb
@@ -32,7 +32,6 @@ RSpec.describe 'User notifications', :js do
       before do
         find_by_id('notifications-dropdown-trigger').click if mobile?
         within('#filters') { check('Comments') }
-        click_button('filter-button') # apply the filters
       end
 
       it 'shows all unread comment notifications' do
@@ -44,7 +43,6 @@ RSpec.describe 'User notifications', :js do
       before do
         find_by_id('notifications-dropdown-trigger').click if mobile? # open the filter dropdown
         within('#filters') { check('Comments') }
-        click_button('filter-button') # apply the filters
         toggle_checkbox("notification_ids_#{notification_for_projects_comment.id}")
         toggle_checkbox("notification_ids_#{another_notification_for_projects_comment.id}")
         click_button('read-button')
@@ -74,7 +72,6 @@ RSpec.describe 'User notifications', :js do
           check(project.name)
           click_button('filter-projects-button') # close the filter
         end
-        click_button('filter-button') # apply the filters
 
         expect(page).to have_text(notification_for_projects_comment.notifiable.commentable_type)
       end


### PR DESCRIPTION
Do not use an Apply button to submit multiple filters, apply one by one as soon as they are clicked (with just a bit of a delay to collect multiple clicks).

**Note**: the delay has been set to an arbitrary value of **1.5 second** (intended to be "let the user clicks multiple times, but do now wait too long if he is finished clicking")