### PR TITLE
Do not paginate requests before filters

### DIFF
--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -332,7 +332,7 @@ class Webui::RequestController < Webui::WebuiController
   end
 
   def set_requests
-    @bs_requests = BsRequest.all.page(params[:page])
+    @bs_requests = BsRequest.all
   end
 
   def set_filter_involvement


### PR DESCRIPTION
Pagination to be applied only in the [`index`](https://github.com/openSUSE/open-build-service/blob/master/src/api/app/controllers/webui/request_controller.rb#L37) method, after all the filters are applied, right before returning