### PR TITLE
Add more info. about reported users in notifications

### DIFF
--- a/src/api/app/components/notification_component.html.haml
+++ b/src/api/app/components/notification_component.html.haml
@@ -26,7 +26,7 @@
         .col-auto.pe-0
           = helpers.avatars(@notification)
         .col-auto.ps-xs-2
-          .smart-overflow= @notification.description
+          .smart-overflow= description
       .row.d-none.d-md-block.ps-4
         .col
           %p.mt-3.mb-0= helpers.render_without_markdown(helpers.truncate_to_first_new_line(@notification.excerpt))

--- a/src/api/app/models/notification_report.rb
+++ b/src/api/app/models/notification_report.rb
@@ -2,11 +2,11 @@
 class NotificationReport < Notification
   def description
     case event_type
-    when 'Event::ReportForComment'
-      "'#{notifiable.user.login}' created a report for a comment from #{event_payload['commenter']}. This is the reason:"
     # TODO: Remove `Event::CreateReport` after all existing records are migrated to the new STI classes
-    when 'Event::CreateReport', 'Event::ReportForProject', 'Event::ReportForPackage', 'Event::ReportForUser'
+    when 'Event::CreateReport', 'Event::ReportForProject', 'Event::ReportForPackage'
       "'#{notifiable.user.login}' created a report for a #{event_payload['reportable_type'].downcase}. This is the reason:"
+    when 'Event::ReportForUser'
+      "#{notifiable.user} created a report"
     when 'Event::ReportForRequest'
       "'#{notifiable.user.login}' created a report for a request. This is the reason:"
     when 'Event::FavoredDecision'

--- a/src/api/spec/components/notification_component_spec.rb
+++ b/src/api/spec/components/notification_component_spec.rb
@@ -29,4 +29,36 @@ RSpec.describe NotificationComponent, type: :component do
       expect(rendered_content).to have_css("i.fa-comments[title='Comment notification']")
     end
   end
+
+  context 'reports' do
+    let(:accused) { create(:confirmed_user, login: 'accused') }
+    let(:notification) { create(:notification_for_report, event_payload: event_payload, event_type: event_type, notifiable: notifiable) }
+
+    before do
+      render_inline(described_class.new(notification: notification, selected_filter: selected_filter, page: 1))
+    end
+
+    context 'when the notification is about user' do
+      let(:event_payload) { { reporter: user.login, reportable_id: accused.id, reportable_type: 'User', reason: 'some sample text for reason field', category: 'spam', accused: accused.login } }
+      let(:event_type) { 'Event::ReportForUser' }
+      let(:notifiable) { create(:report, reportable: accused, reason: 'Some sample text') }
+
+      it 'renders information about user state' do
+        expect(rendered_content).to have_css('span', text: accused.state, class: 'badge')
+      end
+    end
+
+    context 'when the notification is about comment' do
+      let(:project) { create(:project, maintainer: user) }
+      let(:comment) { create(:comment, commentable: project) }
+      let(:event_type) { 'Event::ReportForComment' }
+      let(:notifiable) { create(:report, reportable: comment, reason: 'Some sample text') }
+      let(:event_payload) { { reporter: user.login, reportable_id: comment.id, reportable_type: 'Comment', reason: 'some sample text for reason field', category: 'spam' } }
+
+      it 'renders information about user state and its existing reports' do
+        expect(rendered_content).to have_css('span', text: accused.state, class: 'badge')
+        expect(rendered_content).to have_css('span', text: '+1', class: 'badge')
+      end
+    end
+  end
 end


### PR DESCRIPTION
Include user state, reports on user account, and number of reported comments on report user notification. In addition to that, include info about reported number of comments from same user on comment report notifications

![image](https://github.com/user-attachments/assets/165537e8-59dc-4948-9e78-fb8df3c10ed4)
