### PR TITLE
Move the simplecov to the top of the file

### DIFF
--- a/src/api/spec/spec_helper.rb
+++ b/src/api/spec/spec_helper.rb
@@ -2,6 +2,10 @@
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 
+# for generating test coverage
+require 'simplecov'
+SimpleCov.start
+
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
@@ -82,9 +86,6 @@ end
 
 # We never want the OBS backend to autostart itself...
 ENV['BACKEND_STARTED'] = '1'
-
-# for generating test coverage
-require 'simplecov'
 
 ### Our own spec extensions
 # support logging


### PR DESCRIPTION
See
https://github.com/simplecov-ruby/simplecov/blob/main/README.md#getting-started.

It says to put the require at the very top of the file.

Looks like that way the reports are [much more accurate](https://codeclimate.com/github/openSUSE/open-build-service/compare/4ffc8887a964dd597a30d9f822636b3e80f82386...0e04ce832022b5c7c6a16eb1be335c801cac7cbc#ratings).