### PR TITLE
Add hidden submit field to request index filter form

### DIFF
--- a/src/api/app/views/webui/request/index.html.haml
+++ b/src/api/app/views/webui/request/index.html.haml
@@ -28,6 +28,7 @@
               %span.ms-3= page_entries_info(@bs_requests, entry_name: 'request')
           = render partial: 'request_item', collection: @bs_requests, as: :bs_request
           = paginate @bs_requests, views_prefix: 'webui'
+  = form.submit(nil, class: 'd-none')
 
 :javascript
   collectMultiSelects();


### PR DESCRIPTION
Right now its not possible to submit the search input field. For all other inputs of the same form we have auto submit implemented through JS. But this makes little sense for the search input.
By adding a hidden submit button we can default to common browser behavior of submitting the form when pressing the enter button on the selected input.

This is just a quick fix to allow usage of the search, but we might should revisit this and align the filter submission behavior. I noted this down here: https://trello.com/c/7onRo4zi/29-revisit-request-search-input-handling