### PR TITLE
Remove the notification specialized class switcher

### DIFF
--- a/src/api/app/components/notification_component.rb
+++ b/src/api/app/components/notification_component.rb
@@ -17,7 +17,7 @@ class NotificationComponent < ApplicationComponent
   def initialize(notification:, selected_filter:, page:)
     super
 
-    @notification = notification.for_notifiable
+    @notification = notification
     @selected_filter = selected_filter
     @page = page
   end

--- a/src/api/app/models/notification.rb
+++ b/src/api/app/models/notification.rb
@@ -82,31 +82,6 @@ class Notification < ApplicationRecord
     User.find_by(login: event_payload['accused']) || User.find_by(login: event_payload['user_login'])
   end
 
-  # TODO: Remove this method once the Notification STI mechanism has been set up properly
-  # rubocop:disable Metrics/CyclomaticComplexity
-  def for_notifiable
-    return self if type.present?
-
-    notifiable_class = case notifiable
-                       when BsRequest
-                         NotificationBsRequest
-                       when Comment
-                         NotificationComment
-                       when Group
-                         NotificationGroup
-                       when Package
-                         NotificationPackage
-                       when Project
-                         NotificationProject
-                       when Report, DecisionFavored, DecisionCleared
-                         NotificationReport
-                       when WorkflowRun
-                         NotificationWorkflowRun
-                       end
-    notifiable_class.new(attributes)
-  end
-  # rubocop:enable Metrics/CyclomaticComplexity
-
   private
 
   def track_notification_creation

--- a/src/api/app/policies/notification_comment_policy.rb
+++ b/src/api/app/policies/notification_comment_policy.rb
@@ -1,4 +1,4 @@
-class NotificationPolicy < ApplicationPolicy
+class NotificationCommentPolicy < ApplicationPolicy
   def update?
     record.subscriber == user
   end

--- a/src/api/spec/components/notification_component_spec.rb
+++ b/src/api/spec/components/notification_component_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe NotificationComponent, type: :component do
   context 'when the notification is about a relationship with package' do
     let(:package) { create(:package_with_maintainer, maintainer: user) }
     let(:event_payload) { { package: package.name, project: package.project.name } }
-    let(:notification) { create(:notification, :relationship_create_for_project, delivered: true, notifiable: package, event_payload: event_payload) }
+    let(:notification) { create(:notification_project, :relationship_create_for_project, delivered: true, notifiable: package, event_payload: event_payload) }
 
     before do
       render_inline(described_class.new(notification: notification, selected_filter: selected_filter, page: 1))
@@ -19,7 +19,7 @@ RSpec.describe NotificationComponent, type: :component do
   context 'when the notification is about a comment for project' do
     let(:project) { create(:project, maintainer: user) }
     let(:comment) { create(:comment, commentable: project) }
-    let(:notification) { create(:notification, :comment_for_project, delivered: true, notifiable: comment) }
+    let(:notification) { create(:notification_comment, :comment_for_project, delivered: true, notifiable: comment) }
 
     before do
       render_inline(described_class.new(notification: notification, selected_filter: selected_filter, page: 1))

--- a/src/api/spec/components/notification_component_spec.rb
+++ b/src/api/spec/components/notification_component_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe NotificationComponent, type: :component do
   context 'when the notification is about a relationship with package' do
     let(:package) { create(:package_with_maintainer, maintainer: user) }
     let(:event_payload) { { package: package.name, project: package.project.name } }
-    let(:notification) { create(:notification_project, :relationship_create_for_project, delivered: true, notifiable: package, event_payload: event_payload) }
+    let(:notification) { create(:notification_for_project, :relationship_create_for_project, delivered: true, notifiable: package, event_payload: event_payload) }
 
     before do
       render_inline(described_class.new(notification: notification, selected_filter: selected_filter, page: 1))
@@ -19,7 +19,7 @@ RSpec.describe NotificationComponent, type: :component do
   context 'when the notification is about a comment for project' do
     let(:project) { create(:project, maintainer: user) }
     let(:comment) { create(:comment, commentable: project) }
-    let(:notification) { create(:notification_comment, :comment_for_project, delivered: true, notifiable: comment) }
+    let(:notification) { create(:notification_for_comment, :comment_for_project, delivered: true, notifiable: comment) }
 
     before do
       render_inline(described_class.new(notification: notification, selected_filter: selected_filter, page: 1))

--- a/src/api/spec/components/notification_mark_button_component_spec.rb
+++ b/src/api/spec/components/notification_mark_button_component_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe NotificationMarkButtonComponent, type: :component do
   context 'when the notification is read' do
-    let(:notification) { create(:notification, delivered: true) }
+    let(:notification) { create(:notification_bs_request, delivered: true) }
     let(:selected_filter) { { state: 'read' } }
 
     before do
@@ -8,16 +8,16 @@ RSpec.describe NotificationMarkButtonComponent, type: :component do
     end
 
     it 'renders the link with an undo icon' do
-      expect(rendered_content).to have_css("a#update_notification_#{notification.id}[title='Mark as \"Unread\"'] > i.fa-undo")
+      expect(rendered_content).to have_css("a#update_notification_bs_request_#{notification.id}[title='Mark as \"Unread\"'] > i.fa-undo")
     end
 
     it 'sets the update path with the right params' do
-      expect(rendered_content).to have_css("a#update_notification_#{notification.id}[href='/my/notifications?button=unread&notification_ids%5B%5D=#{notification.id}&state=read']")
+      expect(rendered_content).to have_css("a#update_notification_bs_request_#{notification.id}[href='/my/notifications?button=unread&notification_ids%5B%5D=#{notification.id}&state=read']")
     end
   end
 
   context 'when the notification is unread' do
-    let(:notification) { create(:notification, delivered: false) }
+    let(:notification) { create(:notification_bs_request, delivered: false) }
     let(:selected_filter) { { state: 'unread' } }
 
     before do
@@ -25,11 +25,11 @@ RSpec.describe NotificationMarkButtonComponent, type: :component do
     end
 
     it 'renders the link with a check mark icon' do
-      expect(rendered_content).to have_css("a#update_notification_#{notification.id}[title='Mark as \"Read\"'] > i.fa-check")
+      expect(rendered_content).to have_css("a#update_notification_bs_request_#{notification.id}[title='Mark as \"Read\"'] > i.fa-check")
     end
 
     it 'sets the update path with the right params' do
-      expect(rendered_content).to have_css("a#update_notification_#{notification.id}[href='/my/notifications?button=read&notification_ids%5B%5D=#{notification.id}&state=unread']")
+      expect(rendered_content).to have_css("a#update_notification_bs_request_#{notification.id}[href='/my/notifications?button=read&notification_ids%5B%5D=#{notification.id}&state=unread']")
     end
   end
 end

--- a/src/api/spec/components/notification_mark_button_component_spec.rb
+++ b/src/api/spec/components/notification_mark_button_component_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe NotificationMarkButtonComponent, type: :component do
   context 'when the notification is read' do
-    let(:notification) { create(:notification_bs_request, delivered: true) }
+    let(:notification) { create(:notification_for_request, delivered: true) }
     let(:selected_filter) { { state: 'read' } }
 
     before do
@@ -17,7 +17,7 @@ RSpec.describe NotificationMarkButtonComponent, type: :component do
   end
 
   context 'when the notification is unread' do
-    let(:notification) { create(:notification_bs_request, delivered: false) }
+    let(:notification) { create(:notification_for_request, delivered: false) }
     let(:selected_filter) { { state: 'unread' } }
 
     before do

--- a/src/api/spec/controllers/person/notifications_controller_spec.rb
+++ b/src/api/spec/controllers/person/notifications_controller_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Person::NotificationsController do
 
   describe 'index' do
     context 'called by authorized user' do
-      let!(:notifications) { create_list(:web_notification, 2, :request_state_change, subscriber: user) }
+      let!(:notifications) { create_list(:notification_bs_request, 2, :web_notification, :request_state_change, subscriber: user) }
 
       before do
         login user
@@ -40,7 +40,7 @@ RSpec.describe Person::NotificationsController do
       it { expect(response.body).to include('<notifications count="2">') }
 
       context 'filter by kind' do
-        let!(:notifications) { create_list(:web_notification, 2, :request_state_change, subscriber: user, delivered: true) }
+        let!(:notifications) { create_list(:notification_bs_request, 2, :web_notification, :request_state_change, subscriber: user, delivered: true) }
 
         before do
           login user
@@ -82,7 +82,7 @@ RSpec.describe Person::NotificationsController do
   end
 
   describe '#update' do
-    let!(:notification) { create(:web_notification, :comment_for_package, subscriber: user) }
+    let!(:notification) { create(:notification_comment, :web_notification, :comment_for_package, subscriber: user) }
 
     context 'called by an unauthorized user' do
       let(:other_user) { create(:confirmed_user, :in_beta) }

--- a/src/api/spec/controllers/person/notifications_controller_spec.rb
+++ b/src/api/spec/controllers/person/notifications_controller_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Person::NotificationsController do
 
   describe 'index' do
     context 'called by authorized user' do
-      let!(:notifications) { create_list(:notification_bs_request, 2, :web_notification, :request_state_change, subscriber: user) }
+      let!(:notifications) { create_list(:notification_for_request, 2, :web_notification, :request_state_change, subscriber: user) }
 
       before do
         login user
@@ -40,7 +40,7 @@ RSpec.describe Person::NotificationsController do
       it { expect(response.body).to include('<notifications count="2">') }
 
       context 'filter by kind' do
-        let!(:notifications) { create_list(:notification_bs_request, 2, :web_notification, :request_state_change, subscriber: user, delivered: true) }
+        let!(:notifications) { create_list(:notification_for_request, 2, :web_notification, :request_state_change, subscriber: user, delivered: true) }
 
         before do
           login user
@@ -82,7 +82,7 @@ RSpec.describe Person::NotificationsController do
   end
 
   describe '#update' do
-    let!(:notification) { create(:notification_comment, :web_notification, :comment_for_package, subscriber: user) }
+    let!(:notification) { create(:notification_for_comment, :web_notification, :comment_for_package, subscriber: user) }
 
     context 'called by an unauthorized user' do
       let(:other_user) { create(:confirmed_user, :in_beta) }

--- a/src/api/spec/controllers/webui/feeds_controller_spec.rb
+++ b/src/api/spec/controllers/webui/feeds_controller_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Webui::FeedsController, :vcr do
                                                                    person_name: user.login, target_project: project)
                                                           end)
     end
-    let!(:rss_notification) { create(:notification_bs_request, :rss_notification, subscriber: user, event_type: 'Event::RequestCreate', notifiable: bs_request) }
+    let!(:rss_notification) { create(:notification_for_request, :rss_notification, subscriber: user, event_type: 'Event::RequestCreate', notifiable: bs_request) }
 
     context 'with an existing rss secret' do
       render_views
@@ -106,7 +106,7 @@ RSpec.describe Webui::FeedsController, :vcr do
           arch: 'arch'
         }
       end
-      let!(:notification_build_failure) { create(:notification_bs_request, :rss_notification, event_type: 'Event::BuildFail', subscriber: user, notifiable: package, event_payload: event_payload) }
+      let!(:notification_build_failure) { create(:notification_for_request, :rss_notification, event_type: 'Event::BuildFail', subscriber: user, notifiable: package, event_payload: event_payload) }
 
       render_views
       before do
@@ -133,7 +133,7 @@ RSpec.describe Webui::FeedsController, :vcr do
           role: 'role'
         }
       end
-      let!(:notification_relationship_create) { create(:notification_bs_request, :rss_notification, event_type: 'Event::RelationshipCreate', subscriber: user, notifiable: package, event_payload: event_payload) }
+      let!(:notification_relationship_create) { create(:notification_for_request, :rss_notification, event_type: 'Event::RelationshipCreate', subscriber: user, notifiable: package, event_payload: event_payload) }
 
       render_views
       before do

--- a/src/api/spec/controllers/webui/feeds_controller_spec.rb
+++ b/src/api/spec/controllers/webui/feeds_controller_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Webui::FeedsController, :vcr do
                                                                    person_name: user.login, target_project: project)
                                                           end)
     end
-    let!(:rss_notification) { create(:rss_notification, subscriber: user, event_type: 'Event::RequestCreate', notifiable: bs_request) }
+    let!(:rss_notification) { create(:notification_bs_request, :rss_notification, subscriber: user, event_type: 'Event::RequestCreate', notifiable: bs_request) }
 
     context 'with an existing rss secret' do
       render_views
@@ -106,7 +106,7 @@ RSpec.describe Webui::FeedsController, :vcr do
           arch: 'arch'
         }
       end
-      let!(:notification_build_failure) { create(:rss_notification, event_type: 'Event::BuildFail', subscriber: user, notifiable: package, event_payload: event_payload) }
+      let!(:notification_build_failure) { create(:notification_bs_request, :rss_notification, event_type: 'Event::BuildFail', subscriber: user, notifiable: package, event_payload: event_payload) }
 
       render_views
       before do
@@ -133,7 +133,7 @@ RSpec.describe Webui::FeedsController, :vcr do
           role: 'role'
         }
       end
-      let!(:notification_relationship_create) { create(:rss_notification, event_type: 'Event::RelationshipCreate', subscriber: user, notifiable: package, event_payload: event_payload) }
+      let!(:notification_relationship_create) { create(:notification_bs_request, :rss_notification, event_type: 'Event::RelationshipCreate', subscriber: user, notifiable: package, event_payload: event_payload) }
 
       render_views
       before do

--- a/src/api/spec/controllers/webui/users/notifications_controller_spec.rb
+++ b/src/api/spec/controllers/webui/users/notifications_controller_spec.rb
@@ -2,15 +2,15 @@ RSpec.describe Webui::Users::NotificationsController do
   let(:username) { 'reynoldsm' }
   let!(:user) { create(:confirmed_user, :with_home, login: username) }
   let!(:other_user) { create(:confirmed_user) }
-  let(:state_change_notification) { create(:web_notification, :request_state_change, subscriber: user) }
-  let(:creation_notification) { create(:web_notification, :request_created, subscriber: user) }
-  let(:review_notification) { create(:web_notification, :review_wanted, subscriber: user) }
-  let(:comment_for_project_notification) { create(:web_notification, :comment_for_project, subscriber: user) }
-  let(:comment_for_package_notification) { create(:web_notification, :comment_for_package, subscriber: user) }
-  let(:comment_for_request_notification) { create(:web_notification, :comment_for_request, subscriber: user) }
-  let(:read_notification) { create(:web_notification, :request_state_change, subscriber: user, delivered: true) }
-  let(:notifications_for_other_users) { create(:web_notification, :request_state_change, subscriber: other_user) }
-  let(:build_failure) { create(:web_notification, :build_failure, subscriber: user) }
+  let(:state_change_notification) { create(:notification_bs_request, :web_notification, :request_state_change, subscriber: user) }
+  let(:creation_notification) { create(:notification_bs_request, :web_notification, :request_created, subscriber: user) }
+  let(:review_notification) { create(:notification_bs_request, :web_notification, :review_wanted, subscriber: user) }
+  let(:comment_for_project_notification) { create(:notification_comment, :web_notification, :comment_for_project, subscriber: user) }
+  let(:comment_for_package_notification) { create(:notification_comment, :web_notification, :comment_for_package, subscriber: user) }
+  let(:comment_for_request_notification) { create(:notification_comment, :web_notification, :comment_for_request, subscriber: user) }
+  let(:read_notification) { create(:notification_bs_request, :web_notification, :request_state_change, subscriber: user, delivered: true) }
+  let(:notifications_for_other_users) { create(:notification_bs_request, :web_notification, :request_state_change, subscriber: other_user) }
+  let(:build_failure) { create(:notification_package, :web_notification, :build_failure, subscriber: user) }
 
   shared_examples 'returning success' do
     it 'returns ok status' do
@@ -68,7 +68,7 @@ RSpec.describe Webui::Users::NotificationsController do
 
     context "when param type is 'unread'" do
       let(:params) { default_params.merge(state: 'unread') }
-      let(:unread_notification) { create(:web_notification, :request_state_change, subscriber: user, delivered: false) }
+      let(:unread_notification) { create(:notification_bs_request, :web_notification, :request_state_change, subscriber: user, delivered: false) }
 
       before do
         unread_notification
@@ -140,7 +140,7 @@ RSpec.describe Webui::Users::NotificationsController do
                creator: admin_user)
       end
 
-      let!(:request_created_notification) { create(:web_notification, :request_created, notifiable: maintained_request, subscriber: user) }
+      let!(:request_created_notification) { create(:notification_bs_request, :web_notification, :request_created, notifiable: maintained_request, subscriber: user) }
       let!(:review_wanted_notification) { review_notification }
 
       let(:params) { default_params.merge(kind: 'incoming_requests') }
@@ -178,8 +178,8 @@ RSpec.describe Webui::Users::NotificationsController do
                creator: admin_user)
       end
 
-      let!(:state_change_to_declined_notification) { create(:web_notification, :request_state_change, notifiable: declined_bs_request, subscriber: user) }
-      let(:request_created_notification) { create(:web_notification, :request_created, notifiable: maintained_request, subscriber: user) }
+      let!(:state_change_to_declined_notification) { create(:notification_bs_request, :web_notification, :request_state_change, notifiable: declined_bs_request, subscriber: user) }
+      let(:request_created_notification) { create(:notification_bs_request, :web_notification, :request_created, notifiable: maintained_request, subscriber: user) }
 
       let(:params) { default_params.merge(kind: 'outgoing_requests') }
 
@@ -206,7 +206,7 @@ RSpec.describe Webui::Users::NotificationsController do
         put :update, params: { notification_ids: [state_change_notification.id], user_login: user_to_log_in.login, button: 'read' }, xhr: true
       end
 
-      let!(:another_unread_notification) { create(:web_notification, :request_state_change, subscriber: user_to_log_in, title: 'Another read notification') }
+      let!(:another_unread_notification) { create(:notification_bs_request, :web_notification, :request_state_change, subscriber: user_to_log_in, title: 'Another read notification') }
       let(:user_to_log_in) { user }
 
       it 'succeeds' do
@@ -252,8 +252,8 @@ RSpec.describe Webui::Users::NotificationsController do
       end
 
       let(:user_to_log_in) { user }
-      let(:read_notification) { create(:web_notification, :request_state_change, subscriber: user_to_log_in, delivered: true, title: 'Read notifications') }
-      let!(:another_read_notification) { create(:web_notification, :request_state_change, subscriber: user_to_log_in, delivered: true, title: 'Another read notification') }
+      let(:read_notification) { create(:notification_bs_request, :web_notification, :request_state_change, subscriber: user_to_log_in, delivered: true, title: 'Read notifications') }
+      let!(:another_read_notification) { create(:notification_bs_request, :web_notification, :request_state_change, subscriber: user_to_log_in, delivered: true, title: 'Another read notification') }
 
       it 'succeeds' do
         expect(response).to have_http_status(:ok)

--- a/src/api/spec/controllers/webui/users/notifications_controller_spec.rb
+++ b/src/api/spec/controllers/webui/users/notifications_controller_spec.rb
@@ -2,15 +2,15 @@ RSpec.describe Webui::Users::NotificationsController do
   let(:username) { 'reynoldsm' }
   let!(:user) { create(:confirmed_user, :with_home, login: username) }
   let!(:other_user) { create(:confirmed_user) }
-  let(:state_change_notification) { create(:notification_bs_request, :web_notification, :request_state_change, subscriber: user) }
-  let(:creation_notification) { create(:notification_bs_request, :web_notification, :request_created, subscriber: user) }
-  let(:review_notification) { create(:notification_bs_request, :web_notification, :review_wanted, subscriber: user) }
-  let(:comment_for_project_notification) { create(:notification_comment, :web_notification, :comment_for_project, subscriber: user) }
-  let(:comment_for_package_notification) { create(:notification_comment, :web_notification, :comment_for_package, subscriber: user) }
-  let(:comment_for_request_notification) { create(:notification_comment, :web_notification, :comment_for_request, subscriber: user) }
-  let(:read_notification) { create(:notification_bs_request, :web_notification, :request_state_change, subscriber: user, delivered: true) }
-  let(:notifications_for_other_users) { create(:notification_bs_request, :web_notification, :request_state_change, subscriber: other_user) }
-  let(:build_failure) { create(:notification_package, :web_notification, :build_failure, subscriber: user) }
+  let(:state_change_notification) { create(:notification_for_request, :web_notification, :request_state_change, subscriber: user) }
+  let(:creation_notification) { create(:notification_for_request, :web_notification, :request_created, subscriber: user) }
+  let(:review_notification) { create(:notification_for_request, :web_notification, :review_wanted, subscriber: user) }
+  let(:comment_for_project_notification) { create(:notification_for_comment, :web_notification, :comment_for_project, subscriber: user) }
+  let(:comment_for_package_notification) { create(:notification_for_comment, :web_notification, :comment_for_package, subscriber: user) }
+  let(:comment_for_request_notification) { create(:notification_for_comment, :web_notification, :comment_for_request, subscriber: user) }
+  let(:read_notification) { create(:notification_for_request, :web_notification, :request_state_change, subscriber: user, delivered: true) }
+  let(:notifications_for_other_users) { create(:notification_for_request, :web_notification, :request_state_change, subscriber: other_user) }
+  let(:build_failure) { create(:notification_for_package, :web_notification, :build_failure, subscriber: user) }
 
   shared_examples 'returning success' do
     it 'returns ok status' do
@@ -68,7 +68,7 @@ RSpec.describe Webui::Users::NotificationsController do
 
     context "when param type is 'unread'" do
       let(:params) { default_params.merge(state: 'unread') }
-      let(:unread_notification) { create(:notification_bs_request, :web_notification, :request_state_change, subscriber: user, delivered: false) }
+      let(:unread_notification) { create(:notification_for_request, :web_notification, :request_state_change, subscriber: user, delivered: false) }
 
       before do
         unread_notification
@@ -140,7 +140,7 @@ RSpec.describe Webui::Users::NotificationsController do
                creator: admin_user)
       end
 
-      let!(:request_created_notification) { create(:notification_bs_request, :web_notification, :request_created, notifiable: maintained_request, subscriber: user) }
+      let!(:request_created_notification) { create(:notification_for_request, :web_notification, :request_created, notifiable: maintained_request, subscriber: user) }
       let!(:review_wanted_notification) { review_notification }
 
       let(:params) { default_params.merge(kind: 'incoming_requests') }
@@ -178,8 +178,8 @@ RSpec.describe Webui::Users::NotificationsController do
                creator: admin_user)
       end
 
-      let!(:state_change_to_declined_notification) { create(:notification_bs_request, :web_notification, :request_state_change, notifiable: declined_bs_request, subscriber: user) }
-      let(:request_created_notification) { create(:notification_bs_request, :web_notification, :request_created, notifiable: maintained_request, subscriber: user) }
+      let!(:state_change_to_declined_notification) { create(:notification_for_request, :web_notification, :request_state_change, notifiable: declined_bs_request, subscriber: user) }
+      let(:request_created_notification) { create(:notification_for_request, :web_notification, :request_created, notifiable: maintained_request, subscriber: user) }
 
       let(:params) { default_params.merge(kind: 'outgoing_requests') }
 
@@ -206,7 +206,7 @@ RSpec.describe Webui::Users::NotificationsController do
         put :update, params: { notification_ids: [state_change_notification.id], user_login: user_to_log_in.login, button: 'read' }, xhr: true
       end
 
-      let!(:another_unread_notification) { create(:notification_bs_request, :web_notification, :request_state_change, subscriber: user_to_log_in, title: 'Another read notification') }
+      let!(:another_unread_notification) { create(:notification_for_request, :web_notification, :request_state_change, subscriber: user_to_log_in, title: 'Another read notification') }
       let(:user_to_log_in) { user }
 
       it 'succeeds' do
@@ -252,8 +252,8 @@ RSpec.describe Webui::Users::NotificationsController do
       end
 
       let(:user_to_log_in) { user }
-      let(:read_notification) { create(:notification_bs_request, :web_notification, :request_state_change, subscriber: user_to_log_in, delivered: true, title: 'Read notifications') }
-      let!(:another_read_notification) { create(:notification_bs_request, :web_notification, :request_state_change, subscriber: user_to_log_in, delivered: true, title: 'Another read notification') }
+      let(:read_notification) { create(:notification_for_request, :web_notification, :request_state_change, subscriber: user_to_log_in, delivered: true, title: 'Read notifications') }
+      let!(:another_read_notification) { create(:notification_for_request, :web_notification, :request_state_change, subscriber: user_to_log_in, delivered: true, title: 'Another read notification') }
 
       it 'succeeds' do
         expect(response).to have_http_status(:ok)

--- a/src/api/spec/db/data/adapt_review_and_duplicated_notifications_spec.rb
+++ b/src/api/spec/db/data/adapt_review_and_duplicated_notifications_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe AdaptReviewAndDuplicatedNotifications, type: :migration do
 
     context 'review notifiable' do
       before do
-        create(:notification_bs_request, :review_wanted, notifiable: subscriber_review, subscriber: subscriber)
+        create(:notification_for_request, :review_wanted, notifiable: subscriber_review, subscriber: subscriber)
         subject
       end
 
@@ -31,20 +31,20 @@ RSpec.describe AdaptReviewAndDuplicatedNotifications, type: :migration do
       let(:comment_request02) { create(:comment_request, commentable: bs_request_with_submit_action) }
 
       let(:first_request_notification) do
-        create(:notification_bs_request, :request_state_change, notifiable: bs_request_with_submit_action,
-                                                                subscriber: subscriber, web: true)
+        create(:notification_for_request, :request_state_change, notifiable: bs_request_with_submit_action,
+                                                                 subscriber: subscriber, web: true)
       end
       let(:second_request_notification) do
-        create(:notification_bs_request, :request_state_change, notifiable: bs_request_with_submit_action,
-                                                                subscriber: subscriber, web: true)
+        create(:notification_for_request, :request_state_change, notifiable: bs_request_with_submit_action,
+                                                                 subscriber: subscriber, web: true)
       end
       let(:first_comment_notification) do
-        create(:notification_comment, :comment_for_request, notifiable: comment_request,
-                                                            subscriber: subscriber, web: true)
+        create(:notification_for_comment, :comment_for_request, notifiable: comment_request,
+                                                                subscriber: subscriber, web: true)
       end
       let(:second_comment_notification) do
-        create(:notification_comment, :comment_for_request, notifiable: comment_request02,
-                                                            subscriber: subscriber, web: true)
+        create(:notification_for_comment, :comment_for_request, notifiable: comment_request02,
+                                                                subscriber: subscriber, web: true)
       end
 
       before do

--- a/src/api/spec/db/data/adapt_review_and_duplicated_notifications_spec.rb
+++ b/src/api/spec/db/data/adapt_review_and_duplicated_notifications_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe AdaptReviewAndDuplicatedNotifications, type: :migration do
 
     context 'review notifiable' do
       before do
-        create(:notification, :review_wanted, notifiable: subscriber_review, subscriber: subscriber)
+        create(:notification_bs_request, :review_wanted, notifiable: subscriber_review, subscriber: subscriber)
         subject
       end
 
@@ -31,20 +31,20 @@ RSpec.describe AdaptReviewAndDuplicatedNotifications, type: :migration do
       let(:comment_request02) { create(:comment_request, commentable: bs_request_with_submit_action) }
 
       let(:first_request_notification) do
-        create(:notification, :request_state_change, notifiable: bs_request_with_submit_action,
-                                                     subscriber: subscriber, web: true)
+        create(:notification_bs_request, :request_state_change, notifiable: bs_request_with_submit_action,
+                                                                subscriber: subscriber, web: true)
       end
       let(:second_request_notification) do
-        create(:notification, :request_state_change, notifiable: bs_request_with_submit_action,
-                                                     subscriber: subscriber, web: true)
+        create(:notification_bs_request, :request_state_change, notifiable: bs_request_with_submit_action,
+                                                                subscriber: subscriber, web: true)
       end
       let(:first_comment_notification) do
-        create(:notification, :comment_for_request, notifiable: comment_request,
-                                                    subscriber: subscriber, web: true)
+        create(:notification_comment, :comment_for_request, notifiable: comment_request,
+                                                            subscriber: subscriber, web: true)
       end
       let(:second_comment_notification) do
-        create(:notification, :comment_for_request, notifiable: comment_request02,
-                                                    subscriber: subscriber, web: true)
+        create(:notification_comment, :comment_for_request, notifiable: comment_request02,
+                                                            subscriber: subscriber, web: true)
       end
 
       before do

--- a/src/api/spec/db/data/backfill_notified_projects_spec.rb
+++ b/src/api/spec/db/data/backfill_notified_projects_spec.rb
@@ -28,11 +28,11 @@ RSpec.describe BackfillNotifiedProjects, :vcr, type: :migration do
     let(:comment_request) { create(:comment_request) }
 
     before do
-      create(:notification, :request_state_change, notifiable: bs_request_with_submit_action)
-      create(:notification, :review_wanted, notifiable: user_review.bs_request)
-      create(:notification, :comment_for_project, notifiable: comment_project)
-      create(:notification, :comment_for_package, notifiable: comment_package)
-      create(:notification, :comment_for_request, notifiable: comment_request)
+      create(:notification_bs_request, :request_state_change, notifiable: bs_request_with_submit_action)
+      create(:notification_bs_request, :review_wanted, notifiable: user_review.bs_request)
+      create(:notification_comment, :comment_for_project, notifiable: comment_project)
+      create(:notification_comment, :comment_for_package, notifiable: comment_package)
+      create(:notification_comment, :comment_for_request, notifiable: comment_request)
 
       BackfillNotifiedProjects.new.up
     end

--- a/src/api/spec/db/data/backfill_notified_projects_spec.rb
+++ b/src/api/spec/db/data/backfill_notified_projects_spec.rb
@@ -28,11 +28,11 @@ RSpec.describe BackfillNotifiedProjects, :vcr, type: :migration do
     let(:comment_request) { create(:comment_request) }
 
     before do
-      create(:notification_bs_request, :request_state_change, notifiable: bs_request_with_submit_action)
-      create(:notification_bs_request, :review_wanted, notifiable: user_review.bs_request)
-      create(:notification_comment, :comment_for_project, notifiable: comment_project)
-      create(:notification_comment, :comment_for_package, notifiable: comment_package)
-      create(:notification_comment, :comment_for_request, notifiable: comment_request)
+      create(:notification_for_request, :request_state_change, notifiable: bs_request_with_submit_action)
+      create(:notification_for_request, :review_wanted, notifiable: user_review.bs_request)
+      create(:notification_for_comment, :comment_for_project, notifiable: comment_project)
+      create(:notification_for_comment, :comment_for_package, notifiable: comment_package)
+      create(:notification_for_comment, :comment_for_request, notifiable: comment_request)
 
       BackfillNotifiedProjects.new.up
     end

--- a/src/api/spec/db/data/convert_notifications_event_payload_to_json_spec.rb
+++ b/src/api/spec/db/data/convert_notifications_event_payload_to_json_spec.rb
@@ -3,7 +3,7 @@ require Rails.root.join('db/data/20170831143534_convert_notifications_event_payl
 RSpec.describe ConvertNotificationsEventPayloadToJson, type: :migration do
   describe '.up' do
     let!(:yaml) { "---\nhello: world\nhow:\n- are\n- you\n- today?\nim: fine thanks\n" }
-    let!(:notification) { create(:notification_bs_request) }
+    let!(:notification) { create(:notification_for_request) }
 
     before do
       sql = "UPDATE `notifications` SET `event_payload` = '#{yaml}' WHERE id = #{notification.id}"

--- a/src/api/spec/db/data/convert_notifications_event_payload_to_json_spec.rb
+++ b/src/api/spec/db/data/convert_notifications_event_payload_to_json_spec.rb
@@ -3,7 +3,7 @@ require Rails.root.join('db/data/20170831143534_convert_notifications_event_payl
 RSpec.describe ConvertNotificationsEventPayloadToJson, type: :migration do
   describe '.up' do
     let!(:yaml) { "---\nhello: world\nhow:\n- are\n- you\n- today?\nim: fine thanks\n" }
-    let!(:notification) { create(:notification) }
+    let!(:notification) { create(:notification_bs_request) }
 
     before do
       sql = "UPDATE `notifications` SET `event_payload` = '#{yaml}' WHERE id = #{notification.id}"

--- a/src/api/spec/db/data/generate_web_notifications_spec.rb
+++ b/src/api/spec/db/data/generate_web_notifications_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe GenerateWebNotifications, type: :migration do
 
     let(:owner) { create(:confirmed_user, login: 'bob') }
     let(:requester) { create(:confirmed_user, login: 'ann') }
-    let!(:rss_notifications) { create_list(:notification_bs_request, 5, :rss_notification, subscriber: owner) }
+    let!(:rss_notifications) { create_list(:notification_for_request, 5, :rss_notification, subscriber: owner) }
     let!(:event_subscription_1) { create(:event_subscription_comment_for_project, user: owner) }
     let!(:event_subscription_2) { create(:event_subscription_comment_for_project, user: owner, receiver_role: 'maintainer') }
     let!(:event_subscription_3) { create(:event_subscription_comment_for_project, user: owner, receiver_role: 'bugowner') }

--- a/src/api/spec/db/data/generate_web_notifications_spec.rb
+++ b/src/api/spec/db/data/generate_web_notifications_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe GenerateWebNotifications, type: :migration do
 
     let(:owner) { create(:confirmed_user, login: 'bob') }
     let(:requester) { create(:confirmed_user, login: 'ann') }
-    let!(:rss_notifications) { create_list(:rss_notification, 5, subscriber: owner) }
+    let!(:rss_notifications) { create_list(:notification_bs_request, 5, :rss_notification, subscriber: owner) }
     let!(:event_subscription_1) { create(:event_subscription_comment_for_project, user: owner) }
     let!(:event_subscription_2) { create(:event_subscription_comment_for_project, user: owner, receiver_role: 'maintainer') }
     let!(:event_subscription_3) { create(:event_subscription_comment_for_project, user: owner, receiver_role: 'bugowner') }

--- a/src/api/spec/db/data/remove_notifications_for_missing_notifiables_spec.rb
+++ b/src/api/spec/db/data/remove_notifications_for_missing_notifiables_spec.rb
@@ -1,8 +1,8 @@
 require Rails.root.join('db/data/20210205131609_remove_notifications_for_missing_notifiables.rb')
 RSpec.describe RemoveNotificationsForMissingNotifiables, type: :migration do
   describe 'up' do
-    let!(:notification1) { create(:notification, :comment_for_request) }
-    let!(:notification2) { create(:notification, :comment_for_request) }
+    let!(:notification1) { create(:notification_comment, :comment_for_request) }
+    let!(:notification2) { create(:notification_comment, :comment_for_request) }
 
     before do
       # Simulate the wrong behaviour we had before. When a BsRequest was removed,

--- a/src/api/spec/db/data/remove_notifications_for_missing_notifiables_spec.rb
+++ b/src/api/spec/db/data/remove_notifications_for_missing_notifiables_spec.rb
@@ -1,8 +1,8 @@
 require Rails.root.join('db/data/20210205131609_remove_notifications_for_missing_notifiables.rb')
 RSpec.describe RemoveNotificationsForMissingNotifiables, type: :migration do
   describe 'up' do
-    let!(:notification1) { create(:notification_comment, :comment_for_request) }
-    let!(:notification2) { create(:notification_comment, :comment_for_request) }
+    let!(:notification1) { create(:notification_for_comment, :comment_for_request) }
+    let!(:notification2) { create(:notification_for_comment, :comment_for_request) }
 
     before do
       # Simulate the wrong behaviour we had before. When a BsRequest was removed,

--- a/src/api/spec/db/data/remove_obsolete_notifications_spec.rb
+++ b/src/api/spec/db/data/remove_obsolete_notifications_spec.rb
@@ -3,23 +3,23 @@ require Rails.root.join('db/data/20200326170855_remove_obsolete_notifications.rb
 RSpec.describe RemoveObsoleteNotifications, type: :migration do
   describe 'up' do
     # 'Event::RequestCreate'
-    let!(:request_create_with_notifiable) { create(:notification, :request_created) }
-    let!(:request_create_without_notifiable) { create(:notification, :request_created, notifiable: nil) }
+    let!(:request_create_with_notifiable) { create(:notification_bs_request, :request_created) }
+    let!(:request_create_without_notifiable) { create(:notification_bs_request, :request_created, notifiable: nil) }
     # 'Event::RequestStatechange'
-    let!(:request_state_change_with_notifiable) { create(:notification, :request_state_change) }
-    let!(:request_state_change_without_notifiable) { create(:notification, :request_state_change, notifiable: nil) }
+    let!(:request_state_change_with_notifiable) { create(:notification_bs_request, :request_state_change) }
+    let!(:request_state_change_without_notifiable) { create(:notification_bs_request, :request_state_change, notifiable: nil) }
     # 'Event::ReviewWanted'
-    let!(:review_wanted_with_notifiable) { create(:notification, :review_wanted) }
-    let!(:review_wanted_without_notifiable) { create(:notification, :review_wanted, notifiable: nil) }
+    let!(:review_wanted_with_notifiable) { create(:notification_bs_request, :review_wanted) }
+    let!(:review_wanted_without_notifiable) { create(:notification_bs_request, :review_wanted, notifiable: nil) }
     # 'Event::CommentForRequest'
-    let!(:comment_for_request_with_notifiable) { create(:notification, :comment_for_request) }
-    let!(:comment_for_request_without_notifiable) { create(:notification, :comment_for_request, notifiable: nil) }
+    let!(:comment_for_request_with_notifiable) { create(:notification_comment, :comment_for_request) }
+    let!(:comment_for_request_without_notifiable) { create(:notification_comment, :comment_for_request, notifiable: nil) }
     # 'Event::CommentForProject'
-    let!(:comment_for_project_with_notifiable) { create(:notification, :comment_for_project) }
-    let!(:comment_for_project_without_notifiable) { create(:notification, :comment_for_project, notifiable: nil) }
+    let!(:comment_for_project_with_notifiable) { create(:notification_comment, :comment_for_project) }
+    let!(:comment_for_project_without_notifiable) { create(:notification_comment, :comment_for_project, notifiable: nil) }
     # 'Event::CommentForPackage'
-    let!(:comment_for_package_with_notifiable) { create(:notification, :comment_for_package) }
-    let!(:comment_for_package_without_notifiable) { create(:notification, :comment_for_package, notifiable: nil) }
+    let!(:comment_for_package_with_notifiable) { create(:notification_comment, :comment_for_package) }
+    let!(:comment_for_package_without_notifiable) { create(:notification_comment, :comment_for_package, notifiable: nil) }
 
     before do
       RemoveObsoleteNotifications.new.up

--- a/src/api/spec/db/data/remove_obsolete_notifications_spec.rb
+++ b/src/api/spec/db/data/remove_obsolete_notifications_spec.rb
@@ -3,23 +3,23 @@ require Rails.root.join('db/data/20200326170855_remove_obsolete_notifications.rb
 RSpec.describe RemoveObsoleteNotifications, type: :migration do
   describe 'up' do
     # 'Event::RequestCreate'
-    let!(:request_create_with_notifiable) { create(:notification_bs_request, :request_created) }
-    let!(:request_create_without_notifiable) { create(:notification_bs_request, :request_created, notifiable: nil) }
+    let!(:request_create_with_notifiable) { create(:notification_for_request, :request_created) }
+    let!(:request_create_without_notifiable) { create(:notification_for_request, :request_created, notifiable: nil) }
     # 'Event::RequestStatechange'
-    let!(:request_state_change_with_notifiable) { create(:notification_bs_request, :request_state_change) }
-    let!(:request_state_change_without_notifiable) { create(:notification_bs_request, :request_state_change, notifiable: nil) }
+    let!(:request_state_change_with_notifiable) { create(:notification_for_request, :request_state_change) }
+    let!(:request_state_change_without_notifiable) { create(:notification_for_request, :request_state_change, notifiable: nil) }
     # 'Event::ReviewWanted'
-    let!(:review_wanted_with_notifiable) { create(:notification_bs_request, :review_wanted) }
-    let!(:review_wanted_without_notifiable) { create(:notification_bs_request, :review_wanted, notifiable: nil) }
+    let!(:review_wanted_with_notifiable) { create(:notification_for_request, :review_wanted) }
+    let!(:review_wanted_without_notifiable) { create(:notification_for_request, :review_wanted, notifiable: nil) }
     # 'Event::CommentForRequest'
-    let!(:comment_for_request_with_notifiable) { create(:notification_comment, :comment_for_request) }
-    let!(:comment_for_request_without_notifiable) { create(:notification_comment, :comment_for_request, notifiable: nil) }
+    let!(:comment_for_request_with_notifiable) { create(:notification_for_comment, :comment_for_request) }
+    let!(:comment_for_request_without_notifiable) { create(:notification_for_comment, :comment_for_request, notifiable: nil) }
     # 'Event::CommentForProject'
-    let!(:comment_for_project_with_notifiable) { create(:notification_comment, :comment_for_project) }
-    let!(:comment_for_project_without_notifiable) { create(:notification_comment, :comment_for_project, notifiable: nil) }
+    let!(:comment_for_project_with_notifiable) { create(:notification_for_comment, :comment_for_project) }
+    let!(:comment_for_project_without_notifiable) { create(:notification_for_comment, :comment_for_project, notifiable: nil) }
     # 'Event::CommentForPackage'
-    let!(:comment_for_package_with_notifiable) { create(:notification_comment, :comment_for_package) }
-    let!(:comment_for_package_without_notifiable) { create(:notification_comment, :comment_for_package, notifiable: nil) }
+    let!(:comment_for_package_with_notifiable) { create(:notification_for_comment, :comment_for_package) }
+    let!(:comment_for_package_without_notifiable) { create(:notification_for_comment, :comment_for_package, notifiable: nil) }
 
     before do
       RemoveObsoleteNotifications.new.up

--- a/src/api/spec/factories/notification.rb
+++ b/src/api/spec/factories/notification.rb
@@ -32,7 +32,7 @@ FactoryBot.define do
       created_at { 13.months.ago }
     end
 
-    factory :notification_bs_request, class: 'NotificationBsRequest' do
+    factory :notification_for_request, class: 'NotificationBsRequest' do
       trait :request_state_change do
         event_type { 'Event::RequestStatechange' }
         notifiable factory: [:bs_request_with_submit_action]
@@ -50,7 +50,7 @@ FactoryBot.define do
       end
     end
 
-    factory :notification_comment, class: 'NotificationComment' do
+    factory :notification_for_comment, class: 'NotificationComment' do
       trait :comment_for_project do
         event_type { 'Event::CommentForProject' }
         notifiable factory: [:comment_project]
@@ -67,7 +67,7 @@ FactoryBot.define do
       end
     end
 
-    factory :notification_project, class: 'NotificationProject' do
+    factory :notification_for_project, class: 'NotificationProject' do
       trait :relationship_create_for_project do
         event_type { 'Event::RelationshipCreate' }
         notifiable factory: [:project]
@@ -79,7 +79,7 @@ FactoryBot.define do
       end
     end
 
-    factory :notification_package, class: 'NotificationPackage' do
+    factory :notification_for_package, class: 'NotificationPackage' do
       trait :relationship_create_for_package do
         event_type { 'Event::RelationshipCreate' }
         notifiable factory: [:package]
@@ -96,7 +96,7 @@ FactoryBot.define do
       end
     end
 
-    factory :notification_report, class: 'NotificationReport' do
+    factory :notification_for_report, class: 'NotificationReport' do
       trait :create_report do
         event_type { 'Event::CreateReport' }
         notifiable factory: [:report]

--- a/src/api/spec/factories/notification.rb
+++ b/src/api/spec/factories/notification.rb
@@ -1,4 +1,13 @@
 FactoryBot.define do
+  # Notification-wide defined traits so we can use them in whatever factory we want
+  trait :rss_notification do
+    rss { true }
+  end
+
+  trait :web_notification do
+    web { true }
+  end
+
   factory :notification do
     event_type { 'Event::RequestStatechange' }
     event_payload { { fake: 'payload' } }
@@ -23,104 +32,107 @@ FactoryBot.define do
       created_at { 13.months.ago }
     end
 
-    trait :request_state_change do
-      event_type { 'Event::RequestStatechange' }
-      notifiable factory: [:bs_request_with_submit_action]
-      bs_request_oldstate { :new }
-    end
-
-    trait :request_created do
-      event_type { 'Event::RequestCreate' }
-      notifiable factory: [:bs_request_with_submit_action]
-    end
-
-    trait :review_wanted do
-      event_type { 'Event::ReviewWanted' }
-      notifiable factory: [:bs_request_with_submit_action]
-    end
-
-    trait :comment_for_project do
-      event_type { 'Event::CommentForProject' }
-      notifiable factory: [:comment_project]
-    end
-
-    trait :comment_for_package do
-      event_type { 'Event::CommentForPackage' }
-      notifiable factory: [:comment_package]
-    end
-
-    trait :comment_for_request do
-      event_type { 'Event::CommentForRequest' }
-      notifiable factory: [:comment_request]
-    end
-
-    trait :relationship_create_for_project do
-      event_type { 'Event::RelationshipCreate' }
-      notifiable factory: [:project]
-    end
-
-    trait :relationship_delete_for_project do
-      event_type { 'Event::RelationshipDelete' }
-      notifiable factory: [:project]
-    end
-    trait :relationship_create_for_package do
-      event_type { 'Event::RelationshipCreate' }
-      notifiable factory: [:package]
-    end
-
-    trait :relationship_delete_for_package do
-      event_type { 'Event::RelationshipDelete' }
-      notifiable factory: [:package]
-    end
-
-    trait :build_failure do
-      event_type { 'Event::BuildFail' }
-      notifiable factory: [:package]
-    end
-
-    trait :create_report do
-      event_type { 'Event::CreateReport' }
-      notifiable factory: [:report]
-
-      transient do
-        reason { nil }
+    factory :notification_bs_request, class: 'NotificationBsRequest' do
+      trait :request_state_change do
+        event_type { 'Event::RequestStatechange' }
+        notifiable factory: [:bs_request_with_submit_action]
+        bs_request_oldstate { :new }
       end
 
-      after(:build) do |notification, evaluator|
-        notification.event_payload['reportable_type'] ||= notification.notifiable.reportable.class.to_s
-        notification.event_payload['reason'] ||= evaluator.reason
+      trait :request_created do
+        event_type { 'Event::RequestCreate' }
+        notifiable factory: [:bs_request_with_submit_action]
+      end
+
+      trait :review_wanted do
+        event_type { 'Event::ReviewWanted' }
+        notifiable factory: [:bs_request_with_submit_action]
       end
     end
 
-    trait :cleared_decision do
-      event_type { 'Event::ClearedDecision' }
-      notifiable { association(:decision_cleared) }
+    factory :notification_comment, class: 'NotificationComment' do
+      trait :comment_for_project do
+        event_type { 'Event::CommentForProject' }
+        notifiable factory: [:comment_project]
+      end
 
-      after(:build) do |notification|
-        notification.event_payload['reportable_type'] ||= notification.notifiable.reports.first.reportable.class.to_s
+      trait :comment_for_package do
+        event_type { 'Event::CommentForPackage' }
+        notifiable factory: [:comment_package]
+      end
+
+      trait :comment_for_request do
+        event_type { 'Event::CommentForRequest' }
+        notifiable factory: [:comment_request]
       end
     end
 
-    trait :favored_decision do
-      event_type { 'Event::FavoredDecision' }
-      notifiable { association(:decision_favored) }
+    factory :notification_project, class: 'NotificationProject' do
+      trait :relationship_create_for_project do
+        event_type { 'Event::RelationshipCreate' }
+        notifiable factory: [:project]
+      end
 
-      after(:build) do |notification|
-        notification.event_payload['reportable_type'] ||= notification.notifiable.reports.first.reportable.class.to_s
+      trait :relationship_delete_for_project do
+        event_type { 'Event::RelationshipDelete' }
+        notifiable factory: [:project]
       end
     end
 
-    trait :appeal do
-      event_type { 'Event::AppealCreated' }
-      notifiable { association(:appeal) }
+    factory :notification_package, class: 'NotificationPackage' do
+      trait :relationship_create_for_package do
+        event_type { 'Event::RelationshipCreate' }
+        notifiable factory: [:package]
+      end
+
+      trait :relationship_delete_for_package do
+        event_type { 'Event::RelationshipDelete' }
+        notifiable factory: [:package]
+      end
+
+      trait :build_failure do
+        event_type { 'Event::BuildFail' }
+        notifiable factory: [:package]
+      end
     end
-  end
 
-  factory :rss_notification, parent: :notification do
-    rss { true }
-  end
+    factory :notification_report, class: 'NotificationReport' do
+      trait :create_report do
+        event_type { 'Event::CreateReport' }
+        notifiable factory: [:report]
 
-  factory :web_notification, parent: :notification do
-    web { true }
+        transient do
+          reason { nil }
+        end
+
+        after(:build) do |notification, evaluator|
+          notification.event_payload['reportable_type'] ||= notification.notifiable.reportable.class.to_s
+          notification.event_payload['reason'] ||= evaluator.reason
+        end
+      end
+
+      trait :cleared_decision do
+        event_type { 'Event::ClearedDecision' }
+        notifiable { association(:decision_cleared) }
+
+        after(:build) do |notification|
+          notification.event_payload['reportable_type'] ||= notification.notifiable.reports.first.reportable.class.to_s
+        end
+      end
+
+      trait :favored_decision do
+        event_type { 'Event::FavoredDecision' }
+        notifiable { association(:decision_favored) }
+
+        after(:build) do |notification|
+          notification.event_payload['reportable_type'] ||= notification.notifiable.reports.first.reportable.class.to_s
+        end
+      end
+
+      trait :appeal do
+        event_type { 'Event::AppealCreated' }
+        notifiable { association(:appeal) }
+      end
+    end
   end
 end

--- a/src/api/spec/features/webui/users/notifications_spec.rb
+++ b/src/api/spec/features/webui/users/notifications_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe 'User notifications', :js do
   end
 
   describe 'when having notifications' do
-    let!(:notification_for_projects_comment) { create(:web_notification, :comment_for_package, subscriber: user) }
-    let!(:another_notification_for_projects_comment) { create(:web_notification, :comment_for_package, subscriber: user) }
+    let!(:notification_for_projects_comment) { create(:notification_comment, :web_notification, :comment_for_package, subscriber: user) }
+    let!(:another_notification_for_projects_comment) { create(:notification_comment, :web_notification, :comment_for_package, subscriber: user) }
     let(:notifiable) { notification_for_projects_comment.notifiable }
     let(:another_notifiable) { another_notification_for_projects_comment.notifiable }
     let(:project) { notifiable.commentable.project }

--- a/src/api/spec/features/webui/users/notifications_spec.rb
+++ b/src/api/spec/features/webui/users/notifications_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe 'User notifications', :js do
   end
 
   describe 'when having notifications' do
-    let!(:notification_for_projects_comment) { create(:notification_comment, :web_notification, :comment_for_package, subscriber: user) }
-    let!(:another_notification_for_projects_comment) { create(:notification_comment, :web_notification, :comment_for_package, subscriber: user) }
+    let!(:notification_for_projects_comment) { create(:notification_for_comment, :web_notification, :comment_for_package, subscriber: user) }
+    let!(:another_notification_for_projects_comment) { create(:notification_for_comment, :web_notification, :comment_for_package, subscriber: user) }
     let(:notifiable) { notification_for_projects_comment.notifiable }
     let(:another_notifiable) { another_notification_for_projects_comment.notifiable }
     let(:project) { notifiable.commentable.project }
@@ -78,8 +78,8 @@ RSpec.describe 'User notifications', :js do
     end
 
     context 'when clicking on the request filter' do
-      let!(:notification_for_request) { create(:web_notification, :request_state_change, subscriber: user) }
-      let!(:another_notification_for_request) { create(:web_notification, :request_created, subscriber: user) }
+      let!(:notification_for_request) { create(:notification_for_request, :web_notification, :request_state_change, subscriber: user) }
+      let!(:another_notification_for_request) { create(:notification_for_request, :web_notification, :request_created, subscriber: user) }
       let(:bs_request) { notification_for_request.notifiable }
 
       before do

--- a/src/api/spec/helpers/webui/notification_helper_spec.rb
+++ b/src/api/spec/helpers/webui/notification_helper_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Webui::NotificationHelper do
     let(:link) { mark_as_read_or_unread_button(notification) }
 
     context 'for unread notification' do
-      let(:notification) { create(:notification_comment, :web_notification, delivered: false) }
+      let(:notification) { create(:notification_for_comment, :web_notification, delivered: false) }
 
       it { expect(link).to include(my_notifications_path(notification_ids: [notification.id])) }
       it { expect(link).to include('state=unread') }
@@ -12,7 +12,7 @@ RSpec.describe Webui::NotificationHelper do
     end
 
     context 'for read notification' do
-      let(:notification) { create(:notification_comment, :web_notification, delivered: true) }
+      let(:notification) { create(:notification_for_comment, :web_notification, delivered: true) }
 
       it { expect(link).to include(my_notifications_path(notification_ids: [notification.id])) }
       it { expect(link).to include('state=read') }
@@ -59,12 +59,12 @@ RSpec.describe Webui::NotificationHelper do
     let(:staging_workflow) { create(:staging_workflow, project: factory) }
     let(:leap) { create(:project, name: 'openSUSE:Leap:15.0') }
     let(:leap_apache) { create(:package_with_file, name: 'apache2', project: leap) }
-    let(:notification) { create(:notification_bs_request, :request_created, notifiable: bs_request) }
+    let(:notification) { create(:notification_for_request, :request_created, notifiable: bs_request) }
 
     before { User.session = admin }
 
     context 'when displaying users or groups' do
-      let(:notification) { create(:notification_bs_request, :request_created) }
+      let(:notification) { create(:notification_for_request, :request_created) }
 
       it { expect(avatars(notification)).to include 'gravatar' }
     end

--- a/src/api/spec/helpers/webui/notification_helper_spec.rb
+++ b/src/api/spec/helpers/webui/notification_helper_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Webui::NotificationHelper do
     let(:link) { mark_as_read_or_unread_button(notification) }
 
     context 'for unread notification' do
-      let(:notification) { create(:web_notification, delivered: false) }
+      let(:notification) { create(:notification_comment, :web_notification, delivered: false) }
 
       it { expect(link).to include(my_notifications_path(notification_ids: [notification.id])) }
       it { expect(link).to include('state=unread') }
@@ -12,7 +12,7 @@ RSpec.describe Webui::NotificationHelper do
     end
 
     context 'for read notification' do
-      let(:notification) { create(:web_notification, delivered: true) }
+      let(:notification) { create(:notification_comment, :web_notification, delivered: true) }
 
       it { expect(link).to include(my_notifications_path(notification_ids: [notification.id])) }
       it { expect(link).to include('state=read') }
@@ -59,14 +59,14 @@ RSpec.describe Webui::NotificationHelper do
     let(:staging_workflow) { create(:staging_workflow, project: factory) }
     let(:leap) { create(:project, name: 'openSUSE:Leap:15.0') }
     let(:leap_apache) { create(:package_with_file, name: 'apache2', project: leap) }
-    let(:notification) { create(:notification, :request_created, notifiable: bs_request) }
+    let(:notification) { create(:notification_bs_request, :request_created, notifiable: bs_request) }
 
     before { User.session = admin }
 
     context 'when displaying users or groups' do
-      let(:notification) { create(:notification, :request_created) }
+      let(:notification) { create(:notification_bs_request, :request_created) }
 
-      it { expect(avatars(notification.for_notifiable)).to include 'gravatar' }
+      it { expect(avatars(notification)).to include 'gravatar' }
     end
 
     context 'when displaying packages' do
@@ -82,7 +82,7 @@ RSpec.describe Webui::NotificationHelper do
         bs_request
       end
 
-      it { expect(avatars(notification.for_notifiable)).to include 'fa-archive' }
+      it { expect(avatars(notification)).to include 'fa-archive' }
     end
 
     context 'when displaying projects' do
@@ -102,8 +102,8 @@ RSpec.describe Webui::NotificationHelper do
         bs_request
       end
 
-      it { expect(avatars(notification.for_notifiable)).to include 'fa-cubes' }
-      it { expect(avatars(notification.for_notifiable)).to include 'avatars-counter' }
+      it { expect(avatars(notification)).to include 'fa-cubes' }
+      it { expect(avatars(notification)).to include 'avatars-counter' }
     end
   end
 end

--- a/src/api/spec/jobs/cleanup_notifications_job_spec.rb
+++ b/src/api/spec/jobs/cleanup_notifications_job_spec.rb
@@ -3,8 +3,8 @@ RSpec.describe CleanupNotificationsJob do
 
   describe '#perform' do
     it 'only deletes old notifications' do
-      create(:notification, :stale)
-      create(:notification)
+      create(:notification_bs_request, :stale)
+      create(:notification_bs_request)
 
       expect { described_class.new.perform }.to change(Notification, :count).by(-1)
     end

--- a/src/api/spec/jobs/cleanup_notifications_job_spec.rb
+++ b/src/api/spec/jobs/cleanup_notifications_job_spec.rb
@@ -3,8 +3,8 @@ RSpec.describe CleanupNotificationsJob do
 
   describe '#perform' do
     it 'only deletes old notifications' do
-      create(:notification_bs_request, :stale)
-      create(:notification_bs_request)
+      create(:notification_for_request, :stale)
+      create(:notification_for_request)
 
       expect { described_class.new.perform }.to change(Notification, :count).by(-1)
     end

--- a/src/api/spec/models/notification_spec.rb
+++ b/src/api/spec/models/notification_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Notification do
   let(:delete_package_event) { Event::DeletePackage.new(payload) }
 
   describe '#event' do
-    subject { create(:rss_notification, event_type: 'Event::DeletePackage', event_payload: payload).event }
+    subject { create(:notification_package, :rss_notification, event_type: 'Event::DeletePackage', event_payload: payload).event }
 
     it { expect(subject.class).to eq(delete_package_event.class) }
     it { expect(subject.payload).to eq(delete_package_event.payload) }
@@ -11,14 +11,14 @@ RSpec.describe Notification do
 
   describe 'relationship with users' do
     let(:regular_user) { create(:confirmed_user, login: 'foo') }
-    let(:notification) { create(:rss_notification, subscriber: regular_user) }
+    let(:notification) { create(:notification_bs_request, :rss_notification, subscriber: regular_user) }
 
     it { expect(regular_user.notifications).to include(notification) }
   end
 
   describe 'relationship with groups' do
     let(:test_group) { create(:group, title: 'my_test_group') }
-    let(:notification) { create(:rss_notification, subscriber: test_group) }
+    let(:notification) { create(:notification_bs_request, :rss_notification, subscriber: test_group) }
 
     it { expect(test_group.notifications).to include(notification) }
   end
@@ -26,7 +26,7 @@ RSpec.describe Notification do
   describe '#user_active?' do
     subject { rss_notification.user_active? }
 
-    let(:rss_notification) { create(:rss_notification, subscriber: test_user) }
+    let(:rss_notification) { create(:notification_bs_request, :rss_notification, subscriber: test_user) }
 
     context 'when subscriber is away' do
       let(:test_user) { create(:dead_user, login: 'foo') }
@@ -44,7 +44,7 @@ RSpec.describe Notification do
   describe '#any_user_in_group_active?' do
     subject { rss_notification.any_user_in_group_active? }
 
-    let(:rss_notification) { create(:rss_notification, subscriber: test_group) }
+    let(:rss_notification) { create(:notification_bs_request, :rss_notification, subscriber: test_group) }
     let(:test_group) { create(:group) }
 
     before do
@@ -66,7 +66,7 @@ RSpec.describe Notification do
 
   describe 'Instrumentation' do
     let!(:test_user) { create(:confirmed_user, login: 'foo') }
-    let!(:web_notification) { create(:web_notification, subscriber: test_user) }
+    let!(:web_notification) { create(:notification_bs_request, :web_notification, subscriber: test_user) }
 
     before do
       allow(RabbitmqBus).to receive(:send_to_bus).with('metrics', 'notification,action=read value=1')

--- a/src/api/spec/models/notification_spec.rb
+++ b/src/api/spec/models/notification_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Notification do
   let(:delete_package_event) { Event::DeletePackage.new(payload) }
 
   describe '#event' do
-    subject { create(:notification_package, :rss_notification, event_type: 'Event::DeletePackage', event_payload: payload).event }
+    subject { create(:notification_for_package, :rss_notification, event_type: 'Event::DeletePackage', event_payload: payload).event }
 
     it { expect(subject.class).to eq(delete_package_event.class) }
     it { expect(subject.payload).to eq(delete_package_event.payload) }
@@ -11,14 +11,14 @@ RSpec.describe Notification do
 
   describe 'relationship with users' do
     let(:regular_user) { create(:confirmed_user, login: 'foo') }
-    let(:notification) { create(:notification_bs_request, :rss_notification, subscriber: regular_user) }
+    let(:notification) { create(:notification_for_request, :rss_notification, subscriber: regular_user) }
 
     it { expect(regular_user.notifications).to include(notification) }
   end
 
   describe 'relationship with groups' do
     let(:test_group) { create(:group, title: 'my_test_group') }
-    let(:notification) { create(:notification_bs_request, :rss_notification, subscriber: test_group) }
+    let(:notification) { create(:notification_for_request, :rss_notification, subscriber: test_group) }
 
     it { expect(test_group.notifications).to include(notification) }
   end
@@ -26,7 +26,7 @@ RSpec.describe Notification do
   describe '#user_active?' do
     subject { rss_notification.user_active? }
 
-    let(:rss_notification) { create(:notification_bs_request, :rss_notification, subscriber: test_user) }
+    let(:rss_notification) { create(:notification_for_request, :rss_notification, subscriber: test_user) }
 
     context 'when subscriber is away' do
       let(:test_user) { create(:dead_user, login: 'foo') }
@@ -44,7 +44,7 @@ RSpec.describe Notification do
   describe '#any_user_in_group_active?' do
     subject { rss_notification.any_user_in_group_active? }
 
-    let(:rss_notification) { create(:notification_bs_request, :rss_notification, subscriber: test_group) }
+    let(:rss_notification) { create(:notification_for_request, :rss_notification, subscriber: test_group) }
     let(:test_group) { create(:group) }
 
     before do
@@ -66,7 +66,7 @@ RSpec.describe Notification do
 
   describe 'Instrumentation' do
     let!(:test_user) { create(:confirmed_user, login: 'foo') }
-    let!(:web_notification) { create(:notification_bs_request, :web_notification, subscriber: test_user) }
+    let!(:web_notification) { create(:notification_for_request, :web_notification, subscriber: test_user) }
 
     before do
       allow(RabbitmqBus).to receive(:send_to_bus).with('metrics', 'notification,action=read value=1')

--- a/src/api/spec/models/user_spec.rb
+++ b/src/api/spec/models/user_spec.rb
@@ -359,9 +359,9 @@ RSpec.describe User do
       subject { confirmed_user.combined_rss_feed_items }
 
       before do
-        create_list(:notification_bs_request, max_items_per_group, :rss_notification, subscriber: group)
-        create_list(:notification_bs_request, max_items_per_user + 5, :rss_notification, subscriber: confirmed_user)
-        create_list(:notification_bs_request, 3, :rss_notification, subscriber: user)
+        create_list(:notification_for_request, max_items_per_group, :rss_notification, subscriber: group)
+        create_list(:notification_for_request, max_items_per_user + 5, :rss_notification, subscriber: confirmed_user)
+        create_list(:notification_for_request, 3, :rss_notification, subscriber: user)
       end
 
       it { expect(subject.count).to be(max_items_per_user) }
@@ -374,9 +374,9 @@ RSpec.describe User do
       subject { confirmed_user.combined_rss_feed_items }
 
       before do
-        create_list(:notification_bs_request, 5, :rss_notification, subscriber: confirmed_user)
-        create_list(:notification_bs_request, max_items_per_group - 1, :rss_notification, subscriber: group)
-        create_list(:notification_bs_request, 3, :rss_notification, subscriber: user)
+        create_list(:notification_for_request, 5, :rss_notification, subscriber: confirmed_user)
+        create_list(:notification_for_request, max_items_per_group - 1, :rss_notification, subscriber: group)
+        create_list(:notification_for_request, 3, :rss_notification, subscriber: user)
       end
 
       it { expect(subject.count).to be(max_items_per_user) }
@@ -391,11 +391,11 @@ RSpec.describe User do
       let(:batch) { max_items_per_user / 4 }
 
       before do
-        create_list(:notification_bs_request, max_items_per_user + batch, :rss_notification, subscriber: confirmed_user)
-        create_list(:notification_bs_request, batch, :rss_notification, subscriber: group)
-        create_list(:notification_bs_request, batch, :rss_notification, subscriber: confirmed_user)
-        create_list(:notification_bs_request, batch, :rss_notification, subscriber: group)
-        create_list(:notification_bs_request, 3, :rss_notification, subscriber: user)
+        create_list(:notification_for_request, max_items_per_user + batch, :rss_notification, subscriber: confirmed_user)
+        create_list(:notification_for_request, batch, :rss_notification, subscriber: group)
+        create_list(:notification_for_request, batch, :rss_notification, subscriber: confirmed_user)
+        create_list(:notification_for_request, batch, :rss_notification, subscriber: group)
+        create_list(:notification_for_request, 3, :rss_notification, subscriber: user)
       end
 
       it { expect(subject.count).to be(max_items_per_user) }

--- a/src/api/spec/models/user_spec.rb
+++ b/src/api/spec/models/user_spec.rb
@@ -359,9 +359,9 @@ RSpec.describe User do
       subject { confirmed_user.combined_rss_feed_items }
 
       before do
-        create_list(:rss_notification, max_items_per_group, subscriber: group)
-        create_list(:rss_notification, max_items_per_user + 5, subscriber: confirmed_user)
-        create_list(:rss_notification, 3, subscriber: user)
+        create_list(:notification_bs_request, max_items_per_group, :rss_notification, subscriber: group)
+        create_list(:notification_bs_request, max_items_per_user + 5, :rss_notification, subscriber: confirmed_user)
+        create_list(:notification_bs_request, 3, :rss_notification, subscriber: user)
       end
 
       it { expect(subject.count).to be(max_items_per_user) }
@@ -374,9 +374,9 @@ RSpec.describe User do
       subject { confirmed_user.combined_rss_feed_items }
 
       before do
-        create_list(:rss_notification, 5, subscriber: confirmed_user)
-        create_list(:rss_notification, max_items_per_group - 1, subscriber: group)
-        create_list(:rss_notification, 3, subscriber: user)
+        create_list(:notification_bs_request, 5, :rss_notification, subscriber: confirmed_user)
+        create_list(:notification_bs_request, max_items_per_group - 1, :rss_notification, subscriber: group)
+        create_list(:notification_bs_request, 3, :rss_notification, subscriber: user)
       end
 
       it { expect(subject.count).to be(max_items_per_user) }
@@ -391,11 +391,11 @@ RSpec.describe User do
       let(:batch) { max_items_per_user / 4 }
 
       before do
-        create_list(:rss_notification, max_items_per_user + batch, subscriber: confirmed_user)
-        create_list(:rss_notification, batch, subscriber: group)
-        create_list(:rss_notification, batch, subscriber: confirmed_user)
-        create_list(:rss_notification, batch, subscriber: group)
-        create_list(:rss_notification, 3, subscriber: user)
+        create_list(:notification_bs_request, max_items_per_user + batch, :rss_notification, subscriber: confirmed_user)
+        create_list(:notification_bs_request, batch, :rss_notification, subscriber: group)
+        create_list(:notification_bs_request, batch, :rss_notification, subscriber: confirmed_user)
+        create_list(:notification_bs_request, batch, :rss_notification, subscriber: group)
+        create_list(:notification_bs_request, 3, :rss_notification, subscriber: user)
       end
 
       it { expect(subject.count).to be(max_items_per_user) }

--- a/src/api/spec/policies/notification_comment_policy_spec.rb
+++ b/src/api/spec/policies/notification_comment_policy_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe NotificationCommentPolicy do
 
   let(:user) { create(:confirmed_user) }
   let(:other_user) { create(:confirmed_user) }
-  let(:notification) { create(:notification_package, :web_notification, :build_failure, subscriber: user, delivered: false) }
+  let(:notification) { create(:notification_for_package, :web_notification, :build_failure, subscriber: user, delivered: false) }
 
   permissions :update? do
     it { is_expected.not_to permit(other_user, notification) }

--- a/src/api/spec/policies/notification_comment_policy_spec.rb
+++ b/src/api/spec/policies/notification_comment_policy_spec.rb
@@ -1,9 +1,9 @@
-RSpec.describe NotificationPolicy do
+RSpec.describe NotificationCommentPolicy do
   subject { described_class }
 
   let(:user) { create(:confirmed_user) }
   let(:other_user) { create(:confirmed_user) }
-  let(:notification) { create(:web_notification, :build_failure, subscriber: user, delivered: false) }
+  let(:notification) { create(:notification_package, :web_notification, :build_failure, subscriber: user, delivered: false) }
 
   permissions :update? do
     it { is_expected.not_to permit(other_user, notification) }

--- a/src/api/spec/services/notification_service/web_channel_spec.rb
+++ b/src/api/spec/services/notification_service/web_channel_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe NotificationService::WebChannel do
           create(:comment_request, commentable: new_bs_request, user: requester, updated_at: 1.hour.ago, body: 'Latest comment')
         end
         let(:previous_notification) do
-          create(:notification_comment, :web_notification, :comment_for_request, subscription_receiver_role: 'target_maintainer', notifiable: first_comment, subscriber: owner, delivered: false)
+          create(:notification_for_comment, :web_notification, :comment_for_request, subscription_receiver_role: 'target_maintainer', notifiable: first_comment, subscriber: owner, delivered: false)
         end
 
         before do
@@ -134,7 +134,7 @@ RSpec.describe NotificationService::WebChannel do
           create(:comment_request, commentable: new_bs_request, user: requester, updated_at: 1.hour.ago, body: 'Latest comment')
         end
         let(:previous_notification) do
-          create(:notification_comment, :web_notification, :comment_for_request, subscription_receiver_role: 'target_maintainer', notifiable: first_comment, subscriber: owner, delivered: true)
+          create(:notification_for_comment, :web_notification, :comment_for_request, subscription_receiver_role: 'target_maintainer', notifiable: first_comment, subscriber: owner, delivered: true)
         end
 
         before do
@@ -223,7 +223,7 @@ RSpec.describe NotificationService::WebChannel do
           create(:comment_request, commentable: new_bs_request, user: requester, updated_at: 1.hour.ago, body: 'Latest comment')
         end
         let(:previous_notification) do
-          create(:notification_comment, :web_notification, :comment_for_request,
+          create(:notification_for_comment, :web_notification, :comment_for_request,
                  subscription_receiver_role: 'target_maintainer', notifiable: first_comment, subscriber: owner, delivered: false,
                  groups: [group_maintainers])
         end
@@ -261,7 +261,7 @@ RSpec.describe NotificationService::WebChannel do
           create(:comment_request, commentable: new_bs_request, user: requester, updated_at: 1.hour.ago, body: 'Latest comment')
         end
         let(:previous_notification) do
-          create(:notification_comment, :web_notification, :comment_for_request,
+          create(:notification_for_comment, :web_notification, :comment_for_request,
                  subscription_receiver_role: 'target_maintainer', notifiable: first_comment, subscriber: owner, delivered: true,
                  groups: [group_maintainers])
         end

--- a/src/api/spec/services/notification_service/web_channel_spec.rb
+++ b/src/api/spec/services/notification_service/web_channel_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe NotificationService::WebChannel do
           create(:comment_request, commentable: new_bs_request, user: requester, updated_at: 1.hour.ago, body: 'Latest comment')
         end
         let(:previous_notification) do
-          create(:web_notification, :comment_for_request, subscription_receiver_role: 'target_maintainer', notifiable: first_comment, subscriber: owner, delivered: false)
+          create(:notification_comment, :web_notification, :comment_for_request, subscription_receiver_role: 'target_maintainer', notifiable: first_comment, subscriber: owner, delivered: false)
         end
 
         before do
@@ -134,7 +134,7 @@ RSpec.describe NotificationService::WebChannel do
           create(:comment_request, commentable: new_bs_request, user: requester, updated_at: 1.hour.ago, body: 'Latest comment')
         end
         let(:previous_notification) do
-          create(:web_notification, :comment_for_request, subscription_receiver_role: 'target_maintainer', notifiable: first_comment, subscriber: owner, delivered: true)
+          create(:notification_comment, :web_notification, :comment_for_request, subscription_receiver_role: 'target_maintainer', notifiable: first_comment, subscriber: owner, delivered: true)
         end
 
         before do
@@ -223,7 +223,7 @@ RSpec.describe NotificationService::WebChannel do
           create(:comment_request, commentable: new_bs_request, user: requester, updated_at: 1.hour.ago, body: 'Latest comment')
         end
         let(:previous_notification) do
-          create(:web_notification, :comment_for_request,
+          create(:notification_comment, :web_notification, :comment_for_request,
                  subscription_receiver_role: 'target_maintainer', notifiable: first_comment, subscriber: owner, delivered: false,
                  groups: [group_maintainers])
         end
@@ -261,7 +261,7 @@ RSpec.describe NotificationService::WebChannel do
           create(:comment_request, commentable: new_bs_request, user: requester, updated_at: 1.hour.ago, body: 'Latest comment')
         end
         let(:previous_notification) do
-          create(:web_notification, :comment_for_request,
+          create(:notification_comment, :web_notification, :comment_for_request,
                  subscription_receiver_role: 'target_maintainer', notifiable: first_comment, subscriber: owner, delivered: true,
                  groups: [group_maintainers])
         end


### PR DESCRIPTION
Depends on #16477

This should be merged after #16477 is deployed on our internal instances