### PR TITLE
Don't set unread notifications count on AJAX requests

### DIFF
--- a/src/api/app/controllers/webui/webui_controller.rb
+++ b/src/api/app/controllers/webui/webui_controller.rb
@@ -23,7 +23,7 @@ class Webui::WebuiController < ActionController::Base
   before_action :current_announcement, unless: -> { request.xhr? }
   before_action :fetch_watchlist_items
   before_action :set_paper_trail_whodunnit
-  before_action :set_unread_notifications_count
+  before_action :set_unread_notifications_count, unless: -> { request.xhr? }
   after_action :clean_cache
 
   # :notice and :alert are default, we add :success and :error


### PR DESCRIPTION
In cases like AJAX queries for build results or RPM lint results, we don't need to set the unread notifications counter.