### PR TITLE
Optimize query to avoid N+1 between Review, User and Group

### DIFF
--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -520,7 +520,7 @@ class Webui::RequestController < Webui::WebuiController
     end
 
     target_project = Project.find_by_name(@bs_request.target_project_name)
-    @request_reviews = @bs_request.reviews.for_non_staging_projects(target_project)
+    @request_reviews = @bs_request.reviews.includes(%i[user group]).for_non_staging_projects(target_project)
     @staging_status = staging_status(@bs_request, target_project) if Staging::Workflow.find_by(project: target_project)
 
     # Collecting all issues in a hash. Each key is the issue name and the value is a hash containing all the issue details.


### PR DESCRIPTION
`User` is consumed [here](https://github.com/openSUSE/open-build-service/blob/5a803518e1d9f885da7ad638b12fdf6b434f6660/src/api/app/components/bs_request_overview_avatars_component.rb#L14) and `Group` is consumed [here](https://github.com/openSUSE/open-build-service/blob/5a803518e1d9f885da7ad638b12fdf6b434f6660/src/api/app/components/bs_request_overview_avatars_component.rb#L25)