### PR TITLE
Escape HTML blocks instead of removing them

### DIFF
--- a/src/api/lib/obsapi/markdown_renderer.rb
+++ b/src/api/lib/obsapi/markdown_renderer.rb
@@ -21,12 +21,6 @@ module OBSApi
       fulldoc
     end
 
-    def block_html(raw_html)
-      # sanitize the HTML we get
-      scrubber = Rails::Html::PermitScrubber.new.tap { |a| a.tags = %w[b em i strong u pre] }
-      Rails::Html::SafeListSanitizer.new.sanitize(raw_html, scrubber: scrubber)
-    end
-
     # unfortunately we can't call super (into C) - see vmg/redcarpet#51
     def link(link, title, content)
       # A return value of nil will not output any data

--- a/src/api/spec/helpers/webui/markdown_helper_spec.rb
+++ b/src/api/spec/helpers/webui/markdown_helper_spec.rb
@@ -49,8 +49,8 @@ RSpec.describe Webui::MarkdownHelper do
       expect(render_as_markdown("```ruby\ndef\n```")).to eq("<div class=\"CodeRay\">\n  <div class=\"code\"><pre><span class=\"keyword\">def</span>\n</pre></div>\n</div>\n")
     end
 
-    it 'does remove dangerous html from the view' do
-      expect(render_as_markdown('<script></script>')).to eq("\n")
+    it 'escapes dangerous html' do
+      expect(render_as_markdown('<script></script>')).to eq("<p>&lt;script&gt;&lt;/script&gt;</p>\n")
     end
 
     it 'does remove dangerous html from inside the code blocks with a language' do


### PR DESCRIPTION
The `block_html` callback gets called when a `<pre></pre>` section or a `<script></script>` section is found. This method doesn't get called for `<b>`, `<em>`, `<i>`, `<strong>` or `<u>` elements.

Rely on the default escape policy of the parser, instead of parsing HTML blocks and then leave `<pre></pre>` elements and remove `<script></script>` elements.

A text with this content:

![Screenshot from 2024-08-12 13-25-41](https://github.com/user-attachments/assets/7edb7bad-c31e-468d-b76f-77b164d60dc1)

Was rendered like this, before:

![Screenshot from 2024-08-12 13-24-38](https://github.com/user-attachments/assets/8d25f1d6-deb7-428d-8c56-ff02468c28fd)

And like this, after:

![Screenshot from 2024-08-12 13-30-23](https://github.com/user-attachments/assets/4b9247c2-04f3-4253-b6af-bb0e66a9cb98)
