### PR TITLE
Make sure '/public/image_templates.xml' is accessible without login

### DIFF
--- a/src/api/app/controllers/public_controller.rb
+++ b/src/api/app/controllers/public_controller.rb
@@ -197,6 +197,11 @@ class PublicController < ApplicationController
     end
   end
 
+  def image_templates
+    @projects = Project.image_templates
+    render 'webui/image_templates/index'
+  end
+
   private
 
   # removes /private prefix from path

--- a/src/api/config/routes/api.rb
+++ b/src/api/config/routes/api.rb
@@ -192,10 +192,7 @@ constraints(RoutesHelper::APIMatcher) do
     get 'public/distributions' => :distributions
     get 'public/binary_packages/:project/:package' => :binary_packages, constraints: cons
     get 'public/build/:project(/:repository(/:arch(/:package(/:filename))))' => 'public#build', constraints: cons, as: :public_build
-  end
-
-  scope 'public' do
-    resources :image_templates, constraints: cons, only: [:index], controller: 'webui/image_templates'
+    get 'public/image_templates' => :image_templates, constraints: cons
   end
 
   resources :image_templates, constraints: cons, only: [:index], controller: 'webui/image_templates'


### PR DESCRIPTION
Also makes sure that remote instances use the `/public` route to access image templates feature