### PR TITLE
Add single quotation marks missing in interpolation

### DIFF
--- a/src/api/app/components/notification_notifiable_link_component.rb
+++ b/src/api/app/components/notification_notifiable_link_component.rb
@@ -41,9 +41,9 @@ class NotificationNotifiableLinkComponent < ApplicationComponent
         "Removed as #{role} of a project"
       end
     when 'Event::AddedUserToGroup'
-      "#{@notification.event_payload['who'] || Someone} added you to the group '#{@notification.event_payload['group']}'"
+      "#{@notification.event_payload['who'] || 'Someone'} added you to the group '#{@notification.event_payload['group']}'"
     when 'Event::RemovedUserFromGroup'
-      "#{@notification.event_payload['who'] || Someone} removed you from the group '#{@notification.event_payload['group']}'"
+      "#{@notification.event_payload['who'] || 'Someone'} removed you from the group '#{@notification.event_payload['group']}'"
     when 'Event::BuildFail'
       project = @notification.event_payload['project']
       package = @notification.event_payload['package']


### PR DESCRIPTION
Otherwise, the code crashes when `who` is not present in the payload.