### PR TITLE
Use renamed NotificationCommentPolicy

### DIFF
--- a/src/api/app/controllers/concerns/webui/notifications_handler.rb
+++ b/src/api/app/controllers/concerns/webui/notifications_handler.rb
@@ -6,7 +6,7 @@ module Webui::NotificationsHandler
 
     current_notification = Notification.find(params[:notification_id])
 
-    return unless NotificationPolicy.new(User.session, current_notification).update?
+    return unless NotificationCommentPolicy.new(User.session, current_notification).update?
 
     current_notification
   end

--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -151,7 +151,7 @@ class Webui::PackageController < Webui::WebuiController
     @roles = Role.local_roles
     if User.session && params[:notification_id]
       @current_notification = Notification.find(params[:notification_id])
-      authorize @current_notification, :update?, policy_class: NotificationPolicy
+      authorize @current_notification, :update?, policy_class: NotificationCommentPolicy
     end
     @current_request_action = BsRequestAction.find(params[:request_action_id]) if User.session && params[:request_action_id]
   end

--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -164,7 +164,7 @@ class Webui::ProjectController < Webui::WebuiController
     @roles = Role.local_roles
     if User.session && params[:notification_id]
       @current_notification = Notification.find(params[:notification_id])
-      authorize @current_notification, :update?, policy_class: NotificationPolicy
+      authorize @current_notification, :update?, policy_class: NotificationCommentPolicy
     end
     @current_request_action = BsRequestAction.find(params[:request_action_id]) if User.session && params[:request_action_id]
   end


### PR DESCRIPTION
This change was missing when the policy was renamed from `NotificationPolicy` to `NotificationCommentPolicy`, in #16486.

Fixes #16551.