### PR TITLE
Backfill censored

### DIFF
--- a/src/api/db/data/20240814142031_backfill_censored_on_users.rb
+++ b/src/api/db/data/20240814142031_backfill_censored_on_users.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class BackfillCensoredOnUsers < ActiveRecord::Migration[7.0]
+  def up
+    User.where(blocked_from_commenting: true).in_batches do |batch|
+      batch.find_each do |user|
+        user.update(censored: user.blocked_from_commenting)
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/src/api/db/data_schema.rb
+++ b/src/api/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20240724091140)
+DataMigrate::Data.define(version: 20240814142031)


### PR DESCRIPTION
Follow-up  #16695

This is the third PR in a series to avoid downtime. The steps are:

1. Add new column `censored` to the users table.
1. Write to both columns 
2. Backfill data from the old column to the new column  :arrow_left:
3. Move reads from the old column to the new column
4. Stop writing to the old column
5. Drop the old column

~**DO NOT MERGE** until the previous PR is deployed~ The previous PR is deployed.
