### PR TITLE
Make sure binaries show and dependency work on multibuild packages

### DIFF
--- a/src/api/app/views/webui/packages/binaries/dependency.html.haml
+++ b/src/api/app/views/webui/packages/binaries/dependency.html.haml
@@ -21,6 +21,6 @@
     = render partial: 'fileinfo', locals: { fileinfo: @fileinfo,
                                             filename: @filename,
                                             project: @project,
-                                            package: @package,
+                                            package: @package_name,
                                             repository: @repository,
                                             architecture: @architecture }

--- a/src/api/app/views/webui/packages/binaries/show.html.haml
+++ b/src/api/app/views/webui/packages/binaries/show.html.haml
@@ -14,6 +14,6 @@
     = render partial: 'fileinfo', locals: { fileinfo: @fileinfo,
                                             filename: @filename,
                                             project: @project,
-                                            package: @package,
+                                            package: @package_name,
                                             repository: @repository,
                                             architecture: @architecture }


### PR DESCRIPTION
Fixes #16271 

Multibuild packages weren't properly covered in show and dependency binary views. This fixes the issue