### PR TITLE
Workflow run notifications

### DIFF
--- a/src/api/app/models/event/workflow_run_fail.rb
+++ b/src/api/app/models/event/workflow_run_fail.rb
@@ -3,7 +3,7 @@ module Event
     self.description = 'Workflow run failed'
     payload_keys :id, :token_id, :hook_event, :summary, :repository_full_name
 
-    receiver_roles :token_executor
+    receiver_roles :token_executor, :token_member
 
     self.notification_explanation = 'Receive notifications for failed workflow runs on SCM/CI integration.'
 
@@ -14,11 +14,22 @@ module Event
     end
 
     def token_executors
-      [Token.find_by(id: payload['token_id'], type: 'Token::Workflow')&.executor].compact
+      [token&.executor].compact
+    end
+
+    def token_members
+      token&.users&.compact
+      # TODO: + token&.groups&.compact
     end
 
     def parameters_for_notification
       super.merge(notifiable_type: 'WorkflowRun', notifiable_id: payload['id'])
+    end
+
+    private
+
+    def token
+      Token.find_by(id: payload['token_id'], type: 'Token::Workflow')
     end
   end
 end

--- a/src/api/app/models/event/workflow_run_fail.rb
+++ b/src/api/app/models/event/workflow_run_fail.rb
@@ -18,8 +18,7 @@ module Event
     end
 
     def token_members
-      token&.users&.compact
-      # TODO: + token&.groups&.compact
+      [token&.users, token&.groups].flatten.compact
     end
 
     def parameters_for_notification

--- a/src/api/app/models/event_subscription.rb
+++ b/src/api/app/models/event_subscription.rb
@@ -18,6 +18,7 @@ class EventSubscription < ApplicationRecord
     request_watcher: 'Watching the request',
     moderator: 'User with moderator role',
     token_executor: 'User who runs the workflow',
+    token_member: 'User the token is shared with',
     reporter: 'Reporter',
     offender: 'Offender',
     member: 'Member'
@@ -48,7 +49,7 @@ class EventSubscription < ApplicationRecord
            reviewer commenter creator
            project_watcher source_project_watcher target_project_watcher
            package_watcher target_package_watcher source_package_watcher request_watcher any_role
-           moderator reporter offender token_executor member]
+           moderator reporter offender token_executor token_member member]
   }
 
   scope :for_eventtype, ->(eventtype) { where(eventtype: eventtype) }

--- a/src/api/lib/tasks/dev/notifications.rake
+++ b/src/api/lib/tasks/dev/notifications.rake
@@ -78,6 +78,13 @@ namespace :dev do
         another_group = create(:group, title: Faker::Lorem.word)
         another_group.users << admin
 
+        # Admin is already subscribed as token_executor, Iggy is now subscribedas token_member
+        iggy = User.find_by(login: 'Iggy')
+        create(:event_subscription_workflow_run_fail, channel: :web, user: iggy, receiver_role: 'token_member')
+        token = Token.find_by(executor: admin)
+        token.users << iggy # share token with iggy
+        create(:workflow_run, :failed, token: token)
+
         # Process notifications immediately to see them in the web UI
         SendEventEmailsJob.new.perform_now
       end

--- a/src/api/lib/tasks/dev/notifications.rake
+++ b/src/api/lib/tasks/dev/notifications.rake
@@ -78,11 +78,12 @@ namespace :dev do
         another_group = create(:group, title: Faker::Lorem.word)
         another_group.users << admin
 
-        # Admin is already subscribed as token_executor, Iggy is now subscribedas token_member
+        # Admin is already subscribed as token_executor, Iggy and another_group are now subscribed as token_member
         iggy = User.find_by(login: 'Iggy')
         create(:event_subscription_workflow_run_fail, channel: :web, user: iggy, receiver_role: 'token_member')
         token = Token.find_by(executor: admin)
         token.users << iggy # share token with iggy
+        token.groups << another_group
         create(:workflow_run, :failed, token: token)
 
         # Process notifications immediately to see them in the web UI

--- a/src/api/lib/tasks/dev/rake_support.rb
+++ b/src/api/lib/tasks/dev/rake_support.rb
@@ -61,6 +61,8 @@ module RakeSupport
     create(:event_subscription_added_user_to_group, channel: :web, user: user)
     create(:event_subscription_removed_user_from_group, channel: :web, user: user)
 
+    create(:event_subscription_workflow_run_fail, channel: :web, user: user, receiver_role: 'token_executor')
+
     user.groups.each do |group|
       create(:event_subscription_request_created, channel: :web, user: nil, group: group, receiver_role: 'target_maintainer')
       create(:event_subscription_review_wanted, channel: 'web', user: nil, group: group, receiver_role: 'reviewer')


### PR DESCRIPTION
We notify token executors about a workflow run. We are going to notify users and groups the token is shared with.

TODO:
- [x] Include groups in the receiver roles
- [x] Specs 