### PR TITLE
Introduce wildcard searching in development mode

### DIFF
--- a/src/api/config/thinking_sphinx.yml.example
+++ b/src/api/config/thinking_sphinx.yml.example
@@ -4,6 +4,7 @@ development:
   mem_limit: 512M
   charset_table: "0..9, a..z, A..Z->a..z, U+410..U+42F->U+430..U+44F, U+430..U+44F"
   real_time_tidy: true
+  min_infix_len: 6
 test:
   mysql41: 9313
   bin_path: /usr/bin


### PR DESCRIPTION
As first step, to ensure this is not causing any issue, we are going to enable it only in development environment.

See #11347 and #11374.

As reference: http://www.sphinxsearch.com/docs/current.html#conf-min-infix-len