### PR TITLE
Write to censor column

### DIFF
--- a/src/api/app/controllers/webui/users_controller.rb
+++ b/src/api/app/controllers/webui/users_controller.rb
@@ -72,6 +72,7 @@ class Webui::UsersController < Webui::WebuiController
     authorize @displayed_user, :block_commenting?
 
     @displayed_user.update(params.require(:user).permit(:blocked_from_commenting))
+    @displayed_user.update(censored: @displayed_user.blocked_from_commenting) # TODO: remove when the renaming is finished
 
     if @displayed_user.save
       status = @displayed_user.blocked_from_commenting ? 'blocked from commenting' : 'allowed to comment again'


### PR DESCRIPTION
Follow-up  #16693

This is the second PR in a series to avoid downtime. The steps are:

1. Add new column `censored` to the users table.
1. Write to both columns  :arrow_left:
2. Backfill data from the old column to the new column
3. Move reads from the old column to the new column
4. Stop writing to the old column
5. Drop the old column

~**DO NOT MERGE** until the previous PR is deployed~ The previous PR is deployed.
