### PR TITLE
Add `request_index` feature to flipper initializer

### DIFF
--- a/src/api/config/initializers/flipper.rb
+++ b/src/api/config/initializers/flipper.rb
@@ -6,7 +6,8 @@ ENABLED_FEATURE_TOGGLES = [
   { name: :content_moderation, description: 'Reporting inappropriate content' },
   { name: :color_themes, description: 'Color themes' },
   { name: :foster_collaboration, description: 'Features improving the collaboration opportunities between users of the build service.' },
-  { name: :labels, description: 'Allow to apply labels to packages, submit requests and projects to improve collaboration between build service users.' }
+  { name: :labels, description: 'Allow to apply labels to packages, submit requests and projects to improve collaboration between build service users.' },
+  { name: :request_index, description: 'Redesign of listing requests' }
 ].freeze
 
 Flipper.configure do


### PR DESCRIPTION
*DO NOT MERGE*:

We want to only show this to staff users for now in order to be more agile during the implementation. After all UI parts are connected we can enable this for beta users.