### PR TITLE
Fix user denied deletion of its own subprojects

### DIFF
--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -552,9 +552,9 @@ class User < ApplicationRecord
     when Project
       logger.debug "running local permission check: user #{login}, project #{object.name}, permission '#{perm_string}'"
 
-      # Users have permissions to manage their own home project
+      # Users have permissions to manage their own home project and it's subprojects
       # This is needed since users sometimes remove themselves from the maintainers of their own home project
-      return true if object.name == home_project_name
+      return true if object.name == home_project_name || object.name.starts_with?("#{home_project_name}:")
 
       # check permission for given project
       parent = object.parent

--- a/src/api/spec/models/user_spec.rb
+++ b/src/api/spec/models/user_spec.rb
@@ -623,4 +623,27 @@ RSpec.describe User do
       end
     end
   end
+
+  describe '#can_modify?' do
+    let(:user) { create(:confirmed_user, :with_home, login: 'hans') }
+    let(:project) { user.home_project }
+
+    context 'projects' do
+      context 'can modify a home project' do
+        it { expect(user.can_modify?(project)).to be true }
+      end
+
+      context 'can modify sub-projects of a home project' do
+        let(:child_project) { create(:project, name: "#{project.name}:something") }
+
+        it { expect(user.can_modify?(child_project)).to be true }
+      end
+
+      context "cannot modify other people's projects" do
+        let(:project) { create(:project, name: 'home:dani:branches:home:hans:something') }
+
+        it { expect(user.can_modify?(project)).to be false }
+      end
+    end
+  end
 end

--- a/src/api/test/unit/user_test.rb
+++ b/src/api/test/unit/user_test.rb
@@ -20,17 +20,6 @@ class UserTest < ActiveSupport::TestCase
     assert_not Project.find_by(name: 'home:bob')
   end
 
-  def test_can_modify_project
-    user = User.find_by(login: 'adrian')
-    project = Project.find_by(name: 'home:adrian')
-
-    assert user.can_modify_project?(project)
-
-    assert_raise(ArgumentError, 'illegal parameter type to User#can_modify_project?: Package') do
-      user.can_modify_project?(Package.last)
-    end
-  end
-
   def test_subaccount_permission
     user = User.find_by(login: 'adrian')
 


### PR DESCRIPTION
Users can delete its own home project and they can create subprojects without the parent project being present.

In both cases you would end up having a hierarchy of projects that you were left out without having permission to do anything on them.

This PR allows a user full control over its subprojects.

Fixes #16328