### PR TITLE
Change event_payload column size from TEXT to MEDIUMTEXT

### DIFF
--- a/src/api/app/models/notification.rb
+++ b/src/api/app/models/notification.rb
@@ -105,7 +105,7 @@ end
 #  bs_request_oldstate        :string(255)
 #  bs_request_state           :string(255)
 #  delivered                  :boolean          default(FALSE), indexed
-#  event_payload              :text(65535)      not null
+#  event_payload              :text(16777215)   not null
 #  event_type                 :string(255)      not null, indexed
 #  last_seen_at               :datetime
 #  notifiable_type            :string(255)      indexed => [notifiable_id]

--- a/src/api/app/models/notification_bs_request.rb
+++ b/src/api/app/models/notification_bs_request.rb
@@ -37,7 +37,7 @@ end
 #  bs_request_oldstate        :string(255)
 #  bs_request_state           :string(255)
 #  delivered                  :boolean          default(FALSE), indexed
-#  event_payload              :text(65535)      not null
+#  event_payload              :text(16777215)   not null
 #  event_type                 :string(255)      not null, indexed
 #  last_seen_at               :datetime
 #  notifiable_type            :string(255)      indexed => [notifiable_id]

--- a/src/api/app/models/notification_comment.rb
+++ b/src/api/app/models/notification_comment.rb
@@ -75,7 +75,7 @@ end
 #  bs_request_oldstate        :string(255)
 #  bs_request_state           :string(255)
 #  delivered                  :boolean          default(FALSE), indexed
-#  event_payload              :text(65535)      not null
+#  event_payload              :text(16777215)   not null
 #  event_type                 :string(255)      not null, indexed
 #  last_seen_at               :datetime
 #  notifiable_type            :string(255)      indexed => [notifiable_id]

--- a/src/api/app/models/notification_group.rb
+++ b/src/api/app/models/notification_group.rb
@@ -35,7 +35,7 @@ end
 #  bs_request_oldstate        :string(255)
 #  bs_request_state           :string(255)
 #  delivered                  :boolean          default(FALSE), indexed
-#  event_payload              :text(65535)      not null
+#  event_payload              :text(16777215)   not null
 #  event_type                 :string(255)      not null, indexed
 #  last_seen_at               :datetime
 #  notifiable_type            :string(255)      indexed => [notifiable_id]

--- a/src/api/app/models/notification_package.rb
+++ b/src/api/app/models/notification_package.rb
@@ -54,7 +54,7 @@ end
 #  bs_request_oldstate        :string(255)
 #  bs_request_state           :string(255)
 #  delivered                  :boolean          default(FALSE), indexed
-#  event_payload              :text(65535)      not null
+#  event_payload              :text(16777215)   not null
 #  event_type                 :string(255)      not null, indexed
 #  last_seen_at               :datetime
 #  notifiable_type            :string(255)      indexed => [notifiable_id]

--- a/src/api/app/models/notification_project.rb
+++ b/src/api/app/models/notification_project.rb
@@ -42,7 +42,7 @@ end
 #  bs_request_oldstate        :string(255)
 #  bs_request_state           :string(255)
 #  delivered                  :boolean          default(FALSE), indexed
-#  event_payload              :text(65535)      not null
+#  event_payload              :text(16777215)   not null
 #  event_type                 :string(255)      not null, indexed
 #  last_seen_at               :datetime
 #  notifiable_type            :string(255)      indexed => [notifiable_id]

--- a/src/api/app/models/notification_report.rb
+++ b/src/api/app/models/notification_report.rb
@@ -150,7 +150,7 @@ end
 #  bs_request_oldstate        :string(255)
 #  bs_request_state           :string(255)
 #  delivered                  :boolean          default(FALSE), indexed
-#  event_payload              :text(65535)      not null
+#  event_payload              :text(16777215)   not null
 #  event_type                 :string(255)      not null, indexed
 #  last_seen_at               :datetime
 #  notifiable_type            :string(255)      indexed => [notifiable_id]

--- a/src/api/app/models/notification_workflow_run.rb
+++ b/src/api/app/models/notification_workflow_run.rb
@@ -30,7 +30,7 @@ end
 #  bs_request_oldstate        :string(255)
 #  bs_request_state           :string(255)
 #  delivered                  :boolean          default(FALSE), indexed
-#  event_payload              :text(65535)      not null
+#  event_payload              :text(16777215)   not null
 #  event_type                 :string(255)      not null, indexed
 #  last_seen_at               :datetime
 #  notifiable_type            :string(255)      indexed => [notifiable_id]

--- a/src/api/db/migrate/20241205104819_change_notification_event_payload_to_mediumtext.rb
+++ b/src/api/db/migrate/20241205104819_change_notification_event_payload_to_mediumtext.rb
@@ -1,0 +1,9 @@
+class ChangeNotificationEventPayloadToMediumtext < ActiveRecord::Migration[7.0]
+  def up
+    safety_assured { change_column :notifications, :event_payload, :mediumtext }
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_10_22_134922) do
+ActiveRecord::Schema[7.0].define(version: 2024_12_05_104819) do
   create_table "active_storage_attachments", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -778,7 +778,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_10_22_134922) do
 
   create_table "notifications", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "event_type", null: false
-    t.text "event_payload", null: false
+    t.text "event_payload", size: :medium, null: false
     t.string "subscription_receiver_role", null: false
     t.boolean "delivered", default: false
     t.datetime "created_at", precision: nil, null: false


### PR DESCRIPTION
This change was missing when the payload colum size of table events was changed.

Related to #15649.