### PR TITLE
Fix typo in markdown

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,4 +1,4 @@
-# Do you want to contibute, but you need help?
+# Do you want to contribute, but you need help?
 
 We love to hear that you want to contribute to Open Build Service
 and we are always willing to help you. :green_heart:
@@ -9,18 +9,15 @@ You can write the OBS Team via IRC on the channel
 on Libera.Chat.
 Or using our mailing list
 [opensuse-buildservice@opensuse.org](mailto:opensuse-buildservice+subscribe@opensuse.org).
-You can also contact each of us directly. 
-Our email, IRC username and other information can be found in 
+You can also contact each of us directly.  
+Our email, IRC username and other information can be found in  
 [the team page on openbuildservice.org](http://openbuildservice.org/team).
-
 
 If you find something that does not work properly, you can also
 [open an issue](https://github.com/openSUSE/open-build-service/issues/new)
 to let us know.
 If you have modified some code and you have questions about it,
-do not be shy and send a PR. It is always easier to discuss about code seeing the code. :wink:
+do not be shy and send a PR.
+It is always easier to discuss about code seeing the code. :wink:
 
 Happy Hacking! - :green_heart: Your Open Build Service Team
-
-
-


### PR DESCRIPTION
* Remove every warning to markdown file.
* Have no warning on mardown lint prevent rendering error.

```bash
markdownlint ./SUPPORT.md
```