### PR TITLE
Don't show build logs when rmplint logs are not available

### DIFF
--- a/src/api/app/services/rpmlint_log_extractor.rb
+++ b/src/api/app/services/rpmlint_log_extractor.rb
@@ -37,6 +37,8 @@ class RpmlintLogExtractor
 
   private
 
+  # Note: This method is used when rpmlint.log file is not available in the backend.
+  # It parses the '_log' file and search for rpmlint logs in it
   def retrieve_rpmlint_log_from_log
     @parse_internal_log_file = true
 
@@ -49,7 +51,7 @@ class RpmlintLogExtractor
     mark2 = '\[\s*\d+s\]\sRPMLINT report:\n'
     mark3 = '\[\s*\d+s\]\s===============\n'
 
-    log_content.sub!(/.+#{mark1}#{mark2}#{mark3}/m, '')
+    log_content = log_content.sub!(/.+#{mark1}#{mark2}#{mark3}/m, '')
 
     # Return if the OBS rpmlint mark was not found
     return unless (@mark_found = log_content.present?)

--- a/src/api/spec/fixtures/files/rpmlint_log_extractor_log
+++ b/src/api/spec/fixtures/files/rpmlint_log_extractor_log
@@ -16,7 +16,7 @@ X-Runtime: 0.900190
 Server-Timing: sql.active_record;dur=34.83, start_processing.action_controller;dur=0.18, instantiation.active_record;dur=24.52, cache_read.active_support;dur=1.77, cache_write.active_support;dur=0.60, send_file.action_controller;dur=0.36, process_action.action_controller;dur=662.78
 Content-Length: 34454
 
-[    0s] Memory limit set to 21805314KB
+[    0s] this is an invalid byte sequence \xED
 [    0s] Using BUILD_ROOT=/var/cache/obs/worker/root_2
 [    0s] Using BUILD_ARCH=x86_64:i686:i586:i486:i386
 [    0s] 

--- a/src/api/spec/fixtures/files/rpmlint_log_extractor_log_without_mark
+++ b/src/api/spec/fixtures/files/rpmlint_log_extractor_log_without_mark
@@ -1,0 +1,2591 @@
+[    0s] Using BUILD_ROOT=/var/cache/obs/worker/root_11/.mount
+[    0s] Using BUILD_ARCH=x86_64:i686:i586:i486:i386
+[    0s] Doing kvm build in /var/cache/obs/worker/root_11/root
+[    0s] 
+[    0s] 
+[    0s] i01-ch2d started "build debian.dsc" at Thu Jul 25 03:35:16 UTC 2024.
+[    0s] 
+[    0s] Building kanku for project 'devel:kanku' repository 'Debian_Unstable' arch 'x86_64' srcmd5 '781a6eb32fb97b7662d1fb9e49a195f7'
+[    0s] 
+[    0s] processing recipe /var/cache/obs/worker/root_11/.build-srcdir/debian.dsc ...
+[    0s] running changelog2spec --target debian --file /var/cache/obs/worker/root_11/.build-srcdir/debian.dsc
+[    0s] don't know how to convert changelog to format 'debian'
+[    0s] init_buildsystem --configdir /var/run/obs/worker/11/build/configs --cachedir /var/cache/build --prepare --clean --rpmlist /var/cache/obs/worker/root_11/.build.rpmlist /var/cache/obs/worker/root_11/.build-srcdir/debian.dsc build ...
+[    1s] cycle: libc6 -> libgcc-s1
+[    1s]   breaking dependency libgcc-s1 -> libc6
+[    1s] [1/63] preinstalling debconf...
+[    1s] [2/63] preinstalling gcc-14-base...
+[    1s] [3/63] preinstalling libaudit-common...
+[    1s] [4/63] preinstalling libsemanage-common...
+[    1s] [5/63] preinstalling readline-common...
+[    1s] [6/63] preinstalling libgcc-s1...
+[    1s] [7/63] preinstalling libc6...
+[    2s] [8/63] preinstalling debianutils...
+[    2s] [9/63] preinstalling diffutils...
+[    2s] [10/63] preinstalling libacl1...
+[    2s] [11/63] preinstalling libattr1...
+[    2s] [12/63] preinstalling libbz2-1.0...
+[    2s] [13/63] preinstalling libc-bin...
+[    2s] [14/63] preinstalling libcap-ng0...
+[    2s] [15/63] preinstalling libcap2...
+[    2s] [16/63] preinstalling libcrypt1...
+[    2s] [17/63] preinstalling libdb5.3t64...
+[    2s] [18/63] preinstalling libdebconfclient0...
+[    2s] [19/63] preinstalling libgdbm6t64...
+[    2s] [20/63] preinstalling libgmp10...
+[    2s] [21/63] preinstalling liblzma5...
+[    2s] [22/63] preinstalling libmd0...
+[    2s] [23/63] preinstalling libpcre2-8-0...
+[    2s] [24/63] preinstalling libsepol2...
+[    2s] [25/63] preinstalling libsigsegv2...
+[    2s] [26/63] preinstalling libtinfo6...
+[    2s] [27/63] preinstalling libzstd1...
+[    2s] [28/63] preinstalling zlib1g...
+[    2s] [29/63] preinstalling dash...
+[    2s] [30/63] preinstalling grep...
+[    2s] [31/63] preinstalling libbsd0...
+[    2s] [32/63] preinstalling libgdbm-compat4t64...
+[    2s] [33/63] preinstalling libmpfr6...
+[    3s] [34/63] preinstalling libselinux1...
+[    3s] [35/63] preinstalling libsystemd0...
+[    3s] [36/63] preinstalling xz-utils...
+[    3s] [37/63] preinstalling libaudit1...
+[    3s] [38/63] preinstalling libreadline8t64...
+[    3s] [39/63] preinstalling libssl3t64...
+[    3s] [40/63] preinstalling findutils...
+[    3s] [41/63] preinstalling base-passwd...
+[    3s] [42/63] preinstalling libpam0g...
+[    3s] [43/63] preinstalling sed...
+[    3s] [44/63] preinstalling tar...
+[    3s] [45/63] preinstalling gawk...
+[    3s] [46/63] preinstalling coreutils...
+[    3s] [47/63] preinstalling libsemanage2...
+[    3s] [48/63] preinstalling libpam-modules-bin...
+[    3s] [49/63] preinstalling dpkg...
+[    4s] [50/63] preinstalling gzip...
+[    4s] [51/63] preinstalling perl-base...
+[    4s] [52/63] preinstalling libpam-modules...
+[    4s] [53/63] preinstalling libpam-runtime...
+[    4s] [54/63] preinstalling perl-modules-5.38...
+[    4s] [55/63] preinstalling libperl5.38t64...
+[    4s] [56/63] preinstalling login...
+[    5s] [57/63] preinstalling perl...
+[    5s] [58/63] preinstalling passwd...
+[    5s] [59/63] preinstalling adduser...
+[    5s] [60/63] preinstalling user-setup...
+[    5s] [61/63] preinstalling base-files...
+[    5s] [62/63] preinstalling init-system-helpers...
+[    5s] [63/63] preinstalling bash...
+[    5s] 
+[    5s] [1/18] preinstalling binutils-common...
+[    5s] [2/18] preinstalling kernel-obs-build...
+[    5s] [3/18] preinstalling libblkid1...
+[    5s] [4/18] preinstalling libctf-nobfd0...
+[    6s] [5/18] preinstalling libjansson4...
+[    6s] [6/18] preinstalling libsframe1...
+[    6s] [7/18] preinstalling libsmartcols1...
+[    6s] [8/18] preinstalling libstdc++6...
+[    6s] [9/18] preinstalling libudev1...
+[    6s] [10/18] preinstalling libuuid1...
+[    6s] [11/18] preinstalling libmount1...
+[    6s] [12/18] preinstalling libbinutils...
+[    6s] [13/18] preinstalling libctf0...
+[    6s] [14/18] preinstalling libgprofng0...
+[    6s] [15/18] preinstalling mount...
+[    6s] [16/18] preinstalling util-linux...
+[    6s] [17/18] preinstalling binutils-x86-64-linux-gnu...
+[    6s] [18/18] preinstalling binutils...
+[    6s] copying packages...
+[    8s] reordering...cycle: libc6 -> libgcc-s1
+[    8s]   breaking dependency libgcc-s1 -> libc6
+[    8s] cycle: libwww-perl -> liblwp-protocol-https-perl
+[    8s]   breaking dependency libwww-perl -> liblwp-protocol-https-perl
+[    8s] done
+[    8s] Detected virtio-serial support
+[    9s] booting kvm...
+[    9s] ### VM INTERACTION START ###
+[    9s] Using virtio-serial support and enabling console input
+[    9s] /usr/bin/qemu-kvm -nodefaults -no-reboot -nographic -vga none -cpu host -M pc,accel=kvm,usb=off,dump-guest-core=off,vmport=off -sandbox on -bios /usr/share/qemu/qboot.rom -object rng-random,filename=/dev/random,id=rng0 -device virtio-rng-pci,rng=rng0 -object iothread,id=io0 -runas qemu -net none -kernel /var/cache/obs/worker/root_11/.mount/boot/kernel -initrd /var/cache/obs/worker/root_11/.mount/boot/initrd -append root=/dev/disk/by-id/virtio-0 rootfstype=ext3 rootflags=data=writeback,nobarrier,commit=150,noatime elevator=noop nmi_watchdog=0 rw oops=panic panic=1 quiet console=hvc0 init=/.build/build -m 16384 -drive file=/var/cache/obs/worker/root_11/root,format=raw,if=none,id=disk,cache=unsafe,aio=io_uring -device virtio-blk-pci,iothread=io0,drive=disk,serial=0 -drive file=/var/cache/obs/worker/root_11/swap,format=raw,if=none,id=swap,cache=unsafe,aio=io_uring -device virtio-blk-pci,iothread=io0,drive=swap,serial=1 -device virtio-serial,max_ports=2 -device virtconsole,chardev=virtiocon0 -chardev stdio,mux=on,id=virtiocon0 -mon chardev=virtiocon0 -chardev socket,id=monitor,server=on,wait=off,path=/var/cache/obs/worker/root_11/root.qemu/monitor -mon chardev=monitor,mode=readline -smp 4
+[   11s] ### VM INTERACTION END ###
+[   11s] 2nd stage started in virtual machine
+[   11s] machine type: x86_64
+[   11s] Linux version: 6.4.11-1-default #1 SMP PREEMPT_DYNAMIC Thu Aug 17 04:57:43 UTC 2023 (2a5b3f6)
+[   11s] Time: Thu Jul 25 03:35:27 UTC 2024
+[   11s] Increasing log level from now on...
+[   11s] [    1.984437][  T365] sysrq: Changing Loglevel
+[   11s] [    1.984495][  T365] sysrq: Loglevel set to 4
+[   11s] Enable sysrq operations
+[   11s] Setting up swapspace version 1, size = 4 GiB (4294963200 bytes)
+[   11s] no label, UUID=d116788c-9836-4d70-bb9f-259e1b625e46
+[   11s] swapon: /dev/vdb: found signature [pagesize=4096, signature=swap]
+[   11s] swapon: /dev/vdb: pagesize=4096, swapsize=4294967296, devsize=4294967296
+[   11s] swapon /dev/vdb
+[   11s] WARNING: udev not running, creating extra device nodes
+[   11s] logging output to //.build.log...
+[   11s] processing recipe //.build-srcdir/debian.dsc ...
+[   11s] init_buildsystem --configdir /.build/configs --cachedir /var/cache/build //.build-srcdir/debian.dsc build ...
+[   11s] running base-files preinstall script
+[   11s] running base-files postinstall script
+[   11s] chown: invalid user: 'root:root'
+[   11s] running base-passwd preinstall script
+[   11s] running base-passwd postinstall script
+[   11s] running gawk postinstall script
+[   11s] running user-setup postinstall script
+[   12s] querying package ids...
+[   13s] [1/483] installing autotools-dev-20220109.1
+[   14s] [2/483] installing binutils-common-2.42.90.20240720-2
+[   14s] [3/483] installing debconf-1.5.87
+[   14s] [4/483] installing gcc-14-base-14.1.0-5
+[   14s] [5/483] installing gnupg-l10n-2.2.43-8
+[   14s] [6/483] installing kernel-obs-build-6.4.11-2.1
+[   14s] [7/483] installing libaudit-common-1:3.1.2-4
+[   14s] [8/483] installing libjs-jquery-3.6.1+dfsg+~3.5.14-1
+[   14s] [9/483] installing libmagic-mgc-1:5.45-3
+[   14s] [10/483] installing libnumber-compare-perl-0.03-3
+[   14s] [11/483] installing libsemanage-common-3.5-1
+[   14s] [12/483] installing libtext-glob-perl-0.11-3
+[   14s] [13/483] installing libtirpc-common-1.3.4+ds-1.3
+[   14s] [14/483] installing linux-libc-dev-6.9.10-1
+[   14s] [15/483] installing ncurses-base-6.5-2
+[   15s] [16/483] installing netbase-6.4
+[   15s] [17/483] installing readline-common-8.2-4
+[   15s] [18/483] installing sensible-utils-0.0.24
+[   15s] [19/483] installing vim-common-2:9.1.0496-1
+[   15s] [20/483] installing vim-runtime-2:9.1.0496-1
+[   15s] Adding 'diversion of /usr/share/vim/vim91/doc/help.txt to /usr/share/vim/vim91/doc/help.txt.vim-tiny by vim-runtime'
+[   15s] Adding 'diversion of /usr/share/vim/vim91/doc/tags to /usr/share/vim/vim91/doc/tags.vim-tiny by vim-runtime'
+[   15s] [21/483] installing tzdata-2024a-4
+[   15s] Current default time zone: 'Etc/UTC'
+[   15s] Local time is now:      Thu Jul 25 03:35:31 UTC 2024.
+[   15s] Universal Time is now:  Thu Jul 25 03:35:31 UTC 2024.
+[   15s] Run 'dpkg-reconfigure tzdata' if you wish to change it.
+[   15s] [22/483] installing ucf-3.0043+nmu1
+[   15s] Moving old data out of the way
+[   15s] [23/483] installing libgcc-s1-14.1.0-5
+[   15s] dpkg: libgcc-s1:amd64: dependency problems, but configuring anyway as you requested:
+[   15s]  libgcc-s1:amd64 depends on libc6 (>= 2.35); however:
+[   15s]   Package libc6 is not installed.
+[   15s] [24/483] installing libc6-2.39-6
+[   15s] dpkg-query: no packages found matching base-files
+[   16s] [25/483] installing debianutils-5.20
+[   16s] update-alternatives: using /usr/bin/which.debianutils to provide /usr/bin/which (which) in auto mode
+[   16s] [26/483] installing diffutils-1:3.10-1
+[   16s] [27/483] installing gettext-base-0.22.5-1
+[   16s] [28/483] installing hostname-3.23+nmu2
+[   16s] [29/483] installing libacl1-2.3.2-2
+[   16s] [30/483] installing libapparmor1-3.1.7-1+b1
+[   16s] [31/483] installing libattr1-1:2.5.2-1
+[   16s] [32/483] installing libblkid1-2.40.2-1
+[   16s] [33/483] installing libbrotli1-1.1.0-2+b4
+[   16s] [34/483] installing libbz2-1.0-1.0.8-5.1
+[   16s] [35/483] installing libc-bin-2.39-6
+[   16s] [36/483] installing libc-dev-bin-2.39-6
+[   16s] [37/483] installing libcap-ng0-0.8.5-1+b1
+[   16s] [38/483] installing libcap2-1:2.66-5
+[   16s] [39/483] installing libcom-err2-1.47.1-1
+[   16s] [40/483] installing libcrypt1-1:4.4.36-4
+[   16s] [41/483] installing libdb5.3t64-5.3.28+dfsg2-7
+[   16s] [42/483] installing libdebconfclient0-0.272
+[   16s] [43/483] installing libexpat1-2.6.2-1
+[   16s] [44/483] installing libext2fs2t64-1.47.1-1
+[   16s] Adding 'diversion of /lib/x86_64-linux-gnu/libe2p.so.2 to /lib/x86_64-linux-gnu/libe2p.so.2.usr-is-merged by libext2fs2t64'
+[   16s] Adding 'diversion of /lib/x86_64-linux-gnu/libe2p.so.2.3 to /lib/x86_64-linux-gnu/libe2p.so.2.3.usr-is-merged by libext2fs2t64'
+[   16s] Adding 'diversion of /lib/x86_64-linux-gnu/libext2fs.so.2 to /lib/x86_64-linux-gnu/libext2fs.so.2.usr-is-merged by libext2fs2t64'
+[   16s] Adding 'diversion of /lib/x86_64-linux-gnu/libext2fs.so.2.4 to /lib/x86_64-linux-gnu/libext2fs.so.2.4.usr-is-merged by libext2fs2t64'
+[   16s] [45/483] installing libfakeroot-1.35.1-1
+[   16s] [46/483] installing libffi8-3.4.6-1
+[   16s] [47/483] installing libgdbm6t64-1.23-6
+[   16s] [48/483] installing libgmp10-2:6.3.0+dfsg-2+b1
+[   16s] [49/483] installing libgpg-error0-1.49-2
+[   16s] [50/483] installing libgpm2-1.20.7-11
+[   16s] [51/483] installing libjansson4-2.14-2+b2
+[   17s] [52/483] installing libkeyutils1-1.6.3-3
+[   17s] [53/483] installing libkrb5support0-1.21.3-3
+[   17s] [54/483] installing liblzma5-5.6.2-2
+[   17s] [55/483] installing libmd0-1.1.0-2
+[   17s] [56/483] installing libnettle8t64-3.10-1
+[   17s] [57/483] installing libnghttp2-14-1.62.1-2
+[   17s] [58/483] installing libnghttp3-9-1.4.0-1
+[   17s] [59/483] installing libngtcp2-16-1.5.0-2
+[   17s] [60/483] installing libnl-3-200-3.7.0-0.3
+[   17s] [61/483] installing libnpth0t64-1.6-3.1
+[   17s] [62/483] installing libnuma1-2.0.18-1
+[   17s] [63/483] installing libpcre2-8-0-10.42-4+b1
+[   17s] [64/483] installing libpipeline1-1.5.7-2
+[   17s] [65/483] installing libseccomp2-2.5.5-1+b1
+[   17s] [66/483] installing libsepol2-3.5-2+b1
+[   17s] [67/483] installing libsframe1-2.42.90.20240720-2
+[   17s] [68/483] installing libsigsegv2-2.14-1+b1
+[   17s] [69/483] installing libsmartcols1-2.40.2-1
+[   17s] [70/483] installing libsodium23-1.0.18-1+b1
+[   17s] [71/483] installing libsqlite3-0-3.46.0-1
+[   17s] [72/483] installing libtasn1-6-4.19.0-3+b2
+[   17s] [73/483] installing libtinfo6-6.5-2
+[   17s] [74/483] installing libunistring5-1.2-1
+[   17s] [75/483] installing libuuid1-2.40.2-1
+[   17s] [76/483] installing libyajl2-2.1.0-5+b1
+[   17s] [77/483] installing libzstd1-1.5.6+dfsg-1
+[   17s] [78/483] installing logsave-1.47.1-1
+[   17s] [79/483] installing m4-1.4.19-4
+[   17s] [80/483] installing make-4.3-4.1
+[   17s] [81/483] installing patch-2.7.6-7
+[   17s] [82/483] installing rpcsvc-proto-1.4.3-1
+[   17s] [83/483] installing sysvinit-utils-3.09-2
+[   18s] [84/483] installing zlib1g-1:1.3.dfsg+really1.3.1-1
+[   18s] [85/483] installing libatomic1-14.1.0-5
+[   18s] [86/483] installing libgomp1-14.1.0-5
+[   18s] [87/483] installing libitm1-14.1.0-5
+[   18s] [88/483] installing libquadmath0-14.1.0-5
+[   18s] [89/483] installing libasan8-14.1.0-5
+[   18s] [90/483] installing libhwasan0-14.1.0-5
+[   18s] [91/483] installing liblsan0-14.1.0-5
+[   18s] [92/483] installing libstdc++6-14.1.0-5
+[   18s] [93/483] installing libtsan2-14.1.0-5
+[   18s] [94/483] installing libcrypt-dev-1:4.4.36-4
+[   18s] [95/483] installing bzip2-1.0.8-5.1
+[   18s] [96/483] installing dash-0.5.12-9
+[   18s] [97/483] installing fakeroot-1.35.1-1
+[   18s] update-alternatives: using /usr/bin/fakeroot-sysv to provide /usr/bin/fakeroot (fakeroot) in auto mode
+[   18s] [98/483] installing grep-3.11-4
+[   18s] [99/483] installing less-643-1
+[   18s] [100/483] installing libassuan0-2.5.6-1+b1
+[   18s] [101/483] installing libbsd0-0.12.2-1
+[   19s] [102/483] installing libctf-nobfd0-2.42.90.20240720-2
+[   19s] [103/483] installing libgcrypt20-1.11.0-2
+[   19s] [104/483] installing libgdbm-compat4t64-1.23-6
+[   19s] [105/483] installing libidn2-0-2.3.7-2
+[   19s] [106/483] installing libisl23-0.26-3+b2
+[   19s] [107/483] installing libk5crypto3-1.21.3-3
+[   19s] [108/483] installing libksba8-1.6.7-2
+[   19s] [109/483] installing libmpfr6-4.2.1-1+b1
+[   19s] [110/483] installing libncursesw6-6.5-2
+[   19s] [111/483] installing libp11-kit0-0.25.5-2
+[   19s] [112/483] installing libsasl2-modules-db-2.1.28+dfsg1-6
+[   19s] [113/483] installing libselinux1-3.5-2+b3
+[   19s] [114/483] installing libss2-1.47.1-1
+[   19s] [115/483] installing libsystemd0-256.4-1
+[   19s] [116/483] installing libudev1-256.4-1
+[   19s] [117/483] installing libunwind8-1.6.2-3.1
+[   19s] [118/483] installing ncurses-bin-6.5-2
+[   19s] [119/483] installing psmisc-23.7-1
+[   19s] [120/483] installing xz-utils-5.6.2-2
+[   19s] update-alternatives: using /usr/bin/xz to provide /usr/bin/lzma (lzma) in auto mode
+[   19s] [121/483] installing libaudit1-1:3.1.2-4+b1
+[   19s] [122/483] installing libelf1t64-0.191-2
+[   19s] [123/483] installing libhogweed6t64-3.10-1
+[   19s] [124/483] installing libicu72-72.1-5
+[   20s] [125/483] installing libreadline8t64-8.2-4
+[   20s] Adding 'diversion of /lib/x86_64-linux-gnu/libhistory.so.8 to /lib/x86_64-linux-gnu/libhistory.so.8.usr-is-merged by libreadline8t64'
+[   20s] Adding 'diversion of /lib/x86_64-linux-gnu/libhistory.so.8.2 to /lib/x86_64-linux-gnu/libhistory.so.8.2.usr-is-merged by libreadline8t64'
+[   20s] Adding 'diversion of /lib/x86_64-linux-gnu/libreadline.so.8 to /lib/x86_64-linux-gnu/libreadline.so.8.usr-is-merged by libreadline8t64'
+[   20s] Adding 'diversion of /lib/x86_64-linux-gnu/libreadline.so.8.2 to /lib/x86_64-linux-gnu/libreadline.so.8.2.usr-is-merged by libreadline8t64'
+[   20s] [126/483] installing libssl3t64-3.2.2-1
+[   20s] [127/483] installing libuchardet0-0.0.8-1+b1
+[   20s] [128/483] installing libcc1-0-14.1.0-5
+[   20s] [129/483] installing libubsan1-14.1.0-5
+[   20s] [130/483] installing libbinutils-2.42.90.20240720-2
+[   20s] [131/483] installing libmagic1t64-1:5.45-3
+[   20s] [132/483] installing autopoint-0.22.5-1
+[   20s] [133/483] installing bsdutils-1:2.40.2-1
+[   20s] [134/483] installing dwz-0.15-1+b1
+[   20s] [135/483] installing file-1:5.45-3
+[   20s] [136/483] installing findutils-4.10.0-2
+[   20s] [137/483] installing libproc2-0-2:4.0.4-5
+[   20s] [138/483] installing net-tools-2.10-1.1
+[   20s] [139/483] installing openssl-3.2.2-1
+[   20s] [140/483] installing perl-openssl-defaults-7+b2
+[   20s] [141/483] installing strace-6.8-2
+[   20s] [142/483] installing base-passwd-3.6.4
+[   21s] [143/483] installing libctf0-2.42.90.20240720-2
+[   21s] [144/483] installing libmount1-2.40.2-1
+[   21s] [145/483] installing libmpc3-1.3.1-1+b2
+[   21s] [146/483] installing libpam0g-1.5.3-7
+[   21s] [147/483] installing libpsl5t64-0.21.2-1.1
+[   21s] [148/483] installing libsasl2-2-2.1.28+dfsg1-6
+[   21s] [149/483] installing libssh2-1t64-1.11.0-5
+[   21s] [150/483] installing sed-4.9-2
+[   21s] [151/483] installing tar-1.35+dfsg-3
+[   21s] update-alternatives: using /usr/sbin/rmt-tar to provide /usr/sbin/rmt (rmt) in auto mode
+[   21s] [152/483] installing bsdextrautils-2.40.2-1
+[   21s] [153/483] installing groff-base-1.23.0-5
+[   21s] [154/483] installing libkmod2-32+20240611-1
+[   21s] [155/483] installing libxml2-2.12.7+dfsg-3+b1
+[   21s] [156/483] installing gawk-1:5.2.1-2+b1
+[   21s] [157/483] installing gpgconf-2.2.43-8
+[   21s] [158/483] installing libc6-dev-2.39-6
+[   21s] [159/483] installing libgprofng0-2.42.90.20240720-2
+[   22s] [160/483] installing pinentry-curses-1.2.1-3+b2
+[   22s] [161/483] installing coreutils-9.4-3.1
+[   22s] [162/483] installing libkrb5-3-1.21.3-3
+[   22s] [163/483] installing libsemanage2-3.5-1+b4
+[   22s] [164/483] installing e2fsprogs-1.47.1-1
+[   22s] [165/483] installing libgnutls30t64-3.8.6-2
+[   22s] [166/483] installing vim-2:9.1.0496-1+b1
+[   22s] update-alternatives: using /usr/bin/vim.basic to provide /usr/bin/editor (editor) in auto mode
+[   22s] update-alternatives: using /usr/bin/vim.basic to provide /usr/bin/ex (ex) in auto mode
+[   22s] update-alternatives: using /usr/bin/vim.basic to provide /usr/bin/rview (rview) in auto mode
+[   22s] update-alternatives: using /usr/bin/vim.basic to provide /usr/bin/rvim (rvim) in auto mode
+[   22s] update-alternatives: using /usr/bin/vim.basic to provide /usr/bin/vi (vi) in auto mode
+[   22s] update-alternatives: using /usr/bin/vim.basic to provide /usr/bin/view (view) in auto mode
+[   22s] update-alternatives: using /usr/bin/vim.basic to provide /usr/bin/vim (vim) in auto mode
+[   22s] update-alternatives: using /usr/bin/vim.basic to provide /usr/bin/vimdiff (vimdiff) in auto mode
+[   22s] [167/483] installing libgcc-14-dev-14.1.0-5
+[   22s] [168/483] installing ca-certificates-20240203
+[   22s] stat: cannot statx '/usr/local': No such file or directory
+[   23s] stat: cannot statx '/usr/local': No such file or directory
+[   23s] Updating certificates in /etc/ssl/certs...
+[   23s] 146 added, 0 removed; done.
+[   24s] [169/483] installing libldap-2.5-0-2.5.18+dfsg-2
+[   24s] [170/483] installing libngtcp2-crypto-gnutls8-1.5.0-2
+[   24s] [171/483] installing libstdc++-14-dev-14.1.0-5
+[   24s] [172/483] installing gettext-0.22.5-1
+[   24s] [173/483] installing kmod-32+20240611-1
+[   24s] sed: can't read /etc/modules: No such file or directory
+[   24s] [174/483] installing libgssapi-krb5-2-1.21.3-3
+[   24s] [175/483] installing mount-2.40.2-1
+[   24s] [176/483] installing libglib2.0-0t64-2.80.4-1
+[   24s] No schema files found: doing nothing.
+[   24s] [177/483] installing libpam-modules-bin-1.5.3-7
+[   24s] [178/483] installing librtmp1-2.4+20151223.gitfa8646d.1-2+b4
+[   24s] [179/483] installing gpgsm-2.2.43-8
+[   24s] [180/483] installing cpp-14-x86-64-linux-gnu-14.1.0-5
+[   25s] [181/483] keeping dpkg-1.22.9
+[   25s] [182/483] installing man-db-2.12.1-2
+[   25s] Not building database; man-db/auto-update is not 'true'.
+[   25s] [183/483] installing gpg-2.2.43-8
+[   25s] [184/483] installing binutils-x86-64-linux-gnu-2.42.90.20240720-2
+[   25s] [185/483] installing cpp-x86-64-linux-gnu-4:14.1.0-2
+[   25s] [186/483] installing sgml-base-1.31
+[   25s] [187/483] installing cpp-14-14.1.0-5
+[   25s] [188/483] installing gzip-1.12-1.1
+[   25s] [189/483] installing binutils-2.42.90.20240720-2
+[   25s] [190/483] installing libtirpc3t64-1.3.4+ds-1.3
+[   25s] Adding 'diversion of /lib/x86_64-linux-gnu/libtirpc.so.3 to /lib/x86_64-linux-gnu/libtirpc.so.3.usr-is-merged by libtirpc3t64'
+[   25s] Adding 'diversion of /lib/x86_64-linux-gnu/libtirpc.so.3.0.0 to /lib/x86_64-linux-gnu/libtirpc.so.3.0.0.usr-is-merged by libtirpc3t64'
+[   25s] [191/483] installing perl-base-5.38.2-5
+[   26s] [192/483] installing libssh-4-0.10.6-3
+[   26s] [193/483] installing libpam-modules-1.5.3-7
+[   26s] [194/483] installing gcc-14-x86-64-linux-gnu-14.1.0-5
+[   26s] [195/483] installing libcurl3t64-gnutls-8.8.0-4
+[   26s] [196/483] installing cpp-4:14.1.0-2
+[   26s] [197/483] installing gcc-x86-64-linux-gnu-4:14.1.0-2
+[   26s] [198/483] installing libpam-runtime-1.5.3-7
+[   26s] [199/483] installing libuuid-perl-0.35-1
+[   27s] [200/483] installing perl-modules-5.38-5.38.2-5
+[   27s] [201/483] installing gcc-14-14.1.0-5
+[   27s] [202/483] installing g++-14-x86-64-linux-gnu-14.1.0-5
+[   27s] [203/483] installing libvirt0-10.5.0-1
+[   27s] [204/483] installing g++-14-14.1.0-5
+[   27s] [205/483] installing g++-x86-64-linux-gnu-4:14.1.0-2
+[   27s] [206/483] installing gcc-4:14.1.0-2
+[   27s] [207/483] installing libperl5.38t64-5.38.2-5
+[   28s] [208/483] installing login-1:4.15.3-3
+[   28s] [209/483] installing util-linux-2.40.2-1
+[   28s] [210/483] installing perl-5.38.2-5
+[   28s] [211/483] installing g++-4:14.1.0-2
+[   28s] update-alternatives: using /usr/bin/g++ to provide /usr/bin/c++ (c++) in auto mode
+[   28s] [212/483] installing libtool-2.4.7-7
+[   28s] [213/483] installing passwd-1:4.15.3-3
+[   28s] Shadow passwords are now on.
+[   28s] [214/483] installing adduser-3.137
+[   28s] [215/483] installing libalgorithm-c3-perl-0.11-2
+[   28s] [216/483] installing libappconfig-perl-1.71-2.3
+[   28s] [217/483] installing libarchive-zip-perl-1.68-1
+[   28s] [218/483] installing libcapture-tiny-perl-0.48-2
+[   28s] [219/483] installing libcarp-clan-perl-6.08-2
+[   29s] [220/483] installing libclass-data-inheritable-perl-0.08-3
+[   29s] [221/483] installing libclass-inspector-perl-1.36-3
+[   29s] [222/483] installing libclass-makemethods-perl-1.01-7
+[   29s] [223/483] installing libclass-method-modifiers-perl-2.15-1
+[   29s] [224/483] installing libclass-singleton-perl-1.6-2
+[   29s] [225/483] installing libclass-tiny-perl-1.008-2
+[   29s] [226/483] installing libclone-choose-perl-0.010-2
+[   29s] [227/483] installing libconfig-general-perl-2.65-2
+[   29s] [228/483] installing libconfig-tiny-perl-2.30-1
+[   29s] [229/483] installing libcontext-preserve-perl-0.03-3
+[   29s] [230/483] installing libcrypt-saltedhash-perl-0.09-3
+[   29s] [231/483] installing libcurry-perl-2.000001-2
+[   29s] [232/483] installing libdata-dump-perl-1.25-1
+[   29s] [233/483] installing libdata-dumper-concise-perl-2.023-3
+[   29s] [234/483] installing libdbix-class-deploymenthandler-perl-0.002233-1
+[   29s] [235/483] installing libdbix-class-fixtures-perl-1.001039-1
+[   29s] [236/483] installing libdbix-class-migration-perl-0.074-1
+[   29s] [237/483] installing libdebhelper-perl-13.16
+[   29s] [238/483] installing libdevel-stacktrace-perl-2.0500-1
+[   29s] [239/483] installing libencode-locale-perl-1.05-3
+[   29s] [240/483] installing libexporter-tiny-perl-1.006000-1
+[   29s] [241/483] installing libfile-which-perl-1.27-2
+[   29s] [242/483] installing libfilesys-notify-simple-perl-0.14-3
+[   29s] [243/483] installing libhash-merge-simple-perl-0.051-3
+[   29s] [244/483] installing libhash-multivalue-perl-0.16-3
+[   29s] [245/483] installing libhtml-tagset-perl-3.24-1
+[   29s] [246/483] installing libhttp-browserdetect-perl-3.40-1
+[   30s] [247/483] installing libhttp-multipartparser-perl-0.02-3
+[   30s] [248/483] installing libio-html-perl-1.004-3
+[   30s] [249/483] installing libio-interactive-perl-1.025-1
+[   30s] [250/483] installing libio-stringy-perl-2.111-3
+[   30s] [251/483] installing libio-stty-perl-0.04-2
+[   30s] [252/483] installing libio-tiecombine-perl-1.005-3
+[   30s] [253/483] installing liblingua-en-inflect-perl-1.905-2
+[   30s] [254/483] installing liblingua-en-words2nums-perl-0.19-4
+[   30s] [255/483] installing liblingua-pt-stemmer-perl-0.02-2
+[   30s] [256/483] installing liblingua-stem-fr-perl-0.02-3
+[   30s] [257/483] installing liblingua-stem-it-perl-0.02-2
+[   30s] [258/483] installing liblingua-stem-ru-perl-0.04-2
+[   30s] [259/483] installing liblingua-stem-snowball-da-perl-1.01-8
+[   30s] [260/483] installing liblog-log4perl-perl-1.57-1
+[   30s] [261/483] installing liblwp-mediatypes-perl-6.04-2
+[   30s] [262/483] installing libmemoize-expirelru-perl-0.56-3
+[   30s] [263/483] installing libmime-types-perl-2.26-1
+[   30s] [264/483] installing libmodule-find-perl-0.16-2
+[   30s] [265/483] installing libmodule-pluggable-perl-5.2-1
+[   30s] [266/483] installing libmodule-runtime-perl-0.016-1
+[   30s] [267/483] installing libnet-ip-perl-1.26-3
+[   30s] [268/483] installing libnet-obs-client-perl-0.1.2-0
+[   30s] [269/483] installing libparse-recdescent-perl-1.967015+dfsg-4
+[   30s] [270/483] installing libpath-class-perl-0.37-4
+[   30s] [271/483] installing libpath-tiny-perl-0.146-1
+[   30s] [272/483] installing libposix-strftime-compiler-perl-0.46-1
+[   30s] [273/483] installing libprotocol-websocket-perl-0.26-1
+[   30s] [274/483] installing libref-util-perl-0.204-2
+[   30s] [275/483] installing libregexp-common-perl-2017060201-3
+[   30s] [276/483] installing libsafe-isa-perl-1.000010-1
+[   31s] [277/483] installing libscope-guard-perl-0.21-2
+[   31s] [278/483] installing libset-tiny-perl-0.05-1
+[   31s] [279/483] installing libsnowball-norwegian-perl-1.2-4
+[   31s] [280/483] installing libsnowball-swedish-perl-1.2-6
+[   31s] [281/483] installing libsql-tokenizer-perl-0.24-8
+[   31s] [282/483] installing libstream-buffered-perl-0.03-3
+[   31s] [283/483] installing libstrictures-perl-2.000006-1
+[   31s] [284/483] installing libstring-camelcase-perl-0.04-2
+[   31s] [285/483] installing libsub-exporter-progressive-perl-0.001013-3
+[   31s] [286/483] installing libsub-install-perl-0.929-1
+[   31s] [287/483] installing libsub-uplevel-perl-0.2800-3
+[   31s] [288/483] installing libtask-weaken-perl-1.06-2
+[   31s] [289/483] installing libtemplate-tiny-perl-1.14-2
+[   31s] [290/483] installing libtest-sharedfork-perl-0.35-3
+[   31s] [291/483] installing libtext-german-perl-0.06-5
+[   31s] [292/483] installing libtext-unidecode-perl-1.30-3
+[   31s] [293/483] installing libtie-toobject-perl-0.03-6
+[   31s] [294/483] installing libtimedate-perl-2.3300-2
+[   31s] [295/483] installing libtry-tiny-perl-0.31-2
+[   31s] [296/483] installing libuniversal-require-perl-0.19-3
+[   31s] [297/483] installing libwww-form-urlencoded-perl-0.26-2
+[   31s] [298/483] installing libxml-namespacesupport-perl-1.12-2
+[   31s] [299/483] installing libxml-sax-base-perl-1.09-3
+[   31s] [300/483] installing libyaml-perl-1.31-1
+[   31s] [301/483] installing libyaml-pp-perl-0.022-1
+[   31s] [302/483] installing intltool-debian-0.35.0+20060710.6
+[   31s] [303/483] installing libanyevent-perl-7.170-2+b5
+[   32s] [304/483] installing libcommon-sense-perl-3.75-3+b2
+[   32s] [305/483] installing libdpkg-perl-1.22.9
+[   32s] [306/483] installing liblog-any-perl-1.717-1
+[   32s] [307/483] installing libspiffy-perl-0.46-1
+[   32s] [308/483] installing libsub-quote-perl-2.006008-1
+[   32s] [309/483] installing liburi-perl-5.28-1
+[   32s] [310/483] installing autoconf-2.71-3
+[   32s] [311/483] installing libclass-xsaccessor-perl-1.19-4+b3
+[   32s] [312/483] installing libclone-perl-0.46-1+b2
+[   32s] [313/483] installing libdbi-perl-1.643-4+b2
+[   32s] [314/483] installing libfile-find-rule-perl-0.34-3
+[   32s] [315/483] installing libio-pty-perl-1:1.20-1+b1
+[   32s] [316/483] installing liblist-moreutils-xs-perl-0.430-4+b1
+[   32s] [317/483] installing libmath-int64-perl-0.57-1+b1
+[   32s] [318/483] installing libpackage-stash-xs-perl-0.30-1+b3
+[   32s] [319/483] installing libpadwalker-perl-2.5-1+b5
+[   32s] [320/483] installing libparams-util-perl-1.102-3
+[   32s] [321/483] installing libperlio-utf8-strict-perl-0.010-1+b2
+[   32s] [322/483] installing libsession-token-perl-1.503-2+b3
+[   32s] [323/483] installing libsub-identify-perl-0.14-3+b2
+[   32s] [324/483] installing libsub-name-perl-0.27-1+b2
+[   32s] [325/483] installing libterm-readkey-perl-2.38-2+b3
+[   32s] [326/483] installing libxstring-perl-0.005-2+b3
+[   32s] [327/483] installing libfile-libmagic-perl-1.23-2+b1
+[   32s] [328/483] installing libnet-amqp-rabbitmq-perl-2.40010-1
+[   32s] [329/483] installing libssh-session-perl-0.8-1
+[   33s] [330/483] installing libsys-virt-perl-10.5.0-1
+[   33s] [331/483] installing libnet-ssleay-perl-1.94-1+b1
+[   33s] [332/483] installing automake-1:1.16.5-1.3
+[   33s] update-alternatives: using /usr/bin/automake-1.16 to provide /usr/bin/automake (automake) in auto mode
+[   33s] [333/483] installing libapache-logformat-compiler-perl-0.36-3
+[   33s] [334/483] installing libclass-accessor-grouped-perl-0.10014-2
+[   33s] [335/483] installing libclass-accessor-perl-0.51-2
+[   33s] [336/483] installing libclass-c3-perl-0.35-2
+[   33s] [337/483] installing libclass-unload-perl-0.11-3
+[   33s] [338/483] installing libconfig-any-perl-0.33-1
+[   33s] [339/483] installing libcookie-baker-perl-0.12-1
+[   33s] [340/483] installing libdevel-globaldestruction-perl-0.14-4
+[   33s] [341/483] installing libdevel-stacktrace-ashtml-perl-0.15-2
+[   33s] [342/483] installing libdist-checkconflicts-perl-0.11-2
+[   33s] [343/483] installing libfile-homedir-perl-1.006-2
+[   33s] [344/483] installing libfile-sharedir-perl-1.118-3
+[   33s] [345/483] installing libhash-merge-perl-0.302-1
+[   33s] [346/483] installing libhttp-date-perl-6.06-1
+[   33s] [347/483] installing libimport-into-perl-1.002005-2
+[   33s] [348/483] installing libio-all-perl-0.87-2
+[   33s] [349/483] installing libipc-run-perl-20231003.0-2
+[   33s] [350/483] installing liblingua-en-findnumber-perl-1.32-3
+[   33s] [351/483] installing liblingua-en-inflect-number-perl-1.12-3
+[   33s] [352/483] installing librole-tiny-perl-2.002004-1
+[   33s] [353/483] installing libtest-exception-perl-0.43-3
+[   33s] [354/483] installing libtype-tiny-perl-2.004000-1
+[   33s] [355/483] installing libtypes-serialiser-perl-1.01-1
+[   34s] [356/483] installing liburi-ws-perl-0.03-1
+[   34s] [357/483] installing libwww-robotrules-perl-6.02-1
+[   34s] [358/483] installing usrmerge-39
+[   34s] [359/483] installing libanyevent-connector-perl-0.03-1
+[   34s] [360/483] installing libdata-optlist-perl-0.114-1
+[   34s] [361/483] installing libexception-class-perl-1.45-1
+[   34s] [362/483] installing libexpect-perl-1.38-1
+[   34s] [363/483] installing libfile-stripnondeterminism-perl-1.14.0-1
+[   34s] [364/483] installing libio-socket-ssl-perl-2.088-1
+[   34s] [365/483] installing liblist-moreutils-perl-0.430-2
+[   34s] [366/483] installing libmodule-implementation-perl-0.09-1
+[   34s] [367/483] installing libnet-http-perl-6.23-1
+[   34s] [368/483] installing libtest-tcp-perl-2.22-2
+[   34s] [369/483] installing user-setup-1.98
+[   34s] [370/483] installing libb-utils-perl-0.27-3+b2
+[   34s] [371/483] installing libtemplate-perl-2.27-1+b7
+[   34s] [372/483] installing libxml-sax-perl-1.02+dfsg-3
+[   34s] update-perl-sax-parsers: Registering Perl SAX parser XML::SAX::PurePerl with priority 10...
+[   34s] update-perl-sax-parsers: Updating overall Perl SAX parser modules info file...
+[   35s] [373/483] installing po-debconf-1.0.21+nmu1
+[   35s] [374/483] installing libdbd-sqlite3-perl-1.74-1+b2
+[   35s] [375/483] installing libhtml-parser-perl-3.82-1
+[   35s] [376/483] installing dpkg-dev-1.22.9
+[   35s] [377/483] installing liblingua-stem-perl-2.31-2
+[   35s] [378/483] installing base-files-13.3
+[   35s] [379/483] installing cpio-2.15+dfsg-1
+[   35s] update-alternatives: using /bin/mt-gnu to provide /bin/mt (mt) in auto mode
+[   35s] [380/483] installing libfile-listing-perl-6.16-1
+[   35s] [381/483] installing libfile-share-perl-0.27-2
+[   35s] [382/483] installing libhttp-headers-fast-perl-0.22-3
+[   35s] [383/483] installing liblingua-en-number-isordinal-perl-0.05-2
+[   35s] [384/483] installing libmro-compat-perl-0.15-2
+[   35s] [385/483] installing dh-strip-nondeterminism-1.14.0-1
+[   35s] [386/483] installing libb-hooks-endofscope-perl-0.24-1
+[   35s] [387/483] installing libhtml-tree-perl-5.07-3
+[   35s] [388/483] installing libmodule-runtime-conflicts-perl-0.003-2
+[   35s] [389/483] installing libpackage-stash-perl-0.40-1
+[   35s] [390/483] installing libsub-exporter-perl-0.990-1
+[   35s] [391/483] installing liblingua-en-tagger-perl-0.31-3
+[   35s] [392/483] installing libpackage-variant-perl-1.003002-2
+[   35s] [393/483] installing libparams-validate-perl-1.31-2+b2
+[   36s] [394/483] installing build-essential-12.10
+[   36s] [395/483] installing libdata-dump-streamer-perl-2.42-2+b1
+[   36s] [396/483] installing libjson-xs-perl-4.030-2+b3
+[   36s] [397/483] installing libsql-splitstatement-perl-1.00023-2
+[   36s] [398/483] installing dh-autoreconf-20
+[   36s] [399/483] installing libxml-libxml-perl-2.0207+dfsg+really+2.0134-4
+[   36s] update-perl-sax-parsers: Registering Perl SAX parser XML::LibXML::SAX::Parser with priority 50...
+[   36s] update-perl-sax-parsers: Registering Perl SAX parser XML::LibXML::SAX with priority 50...
+[   36s] update-perl-sax-parsers: Updating overall Perl SAX parser modules info file...
+[   36s] Replacing config file /etc/perl/XML/SAX/ParserDetails.ini with new version
+[   36s] [400/483] installing libhttp-message-perl-6.46-1
+[   36s] [401/483] installing libmoo-perl-2.005005-1
+[   36s] [402/483] installing init-system-helpers-1.66
+[   36s] [403/483] installing libeval-closure-perl-0.14-3
+[   36s] [404/483] installing libhttp-negotiate-perl-6.01-2
+[   36s] [405/483] installing libjson-maybexs-perl-1.004005-1
+[   36s] [406/483] installing libstring-rewriteprefix-perl-0.009-1
+[   36s] [407/483] installing libsub-exporter-formethods-perl-0.100055-1
+[   36s] [408/483] installing libconst-fast-perl-0.014-2
+[   36s] [409/483] installing libdevel-overloadinfo-perl-0.007-1
+[   36s] [410/483] installing libhttp-cookies-perl-6.11-1
+[   36s] [411/483] installing libmixin-linewise-perl-0.111-1
+[   37s] [412/483] installing libmodule-manifest-skip-perl-0.23-3
+[   37s] [413/483] installing libnamespace-clean-perl-0.27-1
+[   37s] [414/483] installing libstring-truncate-perl-1.100603-1
+[   37s] [415/483] installing bash-5.2.21-2.1
+[   37s] update-alternatives: using /usr/share/man/man7/bash-builtins.7.gz to provide /usr/share/man/man7/builtins.7.gz (builtins.7.gz) in auto mode
+[   37s] [416/483] installing libclass-c3-componentised-perl-1.001002-2
+[   37s] [417/483] installing libgetopt-long-descriptive-perl-0.111-1
+[   37s] [418/483] installing liblog-contextual-perl-0.009001-1
+[   37s] [419/483] installing libsql-abstract-perl-2.000001-2
+[   37s] [420/483] installing libnet-amqp-perl-0.06~dfsg-4
+[   37s] [421/483] installing libpackage-deprecationmanager-perl-0.18-1
+[   37s] [422/483] installing libclass-load-perl-0.25-2
+[   37s] [423/483] installing liblingua-en-inflect-phrase-perl-0.20-1
+[   37s] [424/483] installing libpath-isdev-perl-1.001003-3
+[   37s] [425/483] installing libsql-translator-perl-1.65-1
+[   37s] [426/483] installing debhelper-13.16
+[   37s] [427/483] installing libperlx-maybe-perl-1.202-1
+[   37s] [428/483] installing libpod-eventual-perl-0.094003-1
+[   37s] [429/483] installing libclass-load-xs-perl-0.10-2+b3
+[   37s] [430/483] installing libdevel-partialdump-perl-0.20-2
+[   37s] [431/483] installing libparams-validationcompiler-perl-0.31-1
+[   37s] [432/483] installing libsql-abstract-classic-perl-1.91-4
+[   38s] [433/483] installing libstring-toidentifier-en-perl-0.12-2
+[   38s] [434/483] installing libcli-osprey-perl-0.08-2
+[   38s] [435/483] installing libnamespace-autoclean-perl-0.29-1
+[   38s] [436/483] installing libpath-finddev-perl-0.5.3-2
+[   38s] [437/483] installing libhttp-entity-parser-perl-0.25-2
+[   38s] [438/483] installing procps-2:4.0.4-5
+[   38s] [439/483] installing gpg-agent-2.2.43-8
+[   38s] [440/483] installing libspecio-perl-0.48-1
+[   38s] [441/483] installing libapp-cmd-perl-0.336-1
+[   38s] [442/483] installing dirmngr-2.2.43-8
+[   39s] [443/483] installing libwww-perl-6.77-1
+[   39s] dpkg: libwww-perl: dependency problems, but configuring anyway as you requested:
+[   39s]  libwww-perl depends on liblwp-protocol-https-perl; however:
+[   39s]   Package liblwp-protocol-https-perl is not installed.
+[   39s] [444/483] installing gnupg-2.2.43-8
+[   39s] [445/483] installing liblwp-protocol-https-perl-6.14-1
+[   39s] [446/483] installing libdatetime-locale-perl-1:1.41-1
+[   39s] [447/483] installing libfile-sharedir-projectdistdir-perl-1.000009-2
+[   39s] [448/483] installing libxml-parser-perl-2.47-1+b2
+[   39s] [449/483] installing libanyevent-websocket-client-perl-0.53-1
+[   39s] [450/483] installing libdatetime-timezone-perl-1:2.62-1+2024a
+[   39s] [451/483] installing libplack-perl-1.0051-1
+[   40s] [452/483] installing libdbix-class-perl-0.082843-1
+[   40s] [453/483] installing libmoose-perl-2.2207-1+b1
+[   40s] [454/483] installing gnupg2-2.2.43-8
+[   40s] [455/483] installing libmoosex-singleton-perl-0.30-2
+[   40s] [456/483] installing libxml-structured-perl-1.01-4
+[   40s] [457/483] installing libplack-middleware-fixmissingbodyinredirect-perl-0.12-1
+[   40s] [458/483] installing libxml-xpath-perl-1.48-1
+[   40s] [459/483] installing libmoosex-markasmethods-perl-0.15-4
+[   40s] [460/483] installing libmoosex-nonmoose-perl-0.26-2
+[   40s] [461/483] installing libanyevent-websocket-server-perl-0.09-1
+[   40s] [462/483] installing libdata-visitor-perl-0.32-1
+[   40s] [463/483] installing libdbicx-sugar-perl-0.0200-3
+[   40s] [464/483] installing libmoosex-role-parameterized-perl-1.11-2
+[   40s] [465/483] installing libdatetime-perl-2:1.65-1+b1
+[   40s] [466/483] installing libmoosex-types-perl-0.50-2
+[   40s] [467/483] installing libmoosex-types-stringlike-perl-0.003-3
+[   40s] [468/483] installing libmoosex-types-path-class-perl-0.09-2
+[   40s] [469/483] installing libmoosex-getopt-perl-0.76-1
+[   40s] [470/483] installing libplack-app-websocket-perl-0.08-1
+[   40s] [471/483] installing libdatetime-format-strptime-perl-1.7900-1
+[   41s] [472/483] installing libpod-elemental-perl-0.103004-1
+[   41s] [473/483] installing libdbix-class-schema-loader-perl-0.07052-1
+[   41s] [474/483] installing libdancer2-perl-1.1.0+dfsg-1
+[   41s] [475/483] installing libdancer2-plugin-dbic-perl-0.0100-1
+[   41s] [476/483] installing libdatetime-format-builder-perl-0.8300-1
+[   41s] [477/483] installing libmoosex-app-perl-1.43-1
+[   41s] [478/483] installing libdancer2-plugin-websocket-perl-0.2.0-1
+[   41s] [479/483] installing libmoosex-types-path-tiny-perl-0.012-2
+[   41s] [480/483] installing libdancer2-plugin-auth-extensible-perl-0.710-1
+[   41s] [481/483] installing libdatetime-format-sqlite-perl-0.11-3
+[   41s] [482/483] installing libmoosex-configfromfile-perl-0.14-2
+[   41s] [483/483] installing libmoosex-app-cmd-perl-0.34-2
+[   41s] configuring all installed packages...
+[   41s] Processing triggers for man-db (2.12.1-2) ...
+[   41s] Not building database; man-db/auto-update is not 'true'.
+[   41s] Processing triggers for ca-certificates (20240203) ...
+[   41s] Updating certificates in /etc/ssl/certs...
+[   42s] 0 added, 0 removed; done.
+[   42s] Running hooks in /etc/ca-certificates/update.d...
+[   42s] done.
+[   42s] Processing triggers for debianutils (5.20) ...
+[   42s] Processing triggers for libc-bin (2.39-6) ...
+[   42s] now finalizing build dir...
+[   42s] SIOCSIFADDR: File exists
+[   42s] Running build time source services...
+[   42s] Found files matching debian.*, running debian transformer...
+[   42s] release: (3.82), release (DEB) (3.82)
+[   42s] ** Started: debtransform --release 3.82 //usr/src/packages/SOURCES //usr/src/packages/SOURCES/debian.dsc //usr/src/packages/SOURCES.DEB
+[   42s] No DEBTRANSFORM-TAR line in the .dsc file.
+[   42s] Attempting automatic discovery of a suitable source archive.
+[   42s] Source archive chosen for transformation: kanku-0.17.1.tar.xz
+[   42s] No DEBTRANSFORM-FILES-TAR line in the .dsc file.
+[   42s] Attempting automatic discovery of a debian archive.
+[   42s] Transforming into source package 1.0 (non-native) format
+[   42s] Added Debian revision to Version field, which is now "0.17.1-1".
+[   42s] converting //usr/src/packages/SOURCES/kanku-0.17.1.tar.xz to kanku-0.17.1.tar.gz
+[   42s] Modifying dsc Version field to "0.17.1-1"
+[   42s] Moving //usr/src/packages/SOURCES/kanku-0.17.1.tar.gz to //usr/src/packages/SOURCES.DEB/kanku_0.17.1.orig.tar.gz
+[   42s] files fd36ba09aa1696bd299dc97c8ea87b8d 3785012 kanku_0.17.1.orig.tar.gz
+[   42s] Scanning //usr/src/packages/SOURCES.DEB/kanku_0.17.1.orig.tar.gz...
+[   43s] Generating //usr/src/packages/SOURCES.DEB/kanku_0.17.1-1.diff
+[   43s] Processing file "//usr/src/packages/SOURCES/debian.rules"...
+[   43s] Processing file "//usr/src/packages/SOURCES/debian.control"...
+[   43s] Processing file "//usr/src/packages/SOURCES/debian.compat"...
+[   43s] Processing file "//usr/src/packages/SOURCES/debian.changelog"...
+[   43s] Found changelog with the last entry version not equal to build package version (0.17.1).
+[   43s] New entry with updated version number added (0.17.1-1).
+[   43s] Processing file "//usr/src/packages/SOURCES/debian.dsc"...
+[   43s] Writing //usr/src/packages/SOURCES.DEB/kanku_0.17.1-1.dsc
+[   43s] dpkg-source: warning: extracting unsigned source package (/usr/src/packages/SOURCES.DEB/kanku_0.17.1-1.dsc)
+[   43s] dpkg-source: info: extracting kanku in /usr/src/packages/BUILD
+[   43s] dpkg-source: info: unpacking kanku_0.17.1.orig.tar.gz
+[   43s] dpkg-source: info: applying kanku_0.17.1-1.diff.gz
+[   43s] -----------------------------------------------------------------
+[   43s] ----- building debian.dsc (user abuild)
+[   43s] -----------------------------------------------------------------
+[   43s] -----------------------------------------------------------------
+[   43s] dpkg-buildpackage: info: source package kanku
+[   43s] dpkg-buildpackage: info: source version 0.17.1-1
+[   43s] dpkg-buildpackage: info: source distribution unstable
+[   43s] dpkg-buildpackage: info: source changed by debtransform <build@opensuse.org>
+[   43s]  dpkg-source --before-build .
+[   43s] dpkg-buildpackage: info: host architecture amd64
+[   43s]  fakeroot debian/rules clean
+[   43s] dh clean
+[   43s]    dh_auto_clean
+[   43s] 	make -j1 clean
+[   43s] make[1]: Entering directory '/usr/src/packages/BUILD'
+[   43s] rm -rf kanku-*.tar.xz
+[   43s] make[1]: Leaving directory '/usr/src/packages/BUILD'
+[   43s]    dh_clean
+[   43s]  dpkg-source -b .
+[   44s] dpkg-source: warning: no source format specified in debian/source/format, see dpkg-source(1)
+[   44s] dpkg-source: warning: source directory 'BUILD' is not <sourcepackage>-<upstreamversion> 'kanku-0.17.1'
+[   44s] dpkg-source: warning: .orig directory name BUILD.orig is not <package>-<upstreamversion> (wanted kanku-0.17.1.orig)
+[   44s] dpkg-source: info: using source format '1.0'
+[   44s] dpkg-source: info: building kanku using existing kanku_0.17.1.orig.tar.gz
+[   44s] dpkg-source: info: building kanku in kanku_0.17.1-1.diff.gz
+[   44s] dpkg-source: info: building kanku in kanku_0.17.1-1.dsc
+[   44s]  debian/rules build
+[   44s] dh build
+[   44s]    dh_update_autotools_config
+[   44s]    dh_autoreconf
+[   44s]    dh_auto_configure
+[   44s]    dh_auto_build
+[   44s] 	make -j1
+[   44s] make[1]: Entering directory '/usr/src/packages/BUILD'
+[   44s] make[1]: Nothing to be done for 'all'.
+[   44s] make[1]: Leaving directory '/usr/src/packages/BUILD'
+[   44s]    dh_auto_test
+[   44s]    create-stamp debian/debhelper-build-stamp
+[   44s]  fakeroot debian/rules binary
+[   44s] dh binary
+[   44s]    dh_testroot
+[   44s]    dh_prep
+[   44s]    dh_auto_install --destdir=debian/kanku/
+[   44s] 	make -j1 install DESTDIR=/usr/src/packages/BUILD/debian/kanku AM_UPDATE_INFO_DIR=no
+[   44s] make[1]: Entering directory '/usr/src/packages/BUILD'
+[   44s] [ -d /usr/src/packages/BUILD/debian/kanku/etc/bash_completion.d/ ] || mkdir -p /usr/src/packages/BUILD/debian/kanku/etc/bash_completion.d/
+[   44s] [ -d /usr/src/packages/BUILD/debian/kanku/etc/apache2/conf.d ]     || mkdir -p /usr/src/packages/BUILD/debian/kanku/etc/apache2/conf.d
+[   44s] [ -d /usr/src/packages/BUILD/debian/kanku/etc/profile.d ]          || mkdir -p /usr/src/packages/BUILD/debian/kanku/etc/profile.d
+[   44s] [ -d /usr/src/packages/BUILD/debian/kanku/etc/kanku ]              || mkdir -p /usr/src/packages/BUILD/debian/kanku/etc/kanku
+[   44s] [ -d /usr/src/packages/BUILD/debian/kanku/var/log/kanku ]          || mkdir -p /usr/src/packages/BUILD/debian/kanku/var/log/kanku
+[   44s] [ -d /usr/src/packages/BUILD/debian/kanku/run/kanku ]              || mkdir -p /usr/src/packages/BUILD/debian/kanku/run/kanku
+[   44s] [ -d /usr/src/packages/BUILD/debian/kanku/var/cache/kanku ]        || mkdir -p /usr/src/packages/BUILD/debian/kanku/var/cache/kanku
+[   44s] [ -d /usr/src/packages/BUILD/debian/kanku/var/lib/kanku ]          || mkdir -p /usr/src/packages/BUILD/debian/kanku/var/lib/kanku
+[   44s] [ -d /usr/src/packages/BUILD/debian/kanku/var/lib/kanku/db ]       || mkdir -p /usr/src/packages/BUILD/debian/kanku/var/lib/kanku/db
+[   44s] [ -d /usr/src/packages/BUILD/debian/kanku/var/lib/kanku/sessions ] || mkdir -p /usr/src/packages/BUILD/debian/kanku/var/lib/kanku/sessions
+[   44s] [ -d /usr/src/packages/BUILD/debian/kanku/usr/lib/systemd/system ] || mkdir -p /usr/src/packages/BUILD/debian/kanku/usr/lib/systemd/system
+[   44s] [ -d /usr/src/packages/BUILD/debian/kanku/usr/bin ]                || mkdir -p /usr/src/packages/BUILD/debian/kanku/usr/bin
+[   44s] [ -d /usr/src/packages/BUILD/debian/kanku/usr/sbin ]               || mkdir -p /usr/src/packages/BUILD/debian/kanku/usr/sbin
+[   44s] [ -d /usr/src/packages/BUILD/debian/kanku//usr/share/doc/packages/kanku//contrib/libvirt-configs ] || mkdir -p /usr/src/packages/BUILD/debian/kanku//usr/share/doc/packages/kanku//contrib/libvirt-configs
+[   44s] [ -d /usr/src/packages/BUILD/debian/kanku/usr/share/kanku ]        || mkdir -p /usr/src/packages/BUILD/debian/kanku/usr/share/kanku
+[   44s] [ -d /usr/src/packages/BUILD/debian/kanku/usr/lib/kanku ]          || mkdir -p /usr/src/packages/BUILD/debian/kanku/usr/lib/kanku
+[   44s] [ -d /usr/src/packages/BUILD/debian/kanku/usr/lib/tmpfiles.d ]     || mkdir -p /usr/src/packages/BUILD/debian/kanku/usr/lib/tmpfiles.d
+[   44s] cp -rv ./lib/ /usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/
+[   44s] './lib/' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib'
+[   44s] './lib/Dancer2' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Dancer2'
+[   44s] './lib/Dancer2/Plugin' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Dancer2/Plugin'
+[   44s] './lib/Dancer2/Plugin/GitLab' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Dancer2/Plugin/GitLab'
+[   44s] './lib/Dancer2/Plugin/GitLab/Webhook.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Dancer2/Plugin/GitLab/Webhook.pm'
+[   44s] './lib/Kanku' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku'
+[   44s] './lib/Kanku/Airbrake' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Airbrake'
+[   44s] './lib/Kanku/Airbrake/Dummy.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Airbrake/Dummy.pm'
+[   44s] './lib/Kanku/Airbrake.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Airbrake.pm'
+[   44s] './lib/Kanku/Cli' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Cli'
+[   44s] './lib/Kanku/Cli/Roles' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Cli/Roles'
+[   44s] './lib/Kanku/Cli/Roles/Remote.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Cli/Roles/Remote.pm'
+[   44s] './lib/Kanku/Cli/Roles/RemoteCommand.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Cli/Roles/RemoteCommand.pm'
+[   44s] './lib/Kanku/Cli/Roles/Schema.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Cli/Roles/Schema.pm'
+[   44s] './lib/Kanku/Cli/Roles/VM.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Cli/Roles/VM.pm'
+[   44s] './lib/Kanku/Cli/Roles/View.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Cli/Roles/View.pm'
+[   44s] './lib/Kanku/Cli/api.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Cli/api.pm'
+[   44s] './lib/Kanku/Cli/ca.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Cli/ca.pm'
+[   44s] './lib/Kanku/Cli/check_configs.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Cli/check_configs.pm'
+[   44s] './lib/Kanku/Cli/console.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Cli/console.pm'
+[   44s] './lib/Kanku/Cli/db.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Cli/db.pm'
+[   44s] './lib/Kanku/Cli/destroy.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Cli/destroy.pm'
+[   44s] './lib/Kanku/Cli/init.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Cli/init.pm'
+[   44s] './lib/Kanku/Cli/ip.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Cli/ip.pm'
+[   44s] './lib/Kanku/Cli/list.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Cli/list.pm'
+[   44s] './lib/Kanku/Cli/login.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Cli/login.pm'
+[   44s] './lib/Kanku/Cli/logout.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Cli/logout.pm'
+[   44s] './lib/Kanku/Cli/lsi.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Cli/lsi.pm'
+[   44s] './lib/Kanku/Cli/pfwd.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Cli/pfwd.pm'
+[   44s] './lib/Kanku/Cli/rabbit.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Cli/rabbit.pm'
+[   44s] './lib/Kanku/Cli/rcomment.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Cli/rcomment.pm'
+[   44s] './lib/Kanku/Cli/retrigger.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Cli/retrigger.pm'
+[   44s] './lib/Kanku/Cli/rguest.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Cli/rguest.pm'
+[   44s] './lib/Kanku/Cli/rhistory.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Cli/rhistory.pm'
+[   44s] './lib/Kanku/Cli/rjob.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Cli/rjob.pm'
+[   44s] './lib/Kanku/Cli/rr.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Cli/rr.pm'
+[   44s] './lib/Kanku/Cli/rtrigger.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Cli/rtrigger.pm'
+[   44s] './lib/Kanku/Cli/rworker.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Cli/rworker.pm'
+[   44s] './lib/Kanku/Cli/setup.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Cli/setup.pm'
+[   44s] './lib/Kanku/Cli/snapshot.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Cli/snapshot.pm'
+[   44s] './lib/Kanku/Cli/ssh.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Cli/ssh.pm'
+[   44s] './lib/Kanku/Cli/startui.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Cli/startui.pm'
+[   44s] './lib/Kanku/Cli/startvm.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Cli/startvm.pm'
+[   44s] './lib/Kanku/Cli/status.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Cli/status.pm'
+[   44s] './lib/Kanku/Cli/stopui.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Cli/stopui.pm'
+[   44s] './lib/Kanku/Cli/stopvm.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Cli/stopvm.pm'
+[   44s] './lib/Kanku/Cli/up.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Cli/up.pm'
+[   44s] './lib/Kanku/Cli/urlwrapper.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Cli/urlwrapper.pm'
+[   44s] './lib/Kanku/Cli.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Cli.pm'
+[   44s] './lib/Kanku/Cmd.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Cmd.pm'
+[   44s] './lib/Kanku/Config' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Config'
+[   44s] './lib/Kanku/Config/Defaults.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Config/Defaults.pm'
+[   44s] './lib/Kanku/Config.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Config.pm'
+[   44s] './lib/Kanku/Daemon' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Daemon'
+[   44s] './lib/Kanku/Daemon/Dispatcher.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Daemon/Dispatcher.pm'
+[   44s] './lib/Kanku/Daemon/Scheduler.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Daemon/Scheduler.pm'
+[   44s] './lib/Kanku/Daemon/TriggerD.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Daemon/TriggerD.pm'
+[   44s] './lib/Kanku/Daemon/Worker.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Daemon/Worker.pm'
+[   44s] './lib/Kanku/Dispatch' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Dispatch'
+[   44s] './lib/Kanku/Dispatch/Local.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Dispatch/Local.pm'
+[   44s] './lib/Kanku/Dispatch/RabbitMQ.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Dispatch/RabbitMQ.pm'
+[   44s] './lib/Kanku/GPG.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/GPG.pm'
+[   44s] './lib/Kanku/Handler' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Handler'
+[   44s] './lib/Kanku/Handler/ChangeDomainState.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Handler/ChangeDomainState.pm'
+[   44s] './lib/Kanku/Handler/CleanupIPTables.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Handler/CleanupIPTables.pm'
+[   44s] './lib/Kanku/Handler/CopyProfile.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Handler/CopyProfile.pm'
+[   44s] './lib/Kanku/Handler/CreateDomain.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Handler/CreateDomain.pm'
+[   44s] './lib/Kanku/Handler/DomainSnapshot.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Handler/DomainSnapshot.pm'
+[   44s] './lib/Kanku/Handler/ExecuteCommandOnHost.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Handler/ExecuteCommandOnHost.pm'
+[   44s] './lib/Kanku/Handler/ExecuteCommandViaConsole.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Handler/ExecuteCommandViaConsole.pm'
+[   44s] './lib/Kanku/Handler/ExecuteCommandViaSSH.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Handler/ExecuteCommandViaSSH.pm'
+[   44s] './lib/Kanku/Handler/GIT.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Handler/GIT.pm'
+[   44s] './lib/Kanku/Handler/HTTPDownload.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Handler/HTTPDownload.pm'
+[   44s] './lib/Kanku/Handler/ImageDownload.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Handler/ImageDownload.pm'
+[   44s] './lib/Kanku/Handler/K8NodePortForward.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Handler/K8NodePortForward.pm'
+[   44s] './lib/Kanku/Handler/OBSCheck.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Handler/OBSCheck.pm'
+[   44s] './lib/Kanku/Handler/OBSServerFrontendTests.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Handler/OBSServerFrontendTests.pm'
+[   44s] './lib/Kanku/Handler/PortForward.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Handler/PortForward.pm'
+[   44s] './lib/Kanku/Handler/PrepareSSH.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Handler/PrepareSSH.pm'
+[   44s] './lib/Kanku/Handler/Reboot.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Handler/Reboot.pm'
+[   44s] './lib/Kanku/Handler/RemoveDomain.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Handler/RemoveDomain.pm'
+[   44s] './lib/Kanku/Handler/ResizeImage.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Handler/ResizeImage.pm'
+[   44s] './lib/Kanku/Handler/RevertQcow2Snapshot.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Handler/RevertQcow2Snapshot.pm'
+[   44s] './lib/Kanku/Handler/SaltSSH.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Handler/SaltSSH.pm'
+[   44s] './lib/Kanku/Handler/SetJobContext.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Handler/SetJobContext.pm'
+[   44s] './lib/Kanku/Handler/SetupNetwork.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Handler/SetupNetwork.pm'
+[   44s] './lib/Kanku/Handler/Wait.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Handler/Wait.pm'
+[   44s] './lib/Kanku/Handler/WaitForSystemd.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Handler/WaitForSystemd.pm'
+[   44s] './lib/Kanku/Handler.pod' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Handler.pod'
+[   44s] './lib/Kanku/Job.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Job.pm'
+[   44s] './lib/Kanku/JobList.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/JobList.pm'
+[   44s] './lib/Kanku/LibVirt' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/LibVirt'
+[   44s] './lib/Kanku/LibVirt/HostList.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/LibVirt/HostList.pm'
+[   44s] './lib/Kanku/Listener' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Listener'
+[   44s] './lib/Kanku/Listener/RabbitMQ.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Listener/RabbitMQ.pm'
+[   44s] './lib/Kanku/Notifier' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Notifier'
+[   44s] './lib/Kanku/Notifier/NSCA.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Notifier/NSCA.pm'
+[   44s] './lib/Kanku/Notifier/NSCAng.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Notifier/NSCAng.pm'
+[   44s] './lib/Kanku/Notifier/Sendmail.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Notifier/Sendmail.pm'
+[   44s] './lib/Kanku/Notifier.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Notifier.pm'
+[   44s] './lib/Kanku/NotifyQueue' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/NotifyQueue'
+[   44s] './lib/Kanku/NotifyQueue/Dummy.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/NotifyQueue/Dummy.pm'
+[   44s] './lib/Kanku/NotifyQueue/RabbitMQ.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/NotifyQueue/RabbitMQ.pm'
+[   44s] './lib/Kanku/NotifyQueue.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/NotifyQueue.pm'
+[   44s] './lib/Kanku/REST' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/REST'
+[   44s] './lib/Kanku/REST/Admin' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/REST/Admin'
+[   44s] './lib/Kanku/REST/Admin/Role.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/REST/Admin/Role.pm'
+[   44s] './lib/Kanku/REST/Admin/Task.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/REST/Admin/Task.pm'
+[   44s] './lib/Kanku/REST/Admin/User.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/REST/Admin/User.pm'
+[   44s] './lib/Kanku/REST/Guest.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/REST/Guest.pm'
+[   44s] './lib/Kanku/REST/Job.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/REST/Job.pm'
+[   44s] './lib/Kanku/REST/JobComment.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/REST/JobComment.pm'
+[   44s] './lib/Kanku/REST/JobGroup.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/REST/JobGroup.pm'
+[   44s] './lib/Kanku/REST/Worker.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/REST/Worker.pm'
+[   44s] './lib/Kanku/REST.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/REST.pm'
+[   44s] './lib/Kanku/RabbitMQ.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/RabbitMQ.pm'
+[   44s] './lib/Kanku/Roles' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Roles'
+[   44s] './lib/Kanku/Roles/Config' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Roles/Config'
+[   44s] './lib/Kanku/Roles/Config/Base.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Roles/Config/Base.pm'
+[   44s] './lib/Kanku/Roles/Config/KankuFile.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Roles/Config/KankuFile.pm'
+[   44s] './lib/Kanku/Roles/Config.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Roles/Config.pm'
+[   44s] './lib/Kanku/Roles/DB.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Roles/DB.pm'
+[   44s] './lib/Kanku/Roles/Daemon.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Roles/Daemon.pm'
+[   44s] './lib/Kanku/Roles/Dispatcher.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Roles/Dispatcher.pm'
+[   44s] './lib/Kanku/Roles/Handler.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Roles/Handler.pm'
+[   44s] './lib/Kanku/Roles/Helpers.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Roles/Helpers.pm'
+[   44s] './lib/Kanku/Roles/Logger.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Roles/Logger.pm'
+[   44s] './lib/Kanku/Roles/ModLoader.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Roles/ModLoader.pm'
+[   44s] './lib/Kanku/Roles/Notifier.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Roles/Notifier.pm'
+[   44s] './lib/Kanku/Roles/NotifyQueue.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Roles/NotifyQueue.pm'
+[   44s] './lib/Kanku/Roles/REST.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Roles/REST.pm'
+[   44s] './lib/Kanku/Roles/SSH.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Roles/SSH.pm'
+[   44s] './lib/Kanku/Roles/Serialize.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Roles/Serialize.pm'
+[   44s] './lib/Kanku/Schema' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Schema'
+[   44s] './lib/Kanku/Schema/Result' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Schema/Result'
+[   44s] './lib/Kanku/Schema/Result/ImageDownloadHistory.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Schema/Result/ImageDownloadHistory.pm'
+[   44s] './lib/Kanku/Schema/Result/JobGroup.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Schema/Result/JobGroup.pm'
+[   44s] './lib/Kanku/Schema/Result/JobHistory.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Schema/Result/JobHistory.pm'
+[   44s] './lib/Kanku/Schema/Result/JobHistoryComment.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Schema/Result/JobHistoryComment.pm'
+[   44s] './lib/Kanku/Schema/Result/JobHistorySub.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Schema/Result/JobHistorySub.pm'
+[   44s] './lib/Kanku/Schema/Result/JobWaitFor.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Schema/Result/JobWaitFor.pm'
+[   44s] './lib/Kanku/Schema/Result/ObsCheckHistory.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Schema/Result/ObsCheckHistory.pm'
+[   44s] './lib/Kanku/Schema/Result/Role.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Schema/Result/Role.pm'
+[   44s] './lib/Kanku/Schema/Result/RoleRequest.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Schema/Result/RoleRequest.pm'
+[   44s] './lib/Kanku/Schema/Result/StateWorker.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Schema/Result/StateWorker.pm'
+[   44s] './lib/Kanku/Schema/Result/User.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Schema/Result/User.pm'
+[   44s] './lib/Kanku/Schema/Result/UserRole.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Schema/Result/UserRole.pm'
+[   44s] './lib/Kanku/Schema/Result/WsSession.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Schema/Result/WsSession.pm'
+[   44s] './lib/Kanku/Schema/Result/WsToken.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Schema/Result/WsToken.pm'
+[   44s] './lib/Kanku/Schema.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Schema.pm'
+[   44s] './lib/Kanku/Setup' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Setup'
+[   44s] './lib/Kanku/Setup/Devel.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Setup/Devel.pm'
+[   44s] './lib/Kanku/Setup/LibVirt' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Setup/LibVirt'
+[   44s] './lib/Kanku/Setup/LibVirt/Network.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Setup/LibVirt/Network.pm'
+[   44s] './lib/Kanku/Setup/Roles' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Setup/Roles'
+[   44s] './lib/Kanku/Setup/Roles/Common.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Setup/Roles/Common.pm'
+[   44s] './lib/Kanku/Setup/Roles/Server.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Setup/Roles/Server.pm'
+[   44s] './lib/Kanku/Setup/Server' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Setup/Server'
+[   44s] './lib/Kanku/Setup/Server/Distributed.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Setup/Server/Distributed.pm'
+[   44s] './lib/Kanku/Setup/Server/Standalone.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Setup/Server/Standalone.pm'
+[   44s] './lib/Kanku/Setup/Worker.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Setup/Worker.pm'
+[   44s] './lib/Kanku/Task' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Task'
+[   44s] './lib/Kanku/Task/Local.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Task/Local.pm'
+[   44s] './lib/Kanku/Task/Remote.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Task/Remote.pm'
+[   44s] './lib/Kanku/Task/RemoteAll.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Task/RemoteAll.pm'
+[   44s] './lib/Kanku/Task.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Task.pm'
+[   44s] './lib/Kanku/Test' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Test'
+[   44s] './lib/Kanku/Test/RabbitMQ.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Test/RabbitMQ.pm'
+[   44s] './lib/Kanku/Util' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Util'
+[   44s] './lib/Kanku/Util/CurlHttpDownload.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Util/CurlHttpDownload.pm'
+[   44s] './lib/Kanku/Util/DoD.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Util/DoD.pm'
+[   44s] './lib/Kanku/Util/IPTables.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Util/IPTables.pm'
+[   44s] './lib/Kanku/Util/VM' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Util/VM'
+[   44s] './lib/Kanku/Util/VM/Console.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Util/VM/Console.pm'
+[   44s] './lib/Kanku/Util/VM/Image.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Util/VM/Image.pm'
+[   44s] './lib/Kanku/Util/VM.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Util/VM.pm'
+[   44s] './lib/Kanku/Util.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Util.pm'
+[   44s] './lib/Kanku/Util.pod' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/Util.pod'
+[   44s] './lib/Kanku/WebSocket' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/WebSocket'
+[   44s] './lib/Kanku/WebSocket/Notification.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/WebSocket/Notification.pm'
+[   44s] './lib/Kanku/WebSocket/Session.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/WebSocket/Session.pm'
+[   44s] './lib/Kanku/YAML.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku/YAML.pm'
+[   44s] './lib/Kanku.pm' -> '/usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/lib/Kanku.pm'
+[   44s] cp -rv share/migrations /usr/src/packages/BUILD/debian/kanku/usr/share/kanku/
+[   44s] 'share/migrations' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations'
+[   44s] 'share/migrations/SQLite' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite'
+[   44s] 'share/migrations/SQLite/deploy' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/deploy'
+[   44s] 'share/migrations/SQLite/deploy/1' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/deploy/1'
+[   44s] 'share/migrations/SQLite/deploy/1/001-auto-__VERSION.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/deploy/1/001-auto-__VERSION.sql'
+[   44s] 'share/migrations/SQLite/deploy/1/001-auto.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/deploy/1/001-auto.sql'
+[   44s] 'share/migrations/SQLite/deploy/10' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/deploy/10'
+[   44s] 'share/migrations/SQLite/deploy/10/001-auto-__VERSION.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/deploy/10/001-auto-__VERSION.sql'
+[   44s] 'share/migrations/SQLite/deploy/10/001-auto.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/deploy/10/001-auto.sql'
+[   44s] 'share/migrations/SQLite/deploy/11' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/deploy/11'
+[   44s] 'share/migrations/SQLite/deploy/11/001-auto-__VERSION.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/deploy/11/001-auto-__VERSION.sql'
+[   44s] 'share/migrations/SQLite/deploy/11/001-auto.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/deploy/11/001-auto.sql'
+[   44s] 'share/migrations/SQLite/deploy/12' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/deploy/12'
+[   44s] 'share/migrations/SQLite/deploy/12/001-auto-__VERSION.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/deploy/12/001-auto-__VERSION.sql'
+[   44s] 'share/migrations/SQLite/deploy/12/001-auto.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/deploy/12/001-auto.sql'
+[   44s] 'share/migrations/SQLite/deploy/13' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/deploy/13'
+[   44s] 'share/migrations/SQLite/deploy/13/001-auto-__VERSION.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/deploy/13/001-auto-__VERSION.sql'
+[   44s] 'share/migrations/SQLite/deploy/13/001-auto.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/deploy/13/001-auto.sql'
+[   44s] 'share/migrations/SQLite/deploy/14' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/deploy/14'
+[   44s] 'share/migrations/SQLite/deploy/14/001-auto-__VERSION.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/deploy/14/001-auto-__VERSION.sql'
+[   44s] 'share/migrations/SQLite/deploy/14/001-auto.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/deploy/14/001-auto.sql'
+[   44s] 'share/migrations/SQLite/deploy/15' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/deploy/15'
+[   44s] 'share/migrations/SQLite/deploy/15/001-auto-__VERSION.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/deploy/15/001-auto-__VERSION.sql'
+[   44s] 'share/migrations/SQLite/deploy/15/001-auto.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/deploy/15/001-auto.sql'
+[   44s] 'share/migrations/SQLite/deploy/16' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/deploy/16'
+[   44s] 'share/migrations/SQLite/deploy/16/001-auto-__VERSION.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/deploy/16/001-auto-__VERSION.sql'
+[   44s] 'share/migrations/SQLite/deploy/16/001-auto.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/deploy/16/001-auto.sql'
+[   44s] 'share/migrations/SQLite/deploy/17' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/deploy/17'
+[   44s] 'share/migrations/SQLite/deploy/17/001-auto-__VERSION.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/deploy/17/001-auto-__VERSION.sql'
+[   44s] 'share/migrations/SQLite/deploy/17/001-auto.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/deploy/17/001-auto.sql'
+[   44s] 'share/migrations/SQLite/deploy/18' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/deploy/18'
+[   44s] 'share/migrations/SQLite/deploy/18/001-auto-__VERSION.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/deploy/18/001-auto-__VERSION.sql'
+[   44s] 'share/migrations/SQLite/deploy/18/001-auto.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/deploy/18/001-auto.sql'
+[   44s] 'share/migrations/SQLite/deploy/2' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/deploy/2'
+[   44s] 'share/migrations/SQLite/deploy/2/001-auto-__VERSION.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/deploy/2/001-auto-__VERSION.sql'
+[   44s] 'share/migrations/SQLite/deploy/2/001-auto.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/deploy/2/001-auto.sql'
+[   44s] 'share/migrations/SQLite/deploy/3' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/deploy/3'
+[   44s] 'share/migrations/SQLite/deploy/3/001-auto-__VERSION.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/deploy/3/001-auto-__VERSION.sql'
+[   44s] 'share/migrations/SQLite/deploy/3/001-auto.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/deploy/3/001-auto.sql'
+[   44s] 'share/migrations/SQLite/deploy/4' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/deploy/4'
+[   44s] 'share/migrations/SQLite/deploy/4/001-auto-__VERSION.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/deploy/4/001-auto-__VERSION.sql'
+[   44s] 'share/migrations/SQLite/deploy/4/001-auto.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/deploy/4/001-auto.sql'
+[   44s] 'share/migrations/SQLite/deploy/5' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/deploy/5'
+[   44s] 'share/migrations/SQLite/deploy/5/001-auto-__VERSION.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/deploy/5/001-auto-__VERSION.sql'
+[   44s] 'share/migrations/SQLite/deploy/5/001-auto.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/deploy/5/001-auto.sql'
+[   44s] 'share/migrations/SQLite/deploy/6' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/deploy/6'
+[   44s] 'share/migrations/SQLite/deploy/6/001-auto-__VERSION.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/deploy/6/001-auto-__VERSION.sql'
+[   44s] 'share/migrations/SQLite/deploy/6/001-auto.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/deploy/6/001-auto.sql'
+[   44s] 'share/migrations/SQLite/deploy/7' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/deploy/7'
+[   44s] 'share/migrations/SQLite/deploy/7/001-auto-__VERSION.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/deploy/7/001-auto-__VERSION.sql'
+[   44s] 'share/migrations/SQLite/deploy/7/001-auto.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/deploy/7/001-auto.sql'
+[   44s] 'share/migrations/SQLite/deploy/8' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/deploy/8'
+[   44s] 'share/migrations/SQLite/deploy/8/001-auto-__VERSION.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/deploy/8/001-auto-__VERSION.sql'
+[   44s] 'share/migrations/SQLite/deploy/8/001-auto.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/deploy/8/001-auto.sql'
+[   44s] 'share/migrations/SQLite/deploy/9' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/deploy/9'
+[   44s] 'share/migrations/SQLite/deploy/9/001-auto-__VERSION.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/deploy/9/001-auto-__VERSION.sql'
+[   44s] 'share/migrations/SQLite/deploy/9/001-auto.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/deploy/9/001-auto.sql'
+[   44s] 'share/migrations/SQLite/downgrade' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/downgrade'
+[   44s] 'share/migrations/SQLite/downgrade/10-9' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/downgrade/10-9'
+[   44s] 'share/migrations/SQLite/downgrade/10-9/001-auto.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/downgrade/10-9/001-auto.sql'
+[   44s] 'share/migrations/SQLite/downgrade/11-10' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/downgrade/11-10'
+[   44s] 'share/migrations/SQLite/downgrade/11-10/001-auto.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/downgrade/11-10/001-auto.sql'
+[   44s] 'share/migrations/SQLite/downgrade/12-11' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/downgrade/12-11'
+[   44s] 'share/migrations/SQLite/downgrade/12-11/001-auto.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/downgrade/12-11/001-auto.sql'
+[   44s] 'share/migrations/SQLite/downgrade/13-12' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/downgrade/13-12'
+[   44s] 'share/migrations/SQLite/downgrade/13-12/001-auto.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/downgrade/13-12/001-auto.sql'
+[   44s] 'share/migrations/SQLite/downgrade/14-13' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/downgrade/14-13'
+[   44s] 'share/migrations/SQLite/downgrade/14-13/001-auto.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/downgrade/14-13/001-auto.sql'
+[   44s] 'share/migrations/SQLite/downgrade/15-14' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/downgrade/15-14'
+[   44s] 'share/migrations/SQLite/downgrade/15-14/001-auto.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/downgrade/15-14/001-auto.sql'
+[   44s] 'share/migrations/SQLite/downgrade/16-15' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/downgrade/16-15'
+[   44s] 'share/migrations/SQLite/downgrade/16-15/001-auto.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/downgrade/16-15/001-auto.sql'
+[   44s] 'share/migrations/SQLite/downgrade/17-16' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/downgrade/17-16'
+[   44s] 'share/migrations/SQLite/downgrade/17-16/001-auto.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/downgrade/17-16/001-auto.sql'
+[   44s] 'share/migrations/SQLite/downgrade/18-17' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/downgrade/18-17'
+[   44s] 'share/migrations/SQLite/downgrade/18-17/001-auto.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/downgrade/18-17/001-auto.sql'
+[   44s] 'share/migrations/SQLite/downgrade/2-1' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/downgrade/2-1'
+[   44s] 'share/migrations/SQLite/downgrade/2-1/001-auto.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/downgrade/2-1/001-auto.sql'
+[   44s] 'share/migrations/SQLite/downgrade/3-2' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/downgrade/3-2'
+[   44s] 'share/migrations/SQLite/downgrade/3-2/001-auto.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/downgrade/3-2/001-auto.sql'
+[   44s] 'share/migrations/SQLite/downgrade/4-3' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/downgrade/4-3'
+[   44s] 'share/migrations/SQLite/downgrade/4-3/001-auto.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/downgrade/4-3/001-auto.sql'
+[   44s] 'share/migrations/SQLite/downgrade/5-4' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/downgrade/5-4'
+[   44s] 'share/migrations/SQLite/downgrade/5-4/001-auto.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/downgrade/5-4/001-auto.sql'
+[   44s] 'share/migrations/SQLite/downgrade/6-5' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/downgrade/6-5'
+[   44s] 'share/migrations/SQLite/downgrade/6-5/001-auto.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/downgrade/6-5/001-auto.sql'
+[   44s] 'share/migrations/SQLite/downgrade/7-6' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/downgrade/7-6'
+[   44s] 'share/migrations/SQLite/downgrade/7-6/001-auto.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/downgrade/7-6/001-auto.sql'
+[   44s] 'share/migrations/SQLite/downgrade/8-7' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/downgrade/8-7'
+[   44s] 'share/migrations/SQLite/downgrade/8-7/001-auto.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/downgrade/8-7/001-auto.sql'
+[   44s] 'share/migrations/SQLite/downgrade/9-8' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/downgrade/9-8'
+[   44s] 'share/migrations/SQLite/downgrade/9-8/001-auto.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/downgrade/9-8/001-auto.sql'
+[   44s] 'share/migrations/SQLite/upgrade' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/upgrade'
+[   44s] 'share/migrations/SQLite/upgrade/1-2' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/upgrade/1-2'
+[   44s] 'share/migrations/SQLite/upgrade/1-2/001-auto.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/upgrade/1-2/001-auto.sql'
+[   44s] 'share/migrations/SQLite/upgrade/10-11' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/upgrade/10-11'
+[   44s] 'share/migrations/SQLite/upgrade/10-11/001-auto.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/upgrade/10-11/001-auto.sql'
+[   44s] 'share/migrations/SQLite/upgrade/11-12' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/upgrade/11-12'
+[   44s] 'share/migrations/SQLite/upgrade/11-12/001-auto.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/upgrade/11-12/001-auto.sql'
+[   44s] 'share/migrations/SQLite/upgrade/12-13' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/upgrade/12-13'
+[   44s] 'share/migrations/SQLite/upgrade/12-13/001-auto.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/upgrade/12-13/001-auto.sql'
+[   44s] 'share/migrations/SQLite/upgrade/13-14' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/upgrade/13-14'
+[   44s] 'share/migrations/SQLite/upgrade/13-14/001-auto.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/upgrade/13-14/001-auto.sql'
+[   44s] 'share/migrations/SQLite/upgrade/14-15' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/upgrade/14-15'
+[   44s] 'share/migrations/SQLite/upgrade/14-15/001-auto.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/upgrade/14-15/001-auto.sql'
+[   44s] 'share/migrations/SQLite/upgrade/15-16' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/upgrade/15-16'
+[   44s] 'share/migrations/SQLite/upgrade/15-16/001-auto.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/upgrade/15-16/001-auto.sql'
+[   44s] 'share/migrations/SQLite/upgrade/16-17' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/upgrade/16-17'
+[   44s] 'share/migrations/SQLite/upgrade/16-17/001-auto.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/upgrade/16-17/001-auto.sql'
+[   44s] 'share/migrations/SQLite/upgrade/17-18' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/upgrade/17-18'
+[   44s] 'share/migrations/SQLite/upgrade/17-18/001-auto.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/upgrade/17-18/001-auto.sql'
+[   44s] 'share/migrations/SQLite/upgrade/2-3' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/upgrade/2-3'
+[   44s] 'share/migrations/SQLite/upgrade/2-3/001-auto.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/upgrade/2-3/001-auto.sql'
+[   44s] 'share/migrations/SQLite/upgrade/3-4' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/upgrade/3-4'
+[   44s] 'share/migrations/SQLite/upgrade/3-4/001-auto.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/upgrade/3-4/001-auto.sql'
+[   44s] 'share/migrations/SQLite/upgrade/4-5' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/upgrade/4-5'
+[   44s] 'share/migrations/SQLite/upgrade/4-5/001-auto.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/upgrade/4-5/001-auto.sql'
+[   44s] 'share/migrations/SQLite/upgrade/5-6' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/upgrade/5-6'
+[   44s] 'share/migrations/SQLite/upgrade/5-6/001-auto.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/upgrade/5-6/001-auto.sql'
+[   44s] 'share/migrations/SQLite/upgrade/6-7' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/upgrade/6-7'
+[   44s] 'share/migrations/SQLite/upgrade/6-7/001-auto.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/upgrade/6-7/001-auto.sql'
+[   44s] 'share/migrations/SQLite/upgrade/7-8' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/upgrade/7-8'
+[   44s] 'share/migrations/SQLite/upgrade/7-8/001-auto.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/upgrade/7-8/001-auto.sql'
+[   44s] 'share/migrations/SQLite/upgrade/8-9' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/upgrade/8-9'
+[   44s] 'share/migrations/SQLite/upgrade/8-9/001-auto.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/upgrade/8-9/001-auto.sql'
+[   44s] 'share/migrations/SQLite/upgrade/9-10' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/upgrade/9-10'
+[   44s] 'share/migrations/SQLite/upgrade/9-10/001-auto.sql' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/SQLite/upgrade/9-10/001-auto.sql'
+[   44s] 'share/migrations/_source' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/_source'
+[   44s] 'share/migrations/_source/deploy' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/_source/deploy'
+[   44s] 'share/migrations/_source/deploy/1' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/_source/deploy/1'
+[   44s] 'share/migrations/_source/deploy/1/001-auto-__VERSION.yml' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/_source/deploy/1/001-auto-__VERSION.yml'
+[   44s] 'share/migrations/_source/deploy/1/001-auto.yml' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/_source/deploy/1/001-auto.yml'
+[   44s] 'share/migrations/_source/deploy/10' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/_source/deploy/10'
+[   44s] 'share/migrations/_source/deploy/10/001-auto-__VERSION.yml' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/_source/deploy/10/001-auto-__VERSION.yml'
+[   44s] 'share/migrations/_source/deploy/10/001-auto.yml' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/_source/deploy/10/001-auto.yml'
+[   44s] 'share/migrations/_source/deploy/11' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/_source/deploy/11'
+[   44s] 'share/migrations/_source/deploy/11/001-auto-__VERSION.yml' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/_source/deploy/11/001-auto-__VERSION.yml'
+[   44s] 'share/migrations/_source/deploy/11/001-auto.yml' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/_source/deploy/11/001-auto.yml'
+[   44s] 'share/migrations/_source/deploy/12' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/_source/deploy/12'
+[   44s] 'share/migrations/_source/deploy/12/001-auto-__VERSION.yml' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/_source/deploy/12/001-auto-__VERSION.yml'
+[   44s] 'share/migrations/_source/deploy/12/001-auto.yml' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/_source/deploy/12/001-auto.yml'
+[   44s] 'share/migrations/_source/deploy/13' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/_source/deploy/13'
+[   44s] 'share/migrations/_source/deploy/13/001-auto-__VERSION.yml' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/_source/deploy/13/001-auto-__VERSION.yml'
+[   44s] 'share/migrations/_source/deploy/13/001-auto.yml' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/_source/deploy/13/001-auto.yml'
+[   44s] 'share/migrations/_source/deploy/14' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/_source/deploy/14'
+[   44s] 'share/migrations/_source/deploy/14/001-auto-__VERSION.yml' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/_source/deploy/14/001-auto-__VERSION.yml'
+[   44s] 'share/migrations/_source/deploy/14/001-auto.yml' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/_source/deploy/14/001-auto.yml'
+[   44s] 'share/migrations/_source/deploy/15' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/_source/deploy/15'
+[   44s] 'share/migrations/_source/deploy/15/001-auto-__VERSION.yml' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/_source/deploy/15/001-auto-__VERSION.yml'
+[   44s] 'share/migrations/_source/deploy/15/001-auto.yml' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/_source/deploy/15/001-auto.yml'
+[   44s] 'share/migrations/_source/deploy/16' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/_source/deploy/16'
+[   44s] 'share/migrations/_source/deploy/16/001-auto-__VERSION.yml' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/_source/deploy/16/001-auto-__VERSION.yml'
+[   44s] 'share/migrations/_source/deploy/16/001-auto.yml' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/_source/deploy/16/001-auto.yml'
+[   44s] 'share/migrations/_source/deploy/17' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/_source/deploy/17'
+[   44s] 'share/migrations/_source/deploy/17/001-auto-__VERSION.yml' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/_source/deploy/17/001-auto-__VERSION.yml'
+[   44s] 'share/migrations/_source/deploy/17/001-auto.yml' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/_source/deploy/17/001-auto.yml'
+[   44s] 'share/migrations/_source/deploy/18' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/_source/deploy/18'
+[   44s] 'share/migrations/_source/deploy/18/001-auto-__VERSION.yml' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/_source/deploy/18/001-auto-__VERSION.yml'
+[   44s] 'share/migrations/_source/deploy/18/001-auto.yml' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/_source/deploy/18/001-auto.yml'
+[   44s] 'share/migrations/_source/deploy/2' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/_source/deploy/2'
+[   44s] 'share/migrations/_source/deploy/2/001-auto-__VERSION.yml' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/_source/deploy/2/001-auto-__VERSION.yml'
+[   44s] 'share/migrations/_source/deploy/2/001-auto.yml' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/_source/deploy/2/001-auto.yml'
+[   44s] 'share/migrations/_source/deploy/3' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/_source/deploy/3'
+[   44s] 'share/migrations/_source/deploy/3/001-auto-__VERSION.yml' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/_source/deploy/3/001-auto-__VERSION.yml'
+[   44s] 'share/migrations/_source/deploy/3/001-auto.yml' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/_source/deploy/3/001-auto.yml'
+[   44s] 'share/migrations/_source/deploy/4' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/_source/deploy/4'
+[   44s] 'share/migrations/_source/deploy/4/001-auto-__VERSION.yml' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/_source/deploy/4/001-auto-__VERSION.yml'
+[   44s] 'share/migrations/_source/deploy/4/001-auto.yml' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/_source/deploy/4/001-auto.yml'
+[   44s] 'share/migrations/_source/deploy/5' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/_source/deploy/5'
+[   44s] 'share/migrations/_source/deploy/5/001-auto-__VERSION.yml' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/_source/deploy/5/001-auto-__VERSION.yml'
+[   44s] 'share/migrations/_source/deploy/5/001-auto.yml' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/_source/deploy/5/001-auto.yml'
+[   44s] 'share/migrations/_source/deploy/6' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/_source/deploy/6'
+[   44s] 'share/migrations/_source/deploy/6/001-auto-__VERSION.yml' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/_source/deploy/6/001-auto-__VERSION.yml'
+[   44s] 'share/migrations/_source/deploy/6/001-auto.yml' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/_source/deploy/6/001-auto.yml'
+[   44s] 'share/migrations/_source/deploy/7' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/_source/deploy/7'
+[   44s] 'share/migrations/_source/deploy/7/001-auto-__VERSION.yml' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/_source/deploy/7/001-auto-__VERSION.yml'
+[   44s] 'share/migrations/_source/deploy/7/001-auto.yml' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/_source/deploy/7/001-auto.yml'
+[   44s] 'share/migrations/_source/deploy/8' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/_source/deploy/8'
+[   44s] 'share/migrations/_source/deploy/8/001-auto-__VERSION.yml' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/_source/deploy/8/001-auto-__VERSION.yml'
+[   44s] 'share/migrations/_source/deploy/8/001-auto.yml' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/_source/deploy/8/001-auto.yml'
+[   44s] 'share/migrations/_source/deploy/9' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/_source/deploy/9'
+[   44s] 'share/migrations/_source/deploy/9/001-auto-__VERSION.yml' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/_source/deploy/9/001-auto-__VERSION.yml'
+[   44s] 'share/migrations/_source/deploy/9/001-auto.yml' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/migrations/_source/deploy/9/001-auto.yml'
+[   44s] cp -rv share/fixtures /usr/src/packages/BUILD/debian/kanku/usr/share/kanku/
+[   44s] 'share/fixtures' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures'
+[   44s] 'share/fixtures/1' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/1'
+[   44s] 'share/fixtures/1/conf' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/1/conf'
+[   44s] 'share/fixtures/1/conf/all_tables.json' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/1/conf/all_tables.json'
+[   44s] 'share/fixtures/10' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/10'
+[   44s] 'share/fixtures/10/conf' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/10/conf'
+[   44s] 'share/fixtures/10/conf/all_tables.json' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/10/conf/all_tables.json'
+[   44s] 'share/fixtures/10/conf/install.json' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/10/conf/install.json'
+[   44s] 'share/fixtures/10/install' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/10/install'
+[   44s] 'share/fixtures/10/install/_config_set' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/10/install/_config_set'
+[   44s] 'share/fixtures/10/install/_dumper_version' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/10/install/_dumper_version'
+[   44s] 'share/fixtures/10/install/role' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/10/install/role'
+[   44s] 'share/fixtures/10/install/role/1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/10/install/role/1.fix'
+[   44s] 'share/fixtures/10/install/role/2.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/10/install/role/2.fix'
+[   44s] 'share/fixtures/10/install/role/3.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/10/install/role/3.fix'
+[   44s] 'share/fixtures/10/install/user' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/10/install/user'
+[   44s] 'share/fixtures/10/install/user/1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/10/install/user/1.fix'
+[   44s] 'share/fixtures/10/install/user_roles' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/10/install/user_roles'
+[   44s] 'share/fixtures/10/install/user_roles/1-1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/10/install/user_roles/1-1.fix'
+[   44s] 'share/fixtures/10/install/user_roles/1-2.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/10/install/user_roles/1-2.fix'
+[   44s] 'share/fixtures/10/install/user_roles/1-3.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/10/install/user_roles/1-3.fix'
+[   44s] 'share/fixtures/11' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/11'
+[   44s] 'share/fixtures/11/conf' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/11/conf'
+[   44s] 'share/fixtures/11/conf/all_tables.json' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/11/conf/all_tables.json'
+[   44s] 'share/fixtures/11/conf/install.json' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/11/conf/install.json'
+[   44s] 'share/fixtures/11/install' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/11/install'
+[   44s] 'share/fixtures/11/install/_config_set' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/11/install/_config_set'
+[   44s] 'share/fixtures/11/install/_dumper_version' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/11/install/_dumper_version'
+[   44s] 'share/fixtures/11/install/role' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/11/install/role'
+[   44s] 'share/fixtures/11/install/role/1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/11/install/role/1.fix'
+[   44s] 'share/fixtures/11/install/role/2.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/11/install/role/2.fix'
+[   44s] 'share/fixtures/11/install/role/3.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/11/install/role/3.fix'
+[   44s] 'share/fixtures/11/install/user' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/11/install/user'
+[   44s] 'share/fixtures/11/install/user/1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/11/install/user/1.fix'
+[   44s] 'share/fixtures/11/install/user_roles' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/11/install/user_roles'
+[   44s] 'share/fixtures/11/install/user_roles/1-1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/11/install/user_roles/1-1.fix'
+[   44s] 'share/fixtures/11/install/user_roles/1-2.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/11/install/user_roles/1-2.fix'
+[   44s] 'share/fixtures/11/install/user_roles/1-3.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/11/install/user_roles/1-3.fix'
+[   44s] 'share/fixtures/12' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/12'
+[   44s] 'share/fixtures/12/all_tables' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/12/all_tables'
+[   44s] 'share/fixtures/12/all_tables/_config_set' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/12/all_tables/_config_set'
+[   44s] 'share/fixtures/12/all_tables/_dumper_version' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/12/all_tables/_dumper_version'
+[   44s] 'share/fixtures/12/all_tables/role' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/12/all_tables/role'
+[   44s] 'share/fixtures/12/all_tables/role/1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/12/all_tables/role/1.fix'
+[   44s] 'share/fixtures/12/all_tables/role/2.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/12/all_tables/role/2.fix'
+[   44s] 'share/fixtures/12/all_tables/role/3.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/12/all_tables/role/3.fix'
+[   44s] 'share/fixtures/12/all_tables/user' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/12/all_tables/user'
+[   44s] 'share/fixtures/12/all_tables/user/1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/12/all_tables/user/1.fix'
+[   44s] 'share/fixtures/12/all_tables/user_roles' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/12/all_tables/user_roles'
+[   44s] 'share/fixtures/12/all_tables/user_roles/1-1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/12/all_tables/user_roles/1-1.fix'
+[   44s] 'share/fixtures/12/all_tables/user_roles/1-2.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/12/all_tables/user_roles/1-2.fix'
+[   44s] 'share/fixtures/12/all_tables/user_roles/1-3.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/12/all_tables/user_roles/1-3.fix'
+[   44s] 'share/fixtures/12/conf' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/12/conf'
+[   44s] 'share/fixtures/12/conf/all_tables.json' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/12/conf/all_tables.json'
+[   44s] 'share/fixtures/12/conf/install.json' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/12/conf/install.json'
+[   44s] 'share/fixtures/12/install' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/12/install'
+[   44s] 'share/fixtures/12/install/_config_set' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/12/install/_config_set'
+[   44s] 'share/fixtures/12/install/_dumper_version' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/12/install/_dumper_version'
+[   44s] 'share/fixtures/12/install/role' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/12/install/role'
+[   44s] 'share/fixtures/12/install/role/1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/12/install/role/1.fix'
+[   44s] 'share/fixtures/12/install/role/2.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/12/install/role/2.fix'
+[   44s] 'share/fixtures/12/install/role/3.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/12/install/role/3.fix'
+[   44s] 'share/fixtures/12/install/user' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/12/install/user'
+[   44s] 'share/fixtures/12/install/user/1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/12/install/user/1.fix'
+[   44s] 'share/fixtures/12/install/user_roles' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/12/install/user_roles'
+[   44s] 'share/fixtures/12/install/user_roles/1-1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/12/install/user_roles/1-1.fix'
+[   44s] 'share/fixtures/12/install/user_roles/1-2.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/12/install/user_roles/1-2.fix'
+[   44s] 'share/fixtures/12/install/user_roles/1-3.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/12/install/user_roles/1-3.fix'
+[   44s] 'share/fixtures/13' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/13'
+[   44s] 'share/fixtures/13/all_tables' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/13/all_tables'
+[   44s] 'share/fixtures/13/all_tables/_config_set' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/13/all_tables/_config_set'
+[   44s] 'share/fixtures/13/all_tables/_dumper_version' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/13/all_tables/_dumper_version'
+[   44s] 'share/fixtures/13/all_tables/role' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/13/all_tables/role'
+[   44s] 'share/fixtures/13/all_tables/role/1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/13/all_tables/role/1.fix'
+[   44s] 'share/fixtures/13/all_tables/role/2.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/13/all_tables/role/2.fix'
+[   44s] 'share/fixtures/13/all_tables/role/3.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/13/all_tables/role/3.fix'
+[   44s] 'share/fixtures/13/all_tables/user' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/13/all_tables/user'
+[   44s] 'share/fixtures/13/all_tables/user/1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/13/all_tables/user/1.fix'
+[   44s] 'share/fixtures/13/all_tables/user_roles' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/13/all_tables/user_roles'
+[   44s] 'share/fixtures/13/all_tables/user_roles/1-1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/13/all_tables/user_roles/1-1.fix'
+[   44s] 'share/fixtures/13/all_tables/user_roles/1-2.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/13/all_tables/user_roles/1-2.fix'
+[   44s] 'share/fixtures/13/all_tables/user_roles/1-3.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/13/all_tables/user_roles/1-3.fix'
+[   44s] 'share/fixtures/13/conf' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/13/conf'
+[   44s] 'share/fixtures/13/conf/all_tables.json' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/13/conf/all_tables.json'
+[   44s] 'share/fixtures/13/conf/install.json' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/13/conf/install.json'
+[   44s] 'share/fixtures/13/install' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/13/install'
+[   44s] 'share/fixtures/13/install/_config_set' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/13/install/_config_set'
+[   44s] 'share/fixtures/13/install/_dumper_version' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/13/install/_dumper_version'
+[   44s] 'share/fixtures/13/install/role' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/13/install/role'
+[   44s] 'share/fixtures/13/install/role/1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/13/install/role/1.fix'
+[   44s] 'share/fixtures/13/install/role/2.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/13/install/role/2.fix'
+[   44s] 'share/fixtures/13/install/role/3.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/13/install/role/3.fix'
+[   44s] 'share/fixtures/13/install/user' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/13/install/user'
+[   44s] 'share/fixtures/13/install/user/1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/13/install/user/1.fix'
+[   44s] 'share/fixtures/13/install/user_roles' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/13/install/user_roles'
+[   44s] 'share/fixtures/13/install/user_roles/1-1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/13/install/user_roles/1-1.fix'
+[   44s] 'share/fixtures/13/install/user_roles/1-2.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/13/install/user_roles/1-2.fix'
+[   44s] 'share/fixtures/13/install/user_roles/1-3.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/13/install/user_roles/1-3.fix'
+[   44s] 'share/fixtures/14' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/14'
+[   44s] 'share/fixtures/14/all_tables' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/14/all_tables'
+[   44s] 'share/fixtures/14/all_tables/_config_set' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/14/all_tables/_config_set'
+[   44s] 'share/fixtures/14/all_tables/_dumper_version' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/14/all_tables/_dumper_version'
+[   44s] 'share/fixtures/14/all_tables/role' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/14/all_tables/role'
+[   44s] 'share/fixtures/14/all_tables/role/1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/14/all_tables/role/1.fix'
+[   44s] 'share/fixtures/14/all_tables/role/2.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/14/all_tables/role/2.fix'
+[   44s] 'share/fixtures/14/all_tables/role/3.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/14/all_tables/role/3.fix'
+[   44s] 'share/fixtures/14/all_tables/user' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/14/all_tables/user'
+[   44s] 'share/fixtures/14/all_tables/user/1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/14/all_tables/user/1.fix'
+[   44s] 'share/fixtures/14/all_tables/user_roles' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/14/all_tables/user_roles'
+[   44s] 'share/fixtures/14/all_tables/user_roles/1-1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/14/all_tables/user_roles/1-1.fix'
+[   44s] 'share/fixtures/14/all_tables/user_roles/1-2.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/14/all_tables/user_roles/1-2.fix'
+[   44s] 'share/fixtures/14/all_tables/user_roles/1-3.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/14/all_tables/user_roles/1-3.fix'
+[   44s] 'share/fixtures/14/conf' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/14/conf'
+[   44s] 'share/fixtures/14/conf/all_tables.json' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/14/conf/all_tables.json'
+[   44s] 'share/fixtures/14/conf/install.json' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/14/conf/install.json'
+[   44s] 'share/fixtures/14/install' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/14/install'
+[   44s] 'share/fixtures/14/install/_config_set' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/14/install/_config_set'
+[   44s] 'share/fixtures/14/install/_dumper_version' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/14/install/_dumper_version'
+[   44s] 'share/fixtures/14/install/role' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/14/install/role'
+[   44s] 'share/fixtures/14/install/role/1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/14/install/role/1.fix'
+[   44s] 'share/fixtures/14/install/role/2.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/14/install/role/2.fix'
+[   44s] 'share/fixtures/14/install/role/3.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/14/install/role/3.fix'
+[   44s] 'share/fixtures/14/install/user' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/14/install/user'
+[   44s] 'share/fixtures/14/install/user/1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/14/install/user/1.fix'
+[   44s] 'share/fixtures/14/install/user_roles' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/14/install/user_roles'
+[   44s] 'share/fixtures/14/install/user_roles/1-1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/14/install/user_roles/1-1.fix'
+[   44s] 'share/fixtures/14/install/user_roles/1-2.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/14/install/user_roles/1-2.fix'
+[   44s] 'share/fixtures/14/install/user_roles/1-3.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/14/install/user_roles/1-3.fix'
+[   44s] 'share/fixtures/15' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/15'
+[   44s] 'share/fixtures/15/all_tables' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/15/all_tables'
+[   44s] 'share/fixtures/15/all_tables/_config_set' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/15/all_tables/_config_set'
+[   44s] 'share/fixtures/15/all_tables/_dumper_version' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/15/all_tables/_dumper_version'
+[   44s] 'share/fixtures/15/all_tables/role' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/15/all_tables/role'
+[   44s] 'share/fixtures/15/all_tables/role/1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/15/all_tables/role/1.fix'
+[   44s] 'share/fixtures/15/all_tables/role/2.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/15/all_tables/role/2.fix'
+[   44s] 'share/fixtures/15/all_tables/role/3.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/15/all_tables/role/3.fix'
+[   44s] 'share/fixtures/15/all_tables/user' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/15/all_tables/user'
+[   44s] 'share/fixtures/15/all_tables/user/1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/15/all_tables/user/1.fix'
+[   44s] 'share/fixtures/15/all_tables/user_roles' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/15/all_tables/user_roles'
+[   44s] 'share/fixtures/15/all_tables/user_roles/1-1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/15/all_tables/user_roles/1-1.fix'
+[   44s] 'share/fixtures/15/all_tables/user_roles/1-2.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/15/all_tables/user_roles/1-2.fix'
+[   44s] 'share/fixtures/15/all_tables/user_roles/1-3.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/15/all_tables/user_roles/1-3.fix'
+[   44s] 'share/fixtures/15/conf' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/15/conf'
+[   44s] 'share/fixtures/15/conf/all_tables.json' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/15/conf/all_tables.json'
+[   44s] 'share/fixtures/15/conf/install.json' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/15/conf/install.json'
+[   44s] 'share/fixtures/15/install' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/15/install'
+[   44s] 'share/fixtures/15/install/_config_set' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/15/install/_config_set'
+[   44s] 'share/fixtures/15/install/_dumper_version' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/15/install/_dumper_version'
+[   44s] 'share/fixtures/15/install/role' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/15/install/role'
+[   44s] 'share/fixtures/15/install/role/1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/15/install/role/1.fix'
+[   44s] 'share/fixtures/15/install/role/2.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/15/install/role/2.fix'
+[   44s] 'share/fixtures/15/install/role/3.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/15/install/role/3.fix'
+[   44s] 'share/fixtures/15/install/user' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/15/install/user'
+[   44s] 'share/fixtures/15/install/user/1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/15/install/user/1.fix'
+[   44s] 'share/fixtures/15/install/user_roles' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/15/install/user_roles'
+[   44s] 'share/fixtures/15/install/user_roles/1-1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/15/install/user_roles/1-1.fix'
+[   44s] 'share/fixtures/15/install/user_roles/1-2.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/15/install/user_roles/1-2.fix'
+[   44s] 'share/fixtures/15/install/user_roles/1-3.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/15/install/user_roles/1-3.fix'
+[   44s] 'share/fixtures/16' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/16'
+[   44s] 'share/fixtures/16/all_tables' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/16/all_tables'
+[   44s] 'share/fixtures/16/all_tables/_config_set' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/16/all_tables/_config_set'
+[   44s] 'share/fixtures/16/all_tables/_dumper_version' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/16/all_tables/_dumper_version'
+[   44s] 'share/fixtures/16/all_tables/role' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/16/all_tables/role'
+[   44s] 'share/fixtures/16/all_tables/role/1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/16/all_tables/role/1.fix'
+[   44s] 'share/fixtures/16/all_tables/role/2.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/16/all_tables/role/2.fix'
+[   44s] 'share/fixtures/16/all_tables/role/3.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/16/all_tables/role/3.fix'
+[   44s] 'share/fixtures/16/all_tables/user' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/16/all_tables/user'
+[   44s] 'share/fixtures/16/all_tables/user/1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/16/all_tables/user/1.fix'
+[   44s] 'share/fixtures/16/all_tables/user_roles' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/16/all_tables/user_roles'
+[   44s] 'share/fixtures/16/all_tables/user_roles/1-1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/16/all_tables/user_roles/1-1.fix'
+[   44s] 'share/fixtures/16/all_tables/user_roles/1-2.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/16/all_tables/user_roles/1-2.fix'
+[   44s] 'share/fixtures/16/all_tables/user_roles/1-3.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/16/all_tables/user_roles/1-3.fix'
+[   44s] 'share/fixtures/16/conf' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/16/conf'
+[   44s] 'share/fixtures/16/conf/all_tables.json' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/16/conf/all_tables.json'
+[   44s] 'share/fixtures/16/conf/install.json' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/16/conf/install.json'
+[   44s] 'share/fixtures/16/install' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/16/install'
+[   44s] 'share/fixtures/16/install/_config_set' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/16/install/_config_set'
+[   44s] 'share/fixtures/16/install/_dumper_version' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/16/install/_dumper_version'
+[   44s] 'share/fixtures/16/install/role' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/16/install/role'
+[   44s] 'share/fixtures/16/install/role/1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/16/install/role/1.fix'
+[   44s] 'share/fixtures/16/install/role/2.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/16/install/role/2.fix'
+[   44s] 'share/fixtures/16/install/role/3.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/16/install/role/3.fix'
+[   44s] 'share/fixtures/16/install/user' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/16/install/user'
+[   44s] 'share/fixtures/16/install/user/1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/16/install/user/1.fix'
+[   44s] 'share/fixtures/16/install/user_roles' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/16/install/user_roles'
+[   44s] 'share/fixtures/16/install/user_roles/1-1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/16/install/user_roles/1-1.fix'
+[   44s] 'share/fixtures/16/install/user_roles/1-2.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/16/install/user_roles/1-2.fix'
+[   44s] 'share/fixtures/16/install/user_roles/1-3.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/16/install/user_roles/1-3.fix'
+[   44s] 'share/fixtures/17' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17'
+[   44s] 'share/fixtures/17/all_tables' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/all_tables'
+[   44s] 'share/fixtures/17/all_tables/_config_set' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/all_tables/_config_set'
+[   44s] 'share/fixtures/17/all_tables/_dumper_version' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/all_tables/_dumper_version'
+[   44s] 'share/fixtures/17/all_tables/role' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/all_tables/role'
+[   44s] 'share/fixtures/17/all_tables/role/1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/all_tables/role/1.fix'
+[   44s] 'share/fixtures/17/all_tables/role/2.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/all_tables/role/2.fix'
+[   44s] 'share/fixtures/17/all_tables/role/3.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/all_tables/role/3.fix'
+[   44s] 'share/fixtures/17/all_tables/user' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/all_tables/user'
+[   44s] 'share/fixtures/17/all_tables/user/1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/all_tables/user/1.fix'
+[   44s] 'share/fixtures/17/all_tables/user_roles' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/all_tables/user_roles'
+[   44s] 'share/fixtures/17/all_tables/user_roles/1-1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/all_tables/user_roles/1-1.fix'
+[   44s] 'share/fixtures/17/all_tables/user_roles/1-2.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/all_tables/user_roles/1-2.fix'
+[   44s] 'share/fixtures/17/all_tables/user_roles/1-3.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/all_tables/user_roles/1-3.fix'
+[   44s] 'share/fixtures/17/conf' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/conf'
+[   44s] 'share/fixtures/17/conf/all_tables.json' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/conf/all_tables.json'
+[   44s] 'share/fixtures/17/conf/install.json' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/conf/install.json'
+[   44s] 'share/fixtures/17/conf/test.json' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/conf/test.json'
+[   44s] 'share/fixtures/17/install' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/install'
+[   44s] 'share/fixtures/17/install/_config_set' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/install/_config_set'
+[   44s] 'share/fixtures/17/install/_dumper_version' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/install/_dumper_version'
+[   44s] 'share/fixtures/17/install/role' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/install/role'
+[   44s] 'share/fixtures/17/install/role/1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/install/role/1.fix'
+[   44s] 'share/fixtures/17/install/role/2.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/install/role/2.fix'
+[   44s] 'share/fixtures/17/install/role/3.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/install/role/3.fix'
+[   44s] 'share/fixtures/17/install/user' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/install/user'
+[   44s] 'share/fixtures/17/install/user/1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/install/user/1.fix'
+[   44s] 'share/fixtures/17/install/user_roles' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/install/user_roles'
+[   44s] 'share/fixtures/17/install/user_roles/1-1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/install/user_roles/1-1.fix'
+[   44s] 'share/fixtures/17/install/user_roles/1-2.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/install/user_roles/1-2.fix'
+[   44s] 'share/fixtures/17/install/user_roles/1-3.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/install/user_roles/1-3.fix'
+[   44s] 'share/fixtures/17/test' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test'
+[   44s] 'share/fixtures/17/test/_config_set' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/_config_set'
+[   44s] 'share/fixtures/17/test/_dumper_version' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/_dumper_version'
+[   44s] 'share/fixtures/17/test/job_history' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history'
+[   44s] 'share/fixtures/17/test/job_history/1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history/1.fix'
+[   44s] 'share/fixtures/17/test/job_history/10.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history/10.fix'
+[   44s] 'share/fixtures/17/test/job_history/11.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history/11.fix'
+[   44s] 'share/fixtures/17/test/job_history/12.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history/12.fix'
+[   44s] 'share/fixtures/17/test/job_history/13.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history/13.fix'
+[   44s] 'share/fixtures/17/test/job_history/14.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history/14.fix'
+[   44s] 'share/fixtures/17/test/job_history/15.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history/15.fix'
+[   44s] 'share/fixtures/17/test/job_history/16.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history/16.fix'
+[   44s] 'share/fixtures/17/test/job_history/17.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history/17.fix'
+[   44s] 'share/fixtures/17/test/job_history/18.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history/18.fix'
+[   44s] 'share/fixtures/17/test/job_history/19.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history/19.fix'
+[   44s] 'share/fixtures/17/test/job_history/2.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history/2.fix'
+[   44s] 'share/fixtures/17/test/job_history/20.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history/20.fix'
+[   44s] 'share/fixtures/17/test/job_history/21.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history/21.fix'
+[   44s] 'share/fixtures/17/test/job_history/22.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history/22.fix'
+[   44s] 'share/fixtures/17/test/job_history/23.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history/23.fix'
+[   44s] 'share/fixtures/17/test/job_history/24.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history/24.fix'
+[   44s] 'share/fixtures/17/test/job_history/25.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history/25.fix'
+[   44s] 'share/fixtures/17/test/job_history/26.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history/26.fix'
+[   44s] 'share/fixtures/17/test/job_history/27.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history/27.fix'
+[   44s] 'share/fixtures/17/test/job_history/28.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history/28.fix'
+[   44s] 'share/fixtures/17/test/job_history/29.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history/29.fix'
+[   44s] 'share/fixtures/17/test/job_history/3.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history/3.fix'
+[   44s] 'share/fixtures/17/test/job_history/30.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history/30.fix'
+[   44s] 'share/fixtures/17/test/job_history/31.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history/31.fix'
+[   44s] 'share/fixtures/17/test/job_history/32.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history/32.fix'
+[   44s] 'share/fixtures/17/test/job_history/33.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history/33.fix'
+[   44s] 'share/fixtures/17/test/job_history/34.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history/34.fix'
+[   44s] 'share/fixtures/17/test/job_history/35.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history/35.fix'
+[   44s] 'share/fixtures/17/test/job_history/36.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history/36.fix'
+[   44s] 'share/fixtures/17/test/job_history/37.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history/37.fix'
+[   44s] 'share/fixtures/17/test/job_history/38.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history/38.fix'
+[   44s] 'share/fixtures/17/test/job_history/39.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history/39.fix'
+[   44s] 'share/fixtures/17/test/job_history/4.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history/4.fix'
+[   44s] 'share/fixtures/17/test/job_history/40.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history/40.fix'
+[   44s] 'share/fixtures/17/test/job_history/41.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history/41.fix'
+[   44s] 'share/fixtures/17/test/job_history/42.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history/42.fix'
+[   44s] 'share/fixtures/17/test/job_history/43.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history/43.fix'
+[   44s] 'share/fixtures/17/test/job_history/44.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history/44.fix'
+[   44s] 'share/fixtures/17/test/job_history/45.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history/45.fix'
+[   44s] 'share/fixtures/17/test/job_history/46.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history/46.fix'
+[   44s] 'share/fixtures/17/test/job_history/47.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history/47.fix'
+[   44s] 'share/fixtures/17/test/job_history/48.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history/48.fix'
+[   44s] 'share/fixtures/17/test/job_history/49.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history/49.fix'
+[   44s] 'share/fixtures/17/test/job_history/5.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history/5.fix'
+[   44s] 'share/fixtures/17/test/job_history/50.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history/50.fix'
+[   44s] 'share/fixtures/17/test/job_history/6.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history/6.fix'
+[   44s] 'share/fixtures/17/test/job_history/7.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history/7.fix'
+[   44s] 'share/fixtures/17/test/job_history/8.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history/8.fix'
+[   44s] 'share/fixtures/17/test/job_history/9.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history/9.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub'
+[   44s] 'share/fixtures/17/test/job_history_sub/1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/1.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/10.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/10.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/100.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/100.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/101.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/101.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/102.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/102.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/103.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/103.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/104.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/104.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/105.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/105.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/106.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/106.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/107.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/107.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/108.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/108.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/109.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/109.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/11.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/11.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/110.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/110.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/111.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/111.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/112.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/112.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/113.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/113.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/114.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/114.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/115.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/115.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/116.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/116.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/117.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/117.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/118.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/118.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/119.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/119.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/12.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/12.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/120.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/120.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/121.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/121.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/122.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/122.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/123.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/123.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/124.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/124.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/125.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/125.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/126.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/126.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/127.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/127.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/128.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/128.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/129.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/129.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/13.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/13.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/130.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/130.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/131.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/131.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/132.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/132.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/133.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/133.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/134.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/134.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/135.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/135.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/136.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/136.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/137.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/137.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/138.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/138.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/139.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/139.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/14.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/14.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/140.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/140.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/141.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/141.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/142.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/142.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/143.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/143.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/144.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/144.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/145.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/145.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/146.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/146.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/147.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/147.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/148.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/148.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/149.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/149.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/15.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/15.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/150.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/150.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/151.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/151.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/152.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/152.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/153.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/153.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/154.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/154.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/155.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/155.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/156.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/156.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/157.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/157.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/158.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/158.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/159.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/159.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/16.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/16.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/160.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/160.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/161.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/161.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/162.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/162.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/163.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/163.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/164.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/164.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/165.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/165.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/166.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/166.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/167.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/167.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/168.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/168.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/169.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/169.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/17.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/17.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/170.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/170.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/171.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/171.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/172.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/172.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/173.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/173.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/174.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/174.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/175.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/175.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/176.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/176.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/177.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/177.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/178.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/178.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/179.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/179.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/18.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/18.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/180.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/180.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/181.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/181.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/182.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/182.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/183.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/183.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/184.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/184.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/185.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/185.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/186.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/186.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/187.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/187.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/188.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/188.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/189.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/189.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/19.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/19.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/190.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/190.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/191.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/191.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/192.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/192.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/193.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/193.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/194.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/194.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/195.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/195.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/196.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/196.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/197.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/197.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/198.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/198.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/199.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/199.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/2.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/2.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/20.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/20.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/200.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/200.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/201.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/201.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/202.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/202.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/203.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/203.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/204.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/204.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/205.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/205.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/206.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/206.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/207.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/207.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/208.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/208.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/209.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/209.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/21.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/21.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/210.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/210.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/211.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/211.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/212.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/212.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/213.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/213.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/214.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/214.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/215.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/215.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/216.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/216.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/217.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/217.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/218.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/218.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/219.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/219.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/22.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/22.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/220.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/220.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/221.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/221.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/222.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/222.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/223.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/223.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/224.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/224.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/225.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/225.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/226.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/226.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/227.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/227.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/228.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/228.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/229.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/229.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/23.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/23.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/230.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/230.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/231.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/231.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/232.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/232.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/233.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/233.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/234.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/234.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/235.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/235.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/236.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/236.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/237.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/237.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/238.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/238.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/239.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/239.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/24.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/24.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/240.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/240.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/241.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/241.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/242.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/242.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/243.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/243.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/244.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/244.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/245.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/245.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/246.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/246.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/247.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/247.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/248.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/248.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/249.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/249.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/25.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/25.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/250.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/250.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/251.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/251.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/252.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/252.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/253.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/253.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/254.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/254.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/255.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/255.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/256.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/256.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/257.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/257.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/258.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/258.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/259.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/259.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/26.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/26.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/260.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/260.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/261.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/261.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/262.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/262.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/263.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/263.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/264.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/264.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/265.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/265.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/266.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/266.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/267.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/267.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/268.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/268.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/269.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/269.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/27.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/27.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/270.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/270.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/271.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/271.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/272.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/272.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/273.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/273.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/274.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/274.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/275.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/275.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/276.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/276.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/277.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/277.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/278.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/278.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/279.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/279.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/28.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/28.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/280.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/280.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/281.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/281.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/282.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/282.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/283.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/283.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/284.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/284.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/285.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/285.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/286.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/286.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/287.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/287.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/288.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/288.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/289.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/289.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/29.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/29.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/290.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/290.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/291.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/291.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/292.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/292.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/293.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/293.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/294.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/294.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/295.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/295.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/296.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/296.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/297.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/297.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/298.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/298.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/299.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/299.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/3.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/3.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/30.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/30.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/300.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/300.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/301.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/301.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/302.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/302.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/303.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/303.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/304.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/304.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/305.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/305.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/306.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/306.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/307.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/307.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/308.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/308.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/309.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/309.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/31.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/31.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/310.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/310.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/311.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/311.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/312.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/312.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/313.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/313.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/314.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/314.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/315.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/315.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/316.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/316.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/32.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/32.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/33.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/33.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/34.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/34.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/35.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/35.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/36.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/36.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/37.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/37.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/38.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/38.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/39.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/39.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/4.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/4.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/40.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/40.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/41.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/41.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/42.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/42.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/43.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/43.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/44.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/44.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/45.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/45.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/46.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/46.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/47.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/47.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/48.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/48.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/49.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/49.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/5.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/5.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/50.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/50.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/51.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/51.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/52.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/52.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/53.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/53.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/54.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/54.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/55.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/55.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/56.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/56.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/57.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/57.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/58.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/58.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/59.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/59.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/6.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/6.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/60.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/60.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/61.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/61.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/62.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/62.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/63.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/63.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/64.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/64.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/65.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/65.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/66.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/66.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/67.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/67.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/68.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/68.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/69.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/69.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/7.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/7.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/70.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/70.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/71.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/71.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/72.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/72.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/73.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/73.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/74.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/74.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/75.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/75.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/76.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/76.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/77.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/77.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/78.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/78.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/79.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/79.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/8.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/8.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/80.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/80.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/81.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/81.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/82.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/82.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/83.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/83.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/84.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/84.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/85.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/85.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/86.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/86.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/87.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/87.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/88.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/88.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/89.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/89.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/9.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/9.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/90.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/90.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/91.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/91.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/92.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/92.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/93.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/93.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/94.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/94.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/95.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/95.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/96.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/96.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/97.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/97.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/98.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/98.fix'
+[   44s] 'share/fixtures/17/test/job_history_sub/99.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_history_sub/99.fix'
+[   44s] 'share/fixtures/17/test/job_wait_for' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_wait_for'
+[   44s] 'share/fixtures/17/test/job_wait_for/16-15.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_wait_for/16-15.fix'
+[   44s] 'share/fixtures/17/test/job_wait_for/17-15.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_wait_for/17-15.fix'
+[   44s] 'share/fixtures/17/test/job_wait_for/19-18.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_wait_for/19-18.fix'
+[   44s] 'share/fixtures/17/test/job_wait_for/20-18.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_wait_for/20-18.fix'
+[   44s] 'share/fixtures/17/test/job_wait_for/22-21.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_wait_for/22-21.fix'
+[   44s] 'share/fixtures/17/test/job_wait_for/23-21.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_wait_for/23-21.fix'
+[   44s] 'share/fixtures/17/test/job_wait_for/25-24.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_wait_for/25-24.fix'
+[   44s] 'share/fixtures/17/test/job_wait_for/26-24.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_wait_for/26-24.fix'
+[   44s] 'share/fixtures/17/test/job_wait_for/28-27.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_wait_for/28-27.fix'
+[   44s] 'share/fixtures/17/test/job_wait_for/29-27.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_wait_for/29-27.fix'
+[   44s] 'share/fixtures/17/test/job_wait_for/31-30.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_wait_for/31-30.fix'
+[   44s] 'share/fixtures/17/test/job_wait_for/32-30.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_wait_for/32-30.fix'
+[   44s] 'share/fixtures/17/test/job_wait_for/34-33.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_wait_for/34-33.fix'
+[   44s] 'share/fixtures/17/test/job_wait_for/35-33.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_wait_for/35-33.fix'
+[   44s] 'share/fixtures/17/test/job_wait_for/37-36.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_wait_for/37-36.fix'
+[   44s] 'share/fixtures/17/test/job_wait_for/38-36.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_wait_for/38-36.fix'
+[   44s] 'share/fixtures/17/test/job_wait_for/40-39.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_wait_for/40-39.fix'
+[   44s] 'share/fixtures/17/test/job_wait_for/41-39.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_wait_for/41-39.fix'
+[   44s] 'share/fixtures/17/test/job_wait_for/43-42.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_wait_for/43-42.fix'
+[   44s] 'share/fixtures/17/test/job_wait_for/44-42.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_wait_for/44-42.fix'
+[   44s] 'share/fixtures/17/test/job_wait_for/47-45.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_wait_for/47-45.fix'
+[   44s] 'share/fixtures/17/test/job_wait_for/47-46.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_wait_for/47-46.fix'
+[   44s] 'share/fixtures/17/test/job_wait_for/50-48.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_wait_for/50-48.fix'
+[   44s] 'share/fixtures/17/test/job_wait_for/50-49.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/17/test/job_wait_for/50-49.fix'
+[   44s] 'share/fixtures/18' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18'
+[   44s] 'share/fixtures/18/all_tables' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/all_tables'
+[   44s] 'share/fixtures/18/all_tables/_config_set' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/all_tables/_config_set'
+[   44s] 'share/fixtures/18/all_tables/_dumper_version' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/all_tables/_dumper_version'
+[   44s] 'share/fixtures/18/all_tables/role' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/all_tables/role'
+[   44s] 'share/fixtures/18/all_tables/role/1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/all_tables/role/1.fix'
+[   44s] 'share/fixtures/18/all_tables/role/2.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/all_tables/role/2.fix'
+[   44s] 'share/fixtures/18/all_tables/role/3.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/all_tables/role/3.fix'
+[   44s] 'share/fixtures/18/all_tables/user' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/all_tables/user'
+[   44s] 'share/fixtures/18/all_tables/user/1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/all_tables/user/1.fix'
+[   44s] 'share/fixtures/18/all_tables/user_roles' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/all_tables/user_roles'
+[   44s] 'share/fixtures/18/all_tables/user_roles/1-1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/all_tables/user_roles/1-1.fix'
+[   44s] 'share/fixtures/18/all_tables/user_roles/1-2.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/all_tables/user_roles/1-2.fix'
+[   44s] 'share/fixtures/18/all_tables/user_roles/1-3.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/all_tables/user_roles/1-3.fix'
+[   44s] 'share/fixtures/18/conf' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/conf'
+[   44s] 'share/fixtures/18/conf/all_tables.json' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/conf/all_tables.json'
+[   44s] 'share/fixtures/18/conf/install.json' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/conf/install.json'
+[   44s] 'share/fixtures/18/conf/test.json' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/conf/test.json'
+[   44s] 'share/fixtures/18/install' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/install'
+[   44s] 'share/fixtures/18/install/_config_set' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/install/_config_set'
+[   44s] 'share/fixtures/18/install/_dumper_version' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/install/_dumper_version'
+[   44s] 'share/fixtures/18/install/role' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/install/role'
+[   44s] 'share/fixtures/18/install/role/1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/install/role/1.fix'
+[   44s] 'share/fixtures/18/install/role/2.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/install/role/2.fix'
+[   44s] 'share/fixtures/18/install/role/3.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/install/role/3.fix'
+[   44s] 'share/fixtures/18/install/user' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/install/user'
+[   44s] 'share/fixtures/18/install/user/1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/install/user/1.fix'
+[   44s] 'share/fixtures/18/install/user_roles' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/install/user_roles'
+[   44s] 'share/fixtures/18/install/user_roles/1-1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/install/user_roles/1-1.fix'
+[   44s] 'share/fixtures/18/install/user_roles/1-2.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/install/user_roles/1-2.fix'
+[   44s] 'share/fixtures/18/install/user_roles/1-3.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/install/user_roles/1-3.fix'
+[   44s] 'share/fixtures/18/test' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test'
+[   44s] 'share/fixtures/18/test/_config_set' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/_config_set'
+[   44s] 'share/fixtures/18/test/_dumper_version' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/_dumper_version'
+[   44s] 'share/fixtures/18/test/job_history' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history'
+[   44s] 'share/fixtures/18/test/job_history/1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history/1.fix'
+[   44s] 'share/fixtures/18/test/job_history/10.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history/10.fix'
+[   44s] 'share/fixtures/18/test/job_history/11.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history/11.fix'
+[   44s] 'share/fixtures/18/test/job_history/12.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history/12.fix'
+[   44s] 'share/fixtures/18/test/job_history/13.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history/13.fix'
+[   44s] 'share/fixtures/18/test/job_history/14.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history/14.fix'
+[   44s] 'share/fixtures/18/test/job_history/15.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history/15.fix'
+[   44s] 'share/fixtures/18/test/job_history/16.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history/16.fix'
+[   44s] 'share/fixtures/18/test/job_history/17.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history/17.fix'
+[   44s] 'share/fixtures/18/test/job_history/18.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history/18.fix'
+[   44s] 'share/fixtures/18/test/job_history/19.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history/19.fix'
+[   44s] 'share/fixtures/18/test/job_history/2.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history/2.fix'
+[   44s] 'share/fixtures/18/test/job_history/20.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history/20.fix'
+[   44s] 'share/fixtures/18/test/job_history/21.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history/21.fix'
+[   44s] 'share/fixtures/18/test/job_history/22.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history/22.fix'
+[   44s] 'share/fixtures/18/test/job_history/23.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history/23.fix'
+[   44s] 'share/fixtures/18/test/job_history/24.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history/24.fix'
+[   44s] 'share/fixtures/18/test/job_history/25.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history/25.fix'
+[   44s] 'share/fixtures/18/test/job_history/26.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history/26.fix'
+[   44s] 'share/fixtures/18/test/job_history/27.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history/27.fix'
+[   44s] 'share/fixtures/18/test/job_history/28.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history/28.fix'
+[   44s] 'share/fixtures/18/test/job_history/29.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history/29.fix'
+[   44s] 'share/fixtures/18/test/job_history/3.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history/3.fix'
+[   44s] 'share/fixtures/18/test/job_history/30.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history/30.fix'
+[   44s] 'share/fixtures/18/test/job_history/31.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history/31.fix'
+[   44s] 'share/fixtures/18/test/job_history/32.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history/32.fix'
+[   44s] 'share/fixtures/18/test/job_history/33.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history/33.fix'
+[   44s] 'share/fixtures/18/test/job_history/34.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history/34.fix'
+[   44s] 'share/fixtures/18/test/job_history/35.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history/35.fix'
+[   44s] 'share/fixtures/18/test/job_history/36.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history/36.fix'
+[   44s] 'share/fixtures/18/test/job_history/37.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history/37.fix'
+[   44s] 'share/fixtures/18/test/job_history/38.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history/38.fix'
+[   44s] 'share/fixtures/18/test/job_history/39.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history/39.fix'
+[   44s] 'share/fixtures/18/test/job_history/4.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history/4.fix'
+[   44s] 'share/fixtures/18/test/job_history/40.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history/40.fix'
+[   44s] 'share/fixtures/18/test/job_history/41.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history/41.fix'
+[   44s] 'share/fixtures/18/test/job_history/42.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history/42.fix'
+[   44s] 'share/fixtures/18/test/job_history/43.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history/43.fix'
+[   44s] 'share/fixtures/18/test/job_history/44.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history/44.fix'
+[   44s] 'share/fixtures/18/test/job_history/45.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history/45.fix'
+[   44s] 'share/fixtures/18/test/job_history/46.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history/46.fix'
+[   44s] 'share/fixtures/18/test/job_history/47.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history/47.fix'
+[   44s] 'share/fixtures/18/test/job_history/48.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history/48.fix'
+[   44s] 'share/fixtures/18/test/job_history/49.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history/49.fix'
+[   44s] 'share/fixtures/18/test/job_history/5.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history/5.fix'
+[   44s] 'share/fixtures/18/test/job_history/50.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history/50.fix'
+[   44s] 'share/fixtures/18/test/job_history/6.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history/6.fix'
+[   44s] 'share/fixtures/18/test/job_history/7.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history/7.fix'
+[   44s] 'share/fixtures/18/test/job_history/8.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history/8.fix'
+[   44s] 'share/fixtures/18/test/job_history/9.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history/9.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub'
+[   44s] 'share/fixtures/18/test/job_history_sub/1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/1.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/10.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/10.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/100.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/100.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/101.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/101.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/102.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/102.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/103.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/103.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/104.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/104.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/105.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/105.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/106.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/106.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/107.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/107.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/108.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/108.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/109.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/109.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/11.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/11.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/110.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/110.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/111.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/111.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/112.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/112.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/113.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/113.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/114.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/114.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/115.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/115.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/116.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/116.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/117.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/117.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/118.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/118.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/119.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/119.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/12.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/12.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/120.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/120.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/121.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/121.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/122.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/122.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/123.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/123.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/124.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/124.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/125.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/125.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/126.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/126.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/127.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/127.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/128.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/128.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/129.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/129.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/13.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/13.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/130.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/130.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/131.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/131.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/132.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/132.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/133.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/133.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/134.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/134.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/135.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/135.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/136.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/136.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/137.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/137.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/138.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/138.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/139.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/139.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/14.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/14.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/140.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/140.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/141.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/141.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/142.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/142.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/143.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/143.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/144.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/144.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/145.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/145.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/146.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/146.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/147.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/147.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/148.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/148.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/149.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/149.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/15.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/15.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/150.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/150.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/151.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/151.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/152.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/152.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/153.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/153.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/154.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/154.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/155.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/155.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/156.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/156.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/157.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/157.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/158.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/158.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/159.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/159.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/16.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/16.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/160.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/160.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/161.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/161.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/162.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/162.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/163.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/163.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/164.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/164.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/165.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/165.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/166.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/166.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/167.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/167.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/168.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/168.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/169.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/169.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/17.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/17.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/170.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/170.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/171.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/171.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/172.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/172.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/173.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/173.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/174.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/174.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/175.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/175.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/176.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/176.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/177.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/177.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/178.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/178.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/179.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/179.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/18.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/18.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/180.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/180.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/181.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/181.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/182.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/182.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/183.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/183.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/184.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/184.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/185.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/185.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/186.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/186.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/187.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/187.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/188.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/188.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/189.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/189.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/19.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/19.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/190.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/190.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/191.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/191.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/192.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/192.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/193.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/193.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/194.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/194.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/195.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/195.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/196.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/196.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/197.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/197.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/198.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/198.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/199.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/199.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/2.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/2.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/20.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/20.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/200.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/200.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/201.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/201.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/202.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/202.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/203.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/203.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/204.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/204.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/205.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/205.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/206.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/206.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/207.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/207.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/208.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/208.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/209.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/209.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/21.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/21.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/210.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/210.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/211.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/211.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/212.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/212.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/213.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/213.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/214.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/214.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/215.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/215.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/216.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/216.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/217.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/217.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/218.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/218.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/219.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/219.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/22.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/22.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/220.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/220.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/221.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/221.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/222.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/222.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/223.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/223.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/224.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/224.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/225.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/225.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/226.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/226.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/227.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/227.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/228.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/228.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/229.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/229.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/23.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/23.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/230.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/230.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/231.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/231.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/232.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/232.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/233.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/233.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/234.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/234.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/235.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/235.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/236.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/236.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/237.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/237.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/238.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/238.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/239.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/239.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/24.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/24.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/240.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/240.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/241.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/241.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/242.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/242.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/243.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/243.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/244.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/244.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/245.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/245.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/246.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/246.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/247.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/247.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/248.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/248.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/249.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/249.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/25.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/25.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/250.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/250.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/251.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/251.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/252.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/252.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/253.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/253.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/254.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/254.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/255.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/255.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/256.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/256.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/257.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/257.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/258.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/258.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/259.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/259.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/26.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/26.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/260.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/260.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/261.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/261.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/262.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/262.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/263.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/263.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/264.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/264.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/265.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/265.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/266.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/266.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/267.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/267.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/268.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/268.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/269.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/269.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/27.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/27.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/270.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/270.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/271.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/271.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/272.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/272.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/273.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/273.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/274.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/274.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/275.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/275.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/276.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/276.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/277.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/277.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/278.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/278.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/279.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/279.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/28.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/28.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/280.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/280.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/281.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/281.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/282.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/282.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/283.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/283.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/284.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/284.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/285.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/285.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/286.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/286.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/287.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/287.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/288.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/288.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/289.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/289.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/29.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/29.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/290.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/290.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/291.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/291.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/292.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/292.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/293.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/293.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/294.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/294.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/295.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/295.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/296.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/296.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/297.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/297.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/298.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/298.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/299.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/299.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/3.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/3.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/30.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/30.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/300.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/300.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/301.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/301.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/302.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/302.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/303.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/303.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/304.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/304.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/305.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/305.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/306.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/306.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/307.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/307.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/308.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/308.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/309.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/309.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/31.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/31.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/310.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/310.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/311.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/311.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/312.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/312.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/313.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/313.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/314.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/314.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/315.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/315.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/316.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/316.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/32.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/32.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/33.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/33.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/34.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/34.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/35.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/35.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/36.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/36.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/37.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/37.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/38.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/38.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/39.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/39.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/4.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/4.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/40.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/40.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/41.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/41.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/42.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/42.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/43.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/43.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/44.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/44.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/45.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/45.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/46.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/46.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/47.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/47.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/48.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/48.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/49.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/49.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/5.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/5.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/50.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/50.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/51.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/51.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/52.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/52.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/53.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/53.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/54.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/54.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/55.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/55.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/56.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/56.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/57.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/57.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/58.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/58.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/59.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/59.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/6.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/6.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/60.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/60.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/61.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/61.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/62.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/62.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/63.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/63.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/64.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/64.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/65.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/65.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/66.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/66.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/67.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/67.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/68.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/68.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/69.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/69.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/7.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/7.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/70.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/70.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/71.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/71.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/72.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/72.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/73.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/73.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/74.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/74.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/75.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/75.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/76.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/76.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/77.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/77.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/78.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/78.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/79.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/79.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/8.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/8.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/80.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/80.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/81.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/81.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/82.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/82.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/83.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/83.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/84.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/84.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/85.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/85.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/86.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/86.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/87.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/87.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/88.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/88.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/89.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/89.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/9.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/9.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/90.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/90.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/91.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/91.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/92.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/92.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/93.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/93.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/94.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/94.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/95.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/95.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/96.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/96.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/97.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/97.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/98.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/98.fix'
+[   44s] 'share/fixtures/18/test/job_history_sub/99.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_history_sub/99.fix'
+[   44s] 'share/fixtures/18/test/job_wait_for' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_wait_for'
+[   44s] 'share/fixtures/18/test/job_wait_for/16-15.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_wait_for/16-15.fix'
+[   44s] 'share/fixtures/18/test/job_wait_for/17-15.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_wait_for/17-15.fix'
+[   44s] 'share/fixtures/18/test/job_wait_for/19-18.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_wait_for/19-18.fix'
+[   44s] 'share/fixtures/18/test/job_wait_for/20-18.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_wait_for/20-18.fix'
+[   44s] 'share/fixtures/18/test/job_wait_for/22-21.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_wait_for/22-21.fix'
+[   44s] 'share/fixtures/18/test/job_wait_for/23-21.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_wait_for/23-21.fix'
+[   44s] 'share/fixtures/18/test/job_wait_for/25-24.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_wait_for/25-24.fix'
+[   44s] 'share/fixtures/18/test/job_wait_for/26-24.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_wait_for/26-24.fix'
+[   44s] 'share/fixtures/18/test/job_wait_for/28-27.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_wait_for/28-27.fix'
+[   44s] 'share/fixtures/18/test/job_wait_for/29-27.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_wait_for/29-27.fix'
+[   44s] 'share/fixtures/18/test/job_wait_for/31-30.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_wait_for/31-30.fix'
+[   44s] 'share/fixtures/18/test/job_wait_for/32-30.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_wait_for/32-30.fix'
+[   44s] 'share/fixtures/18/test/job_wait_for/34-33.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_wait_for/34-33.fix'
+[   44s] 'share/fixtures/18/test/job_wait_for/35-33.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_wait_for/35-33.fix'
+[   44s] 'share/fixtures/18/test/job_wait_for/37-36.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_wait_for/37-36.fix'
+[   44s] 'share/fixtures/18/test/job_wait_for/38-36.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_wait_for/38-36.fix'
+[   44s] 'share/fixtures/18/test/job_wait_for/40-39.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_wait_for/40-39.fix'
+[   44s] 'share/fixtures/18/test/job_wait_for/41-39.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_wait_for/41-39.fix'
+[   44s] 'share/fixtures/18/test/job_wait_for/43-42.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_wait_for/43-42.fix'
+[   44s] 'share/fixtures/18/test/job_wait_for/44-42.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_wait_for/44-42.fix'
+[   44s] 'share/fixtures/18/test/job_wait_for/47-45.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_wait_for/47-45.fix'
+[   44s] 'share/fixtures/18/test/job_wait_for/47-46.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_wait_for/47-46.fix'
+[   44s] 'share/fixtures/18/test/job_wait_for/50-48.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_wait_for/50-48.fix'
+[   44s] 'share/fixtures/18/test/job_wait_for/50-49.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/18/test/job_wait_for/50-49.fix'
+[   44s] 'share/fixtures/2' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/2'
+[   44s] 'share/fixtures/2/all_tables' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/2/all_tables'
+[   44s] 'share/fixtures/2/all_tables/_config_set' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/2/all_tables/_config_set'
+[   44s] 'share/fixtures/2/all_tables/_dumper_version' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/2/all_tables/_dumper_version'
+[   44s] 'share/fixtures/2/all_tables/role' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/2/all_tables/role'
+[   44s] 'share/fixtures/2/all_tables/role/1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/2/all_tables/role/1.fix'
+[   44s] 'share/fixtures/2/all_tables/role/2.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/2/all_tables/role/2.fix'
+[   44s] 'share/fixtures/2/all_tables/user' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/2/all_tables/user'
+[   44s] 'share/fixtures/2/all_tables/user/1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/2/all_tables/user/1.fix'
+[   44s] 'share/fixtures/2/all_tables/user_roles' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/2/all_tables/user_roles'
+[   44s] 'share/fixtures/2/all_tables/user_roles/1-1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/2/all_tables/user_roles/1-1.fix'
+[   44s] 'share/fixtures/2/all_tables/user_roles/1-2.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/2/all_tables/user_roles/1-2.fix'
+[   44s] 'share/fixtures/2/conf' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/2/conf'
+[   44s] 'share/fixtures/2/conf/all_tables.json' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/2/conf/all_tables.json'
+[   44s] 'share/fixtures/3' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/3'
+[   44s] 'share/fixtures/3/all_tables' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/3/all_tables'
+[   44s] 'share/fixtures/3/all_tables/_config_set' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/3/all_tables/_config_set'
+[   44s] 'share/fixtures/3/all_tables/_dumper_version' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/3/all_tables/_dumper_version'
+[   44s] 'share/fixtures/3/all_tables/role' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/3/all_tables/role'
+[   44s] 'share/fixtures/3/all_tables/role/1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/3/all_tables/role/1.fix'
+[   44s] 'share/fixtures/3/all_tables/role/2.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/3/all_tables/role/2.fix'
+[   44s] 'share/fixtures/3/all_tables/user' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/3/all_tables/user'
+[   44s] 'share/fixtures/3/all_tables/user/1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/3/all_tables/user/1.fix'
+[   44s] 'share/fixtures/3/all_tables/user_roles' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/3/all_tables/user_roles'
+[   44s] 'share/fixtures/3/all_tables/user_roles/1-1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/3/all_tables/user_roles/1-1.fix'
+[   44s] 'share/fixtures/3/all_tables/user_roles/1-2.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/3/all_tables/user_roles/1-2.fix'
+[   44s] 'share/fixtures/3/conf' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/3/conf'
+[   44s] 'share/fixtures/3/conf/all_tables.json' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/3/conf/all_tables.json'
+[   44s] 'share/fixtures/4' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/4'
+[   44s] 'share/fixtures/4/all_tables' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/4/all_tables'
+[   44s] 'share/fixtures/4/all_tables/_config_set' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/4/all_tables/_config_set'
+[   44s] 'share/fixtures/4/all_tables/_dumper_version' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/4/all_tables/_dumper_version'
+[   44s] 'share/fixtures/4/all_tables/role' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/4/all_tables/role'
+[   44s] 'share/fixtures/4/all_tables/role/1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/4/all_tables/role/1.fix'
+[   44s] 'share/fixtures/4/all_tables/role/2.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/4/all_tables/role/2.fix'
+[   44s] 'share/fixtures/4/all_tables/user' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/4/all_tables/user'
+[   44s] 'share/fixtures/4/all_tables/user/1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/4/all_tables/user/1.fix'
+[   44s] 'share/fixtures/4/all_tables/user_roles' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/4/all_tables/user_roles'
+[   44s] 'share/fixtures/4/all_tables/user_roles/1-1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/4/all_tables/user_roles/1-1.fix'
+[   44s] 'share/fixtures/4/all_tables/user_roles/1-2.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/4/all_tables/user_roles/1-2.fix'
+[   44s] 'share/fixtures/4/conf' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/4/conf'
+[   44s] 'share/fixtures/4/conf/all_tables.json' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/4/conf/all_tables.json'
+[   44s] 'share/fixtures/5' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/5'
+[   44s] 'share/fixtures/5/all_tables' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/5/all_tables'
+[   44s] 'share/fixtures/5/all_tables/_config_set' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/5/all_tables/_config_set'
+[   44s] 'share/fixtures/5/all_tables/_dumper_version' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/5/all_tables/_dumper_version'
+[   44s] 'share/fixtures/5/all_tables/role' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/5/all_tables/role'
+[   44s] 'share/fixtures/5/all_tables/role/1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/5/all_tables/role/1.fix'
+[   44s] 'share/fixtures/5/all_tables/role/2.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/5/all_tables/role/2.fix'
+[   44s] 'share/fixtures/5/all_tables/user' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/5/all_tables/user'
+[   44s] 'share/fixtures/5/all_tables/user/1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/5/all_tables/user/1.fix'
+[   44s] 'share/fixtures/5/all_tables/user_roles' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/5/all_tables/user_roles'
+[   44s] 'share/fixtures/5/all_tables/user_roles/1-1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/5/all_tables/user_roles/1-1.fix'
+[   44s] 'share/fixtures/5/all_tables/user_roles/1-2.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/5/all_tables/user_roles/1-2.fix'
+[   44s] 'share/fixtures/5/conf' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/5/conf'
+[   44s] 'share/fixtures/5/conf/all_tables.json' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/5/conf/all_tables.json'
+[   44s] 'share/fixtures/6' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/6'
+[   44s] 'share/fixtures/6/conf' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/6/conf'
+[   44s] 'share/fixtures/6/conf/all_tables.json' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/6/conf/all_tables.json'
+[   44s] 'share/fixtures/6/conf/install.json' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/6/conf/install.json'
+[   44s] 'share/fixtures/6/install' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/6/install'
+[   44s] 'share/fixtures/6/install/_config_set' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/6/install/_config_set'
+[   44s] 'share/fixtures/6/install/_dumper_version' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/6/install/_dumper_version'
+[   44s] 'share/fixtures/6/install/role' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/6/install/role'
+[   44s] 'share/fixtures/6/install/role/1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/6/install/role/1.fix'
+[   44s] 'share/fixtures/6/install/role/2.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/6/install/role/2.fix'
+[   44s] 'share/fixtures/6/install/role/3.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/6/install/role/3.fix'
+[   44s] 'share/fixtures/6/install/user' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/6/install/user'
+[   44s] 'share/fixtures/6/install/user/1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/6/install/user/1.fix'
+[   44s] 'share/fixtures/6/install/user_roles' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/6/install/user_roles'
+[   44s] 'share/fixtures/6/install/user_roles/1-1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/6/install/user_roles/1-1.fix'
+[   44s] 'share/fixtures/6/install/user_roles/1-2.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/6/install/user_roles/1-2.fix'
+[   44s] 'share/fixtures/6/install/user_roles/1-3.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/6/install/user_roles/1-3.fix'
+[   44s] 'share/fixtures/7' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/7'
+[   44s] 'share/fixtures/7/conf' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/7/conf'
+[   44s] 'share/fixtures/7/conf/all_tables.json' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/7/conf/all_tables.json'
+[   44s] 'share/fixtures/7/conf/install.json' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/7/conf/install.json'
+[   44s] 'share/fixtures/7/install' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/7/install'
+[   44s] 'share/fixtures/7/install/_config_set' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/7/install/_config_set'
+[   44s] 'share/fixtures/7/install/_dumper_version' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/7/install/_dumper_version'
+[   44s] 'share/fixtures/7/install/role' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/7/install/role'
+[   44s] 'share/fixtures/7/install/role/1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/7/install/role/1.fix'
+[   44s] 'share/fixtures/7/install/role/2.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/7/install/role/2.fix'
+[   44s] 'share/fixtures/7/install/role/3.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/7/install/role/3.fix'
+[   44s] 'share/fixtures/7/install/user' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/7/install/user'
+[   44s] 'share/fixtures/7/install/user/1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/7/install/user/1.fix'
+[   44s] 'share/fixtures/7/install/user_roles' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/7/install/user_roles'
+[   44s] 'share/fixtures/7/install/user_roles/1-1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/7/install/user_roles/1-1.fix'
+[   44s] 'share/fixtures/7/install/user_roles/1-2.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/7/install/user_roles/1-2.fix'
+[   44s] 'share/fixtures/7/install/user_roles/1-3.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/7/install/user_roles/1-3.fix'
+[   44s] 'share/fixtures/8' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/8'
+[   44s] 'share/fixtures/8/conf' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/8/conf'
+[   44s] 'share/fixtures/8/conf/all_tables.json' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/8/conf/all_tables.json'
+[   44s] 'share/fixtures/8/conf/install.json' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/8/conf/install.json'
+[   44s] 'share/fixtures/8/install' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/8/install'
+[   44s] 'share/fixtures/8/install/_config_set' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/8/install/_config_set'
+[   44s] 'share/fixtures/8/install/_dumper_version' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/8/install/_dumper_version'
+[   44s] 'share/fixtures/8/install/role' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/8/install/role'
+[   44s] 'share/fixtures/8/install/role/1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/8/install/role/1.fix'
+[   44s] 'share/fixtures/8/install/role/2.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/8/install/role/2.fix'
+[   44s] 'share/fixtures/8/install/role/3.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/8/install/role/3.fix'
+[   44s] 'share/fixtures/8/install/user' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/8/install/user'
+[   44s] 'share/fixtures/8/install/user/1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/8/install/user/1.fix'
+[   44s] 'share/fixtures/8/install/user_roles' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/8/install/user_roles'
+[   44s] 'share/fixtures/8/install/user_roles/1-1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/8/install/user_roles/1-1.fix'
+[   44s] 'share/fixtures/8/install/user_roles/1-2.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/8/install/user_roles/1-2.fix'
+[   44s] 'share/fixtures/8/install/user_roles/1-3.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/8/install/user_roles/1-3.fix'
+[   44s] 'share/fixtures/9' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/9'
+[   44s] 'share/fixtures/9/conf' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/9/conf'
+[   44s] 'share/fixtures/9/conf/all_tables.json' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/9/conf/all_tables.json'
+[   44s] 'share/fixtures/9/conf/install.json' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/9/conf/install.json'
+[   44s] 'share/fixtures/9/install' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/9/install'
+[   44s] 'share/fixtures/9/install/_config_set' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/9/install/_config_set'
+[   44s] 'share/fixtures/9/install/_dumper_version' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/9/install/_dumper_version'
+[   44s] 'share/fixtures/9/install/role' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/9/install/role'
+[   44s] 'share/fixtures/9/install/role/1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/9/install/role/1.fix'
+[   44s] 'share/fixtures/9/install/role/2.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/9/install/role/2.fix'
+[   44s] 'share/fixtures/9/install/role/3.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/9/install/role/3.fix'
+[   44s] 'share/fixtures/9/install/user' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/9/install/user'
+[   44s] 'share/fixtures/9/install/user/1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/9/install/user/1.fix'
+[   44s] 'share/fixtures/9/install/user_roles' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/9/install/user_roles'
+[   44s] 'share/fixtures/9/install/user_roles/1-1.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/9/install/user_roles/1-1.fix'
+[   44s] 'share/fixtures/9/install/user_roles/1-2.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/9/install/user_roles/1-2.fix'
+[   44s] 'share/fixtures/9/install/user_roles/1-3.fix' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/fixtures/9/install/user_roles/1-3.fix'
+[   44s] cp -rv public /usr/src/packages/BUILD/debian/kanku/usr/share/kanku/
+[   44s] 'public' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public'
+[   44s] 'public/css' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/css'
+[   44s] 'public/css/bootstrap-vue.css' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/css/bootstrap-vue.css'
+[   44s] 'public/css/bootstrap.css' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/css/bootstrap.css'
+[   44s] 'public/css/bootstrap.min.css' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/css/bootstrap.min.css'
+[   44s] 'public/css/bootstrap.min.css.map' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/css/bootstrap.min.css.map'
+[   44s] 'public/css/kanku' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/css/kanku'
+[   44s] 'public/css/kanku/error.css' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/css/kanku/error.css'
+[   44s] 'public/css/kanku/mystyle.css' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/css/kanku/mystyle.css'
+[   44s] 'public/css/kanku/signin.css' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/css/kanku/signin.css'
+[   44s] 'public/css/kanku/style.css' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/css/kanku/style.css'
+[   44s] 'public/favicon.ico' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/favicon.ico'
+[   44s] 'public/fontawesome' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/fontawesome'
+[   44s] 'public/fontawesome-free-5.13.0-web' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/fontawesome-free-5.13.0-web'
+[   44s] 'public/fontawesome-free-5.13.0-web/LICENSE.txt' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/fontawesome-free-5.13.0-web/LICENSE.txt'
+[   44s] 'public/fontawesome-free-5.13.0-web/css' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/fontawesome-free-5.13.0-web/css'
+[   44s] 'public/fontawesome-free-5.13.0-web/css/all.min.css' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/fontawesome-free-5.13.0-web/css/all.min.css'
+[   44s] 'public/fontawesome-free-5.13.0-web/js' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/fontawesome-free-5.13.0-web/js'
+[   44s] 'public/fontawesome-free-5.13.0-web/js/all.min.js' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/fontawesome-free-5.13.0-web/js/all.min.js'
+[   44s] 'public/fontawesome-free-5.13.0-web/webfonts' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/fontawesome-free-5.13.0-web/webfonts'
+[   44s] 'public/fontawesome-free-5.13.0-web/webfonts/fa-brands-400.eot' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/fontawesome-free-5.13.0-web/webfonts/fa-brands-400.eot'
+[   44s] 'public/fontawesome-free-5.13.0-web/webfonts/fa-brands-400.svg' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/fontawesome-free-5.13.0-web/webfonts/fa-brands-400.svg'
+[   44s] 'public/fontawesome-free-5.13.0-web/webfonts/fa-brands-400.ttf' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/fontawesome-free-5.13.0-web/webfonts/fa-brands-400.ttf'
+[   44s] 'public/fontawesome-free-5.13.0-web/webfonts/fa-brands-400.woff' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/fontawesome-free-5.13.0-web/webfonts/fa-brands-400.woff'
+[   44s] 'public/fontawesome-free-5.13.0-web/webfonts/fa-brands-400.woff2' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/fontawesome-free-5.13.0-web/webfonts/fa-brands-400.woff2'
+[   44s] 'public/fontawesome-free-5.13.0-web/webfonts/fa-regular-400.eot' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/fontawesome-free-5.13.0-web/webfonts/fa-regular-400.eot'
+[   44s] 'public/fontawesome-free-5.13.0-web/webfonts/fa-regular-400.svg' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/fontawesome-free-5.13.0-web/webfonts/fa-regular-400.svg'
+[   44s] 'public/fontawesome-free-5.13.0-web/webfonts/fa-regular-400.ttf' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/fontawesome-free-5.13.0-web/webfonts/fa-regular-400.ttf'
+[   44s] 'public/fontawesome-free-5.13.0-web/webfonts/fa-regular-400.woff' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/fontawesome-free-5.13.0-web/webfonts/fa-regular-400.woff'
+[   44s] 'public/fontawesome-free-5.13.0-web/webfonts/fa-regular-400.woff2' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/fontawesome-free-5.13.0-web/webfonts/fa-regular-400.woff2'
+[   44s] 'public/fontawesome-free-5.13.0-web/webfonts/fa-solid-900.eot' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/fontawesome-free-5.13.0-web/webfonts/fa-solid-900.eot'
+[   44s] 'public/fontawesome-free-5.13.0-web/webfonts/fa-solid-900.svg' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/fontawesome-free-5.13.0-web/webfonts/fa-solid-900.svg'
+[   44s] 'public/fontawesome-free-5.13.0-web/webfonts/fa-solid-900.ttf' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/fontawesome-free-5.13.0-web/webfonts/fa-solid-900.ttf'
+[   44s] 'public/fontawesome-free-5.13.0-web/webfonts/fa-solid-900.woff' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/fontawesome-free-5.13.0-web/webfonts/fa-solid-900.woff'
+[   44s] 'public/fontawesome-free-5.13.0-web/webfonts/fa-solid-900.woff2' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/fontawesome-free-5.13.0-web/webfonts/fa-solid-900.woff2'
+[   44s] 'public/images' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/images'
+[   44s] 'public/images/.convert.sh' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/images/.convert.sh'
+[   44s] 'public/images/196' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/images/196'
+[   44s] 'public/images/196/kanku-danger.png' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/images/196/kanku-danger.png'
+[   44s] 'public/images/196/kanku-success.png' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/images/196/kanku-success.png'
+[   44s] 'public/images/196/kanku-warning.png' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/images/196/kanku-warning.png'
+[   44s] 'public/images/196/kanku.png' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/images/196/kanku.png'
+[   44s] 'public/images/32' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/images/32'
+[   44s] 'public/images/32/kanku-danger.png' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/images/32/kanku-danger.png'
+[   44s] 'public/images/32/kanku-success.png' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/images/32/kanku-success.png'
+[   44s] 'public/images/32/kanku-warning.png' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/images/32/kanku-warning.png'
+[   44s] 'public/images/32/kanku.png' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/images/32/kanku.png'
+[   44s] 'public/images/48' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/images/48'
+[   44s] 'public/images/48/kanku-danger.png' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/images/48/kanku-danger.png'
+[   44s] 'public/images/48/kanku-success.png' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/images/48/kanku-success.png'
+[   44s] 'public/images/48/kanku-warning.png' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/images/48/kanku-warning.png'
+[   44s] 'public/images/48/kanku.png' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/images/48/kanku.png'
+[   44s] 'public/images/64' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/images/64'
+[   44s] 'public/images/64/kanku-danger.png' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/images/64/kanku-danger.png'
+[   44s] 'public/images/64/kanku-success.png' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/images/64/kanku-success.png'
+[   44s] 'public/images/64/kanku-warning.png' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/images/64/kanku-warning.png'
+[   44s] 'public/images/64/kanku.png' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/images/64/kanku.png'
+[   44s] 'public/images/help' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/images/help'
+[   44s] 'public/images/help/dispatching.png' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/images/help/dispatching.png'
+[   44s] 'public/images/help/failed.png' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/images/help/failed.png'
+[   44s] 'public/images/help/obs' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/images/help/obs'
+[   44s] 'public/images/help/obs/kanku-job_history-1-admin.png' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/images/help/obs/kanku-job_history-1-admin.png'
+[   44s] 'public/images/help/questionmark.png' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/images/help/questionmark.png'
+[   44s] 'public/images/help/running.png' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/images/help/running.png'
+[   44s] 'public/images/help/scheduled.png' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/images/help/scheduled.png'
+[   44s] 'public/images/help/skipped.png' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/images/help/skipped.png'
+[   44s] 'public/images/help/succeed.png' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/images/help/succeed.png'
+[   44s] 'public/images/help/triggered.png' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/images/help/triggered.png'
+[   44s] 'public/js' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/js'
+[   44s] 'public/js/axios.min.js' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/js/axios.min.js'
+[   44s] 'public/js/axios.min.map' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/js/axios.min.map'
+[   44s] 'public/js/bootstrap-vue.js' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/js/bootstrap-vue.js'
+[   44s] 'public/js/bootstrap.bundle.js' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/js/bootstrap.bundle.js'
+[   44s] 'public/js/bootstrap.bundle.js.map' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/js/bootstrap.bundle.js.map'
+[   44s] 'public/js/bootstrap.bundle.min.js' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/js/bootstrap.bundle.min.js'
+[   44s] 'public/js/bootstrap.bundle.min.js.map' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/js/bootstrap.bundle.min.js.map'
+[   44s] 'public/js/bootstrap.js' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/js/bootstrap.js'
+[   44s] 'public/js/bootstrap.min.js' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/js/bootstrap.min.js'
+[   44s] 'public/js/bootstrap.min.js.map' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/js/bootstrap.min.js.map'
+[   44s] 'public/js/fontawesome.min.js' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/js/fontawesome.min.js'
+[   44s] 'public/js/jquery-1.11.1-min.js' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/js/jquery-1.11.1-min.js'
+[   44s] 'public/js/jquery-3.3.1-slim.min.js' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/js/jquery-3.3.1-slim.min.js'
+[   44s] 'public/js/jquery.min.js' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/js/jquery.min.js'
+[   44s] 'public/js/js.cookie.js' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/js/js.cookie.js'
+[   44s] 'public/js/kanku' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/js/kanku'
+[   44s] 'public/js/kanku/admin.js' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/js/kanku/admin.js'
+[   44s] 'public/js/kanku/common.js' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/js/kanku/common.js'
+[   44s] 'public/js/kanku/guest.js' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/js/kanku/guest.js'
+[   44s] 'public/js/kanku/help.js' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/js/kanku/help.js'
+[   44s] 'public/js/kanku/index.js' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/js/kanku/index.js'
+[   44s] 'public/js/kanku/job.js' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/js/kanku/job.js'
+[   44s] 'public/js/kanku/job_group.js' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/js/kanku/job_group.js'
+[   44s] 'public/js/kanku/job_history.js' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/js/kanku/job_history.js'
+[   44s] 'public/js/kanku/job_result.js' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/js/kanku/job_result.js'
+[   44s] 'public/js/kanku/notify.js' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/js/kanku/notify.js'
+[   44s] 'public/js/kanku/pwreset.js' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/js/kanku/pwreset.js'
+[   44s] 'public/js/kanku/router.js' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/js/kanku/router.js'
+[   44s] 'public/js/kanku/settings.js' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/js/kanku/settings.js'
+[   44s] 'public/js/kanku/signin.js' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/js/kanku/signin.js'
+[   44s] 'public/js/kanku/signup.js' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/js/kanku/signup.js'
+[   44s] 'public/js/kanku/worker.js' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/js/kanku/worker.js'
+[   44s] 'public/js/polyfill.min.js' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/js/polyfill.min.js'
+[   44s] 'public/js/vue-router.js' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/js/vue-router.js'
+[   44s] 'public/js/vue.dev.js' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/js/vue.dev.js'
+[   44s] 'public/js/vue.min.js' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/js/vue.min.js'
+[   44s] 'public/kanku.png' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/public/kanku.png'
+[   44s] cp -rv views /usr/src/packages/BUILD/debian/kanku/usr/share/kanku/
+[   44s] 'views' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/views'
+[   44s] 'views/404.tt' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/views/404.tt'
+[   44s] 'views/500.tt' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/views/500.tt'
+[   44s] 'views/admin.tt' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/views/admin.tt'
+[   44s] 'views/cli' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/views/cli'
+[   44s] 'views/cli/guests.tt' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/views/cli/guests.tt'
+[   44s] 'views/cli/job.tt' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/views/cli/job.tt'
+[   44s] 'views/cli/jobs.tt' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/views/cli/jobs.tt'
+[   44s] 'views/cli/retrigger.tt' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/views/cli/retrigger.tt'
+[   44s] 'views/cli/rjob' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/views/cli/rjob'
+[   44s] 'views/cli/rjob/list.tt' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/views/cli/rjob/list.tt'
+[   44s] 'views/cli/rtrigger.tt' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/views/cli/rtrigger.tt'
+[   44s] 'views/cli/rworker.tt' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/views/cli/rworker.tt'
+[   44s] 'views/guest.tt' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/views/guest.tt'
+[   44s] 'views/index.tt' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/views/index.tt'
+[   44s] 'views/job.tt' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/views/job.tt'
+[   44s] 'views/job_history.tt' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/views/job_history.tt'
+[   44s] 'views/job_result.tt' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/views/job_result.tt'
+[   44s] 'views/layouts' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/views/layouts'
+[   44s] 'views/layouts/main.tt' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/views/layouts/main.tt'
+[   44s] 'views/login' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/views/login'
+[   44s] 'views/login/denied.tt' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/views/login/denied.tt'
+[   44s] 'views/login.tt' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/views/login.tt'
+[   44s] 'views/notifier' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/views/notifier'
+[   44s] 'views/notifier/nsca.tt' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/views/notifier/nsca.tt'
+[   44s] 'views/notifier/sendmail.tt' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/views/notifier/sendmail.tt'
+[   44s] 'views/notify.tt' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/views/notify.tt'
+[   44s] 'views/notify_disabled.tt' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/views/notify_disabled.tt'
+[   44s] 'views/pwreset.tt' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/views/pwreset.tt'
+[   44s] 'views/reset_password.tt' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/views/reset_password.tt'
+[   44s] 'views/settings.tt' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/views/settings.tt'
+[   44s] 'views/signup.tt' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/views/signup.tt'
+[   44s] 'views/worker.tt' -> '/usr/src/packages/BUILD/debian/kanku/usr/share/kanku/views/worker.tt'
+[   44s] install -m 755 bin/network-setup.pl /usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/network-setup.pl
+[   44s] install -m 755 bin/kanku /usr/src/packages/BUILD/debian/kanku/usr/bin/kanku
+[   44s] install -m 755 bin/kanku-app.psgi /usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/kanku-app.psgi
+[   44s] install -m 755 bin/ss_netstat_wrapper /usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/ss_netstat_wrapper
+[   44s] install -m 755 bin/iptables_wrapper /usr/src/packages/BUILD/debian/kanku/usr/lib/kanku/iptables_wrapper
+[   44s] install -m 755 sbin/kanku-worker /usr/src/packages/BUILD/debian/kanku/usr/sbin/kanku-worker
+[   44s] install -m 755 sbin/kanku-dispatcher /usr/src/packages/BUILD/debian/kanku/usr/sbin/kanku-dispatcher
+[   44s] install -m 755 sbin/kanku-scheduler /usr/src/packages/BUILD/debian/kanku/usr/sbin/kanku-scheduler
+[   44s] install -m 755 sbin/kanku-triggerd /usr/src/packages/BUILD/debian/kanku/usr/sbin/kanku-triggerd
+[   44s] install -m 644 ./dist/systemd/kanku-worker.service /usr/src/packages/BUILD/debian/kanku/usr/lib/systemd/system/kanku-worker.service
+[   44s] install -m 644 ./dist/systemd/kanku-scheduler.service /usr/src/packages/BUILD/debian/kanku/usr/lib/systemd/system/kanku-scheduler.service
+[   44s] install -m 644 ./dist/systemd/kanku-triggerd.service /usr/src/packages/BUILD/debian/kanku/usr/lib/systemd/system/kanku-triggerd.service
+[   44s] install -m 644 ./dist/systemd/kanku-web.service /usr/src/packages/BUILD/debian/kanku/usr/lib/systemd/system/kanku-web.service
+[   44s] install -m 644 ./dist/systemd/kanku-dispatcher.service /usr/src/packages/BUILD/debian/kanku/usr/lib/systemd/system/kanku-dispatcher.service
+[   44s] install -m 644 ./dist/systemd/kanku-iptables.service /usr/src/packages/BUILD/debian/kanku/usr/lib/systemd/system/kanku-iptables.service
+[   44s] install -m 644 README.md /usr/src/packages/BUILD/debian/kanku//usr/share/doc/packages/kanku/
+[   44s] install -m 644 CONTRIBUTING.md /usr/src/packages/BUILD/debian/kanku//usr/share/doc/packages/kanku/
+[   44s] install -m 644 INSTALL.md /usr/src/packages/BUILD/debian/kanku//usr/share/doc/packages/kanku/
+[   44s] install -m 644 LICENSE /usr/src/packages/BUILD/debian/kanku//usr/share/doc/packages/kanku/
+[   44s] install -m 644 docs/Development.pod /usr/src/packages/BUILD/debian/kanku//usr/share/doc/packages/kanku//contrib/
+[   44s] install -m 644 docs/README.apache-proxy.md /usr/src/packages/BUILD/debian/kanku//usr/share/doc/packages/kanku//contrib/
+[   44s] install -m 644 docs/README.rabbitmq.md /usr/src/packages/BUILD/debian/kanku//usr/share/doc/packages/kanku//contrib/
+[   44s] install -m 644 docs/README.setup-ovs.md /usr/src/packages/BUILD/debian/kanku//usr/share/doc/packages/kanku//contrib/
+[   44s] install -m 644 docs/README.setup-worker.md /usr/src/packages/BUILD/debian/kanku//usr/share/doc/packages/kanku//contrib/
+[   44s] #
+[   44s] for i in etc/kanku/dancer etc/kanku/jobs etc/kanku/job_groups etc/kanku/jobs/examples etc/kanku/logging;do \
+[   44s] 	[ -d /usr/src/packages/BUILD/debian/kanku/$i ] || mkdir -p /usr/src/packages/BUILD/debian/kanku/$i ; \
+[   44s] done
+[   44s] #
+[   44s] for i in jobs/examples/obs-server.yml jobs/examples/sles11sp3.yml jobs/examples/obs-server-26.yml jobs/remove-domain.yml logging/default.conf logging/console.conf logging/network-setup.conf;do \
+[   44s] 	cp -rv ./etc/$i /usr/src/packages/BUILD/debian/kanku/etc/kanku/$i ;\
+[   44s] done
+[   44s] './etc/jobs/examples/obs-server.yml' -> '/usr/src/packages/BUILD/debian/kanku/etc/kanku/jobs/examples/obs-server.yml'
+[   44s] './etc/jobs/examples/sles11sp3.yml' -> '/usr/src/packages/BUILD/debian/kanku/etc/kanku/jobs/examples/sles11sp3.yml'
+[   44s] './etc/jobs/examples/obs-server-26.yml' -> '/usr/src/packages/BUILD/debian/kanku/etc/kanku/jobs/examples/obs-server-26.yml'
+[   44s] './etc/jobs/remove-domain.yml' -> '/usr/src/packages/BUILD/debian/kanku/etc/kanku/jobs/remove-domain.yml'
+[   44s] './etc/logging/default.conf' -> '/usr/src/packages/BUILD/debian/kanku/etc/kanku/logging/default.conf'
+[   44s] './etc/logging/console.conf' -> '/usr/src/packages/BUILD/debian/kanku/etc/kanku/logging/console.conf'
+[   44s] './etc/logging/network-setup.conf' -> '/usr/src/packages/BUILD/debian/kanku/etc/kanku/logging/network-setup.conf'
+[   44s] #
+[   44s] for i in etc/kanku/templates etc/kanku/templates/cmd etc/kanku/templates/cmd/setup etc/kanku/templates/cmd/setup/etc etc/kanku/templates/examples-vm/ ;do \
+[   44s] 	[ -d /usr/src/packages/BUILD/debian/kanku/$i ] || mkdir -p /usr/src/packages/BUILD/debian/kanku/$i ; \
+[   44s] done
+[   44s] #
+[   44s] for i in templates/with-spice.tt2 templates/vm-x86_64-uefi-tpm2.0.tt2 templates/cmd/init.tt2 templates/cmd/setup/kanku.conf.mod_perl.tt2 templates/cmd/setup/kanku.conf.mod_proxy.tt2 templates/cmd/setup/kanku-vhost.conf.tt2 templates/cmd/setup/openssl.cnf.tt2 templates/cmd/setup/dancer-config.yml.tt2 templates/cmd/setup/kanku-config.yml.tt2 templates/cmd/setup/net-kanku-devel.xml.tt2 templates/cmd/setup/net-kanku-ovs.xml.tt2 templates/cmd/setup/pool-default.xml templates/cmd/setup/rabbitmq.config.tt2 templates/examples-vm/obs-server-26.tt2 templates/examples-vm/sles11sp3.tt2 templates/examples-vm/obs-server.tt2 ;do \
+[   44s] 	cp -rv ./etc/$i /usr/src/packages/BUILD/debian/kanku/etc/kanku/$i ;\
+[   44s] done
+[   44s] './etc/templates/with-spice.tt2' -> '/usr/src/packages/BUILD/debian/kanku/etc/kanku/templates/with-spice.tt2'
+[   44s] './etc/templates/vm-x86_64-uefi-tpm2.0.tt2' -> '/usr/src/packages/BUILD/debian/kanku/etc/kanku/templates/vm-x86_64-uefi-tpm2.0.tt2'
+[   44s] './etc/templates/cmd/init.tt2' -> '/usr/src/packages/BUILD/debian/kanku/etc/kanku/templates/cmd/init.tt2'
+[   44s] './etc/templates/cmd/setup/kanku.conf.mod_perl.tt2' -> '/usr/src/packages/BUILD/debian/kanku/etc/kanku/templates/cmd/setup/kanku.conf.mod_perl.tt2'
+[   44s] './etc/templates/cmd/setup/kanku.conf.mod_proxy.tt2' -> '/usr/src/packages/BUILD/debian/kanku/etc/kanku/templates/cmd/setup/kanku.conf.mod_proxy.tt2'
+[   44s] './etc/templates/cmd/setup/kanku-vhost.conf.tt2' -> '/usr/src/packages/BUILD/debian/kanku/etc/kanku/templates/cmd/setup/kanku-vhost.conf.tt2'
+[   44s] './etc/templates/cmd/setup/openssl.cnf.tt2' -> '/usr/src/packages/BUILD/debian/kanku/etc/kanku/templates/cmd/setup/openssl.cnf.tt2'
+[   44s] './etc/templates/cmd/setup/dancer-config.yml.tt2' -> '/usr/src/packages/BUILD/debian/kanku/etc/kanku/templates/cmd/setup/dancer-config.yml.tt2'
+[   44s] './etc/templates/cmd/setup/kanku-config.yml.tt2' -> '/usr/src/packages/BUILD/debian/kanku/etc/kanku/templates/cmd/setup/kanku-config.yml.tt2'
+[   45s] './etc/templates/cmd/setup/net-kanku-devel.xml.tt2' -> '/usr/src/packages/BUILD/debian/kanku/etc/kanku/templates/cmd/setup/net-kanku-devel.xml.tt2'
+[   45s] './etc/templates/cmd/setup/net-kanku-ovs.xml.tt2' -> '/usr/src/packages/BUILD/debian/kanku/etc/kanku/templates/cmd/setup/net-kanku-ovs.xml.tt2'
+[   45s] './etc/templates/cmd/setup/pool-default.xml' -> '/usr/src/packages/BUILD/debian/kanku/etc/kanku/templates/cmd/setup/pool-default.xml'
+[   45s] './etc/templates/cmd/setup/rabbitmq.config.tt2' -> '/usr/src/packages/BUILD/debian/kanku/etc/kanku/templates/cmd/setup/rabbitmq.config.tt2'
+[   45s] './etc/templates/examples-vm/obs-server-26.tt2' -> '/usr/src/packages/BUILD/debian/kanku/etc/kanku/templates/examples-vm/obs-server-26.tt2'
+[   45s] './etc/templates/examples-vm/sles11sp3.tt2' -> '/usr/src/packages/BUILD/debian/kanku/etc/kanku/templates/examples-vm/sles11sp3.tt2'
+[   45s] './etc/templates/examples-vm/obs-server.tt2' -> '/usr/src/packages/BUILD/debian/kanku/etc/kanku/templates/examples-vm/obs-server.tt2'
+[   45s] PERL5LIB=./lib ./bin/kanku bash_completion > /usr/src/packages/BUILD/debian/kanku/etc/bash_completion.d/kanku.sh
+[   46s] [ -d /usr/src/packages/BUILD/debian/kanku/usr/share/applications/ ] || mkdir -p /usr/src/packages/BUILD/debian/kanku/usr/share/applications/
+[   46s] [ -d /usr/src/packages/BUILD/debian/kanku/usr/share/mime/packages ] || mkdir -p /usr/src/packages/BUILD/debian/kanku/usr/share/mime/packages
+[   46s] install -m 644 dist/kanku-urlwrapper.desktop /usr/src/packages/BUILD/debian/kanku/usr/share/applications/kanku-urlwrapper.desktop
+[   46s] install -m 644 dist/x-scheme-handler_kanku.xml /usr/src/packages/BUILD/debian/kanku/usr/share/mime/packages/kanku.xml
+[   46s] [ -d /usr/src/packages/BUILD/debian/kanku/usr/share/icons/hicolor/32x32/apps ] || mkdir -p /usr/src/packages/BUILD/debian/kanku/usr/share/icons/hicolor/32x32/apps
+[   46s] [ -d /usr/src/packages/BUILD/debian/kanku/usr/share/icons/hicolor/48x48/apps ] || mkdir -p /usr/src/packages/BUILD/debian/kanku/usr/share/icons/hicolor/48x48/apps
+[   46s] [ -d /usr/src/packages/BUILD/debian/kanku/usr/share/icons/hicolor/64x64/apps ] || mkdir -p /usr/src/packages/BUILD/debian/kanku/usr/share/icons/hicolor/64x64/apps
+[   46s] install -m 644 public/images/32/kanku.png /usr/src/packages/BUILD/debian/kanku/usr/share/icons/hicolor/32x32/apps/kanku.png
+[   46s] install -m 644 public/images/48/kanku.png /usr/src/packages/BUILD/debian/kanku/usr/share/icons/hicolor/48x48/apps/kanku.png
+[   46s] install -m 644 public/images/64/kanku.png /usr/src/packages/BUILD/debian/kanku/usr/share/icons/hicolor/64x64/apps/kanku.png
+[   46s] install -m 644 etc/templates/default-vm.tt2.x86_64 /usr/src/packages/BUILD/debian/kanku/etc/kanku/templates/default-vm.tt2
+[   46s] install -m 644 dist/profile.d-kanku.sh /usr/src/packages/BUILD/debian/kanku/etc/profile.d/kanku.sh
+[   46s] install -m 644 dist/tmpfiles.d-kanku /usr/src/packages/BUILD/debian/kanku/usr/lib/tmpfiles.d/kanku.conf
+[   46s] install -m 644 dist/_etc_apache2_conf.d_kanku-worker.conf /usr/src/packages/BUILD/debian/kanku/etc/apache2/conf.d/kanku-worker.conf
+[   46s] make[1]: Leaving directory '/usr/src/packages/BUILD'
+[   46s]    dh_installdocs
+[   46s]    dh_installchangelogs
+[   46s]    dh_systemd_enable
+[   46s]    dh_installinit
+[   46s]    dh_systemd_start
+[   46s]    dh_icons
+[   46s]    dh_perl
+[   46s]    dh_link
+[   47s]    dh_strip_nondeterminism
+[   59s] dh_strip_nondeterminism: warning:     debian/changelog(l47): found start of entry where expected more change data or trailer
+[   59s] LINE: kanku (0.17.0) unstable; urgency=medium
+[   59s] dh_strip_nondeterminism: warning:     debian/changelog(l47): found end of file where expected more change data or trailer
+[   59s]    dh_compress
+[   59s]    dh_fixperms
+[   59s]    dh_missing
+[   59s]    dh_strip
+[   59s]    dh_makeshlibs
+[   60s]    dh_shlibdeps
+[   60s]    dh_installdeb
+[   60s]    dh_gencontrol
+[   60s] dpkg-gencontrol: warning: package kanku: substitution variable ${perl:Depends} unused, but is defined
+[   60s]    dh_md5sums
+[   60s]    dh_builddeb
+[   60s] dpkg-deb: building package 'kanku' in '../kanku_0.17.1-1_amd64.deb'.
+[   63s]  dpkg-genbuildinfo -O../kanku_0.17.1-1_amd64.buildinfo
+[   63s] dpkg-genbuildinfo: warning:     debian/changelog(l47): found start of entry where expected more change data or trailer
+[   63s] LINE: kanku (0.17.0) unstable; urgency=medium
+[   63s] dpkg-genbuildinfo: warning:     debian/changelog(l47): found end of file where expected more change data or trailer
+[   63s]  dpkg-genchanges -O../kanku_0.17.1-1_amd64.changes
+[   63s] dpkg-genchanges: warning:     debian/changelog(l47): found start of entry where expected more change data or trailer
+[   63s] LINE: kanku (0.17.0) unstable; urgency=medium
+[   63s] dpkg-genchanges: warning:     debian/changelog(l47): found end of file where expected more change data or trailer
+[   63s] dpkg-genchanges: info: not including original source code in upload
+[   63s]  dpkg-source --after-build .
+[   63s] dpkg-buildpackage: info: binary and diff upload (original source NOT included)
+[   63s] ln: failed to create hard link '///usr/src/packages/DEBS/kanku_0.17.1-1.dsc': File exists
+[   63s] ln: failed to create hard link '///usr/src/packages/DEBS/kanku_0.17.1-1.diff.gz': File exists
+[   63s] Warning: mkbaselibs missing in build root, skipping baselibs
+[   63s] ... saving statistics
+[   63s] ... saving built packages
+[   63s] DEBS/kanku_0.17.1-1_amd64.buildinfo
+[   63s] DEBS/kanku_0.17.1-1_amd64.deb
+[   63s] DEBS/kanku_0.17.1-1.diff.gz
+[   63s] DEBS/kanku_0.17.1.orig.tar.gz
+[   63s] DEBS/kanku_0.17.1-1.dsc
+[   63s] DEBS/kanku_0.17.1-1_amd64.changes
+[   63s] OTHER/_statistics
+[   63s] 
+[   63s] i01-ch2d finished "build debian.dsc" at Thu Jul 25 03:36:19 UTC 2024.
+[   63s] 
+[   63s] ### VM INTERACTION START ###
+[   63s] [   54.117355][    T1] sysrq: Power Off
+[   63s] [   54.117962][    T9] reboot: Power down
+[   63s] ### VM INTERACTION END ###
+[   64s] build: extracting built packages...
+[   64s] DEBS/kanku_0.17.1-1_amd64.buildinfo
+[   64s] DEBS/kanku_0.17.1-1_amd64.deb
+[   64s] DEBS/kanku_0.17.1-1.diff.gz
+[   64s] DEBS/kanku_0.17.1.orig.tar.gz
+[   64s] DEBS/kanku_0.17.1-1.dsc
+[   64s] DEBS/kanku_0.17.1-1_amd64.changes
+[   64s] OTHER/_statistics


### PR DESCRIPTION
fixes #16555

Currently, if a user has signed up for the Request Show Redesign Beta feature, we display build logs for all repositories if rpmlint logs are not available. This is not correct because it's confusing for reviewers. This PR changes that behavior to show the correct message, indicating that no rpmlint logs are available.