### PR TITLE
Report button too close to reply button

### DIFF
--- a/src/api/app/components/bs_request_comment_component.html.haml
+++ b/src/api/app/components/bs_request_comment_component.html.haml
@@ -24,6 +24,15 @@
                                     action: comment_path(comment) },
                             class: 'dropdown-item delete_link', title: 'Delete comment') do
                 Delete
+            - if policy(Report.new(reportable: comment)).create?
+              = link_to('#', class: 'dropdown-item', id: "js-comment-#{comment.id}",
+                        data: { 'bs-toggle': 'modal',
+                                'bs-target': '#report-modal',
+                                'modal-title': "Report comment from #{comment.user}",
+                                'reportable-type': comment.class.name,
+                                'reportable-id': comment.id }) do
+                Report
+
       .ps-3.pe-5.py-2.border-bottom.d-flex.flex-column.flex-lg-row.justify-content-between.align-items-start.gap-2
         %span
           - if show_username
@@ -60,14 +69,6 @@
     -# This should be refactored to avoid relying on global state
     - if policy(comment).reply?
       .d-flex.justify-content-end.me-2
-        - if policy(Report.new(reportable: comment)).create?
-          = link_to('#', class: 'fst-italic small collapsed me-2', id: "js-comment-#{comment.id}",
-                data: { 'bs-toggle': 'modal',
-                        'bs-target': '#report-modal',
-                        'modal-title': "Report comment from #{comment.user}",
-                        'reportable-type': comment.class.name,
-                        'reportable-id': comment.id }) do
-            Report
         = link_to("#reply_form_of_#{comment.id}", id: "reply_button_of_#{comment.id}", 'data-bs-toggle': 'collapse',
                   class: 'fst-italic small collapsed') do
           Reply

--- a/src/api/app/components/bs_request_comment_component.html.haml
+++ b/src/api/app/components/bs_request_comment_component.html.haml
@@ -4,7 +4,7 @@
     = render(AvatarComponent.new(name: comment.user.name, email: comment.user.email, size: 35, shape: :circle, custom_css: 'avatars-counter'))
   .timeline-item-comment.ms-0.flex-fill.overflow-auto
     .comment-bubble.ms-3.position-relative{ id: "comment-#{comment.id}-bubble" }
-      - if policy(comment).update? || policy(comment).destroy?
+      - if policy(comment).update? || policy(comment).destroy? || policy(Report.new(reportable: comment)).create?
         .dropdown.dropleft.float-end.mx-3.position-absolute.top-0.end-0
           = link_to('#', role: 'button', 'data-bs-toggle': 'dropdown', 'aria-expanded': 'false') do
             %i.fas.fa-ellipsis

--- a/src/api/app/components/bs_request_comment_component.html.haml
+++ b/src/api/app/components/bs_request_comment_component.html.haml
@@ -17,13 +17,6 @@
               - if policy(comment).moderate?
                 = button_to(comment.moderated? ? 'Permit' : 'Moderate', moderate_comment_path(comment),
                             class: 'dropdown-item', remote: true, form_class: 'moderate-form', params: { moderation_state: !comment.moderated? })
-            - if policy(comment).destroy?
-              = link_to('#', data: { 'bs-toggle': 'modal',
-                                    'bs-target': '#delete-comment-modal',
-                                    confirmation_text: 'Please confirm deletion of comment',
-                                    action: comment_path(comment) },
-                            class: 'dropdown-item delete_link', title: 'Delete comment') do
-                Delete
             - if policy(Report.new(reportable: comment)).create?
               = link_to('#', class: 'dropdown-item', id: "js-comment-#{comment.id}",
                         data: { 'bs-toggle': 'modal',
@@ -32,6 +25,13 @@
                                 'reportable-type': comment.class.name,
                                 'reportable-id': comment.id }) do
                 Report
+            - if policy(comment).destroy?
+              = link_to('#', data: { 'bs-toggle': 'modal',
+                  'bs-target': '#delete-comment-modal',
+                  confirmation_text: 'Please confirm deletion of comment',
+                  action: comment_path(comment) },
+                  class: 'dropdown-item delete_link', title: 'Delete comment') do
+                Delete
 
       .ps-3.pe-5.py-2.border-bottom.d-flex.flex-column.flex-lg-row.justify-content-between.align-items-start.gap-2
         %span

--- a/src/api/app/components/bs_request_comment_component.html.haml
+++ b/src/api/app/components/bs_request_comment_component.html.haml
@@ -6,7 +6,7 @@
     .comment-bubble.ms-3.position-relative{ id: "comment-#{comment.id}-bubble" }
       - if policy(comment).update? || policy(comment).destroy? || policy(Report.new(reportable: comment)).create?
         .dropdown.dropleft.float-end.mx-3.position-absolute.top-0.end-0
-          = link_to('#', role: 'button', 'data-bs-toggle': 'dropdown', 'aria-expanded': 'false') do
+          = link_to('#', role: 'button', 'data-bs-toggle': 'dropdown', 'aria-expanded': 'false', id: "comment-#{comment.id}-dropdown-toggle") do
             %i.fas.fa-ellipsis
           .dropdown-menu
             - if policy(comment).update?

--- a/src/api/spec/features/beta/webui/reports_spec.rb
+++ b/src/api/spec/features/beta/webui/reports_spec.rb
@@ -113,6 +113,7 @@ RSpec.describe 'Reports', :js, :vcr do
       end
 
       it 'displays the "You reported this comment." message instantly' do
+        click_link(id: "comment-#{comment.id}-dropdown-toggle")
         click_link('Report', id: "js-comment-#{comment.id}")
         fill_and_submit_report_form
         expect(page).to have_text('You reported this comment.')
@@ -120,6 +121,7 @@ RSpec.describe 'Reports', :js, :vcr do
       end
 
       it 'is possible to report the both the comment and its author' do
+        click_link(id: "comment-#{comment.id}-dropdown-toggle")
         click_link('Report', id: "js-comment-#{comment.id}")
         fill_and_submit_report_form(report_comment_author: true)
         expect(page).to have_text('You reported this comment.')


### PR DESCRIPTION
In the comments feed, the report button was placed next to the reply button.  This ran the risk of accidentally reporting when a reply was intended.

This change moves the Report action under the context menu, as it is a less common action and this will prevent accidental reports.

To verify this, report something by clicking Report under the three-dots context menu.