### PR TITLE
Fix development backend script

### DIFF
--- a/contrib/start_development_backend
+++ b/contrib/start_development_backend
@@ -25,7 +25,7 @@ while getopts "l:d:h:?" opt; do
   case "$opt" in
   l)
     REDIR_LOG=$OPTARG
-    if [[ "REDIR_LOG" =~ [[:space:]] ]]; then
+    if [[ "$REDIR_LOG" =~ [[:space:]] ]]; then
       echo "Directory may not contain whitespaces"
       exit
     fi

--- a/contrib/start_development_backend
+++ b/contrib/start_development_backend
@@ -134,22 +134,30 @@ eval $COMMAND_STRING
 function clean_up {
   echo -e "\ncleaning up and exit"
   echo -e "Terminating Services"
-  killall bs_srcserver
+  "$GIT_HOME"/src/backend/bs_srcserver --stop
   echo -e "Terminated SRC Server"
-  killall bs_repserver
+  "$GIT_HOME"/src/backend/bs_repserver --stop
   echo -e "Terminated REP Server"
-  killall bs_sched
-  echo -e "Terminated Scheduler"
-  killall bs_dispatch
+  "$GIT_HOME"/src/backend/bs_sched --stop i586
+  "$GIT_HOME"/src/backend/bs_sched --stop x86_64
+  echo -e "Terminated Schedulers"
+  "$GIT_HOME"/src/backend/bs_dispatch --stop
   echo -e "Terminated Dispatcher"
-  killall bs_publish
+  "$GIT_HOME"/src/backend/bs_publish --stop
   echo -e "Terminated Publisher"
-  killall bs_service
+  "$GIT_HOME"/src/backend/bs_service --stop
   echo -e "Terminated Publisher"
-  killall bs_signer
+  "$GIT_HOME"/src/backend/bs_signer --stop
   echo -e "Terminated Signer"
-  killall bs_servicedispatch
-  echo -e "Terminated service dispatcher"
+  killall signd
+  gpgconf --kill gpg-agent
+  echo -e "Terminated Signd"
+  "$GIT_HOME"/src/backend/bs_servicedispatch --stop
+  echo -e "Terminated service dispatch"
+  "$GIT_HOME"/src/backend/bs_clouduploadserver --stop
+  echo -e "Terminated cloud upload server"
+  "$GIT_HOME"/src/backend/bs_clouduploadworker --stop
+  echo -e "Terminated cloud upload worker"
   exit;
 }
 

--- a/contrib/start_development_backend
+++ b/contrib/start_development_backend
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-trap clean_up SIGHUP SIGINT SIGTERM SIGKILL
+trap clean_up SIGHUP SIGINT SIGTERM
 
 #function to help with the usage
 function _print_syntax() {


### PR DESCRIPTION
When shutting down the development environment (`Ctrl-C` on a `docker compose` session), the logs of the backend returned (`docker compose logs backend -f`):
```
backend-1  |
backend-1  | cleaning up and exit
backend-1  | Terminating Services
backend-1  | bs_srcserver: no process found
backend-1  | Terminated SRC Server
backend-1  | bs_repserver: no process found
backend-1  | Terminated REP Server
backend-1  | bs_sched: no process found
backend-1  | Terminated Scheduler
backend-1  | bs_dispatch: no process found
backend-1  | Terminated Dispatcher
backend-1  | bs_publish: no process found
backend-1  | Terminated Publisher
backend-1  | bs_service: no process found
backend-1  | Terminated Publisher
backend-1  | bs_signer: no process found
backend-1  | Terminated Signer
backend-1  | bs_servicedispatch: no process found
backend-1  | Terminated service dispatcher
backend-1 exited with code 0
```

With the changes proposed they return:
```
backend-1  |                                                                                                                                                                                   
backend-1  | cleaning up and exit                                                                                                                                                              
backend-1  | Terminating Services                                                                                                                                                              
backend-1  | Name "BSConfig::localarch" used only once: possible typo at /obs/src/backend/bs_srcserver line 1931.                                                                              
backend-1  | 2024-07-30 16:08:19: [12]    src_server exiting...                                                                                                                                
backend-1  | 2024-07-30 16:08:19: [14]    AJAX: src_server exiting.                                                                                                                            
backend-1  | exiting server...                                                                                                                                                                 
backend-1  | Terminated SRC Server                                                                                                                                                             
backend-1  | 2024-07-30 16:08:20: [15]    rep_server exiting...                                                                                                                                
backend-1  | exiting server...                                                                                                                                                                 
backend-1  | Terminated REP Server                                                                                                                                                             
backend-1  | shutting down scheduler for i586...                                                                                                                                               
backend-1  | 2024-07-30 16:08:20: [18]    event exitcomplete                                                                                                                                   
backend-1  | exiting (with complete info)...                                                                                                                                                   
backend-1  | 2024-07-30 16:08:20: [18]    bye.                                                                                                                                                 
backend-1  | shutting down scheduler for x86_64...                                                                                                                                             
backend-1  | 2024-07-30 16:08:20: [19]    event exitcomplete                                                                                                                                   
backend-1  | exiting (with complete info)...                                                                                                                                                   
backend-1  | 2024-07-30 16:08:20: [19]    bye.                                                                                                                                                 
backend-1  | Terminated Schedulers                                                                                                                                                             
backend-1  | 2024-07-30 16:08:20: [17]    AJAX: rep_server exiting.                                                                                                                            
backend-1  | 2024-07-30 16:08:20: [17]    AJAX: rep_server goodbye.                                                                                                                            
backend-1  | exiting dispatcher...                                                                                                                                                             
backend-1  | 2024-07-30 16:08:21: [20]    exiting...                                                                                                                                           
backend-1  | Terminated Dispatcher                                                                                                                                                             
backend-1  | exiting publisher...
backend-1  | 2024-07-30 16:08:22: [21]    publisher exiting...
backend-1  | Terminated Publisher
backend-1  | 2024-07-30 16:08:23: [22]    src_service exiting...
backend-1  | exiting server...
backend-1  | Terminated Publisher
backend-1  | 2024-07-30 16:08:23: 127.0.0.1: sign obsrun@localhost 8bef2fa1c8befd44b8264c71ef9e07cc97563232@0066a90ff7
backend-1  | exiting signer...
backend-1  | 2024-07-30 16:08:23: [23]    signer exiting...
backend-1  | Terminated Signer
backend-1  | Terminated Signd
backend-1  | exiting servicedispatch...
backend-1  | 2024-07-30 16:08:23: [25]    servicedispatch exiting...
backend-1  | Terminated service dispatch
backend-1  | Name "BSConfig::cloudupload_maxchild" used only once: possible typo at /obs/src/backend/bs_clouduploadserver line 58.
backend-1  | 2024-07-30 16:08:24: [26]    clouduploadserver exiting...
backend-1  | exiting server...
backend-1  | Terminated cloud upload server
backend-1  | exiting clouduploadworker...
backend-1  | 2024-07-30 16:08:24: [27]    clouduploadworker exiting...
backend-1  | Terminated cloud upload worker
backend-1 exited with code 0
```