### PR TITLE
Return a Bad Request error when toggling an invalid flag

### DIFF
--- a/src/api/app/controllers/webui/repositories_controller.rb
+++ b/src/api/app/controllers/webui/repositories_controller.rb
@@ -176,7 +176,7 @@ class Webui::RepositoriesController < Webui::WebuiController
       @main_object.flags.of_type(flag_type).where(repo: params[:repository], architecture: architecture).delete_all
     when /^set-(?<status>disable|enable)$/
       flag = @main_object.flags.find_or_create_by(flag: flag_type, repo: params[:repository], architecture: architecture)
-      flag.update(status: $LAST_MATCH_INFO['status'])
+      head :bad_request unless flag.update(status: $LAST_MATCH_INFO['status'])
     end
     @main_object.store
   end


### PR DESCRIPTION
This fixes the "Flag is invalid" errors from

    Validation failed: Flags Duplicated flags, Flags is invalid

Related to #7893