### PR TITLE
[dist] set body request size limit

### DIFF
--- a/dist/obs-apache24.conf
+++ b/dist/obs-apache24.conf
@@ -11,6 +11,8 @@ PassengerMaxPoolSize 20
 # allow long request urls and being part of headers
 LimitRequestLine 20000
 LimitRequestFieldsize 20000
+# unlimited request body (default would be 1GB)
+LimitRequestBody 0
 
 # Just the overview page
 <VirtualHost *:80>


### PR DESCRIPTION
SP6 apache seems to limit to 1GB, going back to unlimited in our config.