### PR TITLE
Fix relationship notifications

### DIFF
--- a/src/api/app/models/event/relationship.rb
+++ b/src/api/app/models/event/relationship.rb
@@ -9,7 +9,7 @@ module Event
     end
 
     def parameters_for_notification
-      super.merge({ notifiable_type: notifiable_type, notifiable_id: notifiable_id })
+      super.merge({ notifiable_type: notifiable_type, notifiable_id: notifiable_id, type: "Notification#{notifiable_type}" })
     end
 
     def any_roles

--- a/src/api/db/data/20240724091140_backfill_type_of_relationship_notifications.rb
+++ b/src/api/db/data/20240724091140_backfill_type_of_relationship_notifications.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class BackfillTypeOfRelationshipNotifications < ActiveRecord::Migration[7.0]
+  def up
+    Notification.where(type: nil, event_type: ['Event::RelationshipCreate', 'Event::RelationshipDelete']).in_batches do |batch|
+      batch.find_each do |notification|
+        notification.update(type: "Notification#{notification.notifiable_type}")
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/src/api/db/data_schema.rb
+++ b/src/api/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20240507120255)
+DataMigrate::Data.define(version: 20240724091140)


### PR DESCRIPTION
In the last refactoring we missed to set the `type` on notifications related to `RelationshipCreate` and `RelationshipDelete`. Since the deployment, we have `type: nil` on both OBS and IBS.

This makes the notifications page crash because it can't access to methods like `link_path`, `excerpt`, etc.

This PR fixes the code to always set the type and also adds the data migration for the affected notifications.

