### PR TITLE
Remove associated notifications when destroying a workflow run

### DIFF
--- a/src/api/app/models/workflow_run.rb
+++ b/src/api/app/models/workflow_run.rb
@@ -28,8 +28,8 @@ class WorkflowRun < ApplicationRecord
   has_many :artifacts, class_name: 'WorkflowArtifactsPerStep', dependent: :destroy
   has_many :scm_status_reports, class_name: 'SCMStatusReport', dependent: :destroy
   has_many :event_subscriptions, dependent: :destroy
+  has_many :notifications, as: :notifiable, dependent: :delete_all
 
-  after_destroy :remove_associated_notifications
   after_save :create_event, if: :status_changed_to_fail?
 
   scope :pull_request, -> { where(generic_event_type: 'pull_request') }
@@ -168,10 +168,6 @@ class WorkflowRun < ApplicationRecord
   # FIXME: How to get the real commit message for tag_push?
   def tag_push_message
     "Tag #{payload['ref']} got pushed"
-  end
-
-  def remove_associated_notifications
-    Notification.where(notifiable_type: 'WorkflowRun', notifiable_id: id).first&.destroy
   end
 end
 

--- a/src/api/app/models/workflow_run.rb
+++ b/src/api/app/models/workflow_run.rb
@@ -29,6 +29,7 @@ class WorkflowRun < ApplicationRecord
   has_many :scm_status_reports, class_name: 'SCMStatusReport', dependent: :destroy
   has_many :event_subscriptions, dependent: :destroy
 
+  after_destroy :remove_associated_notifications
   after_save :create_event, if: :status_changed_to_fail?
 
   scope :pull_request, -> { where(generic_event_type: 'pull_request') }
@@ -167,6 +168,10 @@ class WorkflowRun < ApplicationRecord
   # FIXME: How to get the real commit message for tag_push?
   def tag_push_message
     "Tag #{payload['ref']} got pushed"
+  end
+
+  def remove_associated_notifications
+    Notification.where(notifiable_type: 'WorkflowRun', notifiable_id: id).first&.destroy
   end
 end
 


### PR DESCRIPTION
This PR will only prevent the existence of new Notifications pointing nowhere, we should also clean our reference server from the already existing notifications that point to non-existent WorkflowRun's (given that the number of affected notifications is les than 10 I would do it manually).

See #16586
Fixes #16582