### PR TITLE
Prefer constants for referencing classes.

### DIFF
--- a/src/api/app/models/event/added_user_to_group.rb
+++ b/src/api/app/models/event/added_user_to_group.rb
@@ -5,6 +5,8 @@ module Event
 
     receiver_roles :member
 
+    self.notification_explanation = 'Receive notifications when you are added to a group.'
+
     def subject
       "You were added to the group '#{payload['group']}'" unless payload['who']
 

--- a/src/api/app/models/event/appeal_created.rb
+++ b/src/api/app/models/event/appeal_created.rb
@@ -6,6 +6,8 @@ module Event
 
     payload_keys :id, :appellant_id, :decision_id, :reason, :report_last_id, :reportable_type
 
+    self.notification_explanation = 'Receive notifications when a user appeals against a decision of a moderator.'
+
     def subject
       appeal = Appeal.find(payload['id'])
       "Appeal to #{appeal.decision.reports.first.reportable&.class&.name || appeal.decision.reports.first.reportable_type} decision".squish

--- a/src/api/app/models/event/base.rb
+++ b/src/api/app/models/event/base.rb
@@ -41,13 +41,13 @@ module Event
       @shortenable_key = nil
 
       def notification_events
-        ['Event::BuildFail', 'Event::ServiceFail', 'Event::ReviewWanted', 'Event::RequestCreate',
-         'Event::RequestStatechange', 'Event::CommentForProject', 'Event::CommentForPackage',
-         'Event::CommentForRequest',
-         'Event::RelationshipCreate', 'Event::RelationshipDelete',
-         'Event::ReportForComment', 'Event::ReportForPackage', 'Event::ReportForProject', 'Event::ReportForUser', 'Event::ReportForRequest',
-         'Event::WorkflowRunFail', 'Event::AppealCreated', 'Event::ClearedDecision', 'Event::FavoredDecision',
-         'Event::AddedUserToGroup', 'Event::RemovedUserFromGroup'].map(&:constantize)
+        [Event::BuildFail, Event::ServiceFail, Event::ReviewWanted, Event::RequestCreate,
+         Event::RequestStatechange, Event::CommentForProject, Event::CommentForPackage,
+         Event::CommentForRequest,
+         Event::RelationshipCreate, Event::RelationshipDelete,
+         Event::ReportForComment, Event::ReportForPackage, Event::ReportForProject, Event::ReportForUser, Event::ReportForRequest,
+         Event::WorkflowRunFail, Event::AppealCreated, Event::ClearedDecision, Event::FavoredDecision,
+         Event::AddedUserToGroup, Event::RemovedUserFromGroup]
       end
 
       def classnames

--- a/src/api/app/models/event/base.rb
+++ b/src/api/app/models/event/base.rb
@@ -7,32 +7,8 @@ module Event
 
     after_create :create_project_log_entry_job, if: -> { (PROJECT_CLASSES | PACKAGE_CLASSES).include?(self.class.name) }
 
-    EXPLANATION_FOR_NOTIFICATIONS =  {
-      'Event::BuildFail' => 'Receive notifications for build failures of packages for which you are...',
-      'Event::ServiceFail' => 'Receive notifications for source service failures of packages for which you are...',
-      'Event::ReviewWanted' => 'Receive notifications for reviews created that have you as a wanted...',
-      'Event::RequestCreate' => 'Receive notifications for requests created for projects/packages for which you are...',
-      'Event::RequestStatechange' => 'Receive notifications for requests state changes for projects for which you are...',
-      'Event::CommentForProject' => 'Receive notifications for comments created on projects for which you are...',
-      'Event::CommentForPackage' => 'Receive notifications for comments created on a package for which you are...',
-      'Event::CommentForRequest' => 'Receive notifications for comments created on a request for which you are...',
-      'Event::RelationshipCreate' => "Receive notifications when someone adds you or your group to a project or package with any of these roles: #{Role.local_roles.to_sentence}.",
-      'Event::RelationshipDelete' => "Receive notifications when someone removes you or your group from a project or package with any of these roles: #{Role.local_roles.to_sentence}.",
-      'Event::ReportForComment' => 'Receive notifications for reported comments.',
-      'Event::ReportForPackage' => 'Receive notifications for reported packages.',
-      'Event::ReportForProject' => 'Receive notifications for reported projects.',
-      'Event::ReportForUser' => 'Receive notifications for reported users.',
-      'Event::ReportForRequest' => 'Receive notifications for reported requests.',
-      'Event::ClearedDecision' => 'Receive notifications for cleared report decisions.',
-      'Event::FavoredDecision' => 'Receive notifications for favored report decisions.',
-      'Event::WorkflowRunFail' => 'Receive notifications for failed workflow runs on SCM/CI integration.',
-      'Event::AppealCreated' => 'Receive notifications when a user appeals against a decision of a moderator.',
-      'Event::AddedUserToGroup' => 'Receive notifications when you are added to a group.',
-      'Event::RemovedUserFromGroup' => 'Receive notifications when you are removed from a group.'
-    }.freeze
-
     class << self
-      attr_accessor :description, :message_bus_routing_key
+      attr_accessor :description, :message_bus_routing_key, :notification_explanation
 
       @payload_keys = nil
       @create_jobs = nil

--- a/src/api/app/models/event/build_fail.rb
+++ b/src/api/app/models/event/build_fail.rb
@@ -8,6 +8,8 @@ module Event
 
     create_jobs :report_to_scm_job
 
+    self.notification_explanation = 'Receive notifications for build failures of packages for which you are...'
+
     def subject
       "Build failure of #{payload['project']}/#{payload['package']} in #{payload['repository']}/#{payload['arch']}"
     end

--- a/src/api/app/models/event/cleared_decision.rb
+++ b/src/api/app/models/event/cleared_decision.rb
@@ -5,6 +5,8 @@ module Event
 
     payload_keys :id, :reason, :moderator_id, :report_last_id, :reportable_type
 
+    self.notification_explanation = 'Receive notifications for cleared report decisions.'
+
     def subject
       decision = Decision.find(payload['id'])
       "Cleared #{decision.reports.first.reportable&.class&.name || decision.reports.first.reportable_type} Report".squish

--- a/src/api/app/models/event/comment_for_package.rb
+++ b/src/api/app/models/event/comment_for_package.rb
@@ -6,6 +6,8 @@ module Event
     receiver_roles :maintainer, :bugowner, :project_watcher, :package_watcher
     payload_keys :project, :package, :sender
 
+    self.notification_explanation = 'Receive notifications for comments created on a package for which you are...'
+
     def subject
       "New comment in package #{payload['project']}/#{payload['package']} by #{payload['commenter']}"
     end

--- a/src/api/app/models/event/comment_for_project.rb
+++ b/src/api/app/models/event/comment_for_project.rb
@@ -6,6 +6,8 @@ module Event
     payload_keys :project
     receiver_roles :maintainer, :bugowner, :project_watcher
 
+    self.notification_explanation = 'Receive notifications for comments created on projects for which you are...'
+
     def subject
       "New comment in project #{payload['project']} by #{payload['commenter']}"
     end

--- a/src/api/app/models/event/comment_for_request.rb
+++ b/src/api/app/models/event/comment_for_request.rb
@@ -7,6 +7,8 @@ module Event
     receiver_roles :source_maintainer, :target_maintainer, :creator, :reviewer, :source_project_watcher, :target_project_watcher,
                    :source_package_watcher, :target_package_watcher, :request_watcher
 
+    self.notification_explanation = 'Receive notifications for comments created on a request for which you are...'
+
     def subject
       "Request #{payload['number']} commented by #{payload['commenter']} (#{actions_summary})"
     end

--- a/src/api/app/models/event/favored_decision.rb
+++ b/src/api/app/models/event/favored_decision.rb
@@ -5,6 +5,8 @@ module Event
 
     payload_keys :id, :reason, :moderator_id, :report_last_id, :reportable_type
 
+    self.notification_explanation = 'Receive notifications for favored report decisions.'
+
     def subject
       decision = Decision.find(payload['id'])
       "Favored #{decision.reports.first.reportable&.class&.name || decision.reports.first.reportable_type} Report".squish

--- a/src/api/app/models/event/relationship_create.rb
+++ b/src/api/app/models/event/relationship_create.rb
@@ -5,6 +5,8 @@ module Event
 
     receiver_roles :any_role
 
+    self.notification_explanation = "Receive notifications when someone adds you or your group to a project or package with any of these roles: #{Role.local_roles.to_sentence}."
+
     def subject
       object = payload['project']
       object += "/#{payload['package']}" if payload['package']

--- a/src/api/app/models/event/relationship_delete.rb
+++ b/src/api/app/models/event/relationship_delete.rb
@@ -5,6 +5,8 @@ module Event
 
     receiver_roles :any_role
 
+    self.notification_explanation = "Receive notifications when someone removes you or your group from a project or package with any of these roles: #{Role.local_roles.to_sentence}."
+
     def subject
       object = payload['project']
       object += "/#{payload['package']}" if payload['package']

--- a/src/api/app/models/event/removed_user_from_group.rb
+++ b/src/api/app/models/event/removed_user_from_group.rb
@@ -5,6 +5,8 @@ module Event
 
     receiver_roles :member
 
+    self.notification_explanation = 'Receive notifications when you are removed from a group.'
+
     def subject
       "You were removed from the group '#{payload['group']}'" unless payload['who']
 

--- a/src/api/app/models/event/report_for_comment.rb
+++ b/src/api/app/models/event/report_for_comment.rb
@@ -4,6 +4,8 @@ module Event
     payload_keys :commentable_type, :bs_request_number, :bs_request_action_id,
                  :project_name, :package_name, :commenter
 
+    self.notification_explanation = 'Receive notifications for reported comments.'
+
     def subject
       "Comment by #{payload['commenter']} reported"
     end

--- a/src/api/app/models/event/report_for_package.rb
+++ b/src/api/app/models/event/report_for_package.rb
@@ -3,6 +3,8 @@ module Event
     self.description = 'Report for a package created'
     payload_keys :package_name, :project_name
 
+    self.notification_explanation = 'Receive notifications for reported packages.'
+
     def subject
       "Package #{payload['project_name']}/#{payload['package_name']} reported"
     end

--- a/src/api/app/models/event/report_for_project.rb
+++ b/src/api/app/models/event/report_for_project.rb
@@ -3,6 +3,8 @@ module Event
     self.description = 'Report for a project created'
     payload_keys :project_name
 
+    self.notification_explanation = 'Receive notifications for reported projects.'
+
     def subject
       "Project #{payload['project_name']} reported"
     end

--- a/src/api/app/models/event/report_for_request.rb
+++ b/src/api/app/models/event/report_for_request.rb
@@ -3,6 +3,8 @@ module Event
     self.description = 'Report for a request created'
     payload_keys :bs_request_number
 
+    self.notification_explanation = 'Receive notifications for reported requests.'
+
     def subject
       "Request #{payload['bs_request_number']} reported"
     end

--- a/src/api/app/models/event/report_for_user.rb
+++ b/src/api/app/models/event/report_for_user.rb
@@ -3,6 +3,8 @@ module Event
     self.description = 'Report for a user created'
     payload_keys :accused
 
+    self.notification_explanation = 'Receive notifications for reported users.'
+
     def subject
       "User #{payload['accused']} reported"
     end

--- a/src/api/app/models/event/request_create.rb
+++ b/src/api/app/models/event/request_create.rb
@@ -5,6 +5,8 @@ module Event
     receiver_roles :source_maintainer, :target_maintainer, :source_project_watcher, :target_project_watcher,
                    :source_package_watcher, :target_package_watcher
 
+    self.notification_explanation = 'Receive notifications for requests created for projects/packages for which you are...'
+
     def custom_headers
       base = super
       # we're the one they mean

--- a/src/api/app/models/event/request_statechange.rb
+++ b/src/api/app/models/event/request_statechange.rb
@@ -8,6 +8,8 @@ module Event
 
     create_jobs :report_to_scm_job
 
+    self.notification_explanation = 'Receive notifications for requests state changes for projects for which you are...'
+
     def subject
       "Request #{payload['number']} changed from #{payload['oldstate']} to #{payload['state']} (#{actions_summary})"
     end

--- a/src/api/app/models/event/review_wanted.rb
+++ b/src/api/app/models/event/review_wanted.rb
@@ -5,6 +5,8 @@ module Event
     payload_keys :reviewers, :by_user, :by_group, :by_project, :by_package
     receiver_roles :reviewer
 
+    self.notification_explanation = 'Receive notifications for reviews created that have you as a wanted...'
+
     def subject
       "Request #{payload['number']} requires review (#{actions_summary})"
     end

--- a/src/api/app/models/event/service_fail.rb
+++ b/src/api/app/models/event/service_fail.rb
@@ -6,6 +6,8 @@ module Event
     receiver_roles :maintainer, :bugowner
     create_jobs :update_backend_infos_job
 
+    self.notification_explanation = 'Receive notifications for source service failures of packages for which you are...'
+
     def subject
       "Source service failure of #{payload['project']}/#{payload['package']}"
     end

--- a/src/api/app/models/event/workflow_run_fail.rb
+++ b/src/api/app/models/event/workflow_run_fail.rb
@@ -5,6 +5,8 @@ module Event
 
     receiver_roles :token_executor
 
+    self.notification_explanation = 'Receive notifications for failed workflow runs on SCM/CI integration.'
+
     # Example of subject:
     #   Workflow run failed on Merge request hook
     def subject

--- a/src/api/app/views/webui/subscriptions/_subscriptions_form.html.haml
+++ b/src/api/app/views/webui/subscriptions/_subscriptions_form.html.haml
@@ -3,7 +3,7 @@
   .card.subscriptions-card-bg.mb-2
     .card-body
       %h5.card-title= subscription.event_class.description
-      %p.card-text= Event::Base::EXPLANATION_FOR_NOTIFICATIONS[subscription.event_class.to_s]
+      %p.card-text= subscription.event_class.notification_explanation
       .list-group
         - subscription.roles.each do |role|
           .d-flex.flex-column.flex-sm-row.justify-content-sm-between.list-group-item.list-group-item-action


### PR DESCRIPTION
Instead of referencing classes by strings, and then relying on reflection to get the class instances themselves, let's just use the class name directly.

This helps with navigation and refactoring, as well as readability.