### PR TITLE
Adapt code to censored

### DIFF
--- a/src/api/app/controllers/webui/users_controller.rb
+++ b/src/api/app/controllers/webui/users_controller.rb
@@ -3,7 +3,7 @@ class Webui::UsersController < Webui::WebuiController
 
   before_action :require_login, except: %i[show new create tokens autocomplete]
   before_action :require_admin, only: %i[index edit destroy]
-  before_action :check_displayed_user, only: %i[show edit block_commenting update destroy edit_account]
+  before_action :check_displayed_user, only: %i[show edit censor update destroy edit_account]
   before_action :role_titles, only: %i[show edit_account update]
   before_action :account_edit_link, only: %i[show edit_account update]
 
@@ -68,7 +68,7 @@ class Webui::UsersController < Webui::WebuiController
     end
   end
 
-  def block_commenting
+  def censor
     authorize @displayed_user, :censor?
 
     @displayed_user.update(params.require(:user).permit(:blocked_from_commenting))

--- a/src/api/app/controllers/webui/users_controller.rb
+++ b/src/api/app/controllers/webui/users_controller.rb
@@ -71,11 +71,10 @@ class Webui::UsersController < Webui::WebuiController
   def censor
     authorize @displayed_user, :censor?
 
-    @displayed_user.update(params.require(:user).permit(:blocked_from_commenting))
-    @displayed_user.update(censored: @displayed_user.blocked_from_commenting) # TODO: remove when the renaming is finished
+    @displayed_user.update(params.require(:user).permit(:censored))
 
     if @displayed_user.save
-      status = @displayed_user.blocked_from_commenting ? 'blocked from commenting' : 'allowed to comment again'
+      status = @displayed_user.censored ? "censored, they can't comment" : 'allowed to comment again'
       flash[:success] = "User '#{@displayed_user.login}' successfully #{status}."
     else
       flash[:error] = "Couldn't update user: #{@displayed_user.errors.full_messages.to_sentence}."

--- a/src/api/app/controllers/webui/users_controller.rb
+++ b/src/api/app/controllers/webui/users_controller.rb
@@ -69,7 +69,7 @@ class Webui::UsersController < Webui::WebuiController
   end
 
   def block_commenting
-    authorize @displayed_user, :block_commenting?
+    authorize @displayed_user, :censor?
 
     @displayed_user.update(params.require(:user).permit(:blocked_from_commenting))
     @displayed_user.update(censored: @displayed_user.blocked_from_commenting) # TODO: remove when the renaming is finished

--- a/src/api/app/jobs/measurements_job.rb
+++ b/src/api/app/jobs/measurements_job.rb
@@ -21,7 +21,7 @@ class MeasurementsJob < ApplicationJob
     {
       in_beta: User.in_beta.count,
       in_rollout: User.in_rollout.count,
-      blocked_from_commenting: User.where(blocked_from_commenting: true).count,
+      censored: User.where(censored: true).count,
       count: User.count
     }
       .merge(roles_measurements)

--- a/src/api/app/models/decision_favored_with_user_commenting_restriction.rb
+++ b/src/api/app/models/decision_favored_with_user_commenting_restriction.rb
@@ -13,7 +13,7 @@ class DecisionFavoredWithUserCommentingRestriction < Decision
 
   def self.display?(reportable)
     return false unless reportable.is_a?(Comment)
-    return false if reportable.user.blocked_from_commenting
+    return false if reportable.user.censored
 
     true
   end
@@ -25,7 +25,7 @@ class DecisionFavoredWithUserCommentingRestriction < Decision
   end
 
   def block_user
-    reports.first.reportable.user.update(blocked_from_commenting: true)
+    reports.first.reportable.user.update(censored: true)
   end
 end
 

--- a/src/api/app/policies/comment_policy.rb
+++ b/src/api/app/policies/comment_policy.rb
@@ -6,7 +6,7 @@ class CommentPolicy < ApplicationPolicy
   def create?
     return false if user.blank? || user.is_nobody?
     return true if maintainer? || important_user?
-    return false if user.blocked_from_commenting
+    return false if user.censored
 
     !locked?
   end

--- a/src/api/app/policies/user_policy.rb
+++ b/src/api/app/policies/user_policy.rb
@@ -13,7 +13,7 @@ class UserPolicy < ApplicationPolicy
     user == record || user.is_staff? || user.is_moderator? || user.is_admin?
   end
 
-  def block_commenting?
+  def censor?
     user.is_admin? || user.is_moderator?
   end
 end

--- a/src/api/app/views/webui/user/_basic_info.html.haml
+++ b/src/api/app/views/webui/user/_basic_info.html.haml
@@ -72,7 +72,7 @@
   - if user != User.possibly_nobody && Flipper.enabled?(:content_moderation, User.possibly_nobody)
     = render partial: 'webui/shared/report_modal'
     - if User.possibly_nobody.is_admin? || User.possibly_nobody.is_moderator?
-      = form_with(url: block_commenting_user_path(user), method: :put, remote: true) do |_form|
+      = form_with(url: censor_user_path(user), method: :put, remote: true) do |_form|
         .form-check.form-switch.mt-3
           = hidden_field_tag("user[blocked_from_commenting]", !user.blocked_from_commenting, id: nil)
           = check_box_tag("user[blocked_from_commenting]", !user.blocked_from_commenting, user.blocked_from_commenting,

--- a/src/api/app/views/webui/user/_basic_info.html.haml
+++ b/src/api/app/views/webui/user/_basic_info.html.haml
@@ -74,10 +74,10 @@
     - if User.possibly_nobody.is_admin? || User.possibly_nobody.is_moderator?
       = form_with(url: censor_user_path(user), method: :put, remote: true) do |_form|
         .form-check.form-switch.mt-3
-          = hidden_field_tag("user[blocked_from_commenting]", !user.blocked_from_commenting, id: nil)
-          = check_box_tag("user[blocked_from_commenting]", !user.blocked_from_commenting, user.blocked_from_commenting,
+          = hidden_field_tag("user[censored]", !user.censored, id: nil)
+          = check_box_tag("user[censored]", !user.censored, user.censored,
                           class: 'form-check-input', onChange: 'this.form.submit()')
-          = label_tag("user[blocked_from_commenting]", 'Comment Block', class: 'form-check-label')
+          = label_tag("user[censored]", 'Comment Block', class: 'form-check-label')
 
 :javascript
   $('#toggle-in-place-editing').on('click', function () {

--- a/src/api/config/routes/webui.rb
+++ b/src/api/config/routes/webui.rb
@@ -354,7 +354,7 @@ constraints(RoutesHelper::WebuiMatcher) do
       get 'tokens'
     end
     member do
-      put 'block_commenting'
+      put 'censor'
       post 'change_password'
       post 'rss_secret'
       get 'edit_account'

--- a/src/api/spec/controllers/webui/users_controller_spec.rb
+++ b/src/api/spec/controllers/webui/users_controller_spec.rb
@@ -375,7 +375,7 @@ RSpec.describe Webui::UsersController do
 
       context 'blocking the ability of a user to create comments' do
         before do
-          put :block_commenting, params: { login: user.login, user: { blocked_from_commenting: 'true' } }
+          put :censor, params: { login: user.login, user: { blocked_from_commenting: 'true' } }
         end
 
         it { expect(user.reload.blocked_from_commenting).to be(true) }

--- a/src/api/spec/controllers/webui/users_controller_spec.rb
+++ b/src/api/spec/controllers/webui/users_controller_spec.rb
@@ -373,16 +373,16 @@ RSpec.describe Webui::UsersController do
         login(moderator)
       end
 
-      context 'blocking the ability of a user to create comments' do
+      context 'censor the user so they can not comment' do
         before do
-          put :censor, params: { login: user.login, user: { blocked_from_commenting: 'true' } }
+          put :censor, params: { login: user.login, user: { censored: 'true' } }
         end
 
-        it { expect(user.reload.blocked_from_commenting).to be(true) }
-        it { expect(flash[:success]).to eq("User '#{user.login}' successfully blocked from commenting.") }
+        it { expect(user.reload.censored).to be(true) }
+        it { expect(flash[:success]).to eq("User '#{user.login}' successfully censored, they can't comment.") }
       end
 
-      context 'passing parameters other than the blocked_from_commenting' do
+      context 'passing parameters other than censored' do
         before do
           post :update, params: { login: user.login, user: { email: 'foo@bar.baz' } }
         end

--- a/src/api/spec/policies/comment_policy_spec.rb
+++ b/src/api/spec/policies/comment_policy_spec.rb
@@ -212,9 +212,9 @@ RSpec.describe CommentPolicy do
     it { is_expected.to permit(comment_author, comment) }
     it { is_expected.to permit(admin_user, comment) }
 
-    context 'for a user which is blocked from commenting' do
+    context 'for a user which is censored' do
       before do
-        comment_author.blocked_from_commenting = true
+        comment_author.censored = true
       end
 
       it { is_expected.not_to permit(comment_author, comment) }

--- a/src/api/spec/policies/user_policy_spec.rb
+++ b/src/api/spec/policies/user_policy_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe UserPolicy do
     it { is_expected.to permit(user, user) }
   end
 
-  permissions :block_commenting? do
+  permissions :censor? do
     it { is_expected.not_to permit(user, other_user) }
     it { is_expected.to permit(admin, user) }
     it { is_expected.to permit(moderator, user) }


### PR DESCRIPTION
Follow-up  #16695

This is the second PR in a series to avoid downtime. The steps are:

1. Add new column `censored` to the users table.
1. Write to both columns
2. Backfill data from the old column to the new column
3. Move reads from the old column to the new column  :arrow_left:
4. Stop writing to the old column  :arrow_left:
5. Drop the old column

~**DO NOT MERGE** until the previous PR is deployed~ The previous PR is deployed.
