### PR TITLE
Id typo fix

### DIFF
--- a/src/api/app/views/webui/request/index.html.haml
+++ b/src/api/app/views/webui/request/index.html.haml
@@ -10,9 +10,9 @@
           %i.float-end.mt-1.fa.fa-chevron-down#requests-dropdown-trigger
         .collapse#filters
           = render partial: 'requests_filter', locals: { selected_filter: @selected_filter }
-    .col-md-8.col-lg-9.px-0.px-md-3.d-none#request-list-loading
+    .col-md-8.col-lg-9.px-0.px-md-3.d-none#requests-list-loading
       = render partial: 'webui/shared/loading', locals: { text: 'Loading...', wrapper_css: ['loading'] }
-    .col-md-8.col-lg-9.px-0.px-md-3#request-list
+    .col-md-8.col-lg-9.px-0.px-md-3#requests-list
       .card.sticky-top.mb-3#requests-filter-search-text
         .card-body.row
           .col


### PR DESCRIPTION
Typo fix to match the `id` and the `js` (see below) that look up for it in order to render the `loading` properly and hide the content instead.


```
...
$('#requests-list').hide();
$('#requests-list-loading').removeClass('d-none');
...
```