### PR TITLE
Simplify Package/Project source_access policy

### DIFF
--- a/src/api/app/policies/package_policy.rb
+++ b/src/api/app/policies/package_policy.rb
@@ -15,10 +15,7 @@ class PackagePolicy < ApplicationPolicy
   end
 
   def create_branch?
-    # same as Package.check_source_access!
-    return false if (source_access? || project_source_access?) && !user.can_source_access?(record)
-
-    true
+    source_access?
   end
 
   def update?
@@ -30,14 +27,15 @@ class PackagePolicy < ApplicationPolicy
   end
 
   def save_meta_update?
-    update? && !source_access?
+    update? && source_access?
   end
 
-  def project_source_access?
-    record.project.disabled_for?('sourceaccess', nil, nil)
-  end
+  private
 
   def source_access?
-    record.disabled_for?('sourceaccess', nil, nil)
+    return true if user.has_global_permission?(:source_access)
+    return true if user.has_local_permission?(:source_access, record)
+
+    record.enabled_for?('sourceaccess', nil, nil)
   end
 end

--- a/src/api/app/policies/project_policy.rb
+++ b/src/api/app/policies/project_policy.rb
@@ -39,7 +39,10 @@ class ProjectPolicy < ApplicationPolicy
   end
 
   def source_access?
-    User.admin_session? || !record.disabled_for?('sourceaccess', nil, nil)
+    return true if user.has_global_permission?(:source_access)
+    return true if user.has_local_permission?(:source_access, record)
+
+    record.enabled_for?('sourceaccess', nil, nil)
   end
 
   # staging project

--- a/src/api/spec/policies/package_policy_spec.rb
+++ b/src/api/spec/policies/package_policy_spec.rb
@@ -66,6 +66,14 @@ RSpec.describe PackagePolicy do
   context 'branch as other user' do
     permissions :create_branch? do
       it { expect(subject).to permit(other_user, package) }
+
+      context 'source access disabled' do
+        before do
+          allow(package).to receive(:enabled_for?).with('sourceaccess', nil, nil).and_return(false)
+        end
+
+        it { expect(subject).not_to permit(other_user, package) }
+      end
     end
   end
 
@@ -75,25 +83,5 @@ RSpec.describe PackagePolicy do
 
     it { expect(subject).to permit(admin_user, package) }
     it { expect(subject).to permit(user, package) }
-  end
-
-  context 'source access enabled' do
-    permissions :source_access? do
-      before do
-        allow_any_instance_of(Package).to receive(:disabled_for?).with('sourceaccess', nil, nil).and_return(true)
-      end
-
-      it { expect(subject).to permit(user, package) }
-    end
-  end
-
-  context 'source access disabled' do
-    permissions :source_access? do
-      before do
-        allow_any_instance_of(Package).to receive(:disabled_for?).with('sourceaccess', nil, nil).and_return(false)
-      end
-
-      it { expect(subject).not_to permit(user, package) }
-    end
   end
 end


### PR DESCRIPTION
Less layers of indirection (can_source_access -> can -> has_local_permission) and less duplication (has_local_permission already checks the Project of a Package)