### PR TITLE
Reduce validation value of the length of a submit request description

### DIFF
--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -5,6 +5,9 @@ include MaintenanceHelper
 # rubocop:disable Metrics/ClassLength
 class BsRequest < ApplicationRecord
   include BsRequest::Errors
+
+  MAX_DESCRIPTION_LENGTH_ALLOWED = 64_000
+
   SEARCHABLE_FIELDS = [
     'bs_requests.creator',
     'bs_requests.priority',
@@ -90,7 +93,7 @@ class BsRequest < ApplicationRecord
   validate :check_supersede_state
   validate :check_creator, on: %i[create save!]
   validates :comment, length: { maximum: 65_535 }
-  validates :description, length: { maximum: 65_535 }
+  validates :description, length: { maximum: MAX_DESCRIPTION_LENGTH_ALLOWED }
   validates :number, uniqueness: true
   validates_associated :bs_request_actions, message: ->(_, record) { record[:value].map { |r| r.errors.full_messages }.flatten.to_sentence }
 

--- a/src/api/app/views/webui/requests/submissions/new.html.haml
+++ b/src/api/app/views/webui/requests/submissions/new.html.haml
@@ -37,7 +37,9 @@
               .mb-3
                 = f.label(:description, 'Please describe your reasons to submit this package:')
                 %abbr.text-danger{ title: 'required' } *
-                ~ f.text_area(:description, size: '40x3', class: 'form-control', required: true)
+                %br
+                %abbr.form-text (The content of this field is limited to #{BsRequest::MAX_DESCRIPTION_LENGTH_ALLOWED} characters)
+                ~ f.text_area(:description, size: '40x3', class: 'form-control', required: true, maxlength: BsRequest::MAX_DESCRIPTION_LENGTH_ALLOWED)
               .mb-3.d-none#supersede-display
                 = label_tag(:supersede_requests, 'Supersede requests:')
                 #supersede-requests


### PR DESCRIPTION
This is a workoaround to prevent notifications from not being sent when the descriptions of the submit requests are very big.

![Screenshot from 2024-08-29 13-33-02](https://github.com/user-attachments/assets/44691bef-be98-4c48-bca0-3e7c1a6327b0)
