### PR TITLE
BugFix: notification count for unread only

### DIFF
--- a/src/api/app/controllers/webui/users/notifications_controller.rb
+++ b/src/api/app/controllers/webui/users/notifications_controller.rb
@@ -76,23 +76,17 @@ class Webui::Users::NotificationsController < Webui::WebuiController
     @counted_notifications = {}
     @counted_notifications['all'] = @notifications.count
     @counted_notifications['unread'] = @unread_notifications_count # Variable set in the Webui controller
-    @counted_notifications['read'] = @counted_notifications['all'] - @counted_notifications['unread']
-    @counted_notifications['comments'] = @notifications.for_comments.count
-    @counted_notifications['requests'] = @notifications.for_requests.count
-    @counted_notifications['incoming_requests'] = @notifications.for_incoming_requests(User.session).count
-    @counted_notifications['outgoing_requests'] = @notifications.for_outgoing_requests(User.session).count
-    @counted_notifications['relationships_created'] = @notifications.for_relationships_created.count
-    @counted_notifications['relationships_deleted'] = @notifications.for_relationships_deleted.count
-    @counted_notifications['build_failures'] = @notifications.for_build_failures.count
-    @counted_notifications['reports'] = @notifications.for_reports.count
-    @counted_notifications['workflow_runs'] = @notifications.for_workflow_runs.count
-    @counted_notifications['appealed_decisions'] = @notifications.for_appealed_decisions.count
-    @counted_notifications['member_on_groups'] = @notifications.for_member_on_groups.count
-  end
-
-  def update_counted_notifications
-    @counted_notifications['unread'] = User.session.unread_notifications_count
-    @counted_notifications['read'] = @counted_notifications['all'].to_i - @counted_notifications['unread']
+    @counted_notifications['comments'] = @notifications.unread.for_comments.count
+    @counted_notifications['requests'] = @notifications.unread.for_requests.count
+    @counted_notifications['incoming_requests'] = @notifications.unread.for_incoming_requests(User.session).count
+    @counted_notifications['outgoing_requests'] = @notifications.unread.for_outgoing_requests(User.session).count
+    @counted_notifications['relationships_created'] = @notifications.unread.for_relationships_created.count
+    @counted_notifications['relationships_deleted'] = @notifications.unread.for_relationships_deleted.count
+    @counted_notifications['build_failures'] = @notifications.unread.for_build_failures.count
+    @counted_notifications['reports'] = @notifications.unread.for_reports.count
+    @counted_notifications['workflow_runs'] = @notifications.unread.for_workflow_runs.count
+    @counted_notifications['appealed_decisions'] = @notifications.unread.for_appealed_decisions.count
+    @counted_notifications['member_on_groups'] = @notifications.unread.for_member_on_groups.count
   end
 
   def filter_notifications

--- a/src/api/app/views/webui/shared/_check_box.haml
+++ b/src/api/app/views/webui/shared/_check_box.haml
@@ -6,5 +6,5 @@
         - if defined?(label_icon)
           %i.me-1{ class: label_icon }
         = label
-  - if amount.present? && amount.positive?
+  - if defined?(amount) && amount.positive?
     %span= amount

--- a/src/api/app/views/webui/shared/_radio_button.haml
+++ b/src/api/app/views/webui/shared/_radio_button.haml
@@ -5,5 +5,5 @@
       - if defined?(label_icon)
         %i.me-1{ class: label_icon }
       = label
-  - if amount.positive?
+  - if defined?(amount) && amount.positive?
     %span= amount

--- a/src/api/app/views/webui/users/notifications/_notification_filter.html.haml
+++ b/src/api/app/views/webui/users/notifications/_notification_filter.html.haml
@@ -4,7 +4,7 @@
     %h6.px-3.py-2
       %b State
     .px-4.py-1
-      = render partial: 'webui/shared/radio_button', locals: { label: 'All', amount: counted_notifications['all'],
+      = render partial: 'webui/shared/radio_button', locals: { label: 'All',
                                                                key: 'state[all]', name: 'state', value: 'all',
                                                                checked: selected_filter[:state] == 'all' }
     .px-4.py-1
@@ -12,7 +12,7 @@
                                                                key: 'state[unread]', name: 'state', value: 'unread',
                                                                checked: selected_filter[:state] == 'unread' }
     .px-4.py-1
-      = render partial: 'webui/shared/radio_button', locals: { label: 'Read', amount: counted_notifications['read'],
+      = render partial: 'webui/shared/radio_button', locals: { label: 'Read',
                                                                key: 'state[read]', name: 'state', value: 'read',
                                                                checked: selected_filter[:state] == 'read' }
   .list-group.list-group-flush.mt-4.mb-4
@@ -86,7 +86,7 @@
         .dropdown-menu
           - projects_for_filter.each do |project_name|
             .dropdown-item-text
-              = render partial: 'webui/shared/check_box', locals: { label: project_name, amount: counted_notifications["project_#{project_name}"],
+              = render partial: 'webui/shared/check_box', locals: { label: project_name,
                                                                     key: "project[#{project_name}]", name: 'project[]', value: project_name,
                                                                     checked: selected_filter[:project]&.include?(project_name) }
   - unless groups_for_filter.empty?
@@ -99,7 +99,7 @@
         .dropdown-menu
           - groups_for_filter.each do |group_title|
             .dropdown-item-text
-              = render partial: 'webui/shared/check_box', locals: { label: group_title, amount: counted_notifications["group_#{group_title}"],
+              = render partial: 'webui/shared/check_box', locals: { label: group_title,
                                                                     key: "group[#{group_title}]", name: 'group[]', value: group_title,
                                                                     checked: selected_filter[:group]&.include?(group_title) }
 


### PR DESCRIPTION
Fixes: https://github.com/openSUSE/open-build-service/issues/16325

The count of notifications is visible only for `unread` ones in all the filter labels.

# Before

![image](https://github.com/openSUSE/open-build-service/assets/7080830/7ce670a7-22cc-487f-b6d9-b86369c75b20)


# After

![image](https://github.com/openSUSE/open-build-service/assets/7080830/67077a89-dd1e-4535-99a3-f7b1da60ce69)

