### PR TITLE
Unpin `data_migrate` rubygem

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -64,7 +64,7 @@ gem 'gssapi', require: false
 # for sending events to rabbitmq
 gem 'bunny'
 # for making changes to existing data
-gem 'data_migrate', '~> 9.0'
+gem 'data_migrate'
 # for URI encoding
 gem 'addressable'
 # for XML builder

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -559,7 +559,7 @@ DEPENDENCIES
   coderay
   daemons
   dalli
-  data_migrate (~> 9.0)
+  data_migrate
   database_cleaner-active_record
   database_consistency
   deep_cloneable


### PR DESCRIPTION
Upstream maintainers recommend to use a release candidate of a major version. Unpinning the rubygem would allow to upgrade to the major version once it is available.

Related to: #14533 and #16731

See: https://github.com/ilyakatz/data-migrate/issues/325