### PR TITLE
Require perl(Date::Parse)

### DIFF
--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -266,7 +266,7 @@ Requires(pre):  obs-common
 Requires:       cpio
 Requires:       curl
 Requires:       perl(Compress::Zlib)
-Requires:       perl-TimeDate
+Requires:       perl(Date::Parse)
 Requires:       perl(XML::Parser)
 Requires:       screen
 # for build script


### PR DESCRIPTION
This is a fixup on
commit 1e8688bb749a89bb85e0b32f3061560732885f49
to fix image builds in https://build.opensuse.org/package/show/OBS:Server:Unstable/OBS-Appliance

For some reason, Leap's perl-TimeDate package does not Provide perl(TimeDate)