### PR TITLE
Coerce sensible params to int

### DIFF
--- a/src/api/app/controllers/webui/search_controller.rb
+++ b/src/api/app/controllers/webui/search_controller.rb
@@ -55,7 +55,7 @@ class Webui::SearchController < Webui::WebuiController
   #
   def set_parameters
     @search_attrib_type_id = nil
-    @search_attrib_type_id = params[:attrib_type_id] if params[:attrib_type_id].present?
+    @search_attrib_type_id = Integer.try_convert(params[:attrib_type_id]) if params[:attrib_type_id].present?
 
     search_issue
 


### PR DESCRIPTION
In order to search by attrib_type_id, ensure we don't try to process garbage coming as parameters

Fixes #16255

**How to test this**
1. Open http://localhost:3000/search?attrib_type_id%5B%24testing%5D=1
2. See it **not** failing with
```
undefined method `to_i' for #<ActionController::Parameters {"$testing"=>"1"} permitted: false>
```