### PR TITLE
Fix association between roles and relationships

### DIFF
--- a/src/api/app/models/role.rb
+++ b/src/api/app/models/role.rb
@@ -21,7 +21,7 @@ class Role < ApplicationRecord
   validates :title, uniqueness: { case_sensitive: true,
                                   message: 'is the name of an already existing role' }
 
-  belongs_to :relationships, class_name: 'Relationship', optional: true
+  has_many :relationships, dependent: :destroy
 
   # roles have n:m relations for users
   has_and_belongs_to_many :users, -> { distinct }


### PR DESCRIPTION
In a "one to many" relationship it doesn't make sense to define `belongs_to` associations on both models `Role` and `Relationship` from one to another.

Fix that by defining that a role has many relationships.