### PR TITLE
Render label templates instead of labels

### DIFF
--- a/src/api/app/views/webui/shared/_label_list.html.haml
+++ b/src/api/app/views/webui/shared/_label_list.html.haml
@@ -1,4 +1,4 @@
 - if Flipper.enabled?(:labels, User.session)
-  = render partial: 'webui/shared/label', collection: labelable.labels, as: :label
+  = render partial: 'webui/shared/label', collection: LabelTemplate.where(id: labelable.labels.pluck(:label_template_id)), as: :label
   - if policy(labelable).update_labels?
     = render partial: 'webui/shared/label_form', locals: { labelable:, project: }


### PR DESCRIPTION
This causes collisions with ids between the two, we need to avoid that