### PR TITLE
 Stop supporting objects in arguments to Package.get_by_project_and_name

### DIFF
--- a/src/api/app/components/watchlist_component.rb
+++ b/src/api/app/components/watchlist_component.rb
@@ -33,7 +33,7 @@ class WatchlistComponent < ApplicationComponent
     return project unless package
 
     # maybe package is a multibuild flavor? Try to look up the object of the flavor.
-    package = Package.get_by_project_and_name(project, package, { follow_multibuild: true }) if package.is_a?(String)
+    package = Package.get_by_project_and_name(project.name, package, { follow_multibuild: true }) if package.is_a?(String)
 
     # the package is coming via a project link, don't offer watching it.
     return if package.project != project

--- a/src/api/app/controllers/concerns/triggerable.rb
+++ b/src/api/app/controllers/concerns/triggerable.rb
@@ -15,7 +15,7 @@ module Triggerable
     @package = @token.package
     # If the token has no package, let's find one from the parameters
     if @package_name.present?
-      @package ||= Package.get_by_project_and_name(@project,
+      @package ||= Package.get_by_project_and_name(@project.name,
                                                    @package_name,
                                                    package_find_options)
     end

--- a/src/api/app/controllers/webui/webui_controller.rb
+++ b/src/api/app/controllers/webui/webui_controller.rb
@@ -138,7 +138,7 @@ class Webui::WebuiController < ActionController::Base
     return if @package_name.blank?
 
     begin
-      @package = Package.get_by_project_and_name(@project, @package_name, follow_multibuild: true)
+      @package = Package.get_by_project_and_name(@project.name, @package_name, follow_multibuild: true)
     # why it's not found is of no concern
     rescue APIError
       raise Package::UnknownObjectError, "Package not found: #{@project.name}/#{@package_name}"


### PR DESCRIPTION
We only call Package.get_by_project_and_name with a string as project parameter throughout the app. No need to support passing in a Project. This simplifies this method a lot.