### PR TITLE
Split profile from logout links

### DIFF
--- a/src/api/app/views/layouts/webui/_top_navigation.html.haml
+++ b/src/api/app/views/layouts/webui/_top_navigation.html.haml
@@ -12,19 +12,13 @@
         .toggler.text-center.justify-content-center.nav-item
           = link_to(my_notifications_path, id: 'top-notifications-counter', class: 'nav-link text-light p-0 w-100', alt: 'Notifications') do
             = render partial: 'layouts/webui/unread_notifications_counter', locals: { unread_notifications_count: unread_notifications_count }
-        .toggler.text-center.justify-content-center.nav-item.dropdown
-          = link_to('#', class: 'nav-link dropdown-toggle text-light', id: 'top-navigation-profile-dropdown', role: 'button',
-                    'data-bs-toggle': 'dropdown', aria: { haspopup: true, expanded: false }) do
-            = render(AvatarComponent.new(name: User.session.name, email: User.session.email, size: 32, shape: :circle, custom_css: 'me-2'))
-          .dropdown-menu.dropdown-menu-end{ 'aria-labelledby': 'top-navigation-profile-dropdown' }
-            .dropdown-item
-              = link_to(user_path(User.session), id: 'link-to-user-home', class: 'nav-link text-light p-0 w-100') do
-                = render(AvatarComponent.new(name: User.session.name, email: User.session.email, size: 20, shape: :circle, custom_css: 'me-2'))
-                Your profile
-            .dropdown-item
-              = link_to(session_path, method: :delete, id: 'logout-link', class: 'nav-link text-light p-0 w-100') do
-                %i.fas.fa-sign-out-alt.fa-lg.me-2
-                Logout
+        .toggler.text-center.justify-content-center.nav-item
+          = link_to(user_path(User.session), id: 'link-to-user-home', class: 'nav-link text-light p-0 w-100') do
+            = render(AvatarComponent.new(name: User.session.name, email: User.session.email, size: 32, shape: :circle))
+        .toggler.text-center.justify-content-center.nav-item
+          = link_to(session_path, method: :delete, id: 'logout-link', class: 'nav-link text-light p-0 w-100', alt: 'Logout', data: { toggle: 'logout' }) do
+            %i.fas.fa-sign-out-alt
+            %span.d-block Logout
       - else
         = render partial: 'layouts/webui/top_navigation_nobody'
 


### PR DESCRIPTION
**What**
This PR splits into two separated links the profile page and the logout one.

**Why**
Between the two links, the most of the time the user wants just to go the the user's profile page, and in order to do that he has to click twice: one to open the dropdown, and one to click on the select the profile page link.

**Advantages**
With the current change the user's profile page is one click less far away.


# Before
![image](https://github.com/user-attachments/assets/174e16c5-ea12-416f-b354-e17760e9152f)
![image](https://github.com/user-attachments/assets/8cb6e7bc-7e37-4e72-88fc-576d8fac6901)


# After
## Option 1
#### The current PR implementation, the one I suggest right here right now
![image](https://github.com/user-attachments/assets/95c4f6cf-7ab5-45c1-af06-4f333e581db6)

## Option 2
#### A smaller icon with sub text
![image](https://github.com/user-attachments/assets/754030ca-cd5e-4aa5-988f-0d967b75690f)


