### PR TITLE
Use only project and package sphinx indices for text search

### DIFF
--- a/src/api/app/controllers/webui/search_controller.rb
+++ b/src/api/app/controllers/webui/search_controller.rb
@@ -89,7 +89,6 @@ class Webui::SearchController < Webui::WebuiController
     @search_what = []
     @search_what << 'package' if params[:search_for].in?(%w[0 2])
     @search_what << 'project' if params[:search_for].in?(%w[0 1])
-    @search_what << 'owner' if params[:owner] == '1' && !@search_issue
   end
 
   def set_attribute_list

--- a/src/api/app/models/full_text_search.rb
+++ b/src/api/app/models/full_text_search.rb
@@ -11,13 +11,11 @@ class FullTextSearch
   STAR = false
   MAX_MATCHES = 15_000
 
-  attr_accessor :text, :classes, :fields, :attrib_type_id, :issue_tracker_name, :issue_name
+  attr_reader :text, :classes, :fields, :attrib_type_id, :issue_tracker_name, :issue_name
 
   def initialize(attrib = {})
-    if attrib
-      attrib.each do |att, value|
-        send(:"#{att}=", value)
-      end
+    attrib.each do |att, value|
+      instance_variable_set(:"@#{att}", value)
     end
   end
 

--- a/src/api/app/models/full_text_search.rb
+++ b/src/api/app/models/full_text_search.rb
@@ -15,6 +15,7 @@ class FullTextSearch
     attrib.each do |att, value|
       instance_variable_set(:"@#{att}", value)
     end
+    @classes ||= %w[package project]
   end
 
   def search(options = {})
@@ -40,7 +41,7 @@ class FullTextSearch
       args[:with][:issue_ids] = issue_id.to_i unless issue_id.nil?
       args[:with][:attrib_type_ids] = attrib_type_id.to_i unless attrib_type_id.nil?
     end
-    args[:classes] = classes.map { |i| i.to_s.classify.constantize } if classes
+    args[:classes] = classes.map { |i| i.to_s.classify.constantize }
 
     ThinkingSphinx.search(search_str, args)
   end

--- a/src/api/app/models/full_text_search.rb
+++ b/src/api/app/models/full_text_search.rb
@@ -61,13 +61,11 @@ class FullTextSearch
   private
 
   def search_str
-    if text.blank?
-      nil
-    elsif fields.blank?
-      Riddle::Query.escape(text)
-    else
-      "@(#{fields.map(&:to_s).join(',')}) #{Riddle::Query.escape(text)}"
-    end
+    return nil if text.blank?
+
+    return Riddle::Query.escape(text) if fields.blank?
+
+    "@(#{fields.map(&:to_s).join(',')}) #{Riddle::Query.escape(text)}"
   end
 
   def find_issue_id

--- a/src/api/app/models/full_text_search.rb
+++ b/src/api/app/models/full_text_search.rb
@@ -12,7 +12,6 @@ class FullTextSearch
   MAX_MATCHES = 15_000
 
   attr_accessor :text, :classes, :fields, :attrib_type_id, :issue_tracker_name, :issue_name
-  attr_reader :result
 
   def initialize(attrib = {})
     if attrib
@@ -20,7 +19,6 @@ class FullTextSearch
         send(:"#{att}=", value)
       end
     end
-    @result = nil
   end
 
   def search(options = {})
@@ -48,7 +46,7 @@ class FullTextSearch
     end
     args[:classes] = classes.map { |i| i.to_s.classify.constantize } if classes
 
-    @result = ThinkingSphinx.search(search_str, args)
+    ThinkingSphinx.search(search_str, args)
   end
 
   # Needed by ActiveModel::Serializers

--- a/src/api/app/models/full_text_search.rb
+++ b/src/api/app/models/full_text_search.rb
@@ -1,6 +1,4 @@
 class FullTextSearch
-  include ActiveModel::Serializers::JSON
-
   LINKED_COUNT_WEIGHT = 100
   ACTIVITY_INDEX_WEIGHT = 500
   LINKS_TO_OTHER_WEIGHT = -1000
@@ -45,13 +43,6 @@ class FullTextSearch
     args[:classes] = classes.map { |i| i.to_s.classify.constantize } if classes
 
     ThinkingSphinx.search(search_str, args)
-  end
-
-  # Needed by ActiveModel::Serializers
-  def attributes
-    { 'text' => nil, 'classes' => nil, 'fields' => nil, 'attrib_type_id' => nil,
-      'issue_tracker_name' => nil, 'issue_name' => nil,
-      'result' => nil, 'total_entries' => nil }
   end
 
   private


### PR DESCRIPTION
Recently we introduced an sphinx index for submit requests. Prevent from using this submit request index for searches of projects, packages and issues. This can happen when the query parameter `search_for` is not sent or its value isn't `0`, `1`, or `2`.