### PR TITLE
Fix error when processing bad group updates via xml

### DIFF
--- a/src/api/app/controllers/group_controller.rb
+++ b/src/api/app/controllers/group_controller.rb
@@ -53,8 +53,9 @@ class GroupController < ApplicationController
     end
     authorize group, :update?
 
+    Suse::Validator.validate('group', request.raw_post)
+
     xmlhash = Xmlhash.parse(request.raw_post)
-    raise InvalidParameterError, 'invalid xml provided' if xmlhash.nil?
     raise InvalidParameterError, 'group name from path and xml mismatch' unless group.title == xmlhash.value('title')
 
     group.update_from_xml(xmlhash, user_session_login: User.session.login)

--- a/src/api/app/controllers/group_controller.rb
+++ b/src/api/app/controllers/group_controller.rb
@@ -54,6 +54,7 @@ class GroupController < ApplicationController
     authorize group, :update?
 
     xmlhash = Xmlhash.parse(request.raw_post)
+    raise InvalidParameterError, 'invalid xml provided' if xmlhash.nil?
     raise InvalidParameterError, 'group name from path and xml mismatch' unless group.title == xmlhash.value('title')
 
     group.update_from_xml(xmlhash, user_session_login: User.session.login)

--- a/src/api/app/controllers/group_controller.rb
+++ b/src/api/app/controllers/group_controller.rb
@@ -4,6 +4,7 @@ class GroupController < ApplicationController
   validate_action groupinfo: { method: :get, response: :group }
   validate_action groupinfo: { method: :put, request: :group, response: :status }
   validate_action groupinfo: { method: :delete, response: :status }
+  validate_action update: { method: :put, request: :group }
 
   # raise an exception if authorize has not yet been called.
   after_action :verify_authorized, except: %i[index show]
@@ -52,8 +53,6 @@ class GroupController < ApplicationController
       group = Group.create(title: params[:title])
     end
     authorize group, :update?
-
-    Suse::Validator.validate('group', request.raw_post)
 
     xmlhash = Xmlhash.parse(request.raw_post)
     raise InvalidParameterError, 'group name from path and xml mismatch' unless group.title == xmlhash.value('title')

--- a/src/api/spec/controllers/group_controller_spec.rb
+++ b/src/api/spec/controllers/group_controller_spec.rb
@@ -105,7 +105,6 @@ RSpec.describe GroupController do
     end
 
     context 'when the group does not exist' do
-      let(:new_member) { create(:confirmed_user) }
       let(:valid_xml) do
         <<~XML
           <group>

--- a/src/api/spec/controllers/group_controller_spec.rb
+++ b/src/api/spec/controllers/group_controller_spec.rb
@@ -105,7 +105,21 @@ RSpec.describe GroupController do
     end
 
     context 'when the group does not exist' do
-      before { put :update, body: '<group><title>new_group</title></group>', params: { title: 'new_group', format: :xml } }
+      let(:new_member) { create(:confirmed_user) }
+      let(:valid_xml) do
+        <<~XML
+          <group>
+            <title>new_group</title>
+            <email>tux@openbuildservice.org</email>
+            <maintainer userid='#{admin_user.login}'/>
+            <person>
+              <person userid='#{new_member.login}'/>
+            </person>
+          </group>
+        XML
+      end
+
+      before { put :update, body: valid_xml, params: { title: 'new_group', format: :xml } }
 
       it { expect(response).to have_http_status(:success) }
       it { expect(Group.where(title: 'new_group')).to exist }
@@ -129,6 +143,7 @@ RSpec.describe GroupController do
     end
 
     context 'with an invalid request' do
+      # Note the extra " at the end of the XML
       let(:invalid_xml) do
         <<~XML
           <group>

--- a/src/api/spec/controllers/group_controller_spec.rb
+++ b/src/api/spec/controllers/group_controller_spec.rb
@@ -145,13 +145,11 @@ RSpec.describe GroupController do
 
       before { put :update, body: invalid_xml, params: { title: group.title, format: :xml } }
 
-      it { expect(response).to have_http_status(:success) }
+      it { expect(response).to have_http_status(:bad_request) }
 
-      it 'updates the group' do
+      it 'does not update the group' do
         group.reload
-        expect(group.groups_users.pluck(:user_id)).to contain_exactly(new_member.id, new_maintainer.id)
-        expect(group.email).to eq('tux@openbuildservice.org')
-        expect(group.group_maintainers.pluck(:user_id)).to contain_exactly(new_maintainer.id)
+        expect(group.groups_users).to be_empty
       end
     end
   end

--- a/src/api/test/functional/group_test.rb
+++ b/src/api/test/functional/group_test.rb
@@ -43,10 +43,7 @@ class GroupControllerTest < ActionDispatch::IntegrationTest
   end
 
   def test_create_modify_and_delete_group
-    FactoryBot.create(:confirmed_user, login: 'hans')
-    FactoryBot.create(:confirmed_user, login: 'luke')
-
-    xml = '<group><title>new_group</title><maintainer userid="hans"/><person><person userid="luke"/></person></group>'
+    xml = '<group><title>new_group</title><maintainer userid="Iggy"/><person><person userid="adrian"/></person></group>'
     put '/group/new_group', params: xml
     assert_response :unauthorized
 

--- a/src/api/test/functional/group_test.rb
+++ b/src/api/test/functional/group_test.rb
@@ -43,7 +43,10 @@ class GroupControllerTest < ActionDispatch::IntegrationTest
   end
 
   def test_create_modify_and_delete_group
-    xml = '<group><title>new_group</title></group>'
+    FactoryBot.create(:confirmed_user, login: 'hans')
+    FactoryBot.create(:confirmed_user, login: 'luke')
+
+    xml = '<group><title>new_group</title><maintainer userid="hans"/><person><person userid="luke"/></person></group>'
     put '/group/new_group', params: xml
     assert_response :unauthorized
 


### PR DESCRIPTION
Instead of crashing, we now raise an InvalidParameterError when receiving an invalid XML when trying to update a group.

Fixes #16434