### PR TITLE
List label templates on project show

### DIFF
--- a/src/api/app/controllers/webui/projects/label_templates_controller.rb
+++ b/src/api/app/controllers/webui/projects/label_templates_controller.rb
@@ -1,0 +1,13 @@
+module Webui
+  module Projects
+    class LabelTemplatesController < WebuiController
+      before_action :set_project
+
+      def index
+        head :not_found unless Flipper.enabled?(:labels, User.session)
+
+        @label_templates = @project.label_templates
+      end
+    end
+  end
+end

--- a/src/api/app/controllers/webui/projects/label_templates_controller.rb
+++ b/src/api/app/controllers/webui/projects/label_templates_controller.rb
@@ -4,7 +4,7 @@ module Webui
       before_action :set_project
 
       def index
-        head :not_found unless Flipper.enabled?(:labels, User.session)
+        authorize LabelTemplate.new(project: @project), :index?
 
         @label_templates = @project.label_templates
       end

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -89,6 +89,7 @@ class Project < ApplicationRecord
   has_many :notified_projects, dependent: :destroy
   has_many :notifications, through: :notified_projects
   has_many :reports, as: :reportable, dependent: :nullify
+  has_many :label_templates
 
   default_scope { where.not('projects.id' => Relationship.forbidden_project_ids) }
 

--- a/src/api/app/policies/label_template_policy.rb
+++ b/src/api/app/policies/label_template_policy.rb
@@ -1,0 +1,8 @@
+class LabelTemplatePolicy < ApplicationPolicy
+  def index?
+    return false unless Flipper.enabled?(:labels, @user)
+    return false unless record.project.maintainers.include?(@user)
+
+    true
+  end
+end

--- a/src/api/app/views/webui/project/_basic_info.html.haml
+++ b/src/api/app/views/webui/project/_basic_info.html.haml
@@ -4,12 +4,11 @@
       = category_badge(category)
   - if project.url.present?
     = link_to(project.url, project.url, class: 'mb-3 d-block')
-  #description-text
+  .mb-4#description-text
     - if project.description.blank?
       %i No description set
     - else
       = render partial: 'webui/shared/collapsible_text', locals: { text: project.description }
-
   - if policy(project).update?
     .pt-4
       = link_to(edit_project_path(project), class: 'ps-0', remote: true, title: 'Edit') do

--- a/src/api/app/views/webui/project/_tabs.html.haml
+++ b/src/api/app/views/webui/project/_tabs.html.haml
@@ -29,5 +29,5 @@
         = tab_link('Staging', staging_workflow_path(project), active, 'scrollable-tab-link')
       - elsif policy(Staging::Workflow.new(project: project)).create?
         = tab_link('Staging', new_staging_workflow_path(project: project), active, 'scrollable-tab-link')
-      - if Flipper.enabled?(:labels, User.session)
+      - if policy(LabelTemplate.new(project: project)).index?
         = tab_link('Label templates', project_label_templates_path(project), false, 'scrollable-tab-link')

--- a/src/api/app/views/webui/project/_tabs.html.haml
+++ b/src/api/app/views/webui/project/_tabs.html.haml
@@ -29,3 +29,5 @@
         = tab_link('Staging', staging_workflow_path(project), active, 'scrollable-tab-link')
       - elsif policy(Staging::Workflow.new(project: project)).create?
         = tab_link('Staging', new_staging_workflow_path(project: project), active, 'scrollable-tab-link')
+      - if Flipper.enabled?(:labels, User.session)
+        = tab_link('Label templates', project_label_templates_path(project), false, 'scrollable-tab-link')

--- a/src/api/app/views/webui/projects/label_templates/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui/projects/label_templates/_breadcrumb_items.html.haml
@@ -1,0 +1,3 @@
+= render partial: 'webui/project/breadcrumb_items'
+%li.breadcrumb-item.active{ 'aria-current' => 'page' }
+  Label templates

--- a/src/api/app/views/webui/projects/label_templates/index.html.haml
+++ b/src/api/app/views/webui/projects/label_templates/index.html.haml
@@ -1,0 +1,10 @@
+- @pagetitle = "Label templates for #{@project}"
+.card
+  = render(partial: 'webui/project/tabs', locals: { project: @project })
+
+  .card-body
+    %h3= @pagetitle
+    %ul.list-unstyled
+      - @label_templates.each do |label_template|
+        %li.mb-2
+          = render partial: 'webui/shared/label', locals: { label: label_template }

--- a/src/api/app/views/webui/shared/_label.html.haml
+++ b/src/api/app/views/webui/shared/_label.html.haml
@@ -1,7 +1,7 @@
 :css
   .label-#{label.id} {
     color: #{contrast_text(label.color)};
-    background-color: ##{label.color.to_s(16).rjust(6, "0")};
+    background-color: #{label.color};
   }
 %span.badge{ class: "label-#{label.id}" }
   = label.name

--- a/src/api/config/routes/webui.rb
+++ b/src/api/config/routes/webui.rb
@@ -311,6 +311,7 @@ constraints(RoutesHelper::WebuiMatcher) do
       end
     end
     put 'toggle_watched_item', controller: 'webui/watched_items', constraints: cons
+    resources :label_templates, controller: 'webui/projects/label_templates', only: %i[index], constraints: cons
   end
 
   controller 'webui/request' do


### PR DESCRIPTION
This is how it looks like now
![image](https://github.com/user-attachments/assets/fffa88b7-ddbe-427f-a54e-fdc4cb1f7893)

Depends on #16641

**How to test this**
- With the feature flag `labels` on:
  - Go to `home:Admin`, there you'll see a tab at the end called `Label templates`. 
  - Click on that and you'll be presented with the screen displayed above.

- Without the feature flag `labels` you won't see the tab, nor will you be able to access the page