### PR TITLE
[backend] block scheduler during project scmsync source update

### DIFF
--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -365,7 +365,11 @@ sub triggerscmsyncrun {
     next unless $proj;
     if ($packid eq '_project') {
       die("$projid is a remote project\n") if $proj->{'remoteurl'};
-      BSSrcServer::Service::runservice_obsscm($cgi, $projid, $packid, $proj->{'scmsync'}) if $proj->{'scmsync'};
+      if ($proj->{'scmsync'}) {
+        notify_repservers('suspendproject', $projid, undef, 'suspendproject due to scmsync');
+        BSSrcServer::Service::runservice_obsscm($cgi, $projid, $packid, $proj->{'scmsync'})
+        notify_repservers('resumeproject', $projid, undef, 'resumeproject due to scmsync');
+      }
     } else {
       my $pack = BSRevision::readpack_local($projid, $packid, 1);
       next unless $pack;


### PR DESCRIPTION
suspend and resume scheduler for a project during updating entire projects to avoid that the scheduler pick single changes and don't block them due to other package updates.