### PR TITLE
Coerce sensible params to string

### DIFF
--- a/src/api/app/controllers/webui/monitor_controller.rb
+++ b/src/api/app/controllers/webui/monitor_controller.rb
@@ -44,7 +44,8 @@ class Webui::MonitorController < Webui::WebuiController
   def events
     data = {}
 
-    arch = Architecture.find_by(name: params.fetch(:arch, @default_architecture))
+    arch = Architecture.find_by(name: params.fetch(:arch, @default_architecture).to_s)
+    return render json: {} unless arch
 
     range = params.fetch(:range, DEFAULT_SEARCH_RANGE)
 

--- a/src/api/app/controllers/webui/webui_controller.rb
+++ b/src/api/app/controllers/webui/webui_controller.rb
@@ -48,7 +48,7 @@ class Webui::WebuiController < ActionController::Base
 
   def set_project
     # We've started to use project_name for new routes...
-    project_name = params[:project_name] || params[:project]
+    project_name = (params[:project_name] || params[:project]).to_s
     @project = ::Project.find_by(name: project_name)
     raise Project::Errors::UnknownObjectError, "Project not found: #{project_name}" unless @project
   end


### PR DESCRIPTION
We don't want to crash with

    can't quote ActionController::Parameters

whenever people put garbage inside parameters

Follow up of #16377
Fixes #16379 