### PR TITLE
Drop blocked_from_commenting from users table

### DIFF
--- a/src/api/app/models/unregistered_user.rb
+++ b/src/api/app/models/unregistered_user.rb
@@ -72,7 +72,6 @@ end
 #  id                            :integer          not null, primary key
 #  adminnote                     :text(65535)
 #  biography                     :string(255)      default("")
-#  blocked_from_commenting       :boolean          default(FALSE), not null, indexed
 #  censored                      :boolean          default(FALSE), not null, indexed
 #  color_theme                   :integer          default("system"), not null
 #  deprecated_password           :string(255)      indexed
@@ -95,12 +94,11 @@ end
 #
 # Indexes
 #
-#  index_users_on_blocked_from_commenting  (blocked_from_commenting)
-#  index_users_on_censored                 (censored)
-#  index_users_on_in_beta                  (in_beta)
-#  index_users_on_in_rollout               (in_rollout)
-#  index_users_on_rss_secret               (rss_secret) UNIQUE
-#  index_users_on_state                    (state)
-#  users_login_index                       (login) UNIQUE
-#  users_password_index                    (deprecated_password)
+#  index_users_on_censored    (censored)
+#  index_users_on_in_beta     (in_beta)
+#  index_users_on_in_rollout  (in_rollout)
+#  index_users_on_rss_secret  (rss_secret) UNIQUE
+#  index_users_on_state       (state)
+#  users_login_index          (login) UNIQUE
+#  users_password_index       (deprecated_password)
 #

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -887,7 +887,6 @@ end
 #  id                            :integer          not null, primary key
 #  adminnote                     :text(65535)
 #  biography                     :string(255)      default("")
-#  blocked_from_commenting       :boolean          default(FALSE), not null, indexed
 #  censored                      :boolean          default(FALSE), not null, indexed
 #  color_theme                   :integer          default("system"), not null
 #  deprecated_password           :string(255)      indexed
@@ -910,12 +909,11 @@ end
 #
 # Indexes
 #
-#  index_users_on_blocked_from_commenting  (blocked_from_commenting)
-#  index_users_on_censored                 (censored)
-#  index_users_on_in_beta                  (in_beta)
-#  index_users_on_in_rollout               (in_rollout)
-#  index_users_on_rss_secret               (rss_secret) UNIQUE
-#  index_users_on_state                    (state)
-#  users_login_index                       (login) UNIQUE
-#  users_password_index                    (deprecated_password)
+#  index_users_on_censored    (censored)
+#  index_users_on_in_beta     (in_beta)
+#  index_users_on_in_rollout  (in_rollout)
+#  index_users_on_rss_secret  (rss_secret) UNIQUE
+#  index_users_on_state       (state)
+#  users_login_index          (login) UNIQUE
+#  users_password_index       (deprecated_password)
 #

--- a/src/api/db/data/20240814142031_backfill_censored_on_users.rb
+++ b/src/api/db/data/20240814142031_backfill_censored_on_users.rb
@@ -2,6 +2,8 @@
 
 class BackfillCensoredOnUsers < ActiveRecord::Migration[7.0]
   def up
+    return unless User.columns.any? { |c| c.name == 'blocked_from_commenting' }
+
     User.where(blocked_from_commenting: true).in_batches do |batch|
       batch.find_each do |user|
         user.update(censored: user.blocked_from_commenting)

--- a/src/api/db/migrate/20240823084727_drop_blocked_from_commenting_from_users.rb
+++ b/src/api/db/migrate/20240823084727_drop_blocked_from_commenting_from_users.rb
@@ -1,0 +1,5 @@
+class DropBlockedFromCommentingFromUsers < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured { remove_column :users, :blocked_from_commenting, :boolean }
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_08_14_141544) do
+ActiveRecord::Schema[7.0].define(version: 2024_08_23_084727) do
   create_table "active_storage_attachments", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -1187,9 +1187,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_08_14_141544) do
     t.string "biography", default: ""
     t.string "rss_secret", limit: 200
     t.integer "color_theme", default: 0, null: false
-    t.boolean "blocked_from_commenting", default: false, null: false
     t.boolean "censored", default: false, null: false
-    t.index ["blocked_from_commenting"], name: "index_users_on_blocked_from_commenting"
     t.index ["censored"], name: "index_users_on_censored"
     t.index ["deprecated_password"], name: "users_password_index"
     t.index ["in_beta"], name: "index_users_on_in_beta"


### PR DESCRIPTION
Follow up to #16698.

This is the last PR in a series to avoid downtime. The steps are:

1. Add new column `censored` to the users table.
1. Write to both columns
2. Backfill data from the old column to the new column
3. Move reads from the old column to the new column
4. Stop writing to the old column
5. Drop the old column  :arrow_left:
