### PR TITLE
Stop publishing workflow events on the message bus

### DIFF
--- a/src/api/app/models/event/workflow_run_fail.rb
+++ b/src/api/app/models/event/workflow_run_fail.rb
@@ -1,6 +1,5 @@
 module Event
   class WorkflowRunFail < Base
-    self.message_bus_routing_key = 'workflow_run.fail'
     self.description = 'Workflow run failed'
     payload_keys :id, :token_id, :hook_event, :summary, :repository_full_name
 


### PR DESCRIPTION
This is an event only interesting for one user/group, not the public.