### PR TITLE
Fix mark as read button on the notification bar

### DIFF
--- a/src/api/app/helpers/webui/notification_helper.rb
+++ b/src/api/app/helpers/webui/notification_helper.rb
@@ -38,8 +38,8 @@ module Webui::NotificationHelper
   private
 
   def mark_as_read_or_unread_button(notification)
-    state = notification.unread? ? 'unread' : 'read'
-    update_path = my_notifications_path(notification_ids: [notification.id], state: state)
+    button = notification.unread? ? 'read' : 'unread'
+    update_path = my_notifications_path(notification_ids: [notification.id], button: button)
     title, icon = notification.unread? ? ['Mark as read', 'fa-check'] : ['Mark as unread', 'fa-undo']
     link_to(update_path, id: dom_id(notification, :update), method: :put,
                          class: 'btn btn-sm btn-outline-success', title: title) do

--- a/src/api/spec/helpers/webui/notification_helper_spec.rb
+++ b/src/api/spec/helpers/webui/notification_helper_spec.rb
@@ -5,8 +5,7 @@ RSpec.describe Webui::NotificationHelper do
     context 'for unread notification' do
       let(:notification) { create(:notification_for_comment, :web_notification, delivered: false) }
 
-      it { expect(link).to include(my_notifications_path(notification_ids: [notification.id])) }
-      it { expect(link).to include('state=unread') }
+      it { expect(link).to include('button=read') }
       it { expect(link).to include('Mark as read') }
       it { expect(link).to include('fa-check fas') }
     end
@@ -14,8 +13,7 @@ RSpec.describe Webui::NotificationHelper do
     context 'for read notification' do
       let(:notification) { create(:notification_for_comment, :web_notification, delivered: true) }
 
-      it { expect(link).to include(my_notifications_path(notification_ids: [notification.id])) }
-      it { expect(link).to include('state=read') }
+      it { expect(link).to include('button=unread') }
       it { expect(link).to include('Mark as unread') }
       it { expect(link).to include('fa-undo fas') }
     end


### PR DESCRIPTION
We were not passing what kind of button we had: "mark as read" or "mark as unread"

Fixes: #16587