### PR TITLE
[backend] provide a better hint why a patchinfo build is blocked

### DIFF
--- a/src/backend/BSSched/BuildJob/Patchinfo.pm
+++ b/src/backend/BSSched/BuildJob/Patchinfo.pm
@@ -274,11 +274,11 @@ sub check {
     }
     my $blockedarch;
     for my $apackid (@packages) {
-      my $code = $apackstatus->{$apackid} || '';
+      my $code = $apackstatus->{$apackid} || 'unknown';
       next if $code eq 'excluded';
       if ($code ne 'done' && $code ne 'failed' && $code ne 'succeeded' && $code ne 'disabled' && $code ne 'locked') {
         $blockedarch = 1;
-        push @blocked, "$arch/$apackid";
+        push @blocked, "$arch/$apackid ($code)";
         next;
       }
       if (-e "$agdst/:logfiles.fail/$apackid") {


### PR DESCRIPTION
We now always append the status code to the package name, like we already did with failed packages.