### PR TITLE
Bugfix: missing initialize parameter due to inheritance

### DIFF
--- a/src/api/app/components/workflow_run_header_component.rb
+++ b/src/api/app/components/workflow_run_header_component.rb
@@ -1,5 +1,5 @@
 class WorkflowRunHeaderComponent < WorkflowRunRowComponent
-  def initialize(workflow_run:)
+  def initialize(workflow_run:, token_id:)
     super
 
     @workflow_run = workflow_run

--- a/src/api/app/views/webui/workflow_runs/show.html.haml
+++ b/src/api/app/views/webui/workflow_runs/show.html.haml
@@ -1,5 +1,5 @@
 - @pagetitle = "Workflow Run #{@workflow_run.id}"
 .card
   .card-body
-    = render(WorkflowRunHeaderComponent.new(workflow_run: @workflow_run))
+    = render(WorkflowRunHeaderComponent.new(workflow_run: @workflow_run, token_id: @token.id))
     = render(WorkflowRunDetailComponent.new(workflow_run: @workflow_run))


### PR DESCRIPTION
Fixes https://github.com/openSUSE/open-build-service/issues/16420

Option 1: make the `token_id` parameter optional
Option 2: pass the `token_id` parameter to the `WorkflowRunHeaderComponent` too

Choice: Option 2
Reason: keep the interface consistent between the two component bounded by inheritance