### PR TITLE
Fix the Mark all as Read/Unread button

### DIFF
--- a/src/api/app/components/notification_action_bar_component.rb
+++ b/src/api/app/components/notification_action_bar_component.rb
@@ -28,8 +28,9 @@ class NotificationActionBarComponent < ApplicationComponent
   private
 
   def add_params(path)
-    return "#{path}&update_all=true" if path.include?('?')
+    button = state == 'unread' ? 'read' : 'unread'
+    return "#{path}&update_all=true&button=#{button}" if path.include?('?')
 
-    "#{path}?update_all=true"
+    "#{path}?update_all=true&button=#{button}"
   end
 end

--- a/src/api/spec/components/notification_action_bar_component_spec.rb
+++ b/src/api/spec/components/notification_action_bar_component_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe NotificationActionBarComponent, type: :component do
     end
 
     it do
-      expect(rendered_content).to have_link(href: 'my/notifications?update_all=true')
+      expect(rendered_content).to have_link(href: 'my/notifications?update_all=true&button=read')
     end
 
     it do
@@ -33,7 +33,7 @@ RSpec.describe NotificationActionBarComponent, type: :component do
     end
 
     it do
-      expect(rendered_content).to have_link(href: 'my/notifications?state=read&update_all=true')
+      expect(rendered_content).to have_link(href: 'my/notifications?state=read&update_all=true&button=unread')
     end
 
     it do


### PR DESCRIPTION
It was missing a value for the `button` parameter.

Fixes #16278