### PR TITLE
[backend] bs_notar: support the --signflavor option

### DIFF
--- a/src/backend/bs_notar
+++ b/src/backend/bs_notar
@@ -76,7 +76,7 @@ while (@ARGV) {
     splice(@ARGV, 0, 2);
     next;
   }
-  if ($ARGV[0] eq '-P' || $ARGV[0] eq '--project' || $ARGV[0] eq '-u' || $ARGV[0] eq '--signtype') {
+  if ($ARGV[0] eq '-P' || $ARGV[0] eq '--project' || $ARGV[0] eq '-u' || $ARGV[0] eq '--signtype' || $ARGV[0] eq '--signflavor') {
     push @signcmd, splice(@ARGV, 0, 2);
     next;
   }


### PR DESCRIPTION
Just pass it to the sign tool, like with --signtype