### PR TITLE
Don't count notifications for projects

### DIFF
--- a/src/api/app/components/notification_filter_component.rb
+++ b/src/api/app/components/notification_filter_component.rb
@@ -27,9 +27,6 @@ class NotificationFilterComponent < ApplicationComponent
     counted_notifications['reports'] = @notifications.for_reports.count
     counted_notifications['workflow_runs'] = @notifications.for_workflow_runs.count
     counted_notifications['appealed_decisions'] = @notifications.for_appealed_decisions.count
-    @projects_for_filter.each do |project_name|
-      counted_notifications["project_#{project_name}"] = @notifications.for_project_name(project_name).count
-    end
     @groups_for_filter.each do |group_title|
       counted_notifications["group_#{group_title}"] = @notifications.for_group_title(group_title).count
     end

--- a/src/api/app/views/webui/shared/_check_box.haml
+++ b/src/api/app/views/webui/shared/_check_box.haml
@@ -5,5 +5,5 @@
       - if defined?(label_icon)
         %i.me-1{ class: label_icon }
       = label
-  - if amount.positive?
+  - if amount.present? && amount.positive?
     %span= amount


### PR DESCRIPTION
Prevent from performing N+1 queries for retrieving the count of notifications a user has for every project.

Fixes #16236.