### PR TITLE
Refactor a bit of complexity on SCMStatusReporter

### DIFF
--- a/src/api/app/services/scm_status_reporter.rb
+++ b/src/api/app/services/scm_status_reporter.rb
@@ -1,6 +1,12 @@
 class SCMStatusReporter
   attr_accessor :event_payload, :event_subscription_payload, :state, :initial_report
 
+  REPORTERS = {
+    'github' => GithubStatusReporter,
+    'gitlab' => GitlabStatusReporter,
+    'gitea' => GiteaStatusReporter
+  }.freeze
+
   def initialize(event_payload, event_subscription_payload, scm_token, workflow_run = nil, event_type = nil, initial_report: false)
     @event_payload = event_payload.deep_symbolize_keys
     @event_subscription_payload = event_subscription_payload.deep_symbolize_keys
@@ -17,43 +23,13 @@ class SCMStatusReporter
   end
 
   def call
-    if github?
-      GithubStatusReporter.new(@event_payload,
-                               @event_subscription_payload,
-                               @scm_token,
-                               @state,
-                               @workflow_run,
-                               @event_type,
-                               initial_report: @initial_report).call
-    elsif gitlab?
-      GitlabStatusReporter.new(@event_payload,
-                               @event_subscription_payload,
-                               @scm_token,
-                               @state,
-                               @workflow_run,
-                               @event_type,
-                               initial_report: @initial_report).call
-    elsif gitea?
-      GiteaStatusReporter.new(@event_payload,
-                              @event_subscription_payload,
-                              @scm_token,
-                              @state,
-                              @workflow_run,
-                              @event_type,
-                              initial_report: @initial_report).call
-    end
-  end
-
-  def github?
-    @event_subscription_payload[:scm] == 'github'
-  end
-
-  def gitlab?
-    @event_subscription_payload[:scm] == 'gitlab'
-  end
-
-  def gitea?
-    @event_subscription_payload[:scm] == 'gitea'
+    REPORTERS[@event_subscription_payload[:scm]].new(@event_payload,
+                                                     @event_subscription_payload,
+                                                     @scm_token,
+                                                     @state,
+                                                     @workflow_run,
+                                                     @event_type,
+                                                     initial_report: @initial_report).call
   end
 
   private


### PR DESCRIPTION
We can leverage the use of metaprograming for setting the vendor-specific reporter