### PR TITLE
Introduces page_size to pagination navigation

### DIFF
--- a/src/api/app/components/notification_action_bar_component.html.haml
+++ b/src/api/app/components/notification_action_bar_component.html.haml
@@ -11,7 +11,7 @@
         - if state != 'unread'
           = button_tag("Mark selected as 'Unread'", type: 'submit', class: 'btn btn-sm btn-outline-success px-3', id: 'unread-button',
                        disabled: 'disabled', 'data-disable-with': disable_with_content, value: 'unread')
-      - if counted_notifications['all'] > Notification::MAX_PER_PAGE
+      - if counted_notifications['all'] > Notification.max_per_page
         .ms-4
           = link_to(button_text(all: true), @update_path, method: :put, remote: true,
                     class: 'btn btn-sm btn-outline-secondary px-3', 'data-disable-with': disable_with_content(all: true))

--- a/src/api/app/components/notification_component.html.haml
+++ b/src/api/app/components/notification_component.html.haml
@@ -17,7 +17,7 @@
           - if @notification.notifiable_type == 'WorkflowRun'
             = render WorkflowRunStatusBadgeComponent.new(status: @notification.notifiable.status, css_class: 'ms-1')
         .col-auto.actions.ms-auto.align-self-end.align-self-md-start
-          = render NotificationMarkButtonComponent.new(@notification, @selected_filter, @page, @show_more)
+          = render NotificationMarkButtonComponent.new(@notification, @selected_filter, @page)
       .row.mt-1.ps-sm-4
         .col-auto.pe-0
           = render NotificationAvatarsComponent.new(@notification)

--- a/src/api/app/components/notification_component.rb
+++ b/src/api/app/components/notification_component.rb
@@ -14,13 +14,12 @@ class NotificationComponent < ApplicationComponent
     'WorkflowRun' => 'Workflow run', 'Group' => 'Group members changed'
   }.freeze
 
-  def initialize(notification:, selected_filter:, page:, show_more:)
+  def initialize(notification:, selected_filter:, page:)
     super
 
     @notification = notification
     @selected_filter = selected_filter
     @page = page
-    @show_more = show_more
   end
 
   def notification_icon

--- a/src/api/app/components/notification_mark_button_component.rb
+++ b/src/api/app/components/notification_mark_button_component.rb
@@ -1,11 +1,10 @@
 class NotificationMarkButtonComponent < ApplicationComponent
-  def initialize(notification, selected_filter, page = nil, show_more = nil)
+  def initialize(notification, selected_filter, page = nil)
     super
 
     @notification = notification
     @selected_filter = selected_filter
     @page = page
-    @show_more = show_more
   end
 
   private
@@ -23,6 +22,6 @@ class NotificationMarkButtonComponent < ApplicationComponent
                           state: @selected_filter[:state],
                           button: @notification.unread? ? 'read' : 'unread',
                           project: @selected_filter[:project], group: @selected_filter[:group],
-                          page: @page, show_more: @show_more)
+                          page: @page)
   end
 end

--- a/src/api/app/controllers/person/notifications_controller.rb
+++ b/src/api/app/controllers/person/notifications_controller.rb
@@ -56,7 +56,7 @@ module Person
 
     def show_maximum(notifications)
       total = notifications.size
-      notifications.page(params[:page]).per([total, Notification::MAX_PER_PAGE].min)
+      notifications.page(params[:page]).per([total, Notification.max_per_page].min)
     end
 
     def set_filter_kind

--- a/src/api/app/controllers/webui/users/notifications_controller.rb
+++ b/src/api/app/controllers/webui/users/notifications_controller.rb
@@ -117,19 +117,12 @@ class Webui::Users::NotificationsController < Webui::WebuiController
     @selected_filter = { kind: @filter_kind, state: @filter_state, project: @filter_project, group: @filter_group }
   end
 
-  def show_more(notifications)
-    total = @counted_notifications['all']
-    flash.now[:info] = "You have too many notifications. Displaying a maximum of #{Notification::MAX_PER_PAGE} notifications per page." if total > Notification::MAX_PER_PAGE
-    notifications.page(params[:page]).per([total, Notification::MAX_PER_PAGE].min)
-  end
-
   def send_notifications_information_rabbitmq(delivered, count)
     action = delivered ? 'read' : 'unread'
     RabbitmqBus.send_to_bus('metrics', "notification,action=#{action} value=#{count}") if count.positive?
   end
 
   def paginate_notifications
-    @notifications = params[:show_more] ? show_more(@notifications) : @notifications.page(params[:page])
-    params[:page] = @notifications.total_pages if @notifications.out_of_range?
+    @notifications = @notifications.page(params[:page]).per(params[:page_size])
   end
 end

--- a/src/api/app/helpers/webui/notification_helper.rb
+++ b/src/api/app/helpers/webui/notification_helper.rb
@@ -1,14 +1,6 @@
-# rubocop:disable Metrics/ModuleLength
 module Webui::NotificationHelper
   TRUNCATION_LENGTH = 100
   TRUNCATION_ELLIPSIS_LENGTH = 3 # `...` is the default ellipsis for String#truncate
-
-  def link_to_show_less_or_more
-    parameters = params.slice(:show_more, :state, :project).permit!
-    less_or_more = parameters[:show_more] ? 'less' : 'more'
-    parameters[:show_more] = parameters[:show_more] ? nil : '1'
-    link_to("Show #{less_or_more}", my_notifications_path(parameters))
-  end
 
   # TODO: Content of ViewComponent. Move to sub-classes once STI is set.
   def excerpt(notification)
@@ -127,4 +119,3 @@ module Webui::NotificationHelper
     end
   end
 end
-# rubocop:enable Metrics/ModuleLength

--- a/src/api/app/models/notification.rb
+++ b/src/api/app/models/notification.rb
@@ -1,7 +1,6 @@
 class Notification < ApplicationRecord
   MAX_RSS_ITEMS_PER_USER = 10
   MAX_RSS_ITEMS_PER_GROUP = 10
-  MAX_PER_PAGE = 300
 
   belongs_to :subscriber, polymorphic: true, optional: true
   belongs_to :notifiable, polymorphic: true, optional: true
@@ -41,6 +40,9 @@ class Notification < ApplicationRecord
   scope :for_project_name, ->(project_name) { joins(:projects).where(projects: { name: project_name }) }
   scope :for_group_title, ->(group_title) { joins(:groups).where(groups: { title: group_title }) }
   scope :stale, -> { where(created_at: ...(CONFIG['notifications_lifetime'] ||= 365).days.ago) }
+
+  paginates_per 30
+  max_paginates_per 300
 
   def event
     @event ||= event_type.constantize.new(event_payload)

--- a/src/api/app/views/webui/users/notifications/_notifications_list.html.haml
+++ b/src/api/app/views/webui/users/notifications/_notifications_list.html.haml
@@ -8,7 +8,7 @@
   :ruby
     update_path = my_notifications_path(kind: selected_filter[:kind], state: selected_filter[:state],
                                         project: selected_filter[:project], group: selected_filter[:group],
-                                        page: params[:page], show_more: params[:show_more])
+                                        page: params[:page])
   = form_tag(update_path, method: :put, remote: true) do
     = render(NotificationActionBarComponent.new(state: selected_filter[:state],
                                                 update_path: update_path,
@@ -17,12 +17,11 @@
       .card-body
         .text-center
           %span.ms-3= page_entries_info notifications, entry_name: ''
-          = link_to_show_less_or_more unless notifications.total_pages == 1 && params[:show_more].nil?
         .list-group.list-group-flush.mt-3
           = render NotificationComponent.with_collection(notifications, selected_filter: selected_filter,
-                                                                        page: params[:page],
-                                                                        show_more: params[:show_more])
+                                                                        page: params[:page])
   = paginate notifications, views_prefix: 'webui', window: 2, params: { action: 'index', id: nil }
+  = render partial: 'page_size_navigation', locals: { paginated_objects: notifications }
 
 - content_for :ready_function do
   handleNotificationCheckboxSelection();

--- a/src/api/app/views/webui/users/notifications/_page_size_navigation.html.haml
+++ b/src/api/app/views/webui/users/notifications/_page_size_navigation.html.haml
@@ -1,0 +1,14 @@
+- if paginated_objects.total_pages > 1
+  - page_size = params[:page_size]&.to_i || paginated_objects.default_per_page
+  .text-center
+    .dropdown
+      = link_to '#', class: 'btn btn-secondary dropdown-toggle', role: 'button', 'data-bs-toggle': 'dropdown', 'aria-expanded': 'false' do
+        Show
+        = page_size
+        per page
+      .dropdown-menu
+        - page_size = params[:page_size]&.to_i || paginated_objects.default_per_page
+        - [paginated_objects.default_per_page, 100, 300].each do |size|
+          - active = 'active' if page_size == size
+          = link_to(url_for( page_size: size ), class: "dropdown-item #{active}") do
+            = size

--- a/src/api/lib/tasks/dev/notifications.rake
+++ b/src/api/lib/tasks/dev/notifications.rake
@@ -1,8 +1,6 @@
 namespace :dev do
   namespace :notifications do
-    # Run this task with: rails "dev:notifications:data[3]"
-    # replacing 3 with any number to indicate how many times you want this code to be executed.
-    desc 'Creates a notification and all its dependencies'
+    desc 'Creates a notification and all its dependencies. Specify amount with [N], like rake "dev:notifications:data[3]"'
     task :data, [:repetitions] => :development_environment do |_t, args|
       args.with_defaults(repetitions: 1)
       repetitions = args.repetitions.to_i
@@ -21,7 +19,8 @@ namespace :dev do
       requestor_project = Project.find_by(name: 'requestor_project') || RakeSupport.create_and_assign_project('requestor_project', requestor)
 
       # Create notification for roles revoked
-      User.find_by(login: 'Iggy').run_as do
+      iggy = User.find_by(login: 'Iggy') || create(:confirmed_user, :with_home, login: 'Iggy')
+      iggy.run_as do
         home_project_iggy = Project.find_by(name: 'home:Iggy')
         role = Role.find_by_title!('maintainer')
         Relationship::AddRole.new(home_project_iggy, role, check: true, user: admin).add_role

--- a/src/api/spec/components/notification_component_spec.rb
+++ b/src/api/spec/components/notification_component_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe NotificationComponent, type: :component do
     let(:notification) { create(:notification, :relationship_create_for_project, delivered: true, notifiable: package, event_payload: event_payload) }
 
     before do
-      render_inline(described_class.new(notification: notification, selected_filter: selected_filter, page: 1, show_more: 1))
+      render_inline(described_class.new(notification: notification, selected_filter: selected_filter, page: 1))
     end
 
     it 'renders the correct icon' do
@@ -22,7 +22,7 @@ RSpec.describe NotificationComponent, type: :component do
     let(:notification) { create(:notification, :comment_for_project, delivered: true, notifiable: comment) }
 
     before do
-      render_inline(described_class.new(notification: notification, selected_filter: selected_filter, page: 1, show_more: 1))
+      render_inline(described_class.new(notification: notification, selected_filter: selected_filter, page: 1))
     end
 
     it 'renders the correct icon' do

--- a/src/api/spec/features/webui/users/notifications_spec.rb
+++ b/src/api/spec/features/webui/users/notifications_spec.rb
@@ -80,16 +80,5 @@ RSpec.describe 'User notifications', :js do
     context 'when having less notifications than the maximum per page' do
       it { expect(page).to have_no_text("Mark all as 'Read'") }
     end
-
-    context 'when having more notifications than the maximum per page' do
-      before do
-        # Instead of creating Notification::MAX_PER_PAGE + 1 notifications, we better reduce the constant value.
-        # The total amount of notifications exceeds the maximum per page, so the button should be displayed.
-        stub_const('Notification::MAX_PER_PAGE', 1)
-        visit my_notifications_path
-      end
-
-      it { expect(page).to have_text("Mark all as 'Read'") }
-    end
   end
 end


### PR DESCRIPTION
Use the kaminari per scope instead of a hand crafted show_more parameter.

Turns this

![image](https://github.com/openSUSE/open-build-service/assets/514785/199c6eb4-f9b5-4e6e-9076-0be5ed0db653)

into this

![image](https://github.com/openSUSE/open-build-service/assets/514785/b7ca607e-69b4-428d-a5f1-a813a9b19df3)

