### PR TITLE
Stop another leak of user email

### DIFF
--- a/src/api/app/views/webui/user/_basic_info.html.haml
+++ b/src/api/app/views/webui/user/_basic_info.html.haml
@@ -1,6 +1,7 @@
-.editing-form.d-none
-  = render partial: 'webui/user/edit_account_form',
-           locals: { displayed_user: user, role_titles: role_titles, account_edit_link: account_edit_link }
+- if policy(user).update?
+  .editing-form.d-none
+    = render partial: 'webui/user/edit_account_form',
+             locals: { displayed_user: user, role_titles: role_titles, account_edit_link: account_edit_link }
 
 .basic-info
   .d-flex.flex-row-reverse.align-items-center.mb-3


### PR DESCRIPTION
We don't need to render the `edit_account_form` for others (except admins)