### PR TITLE
Refactor `check_access?` method for projects

### DIFF
--- a/src/api/app/models/concerns/project_maintenance.rb
+++ b/src/api/app/models/concerns/project_maintenance.rb
@@ -22,7 +22,7 @@ module ProjectMaintenance
       at ||= AttribType.find_by_namespace_and_name!('OBS', 'MaintenanceProject')
       maintenance_project = Project.find_by_attribute_type(at).first
 
-      return unless maintenance_project && check_access?(maintenance_project)
+      return unless maintenance_project && maintenance_project.check_access?
 
       maintenance_project
     end

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -20,6 +20,8 @@ class Package < ApplicationRecord
   accepts_nested_attributes_for :kiwi_image
 
   belongs_to :project, inverse_of: :packages
+
+  delegate :check_access?, to: :project
   delegate :name, to: :project, prefix: true
 
   attr_accessor :commit_opts, :commit_user
@@ -119,7 +121,7 @@ class Package < ApplicationRecord
     return false if package.nil?
     return false unless package.instance_of?(Package)
 
-    Project.check_access?(package.project)
+    package.project.check_access?
   end
 
   def self.check_cache(project, package, opts)
@@ -303,10 +305,6 @@ class Package < ApplicationRecord
     return false if (disabled_for?('sourceaccess', nil, nil) || project.disabled_for?('sourceaccess', nil, nil)) && !User.possibly_nobody.can_source_access?(self)
 
     true
-  end
-
-  def check_access?
-    Project.check_access?(project)
   end
 
   def check_source_access!


### PR DESCRIPTION
Instead of having a class method, use an instance method. We will always apply this method to an existing project.