### PR TITLE
Ensure the  factory produces valid color codes

### DIFF
--- a/src/api/spec/factories/label_template.rb
+++ b/src/api/spec/factories/label_template.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :label_template do
     name { Faker::Lorem.word.capitalize }
-    color { "##{(rand * 0xffffff).to_i.to_s(16)}" } # Random value from 0x000000 - 0xffffff
+    color { "##{(rand * 0xffffff).to_i.to_s(16).rjust(6, '0')}" } # Random value from 0x000000 - 0xffffff
   end
 end


### PR DESCRIPTION
Depends on #16642

Sometimes the factory produces colors like "#1fb54" which is not a valid color code (it should be "#01fb54".