### PR TITLE
Make it possible to view scmsync'ed package logs

### DIFF
--- a/src/api/app/assets/javascripts/webui/project_monitor.js
+++ b/src/api/app/assets/javascripts/webui/project_monitor.js
@@ -39,6 +39,7 @@ function initializeMonitorDataTable() {
   var statusHash = data.statushash;
   var tableInfo = data.tableinfo;
   var projectName = data.project;
+  var scmsync = data.scmsync;
 
   initializeDataTable('#project-monitor-table', { // jshint ignore:line
     responsive: false,
@@ -58,6 +59,7 @@ function initializeMonitorDataTable() {
         className: 'text-start',
         data: null,
         render: function (packageName) {
+          if (scmsync !== undefined) return packageName;
           var url = '/package/show/' + projectName + '/' + packageName;
           return '<a href="' + url + '">' + packageName + '</a>';
         }

--- a/src/api/app/controllers/webui/packages/build_log_controller.rb
+++ b/src/api/app/controllers/webui/packages/build_log_controller.rb
@@ -103,6 +103,13 @@ module Webui
         end
 
         @package_name = params[:package]
+
+        # No need to check for the package, they only exist on the backend in this case
+        if @project.scmsync
+          @can_modify = User.possibly_nobody.can_modify?(@project)
+          return
+        end
+
         begin
           @package = Package.get_by_project_and_name(@project, @package_name, use_source: false,
                                                                               follow_multibuild: true)

--- a/src/api/app/views/webui/packages/build_log/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui/packages/build_log/_breadcrumb_items.html.haml
@@ -1,5 +1,9 @@
+= render partial: 'webui/project/breadcrumb_items'
 %li.breadcrumb-item.text-word-break-all
   %i.fa.fa-archive
-  = link_to(@package, package_show_path(@project, @package))
-  %li.breadcrumb-item.active{ 'aria-current' => 'page' }
-    Build Log
+  - if @project.scmsync
+    = @package_name
+  - else
+    = link_to(@package, package_show_path(@project, @package))
+%li.breadcrumb-item.active{ 'aria-current' => 'page' }
+  Build Log

--- a/src/api/app/views/webui/packages/build_log/live_build_log.html.haml
+++ b/src/api/app/views/webui/packages/build_log/live_build_log.html.haml
@@ -2,7 +2,8 @@
 - @metarobots = 'noindex,nofollow'
 
 .card.mb-3
-  = render partial: 'webui/package/tabs', locals: { project: @project, package: @package }
+  - unless @project.scmsync
+    = render partial: 'webui/package/tabs', locals: { project: @project, package: @package }
   .card-body
     %h3= @pagetitle
     %p

--- a/src/api/app/views/webui/project/monitor.html.haml
+++ b/src/api/app/views/webui/project/monitor.html.haml
@@ -3,7 +3,6 @@
 .card.mb-3
   = render partial: 'tabs', locals: { project: @project }
   .card-body#project-monitor
-
     - if @buildresult_unavailable
       %p Unavailable Build Results.
     - else
@@ -31,7 +30,11 @@
                     %th.text-center
                       = repository_status_icon(status: @repostatushash[repo][arch], html_class: 'me-1')
                       = arch
-            %tbody{ data: { packagenames: @packagenames, project: @project, statushash: @statushash.to_json, tableinfo: tableinfo } }
+            %tbody{ data: { packagenames: @packagenames,
+                            project: @project,
+                            scmsync: @project.scmsync,
+                            statushash: @statushash.to_json,
+                            tableinfo: tableinfo } }
 
       - content_for :ready_function do
         setupProjectMonitor();


### PR DESCRIPTION
Before we solve the problem with package existing only in the backend in general, people want to look at build logs for this case...

It's a slightly less awkward version of #12351 

Fixes #13176

## How to review

- Enable the interconnect to build.o.o
- Create a project and
  -  set `scmsync` to https://github.com/hennevogel/scmsync-project
  - add a 15.5 repository
- Wait until the packages built and visit the monitor page
