### PR TITLE
[api] allow to request keyinfo via /public

### DIFF
--- a/src/api/app/controllers/public_controller.rb
+++ b/src/api/app/controllers/public_controller.rb
@@ -78,6 +78,7 @@ class PublicController < ApplicationController
   end
 
   # GET /public/source/:project/_config
+  # GET /public/source/:project/_keyinfo
   # GET /public/source/:project/_pubkey
   def project_file
     # project visible/known ?

--- a/src/api/config/routes/api.rb
+++ b/src/api/config/routes/api.rb
@@ -185,6 +185,7 @@ constraints(RoutesHelper::APIMatcher) do
     get 'public/source/:project' => :project_index, constraints: cons
     get 'public/source/:project/_meta' => :project_meta, constraints: cons
     get 'public/source/:project/_config' => :project_file, constraints: cons
+    get 'public/source/:project/_keyinfo' => :project_file, constraints: cons
     get 'public/source/:project/_pubkey' => :project_file, constraints: cons
     get 'public/source/:project/:package' => :package_index, constraints: cons
     get 'public/source/:project/:package/_meta' => :package_meta, constraints: cons


### PR DESCRIPTION
Required by osc for fetching keys when buildig against remote instances