### PR TITLE
Don't throw an exception on project not found

### DIFF
--- a/src/api/app/helpers/webui/request_helper.rb
+++ b/src/api/app/helpers/webui/request_helper.rb
@@ -277,7 +277,7 @@ module Webui::RequestHelper
     target_project_ids = bs_request.bs_request_actions.pluck(:target_project_id).uniq
     return if target_project_ids.count > 1
 
-    Project.find(target_project_ids.last)
+    Project.find_by(id: target_project_ids.last)
   end
 
   def can_apply_labels?(bs_request:, user:)


### PR DESCRIPTION
Throwing an exception prevents from showing requests on deleted projects.

Fixes #16670.