### PR TITLE
Preload projects on polymorphic commentable

### DIFF
--- a/src/api/.database_consistency.todo.yml
+++ b/src/api/.database_consistency.todo.yml
@@ -451,6 +451,9 @@ Comment:
   id:
     PrimaryKeyTypeChecker:
       enabled: false
+  project:
+    ForeignKeyChecker:
+      enabled: false
 CommentLock:
   commentable_type:
     LengthConstraintChecker:

--- a/src/api/app/models/comment.rb
+++ b/src/api/app/models/comment.rb
@@ -5,6 +5,9 @@ class Comment < ApplicationRecord
   belongs_to :user, inverse_of: :comments
   belongs_to :moderator, class_name: 'User', optional: true
 
+  # Preloads for polymorphic commentable:
+  belongs_to :project, foreign_key: 'commentable_id', optional: true
+
   validates :body, presence: true
   # FIXME: this probably should be MEDIUMTEXT(16MB) instead of text (64KB)
   validates :body, length: { maximum: 65_535 }
@@ -30,7 +33,7 @@ class Comment < ApplicationRecord
 
   scope :on_actions_for_request, ->(bs_request) { where(commentable: BsRequestAction.where(bs_request: bs_request)) }
   scope :without_parent, -> { where(parent_id: nil) }
-  scope :with_commentable, -> { where.not(commentable_id: nil) }
+  scope :with_commentable, -> { includes(:project).where.not(commentable_id: nil) }
   scope :newest_first, -> { order(created_at: :desc) }
 
   def to_s


### PR DESCRIPTION
Permit to include the projects table in comments queries with commentable. Therefore, N+1 queries are not performed for comments with a project as a commentable.

This will reduce the number of "Project Load" queries performed. See:
- https://obs-measure.opensuse.org/d/OFTlR0ESz/database-queries
- https://obs-measure.opensuse.org/d/influxdb-rails-slowlog-sql/slowlog-by-sql-query