### PR TITLE
Escape html before parsing the log

### DIFF
--- a/src/api/app/mixins/build_log_support.rb
+++ b/src/api/app/mixins/build_log_support.rb
@@ -9,6 +9,7 @@ module BuildLogSupport
   def get_log_chunk(project, package_name, repo, arch, start, theend)
     log = raw_log_chunk(project, package_name, repo, arch, start, theend)
     log.encode!(invalid: :replace, undef: :replace, cr_newline: true)
+    log = CGI.escapeHTML(log)
     log = ansi_escaped(log, theend - start + 1)
     log.gsub(%r{([^a-zA-Z0-9&;<>/\n\r \t()])}) do |c|
       if c.ord < 32


### PR DESCRIPTION
If the log contained html or xml, it would get rendered. Thankfully we have a sanitizer in front, so this is not a security issue, but it still looks rather weird. Unlike escape_code, ansible doesn't escape html, which is why we have to do this now