### PR TITLE
Make sure that the diff compopnent doesn't newline the content of the diff

### DIFF
--- a/src/api/app/assets/stylesheets/webui/diff.scss
+++ b/src/api/app/assets/stylesheets/webui/diff.scss
@@ -119,6 +119,7 @@
       .content {
         margin-left: 1rem;
         white-space: pre;
+        display: inline-block;
       }
     }
   }


### PR DESCRIPTION
Fixes #16503

Makes sure that the content of the newline isn't moved onto a new line