### PR TITLE
Allow rendering markdown in the description of projects and packages

### DIFF
--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -106,6 +106,7 @@ class Webui::ProjectController < Webui::WebuiController
     respond_to do |format|
       format.js do
         if @project.update(project_params)
+          @project.store
           flash.now[:success] = 'Project was successfully updated.'
         else
           flash.now[:error] = 'Failed to update the project.'

--- a/src/api/app/views/webui/package/_basic_info.html.haml
+++ b/src/api/app/views/webui/package/_basic_info.html.haml
@@ -8,7 +8,8 @@
     - if package.description.blank?
       %i No description set
     - else
-      = render partial: 'webui/shared/collapsible_text', locals: { text: package.description }
+      = render partial: 'webui/shared/collapsible_text', locals: { text: package.description,
+                                                                   render_markdown: Flipper.enabled?('foster_collaboration', User.session) }
 
   - if policy(package).update?
     .pt-4

--- a/src/api/app/views/webui/project/_basic_info.html.haml
+++ b/src/api/app/views/webui/project/_basic_info.html.haml
@@ -8,7 +8,8 @@
     - if project.description.blank?
       %i No description set
     - else
-      = render partial: 'webui/shared/collapsible_text', locals: { text: project.description }
+      = render partial: 'webui/shared/collapsible_text', locals: { text: project.description,
+                                                                   render_markdown: Flipper.enabled?('foster_collaboration', User.session) }
   - if policy(project).update?
     .pt-4
       = link_to(edit_project_path(project), class: 'ps-0', remote: true, title: 'Edit') do

--- a/src/api/app/views/webui/shared/_collapsible_text.html.haml
+++ b/src/api/app/views/webui/shared/_collapsible_text.html.haml
@@ -2,7 +2,10 @@
 - if text.present?
   .obs-collapsible-textbox.vanilla-textbox-to-collapse{ class: "#{extra_css_classes if defined?(extra_css_classes)}" }
     .obs-collapsible-text
-      = sanitize(simple_format(text), tags: %w[br p])
+      - if local_assigns[:render_markdown]
+        = render_as_markdown(text)
+      - else
+        = sanitize(simple_format(text), tags: %w[br p])
 
 :javascript
   setCollapsible();


### PR DESCRIPTION
After the changes proposed, entering some text like this editing a project and clicking in "Update":

![Screenshot from 2024-08-09 08-46-15](https://github.com/user-attachments/assets/7b48a772-0b30-44e4-ba4c-6b771fa50801)

... will result in:

![Screenshot from 2024-08-09 08-46-57](https://github.com/user-attachments/assets/b1e212f1-ed15-4a61-b498-095f4f3992cc)

Fixes #810.