### PR TITLE
Fix invalid byte sequence in UTF-8 processing build logs

### DIFF
--- a/src/api/app/mixins/build_log_support.rb
+++ b/src/api/app/mixins/build_log_support.rb
@@ -10,6 +10,7 @@ module BuildLogSupport
     log = raw_log_chunk(project, package_name, repo, arch, start, theend)
     log.encode!(invalid: :replace, undef: :replace, cr_newline: true)
     log = CGI.escapeHTML(log)
+    log.scrub! # Remove invalid byte sequences in UTF-8
     log = ansi_escaped(log, theend - start + 1)
     log.gsub(%r{([^a-zA-Z0-9&;<>/\n\r \t()])}) do |c|
       if c.ord < 32

--- a/src/api/spec/mixins/build_log_support_spec.rb
+++ b/src/api/spec/mixins/build_log_support_spec.rb
@@ -56,6 +56,12 @@ RSpec.describe BuildLogSupport do
 class=\"ansible_none\">\r[  580s] </span><span class=\"ansible_36\">Reaping 1 jobs</span><span class=\"ansible_none\"></span>")
         }
       end
+
+      context 'with invalid utf-8 byte sequences' do
+        let(:build_log) { "invalid byte sequence ->\xD3'" }
+
+        it { expect(subject).to eq('<span class="ansible_none">invalid byte sequence -&gt;�&#39;</span>') }
+      end
     end
   end
 


### PR DESCRIPTION
Sometimes we get build logs in UTF-8 with invalid byte sequences. We need to be able to process them without failing.

This PR removes the invalid byte sequences

Fixes #16411