### PR TITLE
Prevent from loading the badge twice

### DIFF
--- a/src/api/app/views/webui/package/side_links/_create_badge.html.haml
+++ b/src/api/app/views/webui/package/side_links/_create_badge.html.haml
@@ -23,7 +23,7 @@
             %option{ value: 'default', selected: 'selected' } Default
             %option{ value: 'percent' } Percent
           .d-flex
-            = image_tag(project_package_badge_url(project, package, format: 'svg'), id: 'badge-preview', class: 'mt-3 mx-auto')
+            = image_tag('', id: 'badge-preview', class: 'mt-3 mx-auto')
         .modal-footer
           .input-group.w-100
             = render CopyToClipboardInputComponent.new(input_text: project_package_badge_url(project, package, format: 'svg'))


### PR DESCRIPTION
The image we render will be overwritten by javascript after loading the page.

### For reviewers

On a development environment, browse a page of a package ( http://localhost:3000/package/show/home:Admin/hello_world, for example ). Notice in the logs that the badge is loaded twice.

After the changes, the badge is loaded only once.