### PR TITLE
Avoid performing a querying for the token we just created

### DIFF
--- a/src/api/spec/controllers/webui/users/tokens_controller_spec.rb
+++ b/src/api/spec/controllers/webui/users/tokens_controller_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Webui::Users::TokensController do
       let(:form_parameters) { { token: { type: 'runservice', description: 'My first token' } } }
 
       include_examples 'check for flashing a success'
-      it { is_expected.to redirect_to(token_path(Token.last)) }
+      it { is_expected.to redirect_to(token_path(assigns[:token])) }
     end
 
     context 'type is release, with project parameter, without package parameter' do


### PR DESCRIPTION
We set `@token` in the `create` action, so we don't have to look for it in the DB, just fetch the instance variable.