### PR TITLE
[backend] allow to opt-out setrelease default behaviour

### DIFF
--- a/src/backend/bs_repserver
+++ b/src/backend/bs_repserver
@@ -2571,7 +2571,7 @@ sub copybuild {
         # need to keep associated files in sync with dir
         $oldsetrelease = '' if $bin =~ /^(.*)\.(?:report|milestone|cdx\.json|spdx\.json|[^\.]+\.intoto\.json)$/ && -d "$odir/$1";
       }
-      if (defined($setrelease)) {
+      if (defined($setrelease) && $setrelease ne '-') {
 	$setrelease =~ s/^-?/-/; # "-" will drop the release tag
 	$setrelease =~ s/-?$//;  # drop leading "-", it depends on the format
         # we must ensure to run only one of the following, because people


### PR DESCRIPTION
It stripes by default the build number, what might not be wanted.

Overwriting can be done with setrelease=- query parameter