### PR TITLE
Fix excerpt truncation

### DIFF
--- a/src/api/app/helpers/webui/notification_helper.rb
+++ b/src/api/app/helpers/webui/notification_helper.rb
@@ -5,6 +5,8 @@ module Webui::NotificationHelper
   MAXIMUM_DISPLAYED_AVATARS = 6
 
   def truncate_to_first_new_line(text)
+    return '' if text.blank?
+
     first_new_line_index = text.index("\n")
     truncation_index = !first_new_line_index.nil? && first_new_line_index < TRUNCATION_LENGTH ? first_new_line_index + TRUNCATION_ELLIPSIS_LENGTH : TRUNCATION_LENGTH
     text.truncate(truncation_index)

--- a/src/api/spec/helpers/webui/notification_helper_spec.rb
+++ b/src/api/spec/helpers/webui/notification_helper_spec.rb
@@ -22,6 +22,14 @@ RSpec.describe Webui::NotificationHelper do
   end
 
   describe '#truncate_to_first_new_line' do
+    context 'when the text is nil' do
+      it {  expect(truncate_to_first_new_line(nil)).to eql('') }
+    end
+
+    context 'when the text is empty string' do
+      it { expect(truncate_to_first_new_line('')).to eql('') }
+    end
+
     context 'when text has no newline' do
       it {
         expect(truncate_to_first_new_line('some text without newline'))


### PR DESCRIPTION
Sometimes the text to display in the excerpt is nil and we have nothing to truncate.

Fixes #16492
Fixes #16491