### PR TITLE
Comment GitHub credentials' variables

### DIFF
--- a/src/api/lib/tasks/statistics/github/issues.rake
+++ b/src/api/lib/tasks/statistics/github/issues.rake
@@ -1,6 +1,6 @@
 # GITHUB login required in order to avoid rate limiting on http requests
-GITHUB_USERNAME = ''.freeze
-GITHUB_PASSWORD = ''.freeze
+# GITHUB_USERNAME = ''.freeze
+# GITHUB_PASSWORD = ''.freeze
 
 namespace :statistics do
   namespace :github do

--- a/src/api/lib/tasks/statistics/github/pull_requests.rake
+++ b/src/api/lib/tasks/statistics/github/pull_requests.rake
@@ -1,6 +1,6 @@
 # GITHUB login required in order to avoid rate limiting on http requests
-GITHUB_USERNAME = ''.freeze
-GITHUB_PASSWORD = ''.freeze
+# GITHUB_USERNAME = ''.freeze
+# GITHUB_PASSWORD = ''.freeze
 
 namespace :statistics do
   namespace :github do


### PR DESCRIPTION
Otherwise, we receive these warnings:
```
/obs/src/api/lib/tasks/statistics/github/pull_requests.rake:2: warning: already initialized constant GITHUB_USERNAME
/obs/src/api/lib/tasks/statistics/github/issues.rake:2: warning: previous definition of GITHUB_USERNAME was here
/obs/src/api/lib/tasks/statistics/github/pull_requests.rake:3: warning: already initialized constant GITHUB_PASSWORD
/obs/src/api/lib/tasks/statistics/github/issues.rake:3: warning: previous definition of GITHUB_PASSWORD was here
```

Related to #16700.