### PR TITLE
Duplicated notifications for receivers occurring multiple times

### DIFF
--- a/src/api/app/models/event/workflow_run_fail.rb
+++ b/src/api/app/models/event/workflow_run_fail.rb
@@ -4,6 +4,7 @@ module Event
     payload_keys :id, :token_id, :hook_event, :summary, :repository_full_name
 
     receiver_roles :token_executor, :token_member
+    delegate :members, to: :token, prefix: true
 
     self.notification_explanation = 'Receive notifications for failed workflow runs on SCM/CI integration.'
 
@@ -15,10 +16,6 @@ module Event
 
     def token_executors
       [token&.executor].compact
-    end
-
-    def token_members
-      [token&.users, token&.groups].flatten.compact
     end
 
     def parameters_for_notification

--- a/src/api/app/models/token/workflow.rb
+++ b/src/api/app/models/token/workflow.rb
@@ -63,6 +63,12 @@ class Token::Workflow < Token
     workflow_configuration_path == '.obs/workflows.yml'
   end
 
+  def members
+    # exctract all the users and groups members the token is shared with,
+    # and merge them all together in a single set removing nils and duplicated entries
+    [users, groups&.map(&:users)&.flatten].flatten.compact.uniq
+  end
+
   private
 
   def validation_errors

--- a/src/api/spec/models/event_subscription/find_for_event_spec.rb
+++ b/src/api/spec/models/event_subscription/find_for_event_spec.rb
@@ -621,8 +621,8 @@ RSpec.describe EventSubscription::FindForEvent do
           )
         end
 
-        it 'includes the target group' do
-          expect(subject.map(&:subscriber)).to include(group)
+        it "includes the member's group user" do
+          expect(subject.map(&:subscriber)).to include(user)
         end
       end
     end


### PR DESCRIPTION
Issue: when a token is shared with a userA and a group where the userA is part of, userA receives notification twice.

Explanation: `receiver_roles` are populated in a special way in the `Event::WorkflowRunFail` case: users and group don't have roles on `Token`, the `Token` is **shared** with them instead, and they act like they are the owner too. So in this case, we cannot let the `find_for_event.rb` do it's normal job finding users and group users based on roles and deduct the set of users. We need to send a set of unique users in advance to the `receiver_roles`, so the notification is not sent twice to users they have the token shared directly and they are part of a group the token is shared with too.