### PR TITLE
Request action type filter

### DIFF
--- a/src/api/app/assets/stylesheets/webui/requests.scss
+++ b/src/api/app/assets/stylesheets/webui/requests.scss
@@ -101,11 +101,27 @@
 }
 
 @include media-breakpoint-between(xs, md) {
+  #requests-filter-desktop {
+    &.sticky-top { top: $top-navigation-height; }
+    height: $top-navigation-height;
+    // To not overlap with the notification action bar
+    z-index: calc(#{$zindex-sticky} + 1);
+
+    #filters {
+      max-height: 100vw;
+      overflow: auto;
+    }
+  }
   #requests-filter-search-text {
     &.sticky-top { top: calc(#{$top-navigation-height} * 2); }
   }
-}
 
+  @media (orientation: landscape) {
+    #requests-filter-desktop {
+      #filters { max-height: 20vw; }
+    }
+  }
+}
 
 .fa-custom-pr-closed {
   position: relative;

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -29,7 +29,7 @@ class Webui::RequestController < Webui::WebuiController
                                   if: -> { Flipper.enabled?(:request_show_redesign, User.session) }
   before_action :check_beta_user_redirect, only: %i[build_results rpm_lint changes mentioned_issues]
   before_action :redirect_to_tasks, only: [:index], unless: -> { Flipper.enabled?(:request_index, User.session) }
-  before_action :set_requests, :set_filter_involvement, :set_filter_state, :filter_requests, :set_selected_filter, only: [:index], if: -> { Flipper.enabled?(:request_index, User.session) }
+  before_action :set_requests, :set_filter_involvement, :set_filter_state, :set_filter_action_type, :filter_requests, :set_selected_filter, only: [:index], if: -> { Flipper.enabled?(:request_index, User.session) }
 
   after_action :verify_authorized, only: [:create]
 
@@ -345,15 +345,21 @@ class Webui::RequestController < Webui::WebuiController
     @filter_state = @filter_state.intersection(BsRequest::VALID_REQUEST_STATES.map(&:to_s))
   end
 
+  def set_filter_action_type
+    @filter_action_type = params[:action_type].presence || []
+    @filter_action_type = @filter_action_type.intersection(BsRequestAction::TYPES)
+  end
+
   def filter_requests
     @bs_requests = filter_by_text(params[:requests_search_text])
 
     @bs_requests = filter_by_involvement(@bs_requests, @filter_involvement)
     @bs_requests = @bs_requests.where(state: @filter_state) if @filter_state.present?
+    @bs_requests = @bs_requests.with_action_type(@filter_action_type) if @filter_action_type.present?
   end
 
   def set_selected_filter
-    @selected_filter = { involvement: @filter_involvement, search_text: params[:requests_search_text], state: @filter_state }
+    @selected_filter = { involvement: @filter_involvement, action_type: @filter_action_type, search_text: params[:requests_search_text], state: @filter_state }
   end
 
   def check_beta_user_redirect

--- a/src/api/app/helpers/webui/request_helper.rb
+++ b/src/api/app/helpers/webui/request_helper.rb
@@ -252,4 +252,23 @@ module Webui::RequestHelper
       tag.i(class: "fas fa-#{decode_state_icon(state)} me-1")
     end
   end
+
+  def action_type_icon(type)
+    case type
+    when 'maintenance_incident'
+      'fas fa-person-digging fa-fw'
+    when 'add_role'
+      'fas fa-people-arrows fa-fw'
+    when 'set_bugowner'
+      'fas fa-bug-slash fa-fw'
+    when 'delete'
+      'fas fa-trash-can fa-fw'
+    when 'change_devel'
+      'fas fa-house-flag fa-fw'
+    when 'release', 'maintenance_release'
+      'fas fa-road-circle-check fa-fw'
+    else
+      'fas fa-code-pull-request fa-fw'
+    end
+  end
 end

--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -66,6 +66,8 @@ class BsRequest < ApplicationRecord
       .includes(:reviews)
   }
 
+  scope :with_action_type, ->(action_type) { joins(:bs_request_actions).where(bs_request_actions: { type: action_type }).distinct }
+
   has_many :bs_request_actions, dependent: :destroy
   has_many :reviews, dependent: :delete_all
   has_many :comments, as: :commentable, dependent: :destroy

--- a/src/api/app/models/bs_request_action.rb
+++ b/src/api/app/models/bs_request_action.rb
@@ -4,6 +4,7 @@ class BsRequestAction < ApplicationRecord
   include BsRequestAction::Errors
   #### Constants
   VALID_SOURCEUPDATE_OPTIONS = %w[update noupdate cleanup].freeze
+  TYPES = %w[set_bugowner change_devel delete maintenance_incident maintenance_release release add_role submit].freeze
 
   #### Self config
 

--- a/src/api/app/views/webui/request/_request_item.html.haml
+++ b/src/api/app/views/webui/request/_request_item.html.haml
@@ -1,20 +1,20 @@
 = link_to(request_show_path(bs_request.number), class: 'list-group-item list-group-item-action', id: "request-heading#{bs_request.number}") do
   .row.flex-nowrap
     .col-auto
-      %i.fas.fa-code-pull-request
+      - bs_request.bs_request_actions.pluck(:type).uniq.each do |action_type|
+        %div{ title: action_type.humanize.titleize }
+          %i{ class: "#{action_type_icon(action_type)}" }
     .col.col-with-icon
       .d-flex.justify-content-between.mb-1
         %strong
-          - if bs_request.bs_request_actions.count == 1
-            = bs_request.bs_request_actions.first.class.sti_name.to_s.humanize.titleize
-          - else
+          - if bs_request.bs_request_actions.count != 1
             Multiple Action
-          Request #{bs_request.number}
+          - if bs_request.bs_request_actions.pluck(:type).uniq.count == 1
+            = bs_request.bs_request_actions.first.type.humanize.titleize
+          Request ##{bs_request.number}
         = render BsRequestStateBadgeComponent.new(state: bs_request.state, css_class: 'mb-auto')
       .mb-1
-        - if bs_request.bs_request_actions.count == 1
-          - if bs_request.bs_request_actions.first.source_project.present?
-            = render BsRequestActionSourceAndTargetComponent.new(bs_request)
+        = render BsRequestActionSourceAndTargetComponent.new(bs_request)
       .mb-2.request-index-description.text-truncate
         = bs_request.description
       .text-end

--- a/src/api/app/views/webui/request/_requests_filter.html.haml
+++ b/src/api/app/views/webui/request/_requests_filter.html.haml
@@ -26,5 +26,49 @@
                                                                   value: state,
                                                                   checked: selected_filter[:state]&.include?(state.to_s) }
 
+.mt-3.mb-2
+  %h6.px-3.py-2
+    %b Action Type
+  .px-4.py-1
+    = render partial: 'webui/shared/check_box', locals: { label: 'Bugowner Change', key: 'action_type[set_bugowner]',
+                                                          name: 'action_type[]', value: 'set_bugowner',
+                                                          label_icon: action_type_icon('set_bugowner'),
+                                                          checked: selected_filter[:action_type]&.include?('set_bugowner')}
+
+    = render partial: 'webui/shared/check_box', locals: { label: 'Change Devel Project', key: 'action_type[change_devel]',
+                                                          name: 'action_type[]', value: 'change_devel',
+                                                          label_icon: action_type_icon('change_devel'),
+                                                          checked: selected_filter[:action_type]&.include?('change_devel')}
+
+    = render partial: 'webui/shared/check_box', locals: { label: 'Delete', key: 'action_type[delete]',
+                                                          name: 'action_type[]', value: 'delete',
+                                                          label_icon: action_type_icon('delete'),
+                                                          checked: selected_filter[:action_type]&.include?('delete')}
+
+    = render partial: 'webui/shared/check_box', locals: { label: 'Maintenance Incident', key: 'action_type[maintenance_incident]',
+                                                          name: 'action_type[]', value: 'maintenance_incident',
+                                                          label_icon: action_type_icon('maintenance_incident'),
+                                                          checked: selected_filter[:action_type]&.include?('maintenance_incident')}
+
+    = render partial: 'webui/shared/check_box', locals: { label: 'Maintenance Release', key: 'action_type[maintenance_release]',
+                                                          name: 'action_type[]', value: 'maintenance_release',
+                                                          label_icon: action_type_icon('maintenance_release'),
+                                                          checked: selected_filter[:action_type]&.include?('maintenance_release')}
+
+    = render partial: 'webui/shared/check_box', locals: { label: 'Release', key: 'action_type[release]',
+                                                          name: 'action_type[]', value: 'release',
+                                                          label_icon: action_type_icon('release'),
+                                                          checked: selected_filter[:action_type]&.include?('release')}
+
+    = render partial: 'webui/shared/check_box', locals: { label: 'Role Change', key: 'action_type[add_role]',
+                                                          name: 'action_type[]', value: 'add_role',
+                                                          label_icon: action_type_icon('add_role'),
+                                                          checked: selected_filter[:action_type]&.include?('add_role')}
+
+    = render partial: 'webui/shared/check_box', locals: { label: 'Submit', key: 'action_type[submit]',
+                                                          name: 'action_type[]', value: 'submit',
+                                                          label_icon: action_type_icon('submit'),
+                                                          checked: selected_filter[:action_type]&.include?('submit')}
+
 .text-center.mt-4.mb-4
   = link_to('Clear', requests_path, class: 'btn btn-light border')

--- a/src/api/app/views/webui/request/index.html.haml
+++ b/src/api/app/views/webui/request/index.html.haml
@@ -2,7 +2,7 @@
 
 = form_for(:request, url: requests_path, method: :get, id: 'requests-filter-form') do |form|
   .row
-    .col-md-4.col-lg-3.px-0.px-md-3.sticky-top#requests-filter-desktop
+    .col-md-4.col-lg-3.px-0.px-md-3.sticky-top.mb-3#requests-filter-desktop
       .card
         %strong.d-block.d-md-none.p-3{ data: { 'bs-toggle': 'collapse', 'bs-target': '#filters' },
                                     aria: { expanded: true, controls: 'filters' } }

--- a/src/api/spec/features/beta/webui/requests_index_spec.rb
+++ b/src/api/spec/features/beta/webui/requests_index_spec.rb
@@ -86,4 +86,30 @@ RSpec.describe 'Requests Index' do
     end
     # rubocop:enable RSpec/ExampleLength
   end
+
+  describe 'filters request by action type' do
+    let!(:request_with_maintenance_actions) do
+      create(:bs_request_with_maintenance_release_actions,
+             description: 'This is a maintenance request',
+             creator: receiver,
+             source_package: source_project.packages.first,
+             target_project: other_source_project)
+    end
+
+    # rubocop:disable RSpec/ExampleLength
+    it 'shows all requests with the selected action' do
+      find_by_id('requests-dropdown-trigger').click if mobile? # open the filter dropdown
+      within('#filters') do
+        check('Maintenance Release')
+        sleep 1.5 # there is a timeout before firing the filtering
+      end
+
+      within('#requests') do
+        expect(page).to have_link(href: "/request/show/#{request_with_maintenance_actions.number}")
+        expect(page).to have_css('.list-group-item .fas.fa-road-circle-check')
+        expect(page).to have_no_link(href: "/request/show/#{incoming_request.number}")
+      end
+    end
+    # rubocop:enable RSpec/ExampleLength
+  end
 end


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/69595bdd-fd32-44c3-aa4c-cbefed0f68f3)
Implements a way to filter by action types within the new requests view

Depends on #16536 