### PR TITLE
Deduplicate query criteria

### DIFF
--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -657,7 +657,7 @@ class User < ApplicationRecord
   def incoming_requests(search = nil, states: [:new])
     result = BsRequest.where(state: states).where(id: BsRequestAction.bs_request_ids_of_involved_projects(involved_projects.pluck(:id))).or(
       BsRequest.where(id: BsRequestAction.bs_request_ids_of_involved_packages(involved_packages.pluck(:id)))
-    ).with_actions.where(state: states)
+    ).with_actions
 
     search.present? ? result.do_search(search) : result
   end

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -655,8 +655,10 @@ class User < ApplicationRecord
 
   # list incoming requests involving this user
   def incoming_requests(search = nil, states: [:new])
-    result = BsRequest.where(state: states).where(id: BsRequestAction.bs_request_ids_of_involved_projects(involved_projects.pluck(:id))).or(
-      BsRequest.where(id: BsRequestAction.bs_request_ids_of_involved_packages(involved_packages.pluck(:id)))
+    result = BsRequest.where(state: states).and(
+      BsRequest.where(id: BsRequestAction.bs_request_ids_of_involved_projects(involved_projects.pluck(:id))).or(
+        BsRequest.where(id: BsRequestAction.bs_request_ids_of_involved_packages(involved_packages.pluck(:id)))
+      )
     ).with_actions
 
     search.present? ? result.do_search(search) : result


### PR DESCRIPTION
The `.where(state: states)` is already applied at the beginning when `result = BsRequest.where(state: states)......`