### PR TITLE
Get rid of `find_by_attribute_type` Project class method

### DIFF
--- a/src/api/app/controllers/search_controller.rb
+++ b/src/api/app/controllers/search_controller.rb
@@ -96,7 +96,7 @@ class SearchController < ApplicationController
       if params[:project].blank?
         attribute = AttribType.find_by_name!(params[:attribute] || 'OBS:OwnerRootProject')
         # Find marked projects
-        projects = Project.find_by_attribute_type(attribute)
+        projects = Project.joins(:attribs).where(attribs: { attrib_type_id: attribute.id })
         return projects unless params[:package]
 
         pkgs = []

--- a/src/api/app/jobs/project_create_auto_cleanup_requests_job.rb
+++ b/src/api/app/jobs/project_create_auto_cleanup_requests_job.rb
@@ -41,7 +41,7 @@ These requests are not created for projects with open requests or if you remove 
       @cleanup_attribute = AttribType.find_by_namespace_and_name!('OBS', 'AutoCleanup')
       @cleanup_time = Time.zone.now + cleanup_days.days
 
-      Project.find_by_attribute_type(@cleanup_attribute).each do |prj|
+      Project.joins(:attribs).where(attribs: { attrib_type_id: @cleanup_attribute.id }).find_each do |prj|
         autoclean_project(prj)
       end
     end

--- a/src/api/app/models/branch_package.rb
+++ b/src/api/app/models/branch_package.rb
@@ -468,7 +468,7 @@ class BranchPackage
         end
         # Find all indirect instance via project links
         ltprj = nil
-        Project.find_by_attribute_type(at).each do |lprj|
+        Project.joins(:attribs).where(attribs: { attrib_type_id: at.id }).find_each do |lprj|
           # FIXME: this will not find packages on linked remote projects
           ltprj = lprj
           pkg2 = lprj.find_package(params[:package])

--- a/src/api/app/models/branch_package/lookup_incident_package.rb
+++ b/src/api/app/models/branch_package/lookup_incident_package.rb
@@ -49,6 +49,6 @@ class BranchPackage::LookupIncidentPackage
   end
 
   def maintenance_projects
-    @maintenance_projects ||= Project.find_by_attribute_type(obs_maintenance_project)
+    @maintenance_projects ||= Project.joins(:attribs).where(attribs: { attrib_type_id: obs_maintenance_project.id })
   end
 end

--- a/src/api/app/models/concerns/project_maintenance.rb
+++ b/src/api/app/models/concerns/project_maintenance.rb
@@ -20,7 +20,7 @@ module ProjectMaintenance
   class_methods do
     def get_maintenance_project(at = nil)
       at ||= AttribType.find_by_namespace_and_name!('OBS', 'MaintenanceProject')
-      maintenance_project = Project.find_by_attribute_type(at).first
+      maintenance_project = Project.joins(:attribs).where(attribs: { attrib_type_id: at.id }).first
 
       return unless maintenance_project && check_access?(maintenance_project)
 

--- a/src/api/app/models/owner_search/base.rb
+++ b/src/api/app/models/owner_search/base.rb
@@ -31,7 +31,7 @@ module OwnerSearch
       return [Project.get_by_name(params[:project])] if params[:project]
 
       # Find all marked projects
-      projects = Project.find_by_attribute_type(attribute)
+      projects = Project.joins(:attribs).where(attribs: { attrib_type_id: attribute.id })
       return projects unless projects.empty?
 
       raise AttributeNotSetError, "The attribute #{attribute.fullname} is not set to define default projects."

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -281,10 +281,6 @@ class Project < ApplicationRecord
       dbp
     end
 
-    def find_by_attribute_type(attrib_type)
-      Project.joins(:attribs).where(attribs: { attrib_type_id: attrib_type.id })
-    end
-
     def find_remote_project(name, skip_access: false)
       return unless name
 

--- a/src/api/app/services/user_service/involved.rb
+++ b/src/api/app/services/user_service/involved.rb
@@ -42,7 +42,7 @@ module UserService
     end
 
     def owner_root_project_exists?
-      Project.find_by_attribute_type(AttribType.find_by_name!('OBS:OwnerRootProject')).exists?
+      Project.joins(:attribs).exists?(attribs: { attrib_type: AttribType.find_by_name!('OBS:OwnerRootProject') })
     end
 
     def involved_items_as_owner


### PR DESCRIPTION
It only abstracts what Rails already provides with its Active Record Query interface methods. Also, the `find_by` part of the method is confusing.