### PR TITLE
Collect multiselect selections

### DIFF
--- a/src/api/app/views/webui/request/index.html.haml
+++ b/src/api/app/views/webui/request/index.html.haml
@@ -30,6 +30,8 @@
           = paginate @bs_requests, views_prefix: 'webui'
 
 :javascript
+  collectMultiSelects();
+
   function submitRequestFilters() {
     $('#requests-filter-form').submit();
   }


### PR DESCRIPTION
For some reason, at some point this line of code disappeared.
It is required in order to show the current multiselect values in the filters.

![image](https://github.com/user-attachments/assets/afe30d42-474a-41c2-8eb0-d4e3b2abeb28)
