### PR TITLE
Add infos about additional reports and decision status to notifications

### DIFF
--- a/src/api/app/components/notification_component.html.haml
+++ b/src/api/app/components/notification_component.html.haml
@@ -20,6 +20,19 @@
             = helpers.bs_request_state_badge(@notification.notifiable.state)
           - if @notification.notifiable_type == 'WorkflowRun'
             = render WorkflowRunStatusBadgeComponent.new(status: @notification.notifiable.status, css_class: 'ms-1')
+          - if @notification.notifiable_type == 'Report' && count_of_additional_reports_for_reportable >= 1
+            %span.badge.text-bg-info.ms-1
+              +#{count_of_additional_reports_for_reportable}
+              = 'Report'.pluralize(count_of_additional_reports_for_reportable)
+          - if @notification.notifiable_type == 'Report'
+            - if @notification.notifiable.decision.present?
+              %span.badge.text-bg-success.ms-1
+                %i.fas.fa-gavel.me-1
+                Decided
+            - else
+              %span.badge.text-bg-warning.ms-1
+                %i.fas.fa-hourglass-half.me-1
+                Awaits decision
         .col-auto.actions.ms-auto.align-self-end.align-self-md-start
           = render NotificationMarkButtonComponent.new(@notification, @selected_filter, @page)
       .row.mt-1.ps-sm-4

--- a/src/api/app/components/notification_component.rb
+++ b/src/api/app/components/notification_component.rb
@@ -69,6 +69,10 @@ class NotificationComponent < ApplicationComponent
     Report.where(reportable: accused, decision: nil).count
   end
 
+  def count_of_additional_reports_for_reportable
+    @notification.notifiable.reportable.reports.where(decision: nil).count - 1
+  end
+
   def generate_report_description(reporter, accused, reports_on_comments, reports_on_user, comment: false)
     text = link_to(reporter, user_path(reporter, notification_id: @notification.id))
     text += ' created a report for '


### PR DESCRIPTION
In order to see at the first glance if a report was already processed and how many additional reports exist for the same reportable.


![image](https://github.com/user-attachments/assets/2a7c96a3-4921-4ba9-b43b-e5eeace31572)

TODO:
- ~~Add test case to `notification_component_spec`~~
- ~~Depends on https://github.com/openSUSE/open-build-service/pull/16709 (rebase first after it is merged)~~