### PR TITLE
[backend] scmsync: move repserver notification after the lock was rel…

### DIFF
--- a/src/backend/BSSrcServer/Service.pm
+++ b/src/backend/BSSrcServer/Service.pm
@@ -166,6 +166,11 @@ sub commitobsscm {
     $newrev = $addrev->($cgi, $projid, $packid, $files);
   }
   BSSrcrep::writeobsscmdata($projid, $packid, $servicemark, undef);	# frees lock
+  if ($packid eq '_project') {
+    $notify_repservers->('project', $projid);
+  } else {
+    $notify_repservers->('package', $projid, $packid);
+  }
   return $newrev;
 }
 

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -802,7 +802,7 @@ sub addrev {
                                      user => $user, comment => $comment, 'requestid' => $requestid});
   }
 
-  notify_repservers('package', $projid, $packid);
+  notify_repservers('package', $projid, $packid) unless $cgi->{'commitobsscm'};
 
   # put marker back
   $files->{'/SERVICE'} = $servicemark if $servicemark;


### PR DESCRIPTION
…eased

This fixes a race that made packages be stuck in the "in progress" state in some cases.