### PR TITLE
Add censored column to the users table

### DIFF
--- a/src/api/app/models/unregistered_user.rb
+++ b/src/api/app/models/unregistered_user.rb
@@ -73,6 +73,7 @@ end
 #  adminnote                     :text(65535)
 #  biography                     :string(255)      default("")
 #  blocked_from_commenting       :boolean          default(FALSE), not null, indexed
+#  censored                      :boolean          default(FALSE), not null, indexed
 #  color_theme                   :integer          default("system"), not null
 #  deprecated_password           :string(255)      indexed
 #  deprecated_password_hash_type :string(255)
@@ -95,6 +96,7 @@ end
 # Indexes
 #
 #  index_users_on_blocked_from_commenting  (blocked_from_commenting)
+#  index_users_on_censored                 (censored)
 #  index_users_on_in_beta                  (in_beta)
 #  index_users_on_in_rollout               (in_rollout)
 #  index_users_on_rss_secret               (rss_secret) UNIQUE

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -888,6 +888,7 @@ end
 #  adminnote                     :text(65535)
 #  biography                     :string(255)      default("")
 #  blocked_from_commenting       :boolean          default(FALSE), not null, indexed
+#  censored                      :boolean          default(FALSE), not null, indexed
 #  color_theme                   :integer          default("system"), not null
 #  deprecated_password           :string(255)      indexed
 #  deprecated_password_hash_type :string(255)
@@ -910,6 +911,7 @@ end
 # Indexes
 #
 #  index_users_on_blocked_from_commenting  (blocked_from_commenting)
+#  index_users_on_censored                 (censored)
 #  index_users_on_in_beta                  (in_beta)
 #  index_users_on_in_rollout               (in_rollout)
 #  index_users_on_rss_secret               (rss_secret) UNIQUE

--- a/src/api/db/migrate/20240814141544_add_censored_to_users.rb
+++ b/src/api/db/migrate/20240814141544_add_censored_to_users.rb
@@ -1,0 +1,6 @@
+class AddCensoredToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :censored, :boolean, default: false, null: false
+    add_index :users, :censored
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_08_08_133204) do
+ActiveRecord::Schema[7.0].define(version: 2024_08_14_141544) do
   create_table "active_storage_attachments", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -1188,7 +1188,9 @@ ActiveRecord::Schema[7.0].define(version: 2024_08_08_133204) do
     t.string "rss_secret", limit: 200
     t.integer "color_theme", default: 0, null: false
     t.boolean "blocked_from_commenting", default: false, null: false
+    t.boolean "censored", default: false, null: false
     t.index ["blocked_from_commenting"], name: "index_users_on_blocked_from_commenting"
+    t.index ["censored"], name: "index_users_on_censored"
     t.index ["deprecated_password"], name: "users_password_index"
     t.index ["in_beta"], name: "index_users_on_in_beta"
     t.index ["in_rollout"], name: "index_users_on_in_rollout"


### PR DESCRIPTION
The final goal is to rename `blocked_from_commenting` to `censored` to avoid confusion with the block user action.

This is the first PR in a series to avoid downtime. The steps are:

1. Add new column `censored` to the users table. :arrow_left:
1. Write to both columns
2. Backfill data from the old column to the new column
3. Move reads from the old column to the new column
4. Stop writing to the old column
5. Drop the old column

