### PR TITLE
Remove unused associations in Role model

### DIFF
--- a/src/api/app/models/role.rb
+++ b/src/api/app/models/role.rb
@@ -21,10 +21,7 @@ class Role < ApplicationRecord
   validates :title, uniqueness: { case_sensitive: true,
                                   message: 'is the name of an already existing role' }
 
-  belongs_to :attrib_type_modifiable_bies, class_name: 'AttribTypeModifiableBy', optional: true
   belongs_to :relationships, class_name: 'Relationship', optional: true
-  belongs_to :roles_static_permissions, optional: true
-  belongs_to :roles_users, optional: true
 
   # roles have n:m relations for users
   has_and_belongs_to_many :users, -> { distinct }


### PR DESCRIPTION
`belongs_to: attrib_type_modifiable_bies` is never used.

In the case of `roles_static_permissions` and `roles_users`, they are used with the `has_and_belongs_to_many` associations below.