### PR TITLE
Permit AJAX requests to set roles of packages

### DIFF
--- a/src/api/config/routes/webui.rb
+++ b/src/api/config/routes/webui.rb
@@ -89,9 +89,6 @@ constraints(RoutesHelper::WebuiMatcher) do
       post 'package/create/:project' => :create, constraints: cons, as: 'packages'
       get 'package/new/:project' => :new, constraints: cons, as: 'new_package'
       post 'package/remove/:project/:package' => :remove, constraints: cons
-      post 'package/save_person/:project/:package' => :save_person, constraints: cons, as: 'package_save_person'
-      post 'package/save_group/:project/:package' => :save_group, constraints: cons, as: 'package_save_group'
-      post 'package/remove_role/:project/:package' => :remove_role, constraints: cons, as: 'package_remove_role'
       # For backward compatibility
       get 'package/view_file/:project/:package/:filename', to: redirect('/projects/%{project}/packages/%{package}/files/%{filename}'), constraints: cons
       get 'package/devel_project/:project/:package' => :devel_project, constraints: cons, as: 'package_devel_project'
@@ -107,6 +104,12 @@ constraints(RoutesHelper::WebuiMatcher) do
       # For backward compatibility
       get 'package/files/:project/:package' => :show, constraints: cons
     end
+  end
+
+  controller 'webui/package' do
+    post 'package/save_person/:project/:package' => :save_person, constraints: cons, as: 'package_save_person'
+    post 'package/save_group/:project/:package' => :save_group, constraints: cons, as: 'package_save_group'
+    post 'package/remove_role/:project/:package' => :remove_role, constraints: cons, as: 'package_remove_role'
   end
 
   resources :packages, only: [], param: :name do


### PR DESCRIPTION
This way, setting users and groups roles for packages work the same way as for projects.

Fixes #16433.

 ### For reviewers
 
 You can use the review-app, and see the roles of a package [here](https://obs-reviewlab.opensuse.org/eduardoj-fixajax_in_users_and_groups_of_packages/package/users/home:Admin/hello_world). None of these actions should return a 500 error:
 - Add a user as maintainer (Iggy, for example)
 - Add a role to the user Iggy
 - Remove a role of the user Iggy
 - Remove the user Iggy