### PR TITLE
reduce memory need on packtrack data import

### DIFF
--- a/src/api/app/models/repository.rb
+++ b/src/api/app/models/repository.rb
@@ -12,7 +12,23 @@ class Repository < ApplicationRecord
   has_many :links, class_name: 'PathElement', inverse_of: :link
   has_many :targetlinks, class_name: 'ReleaseTarget', foreign_key: 'target_repository_id'
   has_one :hostsystem, class_name: 'Repository', foreign_key: 'hostsystem_id'
-  has_many :binary_releases, dependent: :destroy
+  has_many :binary_releases, dependent: :destroy do
+    def current
+      where(obsolete_time: nil)
+    end
+
+    def obsolete
+      where.not(obsolete_time: nil)
+    end
+
+    def unchanged
+      where(modify_time: nil)
+    end
+
+    def changed
+      where.not(modify_time: nil)
+    end
+  end
   has_many :product_update_repositories, dependent: :delete_all
   has_many :product_medium, dependent: :delete_all
   has_many :repository_architectures, -> { order('position') }, dependent: :destroy, inverse_of: :repository

--- a/src/api/spec/jobs/update_released_binaries_job_spec.rb
+++ b/src/api/spec/jobs/update_released_binaries_job_spec.rb
@@ -15,15 +15,14 @@ RSpec.describe UpdateReleasedBinariesJob do
   let(:event) { Event::Packtrack.create(project: project.name, repo: repository.name, payload: '12345') }
 
   describe '.perform' do
-    subject { described_class.new.perform(event.id) }
+    subject { event } # # UpdateBackendInfosJob gets scheduled when the event is created
 
     context 'no binary release existed before' do
       before do
         allow(Backend::Api::Server).to receive_messages(notification_payload: [binary_hash].to_json, delete_notification_payload: '')
       end
 
-      it { expect { subject }.not_to raise_error }
-      it { expect { subject }.to change(BinaryRelease, :count).by(1) }
+      it { expect { subject }.to change(BinaryRelease, :count).from(0).to(1) }
     end
 
     context 'an existing binary release should be updated' do
@@ -94,7 +93,7 @@ RSpec.describe UpdateReleasedBinariesJob do
           binary_disturl: binary_hash['disturl'],
           binary_supportstatus: binary_hash['supportstatus'],
           binary_id: binary_hash['binaryid'],
-          binary_buildtime: nil
+          binary_buildtime: Time.zone.now
         )
       end
 


### PR DESCRIPTION
By not storing the full BinaryRelease object in the `old_binary_releases` hash
but only the data needed to detect if the BinaryRelease was modified.
In the case it's modified we need to look it up in the database then, but this
should not happen often.

By only iterating through the current and unchanged BinaryRelease of the Repository.

