### PR TITLE
Make Tumbleweed builds work in development environment

### DIFF
--- a/src/api/spec/factories/packages.rb
+++ b/src/api/spec/factories/packages.rb
@@ -132,9 +132,8 @@ FactoryBot.define do
         remote_package_name { Faker::Lorem.word }
       end
       after(:create) do |package, evaluator|
-        remote_project = create(:remote_project, name: evaluator.remote_project_name)
         PackageKind.create(package_id: package.id, kind: 'link')
-        file_content = "<link package=\"#{evaluator.remote_package_name}\" project=\"#{remote_project.name}\" />"
+        file_content = "<link package=\"#{evaluator.remote_package_name}\" project=\"#{evaluator.remote_project_name}\" />"
 
         if CONFIG['global_write_through']
           Backend::Connection.put(


### PR DESCRIPTION
Creating this remote project ('openSUSE.org:openSUSE:Factory') prevented from building Tumbleweed packages in the development environment.

See: https://github.com/openSUSE/open-build-service/pull/12307#pullrequestreview-910178115

### For reviewers

- Checkout this branch
- Reset your development environment with: `bin/rake dev:test_data:create`
- Check that Tumbleweed packages start building