### PR TITLE
Add more test data for notifications (appeal, build failure and role revoked)

### DIFF
--- a/src/api/lib/tasks/dev/notifications.rake
+++ b/src/api/lib/tasks/dev/notifications.rake
@@ -20,6 +20,16 @@ namespace :dev do
       admin_home_project = admin.home_project || RakeSupport.create_and_assign_project(admin.home_project_name, admin)
       requestor_project = Project.find_by(name: 'requestor_project') || RakeSupport.create_and_assign_project('requestor_project', requestor)
 
+      # Create notification for roles revoked
+      User.find_by(login: 'Iggy').run_as do
+        home_project_iggy = Project.find_by(name: 'home:Iggy')
+        role = Role.find_by_title!('maintainer')
+        Relationship::AddRole.new(home_project_iggy, role, check: true, user: admin).add_role
+        home_project_iggy.store
+        home_project_iggy.remove_role(admin, role)
+        home_project_iggy.store
+      end
+
       repetitions.times do |repetition|
         package_name = "package_#{Time.now.to_i}_#{repetition}"
         admin_package = create(:package_with_file, name: package_name, project: admin_home_project)

--- a/src/api/lib/tasks/dev/notifications.rake
+++ b/src/api/lib/tasks/dev/notifications.rake
@@ -61,6 +61,9 @@ namespace :dev do
         # Will create a notification (RequestStatechange event) for this request change.
         request2.change_state(newstate: %w[accepted declined].sample, force: true, user: requestor.login, comment: 'Declined by requestor')
 
+        # Create notifications for build failures
+        Event::BuildFail.create({ project: admin_home_project.name, package: package_name, repository: "#{Faker::Lorem.word}_repo", arch: "#{Faker::Lorem.word}_arch", reason: 'meta change' })
+
         # Process notifications immediately to see them in the web UI
         SendEventEmailsJob.new.perform_now
       end

--- a/src/api/lib/tasks/dev/rake_support.rb
+++ b/src/api/lib/tasks/dev/rake_support.rb
@@ -56,6 +56,7 @@ module RakeSupport
     create(:event_subscription_report_for_package, channel: :web, user: user)
     create(:event_subscription_report_for_comment, channel: :web, user: user)
     create(:event_subscription_report_for_user, channel: :web, user: user)
+    create(:event_subscription_build_fail, channel: :web, user: user)
 
     user.groups.each do |group|
       create(:event_subscription_request_created, channel: :web, user: nil, group: group, receiver_role: 'target_maintainer')

--- a/src/api/spec/factories/event_subscriptions.rb
+++ b/src/api/spec/factories/event_subscriptions.rb
@@ -150,5 +150,13 @@ FactoryBot.define do
       user
       group { nil }
     end
+
+    factory :event_subscription_build_fail do
+      eventtype { 'Event::BuildFail' }
+      receiver_role { 'maintainer' }
+      channel { :instant_email }
+      user
+      group { nil }
+    end
   end
 end


### PR DESCRIPTION
NOTE: Currently web notifications for appealed decisions are not handled correctly. This is already tracked in the backlog. As soon as this is fixed, the Admin user will receive the notifications for the appeals created in the test data rake task.


 