### PR TITLE
Move the count of unread notifications to the controller

### DIFF
--- a/src/api/app/controllers/webui/users/notifications_controller.rb
+++ b/src/api/app/controllers/webui/users/notifications_controller.rb
@@ -37,6 +37,7 @@ class Webui::Users::NotificationsController < Webui::WebuiController
       format.js do
         render partial: 'update', locals: {
           notifications: @notifications,
+          unread_notifications: User.session.unread_notifications,
           selected_filter: @selected_filter,
           counted_notifications: @counted_notifications,
           show_read_all_button: @show_read_all_button,

--- a/src/api/app/controllers/webui/webui_controller.rb
+++ b/src/api/app/controllers/webui/webui_controller.rb
@@ -22,8 +22,9 @@ class Webui::WebuiController < ActionController::Base
   before_action :require_configuration
   before_action :current_announcement, unless: -> { request.xhr? }
   before_action :fetch_watchlist_items
-  after_action :clean_cache
   before_action :set_paper_trail_whodunnit
+  before_action :set_unread_notifications
+  after_action :clean_cache
 
   # :notice and :alert are default, we add :success and :error
   add_flash_types :success, :error
@@ -226,6 +227,10 @@ class Webui::WebuiController < ActionController::Base
       @watched_packages = User.possibly_nobody.watched_packages
       @watched_projects = User.possibly_nobody.watched_projects
     end
+  end
+
+  def set_unread_notifications
+    @unread_notifications = User.session ? User.session.unread_notifications : 0
   end
 
   def add_arrays(arr1, arr2)

--- a/src/api/app/views/layouts/webui/_bottom_navigation.html.haml
+++ b/src/api/app/views/layouts/webui/_bottom_navigation.html.haml
@@ -7,7 +7,7 @@
           %span.d-block Watchlist
       %li.nav-item.border-start.border-gray-500
         = link_to(my_notifications_path, id: 'bottom-notifications-counter', class: 'nav-link text-light px-1 py-2', alt: 'Notifications') do
-          = render partial: 'layouts/webui/unread_notifications_counter'
+          = render partial: 'layouts/webui/unread_notifications_counter', locals: { unread_notifications: unread_notifications }
       - if content_for?(:actions)
         %li.nav-item.border-start.border-gray-500
           = link_to('javascript:void(0)', class: 'nav-link px-1 py-2 text-light', alt: 'Actions', data: { toggle: 'actions' }) do

--- a/src/api/app/views/layouts/webui/_top_navigation.html.haml
+++ b/src/api/app/views/layouts/webui/_top_navigation.html.haml
@@ -11,7 +11,7 @@
             %span.d-block Watchlist
         .toggler.text-center.justify-content-center.nav-item
           = link_to(my_notifications_path, id: 'top-notifications-counter', class: 'nav-link text-light p-0 w-100', alt: 'Notifications') do
-            = render partial: 'layouts/webui/unread_notifications_counter'
+            = render partial: 'layouts/webui/unread_notifications_counter', locals: { unread_notifications: unread_notifications }
         .toggler.text-center.justify-content-center.nav-item.dropdown
           = link_to('#', class: 'nav-link dropdown-toggle text-light', id: 'top-navigation-profile-dropdown', role: 'button',
                     'data-bs-toggle': 'dropdown', aria: { haspopup: true, expanded: false }) do

--- a/src/api/app/views/layouts/webui/_unread_notifications_counter.html.haml
+++ b/src/api/app/views/layouts/webui/_unread_notifications_counter.html.haml
@@ -1,5 +1,5 @@
 .notifications-counter
   %i.fas.fa-bell
-  - unless User.session.unread_notifications.zero?
-    %span.badge.text-bg-primary.align-text-top= User.session.unread_notifications
+  - unless unread_notifications.zero?
+    %span.badge.text-bg-primary.align-text-top= unread_notifications
   %span.d-block Notifications

--- a/src/api/app/views/layouts/webui/webui.html.haml
+++ b/src/api/app/views/layouts/webui/webui.html.haml
@@ -41,7 +41,7 @@
   %body{ class: feature_css_class }
     #grid
       #top-navigation-area
-        = render partial: 'layouts/webui/top_navigation'
+        = render partial: 'layouts/webui/top_navigation', locals: { unread_notifications: @unread_notifications }
       .navbar-dark.navbar-themed-colors#left-navigation-area{ class: "#{'collapsed' if sidebar_collapsed?}" }
         = render partial: 'layouts/webui/left_navigation', locals: { spider_bot: @spider_bot }
         = render partial: 'layouts/webui/left_navigation_collapse_button'
@@ -73,7 +73,7 @@
 
       - if !current_page?(signup_path) && !current_page?(new_session_path)
         #bottom-navigation-area
-          = render partial: 'layouts/webui/bottom_navigation', locals: { spider_bot: @spider_bot }
+          = render partial: 'layouts/webui/bottom_navigation', locals: { spider_bot: @spider_bot, unread_notifications: @unread_notifications }
 
       -# Collapsible menu shared between top and bottom navigation
       - if User.session

--- a/src/api/app/views/webui/users/notifications/_update.js.erb
+++ b/src/api/app/views/webui/users/notifications/_update.js.erb
@@ -1,5 +1,5 @@
 $('#filters').html("<%= j(render partial: 'notification_filter', locals: { selected_filter: selected_filter, counted_notifications: @counted_notifications, projects_for_filter: @projects_for_filter, groups_for_filter: @groups_for_filter }) %>");
 $('#notifications-list').html("<%= j(render partial: 'notifications_list', locals: { notifications: notifications, selected_filter: selected_filter, show_read_all_button: show_read_all_button, current_user: user }) %>");
 $('#flash').html("<%= escape_javascript(render(layout: false, partial: 'layouts/webui/flash', object: flash)) %>");
-$('#top-notifications-counter, #bottom-notifications-counter').html("<%= escape_javascript(render partial: 'layouts/webui/unread_notifications_counter') %>");
+$('#top-notifications-counter, #bottom-notifications-counter').html("<%= escape_javascript(render partial: 'layouts/webui/unread_notifications_counter', locals: { unread_notifications: unread_notifications }) %>");
 $(document).ready(function() { handleNotificationCheckboxSelection(); });


### PR DESCRIPTION
Prevent from performing an SQL query every time the partial is rendered.

Instead, run the SQL query once in the controller and pass the result to the partial as a local variable.