### PR TITLE
Don't count notifications for groups and incomming and outgoing requests

### DIFF
--- a/src/api/app/components/notification_filter_component.rb
+++ b/src/api/app/components/notification_filter_component.rb
@@ -19,8 +19,6 @@ class NotificationFilterComponent < ApplicationComponent
     counted_notifications['read'] = @notifications.read.count
     counted_notifications['comments'] = @notifications.for_comments.count
     counted_notifications['requests'] = @notifications.for_requests.count
-    counted_notifications['incoming_requests'] = @notifications.for_incoming_requests(User.session).count
-    counted_notifications['outgoing_requests'] = @notifications.for_outgoing_requests(User.session).count
     counted_notifications['relationships_created'] = @notifications.for_relationships_created.count
     counted_notifications['relationships_deleted'] = @notifications.for_relationships_deleted.count
     counted_notifications['build_failures'] = @notifications.for_build_failures.count

--- a/src/api/app/components/notification_filter_component.rb
+++ b/src/api/app/components/notification_filter_component.rb
@@ -27,9 +27,6 @@ class NotificationFilterComponent < ApplicationComponent
     counted_notifications['reports'] = @notifications.for_reports.count
     counted_notifications['workflow_runs'] = @notifications.for_workflow_runs.count
     counted_notifications['appealed_decisions'] = @notifications.for_appealed_decisions.count
-    @groups_for_filter.each do |group_title|
-      counted_notifications["group_#{group_title}"] = @notifications.for_group_title(group_title).count
-    end
     counted_notifications
   end
 end


### PR DESCRIPTION
Prevent from performing N+1 queries for retrieveing the count of notifications a user has for every group.

Also, prevent from doing the incomming and outgoing requests queries which, due to their complexity, make the browsing experience for users in the Web-UI no usable.

Fixes #16235.