### PR TITLE
Add some column defaults for BinaryRelease

### DIFF
--- a/src/api/app/models/binary_release.rb
+++ b/src/api/app/models/binary_release.rb
@@ -235,12 +235,12 @@ end
 #  binary_epoch              :string(64)       indexed => [binary_name, binary_version, binary_release, binary_arch]
 #  binary_maintainer         :string(255)
 #  binary_name               :string(255)      not null, indexed => [binary_epoch, binary_version, binary_release, binary_arch], indexed => [binary_arch], indexed => [repository_id]
-#  binary_release            :string(64)       not null, indexed => [binary_name, binary_epoch, binary_version, binary_arch]
+#  binary_release            :string(64)       default("0"), not null, indexed => [binary_name, binary_epoch, binary_version, binary_arch]
 #  binary_releasetime        :datetime         not null
 #  binary_supportstatus      :string(255)
 #  binary_updateinfo         :string(255)      indexed
 #  binary_updateinfo_version :string(255)
-#  binary_version            :string(64)       not null, indexed => [binary_name, binary_epoch, binary_release, binary_arch]
+#  binary_version            :string(64)       default("0"), not null, indexed => [binary_name, binary_epoch, binary_release, binary_arch]
 #  flavor                    :string(255)
 #  medium                    :string(255)      indexed
 #  modify_time               :datetime

--- a/src/api/db/migrate/20240618110434_add_defaults_to_binary_release.rb
+++ b/src/api/db/migrate/20240618110434_add_defaults_to_binary_release.rb
@@ -1,0 +1,6 @@
+class AddDefaultsToBinaryRelease < ActiveRecord::Migration[7.0]
+  def change
+    change_column_default :binary_releases, :binary_release, from: nil, to: '0'
+    change_column_default :binary_releases, :binary_version, from: nil, to: '0'
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_06_07_131326) do
+ActiveRecord::Schema[7.0].define(version: 2024_06_18_110434) do
   create_table "active_storage_attachments", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -160,8 +160,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_07_131326) do
     t.integer "release_package_id"
     t.string "binary_name", null: false
     t.string "binary_epoch", limit: 64, collation: "utf8mb3_general_ci"
-    t.string "binary_version", limit: 64, null: false, collation: "utf8mb3_general_ci"
-    t.string "binary_release", limit: 64, null: false, collation: "utf8mb3_general_ci"
+    t.string "binary_version", limit: 64, default: "0", null: false, collation: "utf8mb3_general_ci"
+    t.string "binary_release", limit: 64, default: "0", null: false, collation: "utf8mb3_general_ci"
     t.string "binary_arch", limit: 64, null: false, collation: "utf8mb3_general_ci"
     t.string "binary_disturl"
     t.datetime "binary_buildtime", precision: nil


### PR DESCRIPTION
We are currently doing this somewhere in the code that creates `BinaryRelease`. I want to get rid of that once this is merged.