### PR TITLE
Upgrade our CI to run against 15.6

### DIFF
--- a/.circleci/conditional_config.yml
+++ b/.circleci/conditional_config.yml
@@ -134,7 +134,7 @@ aliases:
 jobs:
   pipeline_settings:
     docker:
-      - image: opensuse/leap:15.5
+      - image: opensuse/leap:15.6
     steps:
       - run: echo "run-apidocs-linter is << pipeline.parameters.run-apidocs-linter >>"
       - run: echo "run-backend-tests is << pipeline.parameters.run-backend-tests >>"

--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -9,10 +9,10 @@ testbuild:
     - configure_repositories:
         project: home:bs-team
         repositories:
-          - name: 15.5
+          - name: 15.6
             paths:
               - target_project: OBS:Server:Unstable
-                target_repository: 15.5
+                target_repository: 15.6
             architectures:
               - x86_64
   filters:


### PR DESCRIPTION
This upgrades our CI from 15.5 to 15.6.

I thought about make the CI to detect what we have installed and use one version or the other, but frankly, it's just easier to wait for the maintenance window where our OS will be upgraded and merge this then.