### PR TITLE
[backend] Signkey: return fingerprint/keyid even if the algorithm is …

### DIFF
--- a/src/backend/BSPGP.pm
+++ b/src/backend/BSPGP.pm
@@ -209,7 +209,7 @@ sub pk2keysize {
 }
 
 
-sub pk2fingerprint {
+sub pk2fingerprint_keyid {
   my ($pk) = @_;
   my ($tag, $pack);
   ($tag, $pack, $pk) = pkdecodepacket($pk);
@@ -218,7 +218,12 @@ sub pk2fingerprint {
   die("fingerprint calculation needs at least V4 keys\n") if $ver < 4;
   my $ctx = Digest->new("SHA-1");
   $ctx->add(pack('Cn', 0x99, length($pack)).$pack);
-  return $ctx->hexdigest();
+  my $fp = $ctx->hexdigest();
+  return $fp, substr($fp, -16, 16), $ver;
+}
+
+sub pk2fingerprint {
+  return (pk2fingerprint_keyid($_))[0];
 }
 
 sub pk2sigdata {

--- a/src/backend/BSSched/BuildJob/Patchinfo.pm
+++ b/src/backend/BSSched/BuildJob/Patchinfo.pm
@@ -515,7 +515,7 @@ sub build {
         delete $updateinfodata_tocopy{$tocopy};
       }
     }
-    if ($updateinfodata_tocopy{$tocopy} && (!defined($mpackid) || ($updateinfodata->{'metas'}->{$mpackid} || '') eq $ckmetas->{$mpackid})) {
+    if ($ptype ne 'binary' && $updateinfodata_tocopy{$tocopy} && (!defined($mpackid) || ($updateinfodata->{'metas'}->{$mpackid} || '') eq $ckmetas->{$mpackid})) {
       print "        reusing old packages for '$tocopy'\n";
       $from = "$gdst/$packid";
       @bins = grep {$updateinfodata->{'binaryorigins'}->{$_} eq $tocopy} keys(%{$updateinfodata->{'binaryorigins'}});


### PR DESCRIPTION
…unknown

Also we use a new BSPGP::pk2fingerprint_keyid function to get the keyid because v5 keys do not use the last bytes of the fingerprint for the keyid.