### PR TITLE
Change label_template's color field to string

### DIFF
--- a/src/api/app/models/label_template.rb
+++ b/src/api/app/models/label_template.rb
@@ -17,7 +17,7 @@ class LabelTemplate < ApplicationRecord
 
   #### Validations macros
   validates :name, length: { maximum: 255 }, presence: true
-  validates :color, presence: true
+  validates :color, length: { maximum: 255 }, presence: true
 
   #### Class methods using self. (public and then private)
 
@@ -34,7 +34,7 @@ end
 # Table name: label_templates
 #
 #  id         :bigint           not null, primary key
-#  color      :integer          not null
+#  color      :string(255)      not null
 #  name       :string(255)      not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null

--- a/src/api/db/migrate/20240805122519_change_label_templates_color_to_string.rb
+++ b/src/api/db/migrate/20240805122519_change_label_templates_color_to_string.rb
@@ -1,0 +1,9 @@
+class ChangeLabelTemplatesColorToString < ActiveRecord::Migration[7.0]
+  def up
+    safety_assured { change_column :label_templates, :color, :string, null: false }
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_08_02_093510) do
+ActiveRecord::Schema[7.0].define(version: 2024_08_05_122519) do
   create_table "active_storage_attachments", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -731,7 +731,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_08_02_093510) do
   create_table "label_templates", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "project_id", null: false
     t.string "name", null: false
-    t.integer "color", null: false
+    t.string "color", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["project_id"], name: "index_label_templates_on_project_id"


### PR DESCRIPTION
Rails form field helpers for color expect a string so it's easier if we just use a string field instead of a numeric one.

The field change locks the table during the migration, but as no one is using this table on our reference server it's safe to deploy this whenever we see fit.