### PR TITLE
Move "Lock/Unlock Comments" button to the "Action" section

### DIFF
--- a/src/api/app/helpers/webui/comment_locks_helper.rb
+++ b/src/api/app/helpers/webui/comment_locks_helper.rb
@@ -1,6 +1,6 @@
 module Webui::CommentLocksHelper
   def comment_lock_alert(commentable)
-    alert = 'You can remove the lock by clicking on the button below.'
+    alert = 'You can remove the lock by clicking on the "Unlock Comments" button in the Actions section.'
     return alert if commentable.comment_lock
 
     if commentable.is_a?(Package) && commentable.project.comment_lock

--- a/src/api/app/views/webui/comment/_comment_field.html.haml
+++ b/src/api/app/views/webui/comment/_comment_field.html.haml
@@ -1,5 +1,4 @@
 - entity_type = commentable.class.name == 'BsRequest' ? 'request' : commentable.class.name.downcase
-- modal_id = "lock-#{entity_type}-#{commentable.id}-#{element_suffix}"
 
 = form_for(comment, method: form_method, remote: true, html: { id: "#{element_suffix}_form",
 class: "#{form_method}-comment-form write-and-preview" },
@@ -32,22 +31,11 @@ data: { preview_message_url: preview_comments_path, message_body_param: 'comment
         - case form_method
         - when :post
           = f.submit 'Add comment', class: 'btn btn-primary me-2', data: { disable_with: 'Creating comment...' }, disabled: true
-          - if !comment.parent_id && CommentLockPolicy.new(User.session, commentable).create?
-            = button_tag(type: 'button', class: 'btn btn-warning me-2', data: { 'bs-toggle': 'modal', 'bs-target': "##{modal_id}-modal" }) do
-              - if commentable.comment_lock.blank?
-                %i.fa.fa-lock
-                Lock comments
-              - else
-                %i.fa.fa-unlock
-                Unlock comments
         - when :put
           = f.submit 'Update comment', class: 'btn btn-primary me-2', data: { disable_with: 'Updating comment...' }
         - if has_cancel
           %a.cancel-comment.btn.btn-outline-secondary
             Cancel
-
-- if !comment.parent_id && CommentLockPolicy.new(User.session, commentable).create?
-  = render partial: 'webui/shared/locking_dialog', locals: { commentable: commentable, entity_type: entity_type, modal_id: modal_id }
 
 :javascript
   attachPreviewMessageOnCommentBoxes();

--- a/src/api/app/views/webui/request/_actions.html.haml
+++ b/src/api/app/views/webui/request/_actions.html.haml
@@ -1,6 +1,9 @@
 -# TODO: drop this partial when `request_show_redesign` feature is rolled out
 - content_for :actions do
-  %li.nav-item
-    = link_to('#', data: { 'bs-toggle': 'modal', 'bs-target': '#add-reviewer-modal' }, class: 'nav-link', title: 'Add a Review') do
-      %i.fas.fa-plus-circle.fa-lg.me-2
-      %span.nav-item-name Add a Review
+  - if CommentLockPolicy.new(User.possibly_nobody, bs_request).create?
+    = render partial: 'webui/request/lock_unlock_comment', locals: { bs_request: bs_request }
+  - if can_add_reviews
+    %li.nav-item
+      = link_to('#', data: { 'bs-toggle': 'modal', 'bs-target': '#add-reviewer-modal' }, class: 'nav-link', title: 'Add a Review') do
+        %i.fas.fa-plus-circle.fa-lg.me-2
+        %span.nav-item-name Add a Review

--- a/src/api/app/views/webui/request/_lock_unlock_comment.html.haml
+++ b/src/api/app/views/webui/request/_lock_unlock_comment.html.haml
@@ -1,0 +1,8 @@
+%li.nav-item
+  = link_to('#', class: 'nav-link', data: { 'bs-toggle': 'modal', 'bs-target': "#locking-request-#{bs_request.id}-modal" }) do
+    - if bs_request.comment_lock.blank?
+      %i.fas.fa-comment-slash
+      Lock Comments
+    - else
+      %i.fas.fa-comment
+      Unlock Comments

--- a/src/api/app/views/webui/request/_request_comments.html.haml
+++ b/src/api/app/views/webui/request/_request_comments.html.haml
@@ -24,5 +24,7 @@
           = render partial: 'webui/comment/show', locals: { commentable: superseded,
             comment_counter_id: "#comment-counter-request-#{superseded.number}" }
 
+- if CommentLockPolicy.new(User.possibly_nobody, bs_request).create?
+  = render partial: 'webui/shared/locking_dialog', locals: { commentable: bs_request, entity_type: 'request' }
 - if Flipper.enabled?(:content_moderation, User.possibly_nobody)
   = render partial: 'webui/shared/report_modal'

--- a/src/api/app/views/webui/request/_show_actions.html.haml
+++ b/src/api/app/views/webui/request/_show_actions.html.haml
@@ -1,3 +1,5 @@
 - content_for :actions do
+  - if CommentLockPolicy.new(User.possibly_nobody, bs_request).create?
+    = render partial: 'webui/request/lock_unlock_comment', locals: { bs_request: bs_request }
   - if policy(Report.new(reportable: bs_request)).create?
     = render partial: 'webui/request/report_request', locals: { bs_request: bs_request }

--- a/src/api/app/views/webui/request/beta_show.html.haml
+++ b/src/api/app/views/webui/request/beta_show.html.haml
@@ -121,6 +121,8 @@
   = render DeleteConfirmationDialogComponent.new(modal_id: 'delete-comment-modal',
                                                  method: :delete,
                                                  options: { modal_title: 'Delete comment?', remote: true })
+  - if CommentLockPolicy.new(User.possibly_nobody, @bs_request).create?
+    = render partial: 'webui/shared/locking_dialog', locals: { commentable: @bs_request, entity_type: 'request' }
   - if Flipper.enabled?(:content_moderation, User.possibly_nobody)
     = render partial: 'webui/shared/report_modal'
 -# haml-lint:enable ViewLength

--- a/src/api/app/views/webui/request/show.html.haml
+++ b/src/api/app/views/webui/request/show.html.haml
@@ -26,8 +26,7 @@
                                                      projects: @watched_projects }
       .col-md-4#side-links
         = render partial: 'show_side_links', locals: { bs_request: @bs_request, package_maintainers: @package_maintainers }
-      - if @can_add_reviews
-        = render partial: 'actions'
+      = render partial: 'actions', locals: { bs_request: @bs_request, can_add_reviews: @can_add_reviews }
 
 .card.mb-3
   .card-header.p-0

--- a/src/api/app/views/webui/shared/_locking_dialog.html.haml
+++ b/src/api/app/views/webui/shared/_locking_dialog.html.haml
@@ -1,4 +1,4 @@
-.modal.fade{ tabindex: -1, id: "#{modal_id}-modal" }
+.modal.fade{ tabindex: -1, id: "locking-#{entity_type}-#{commentable.id}-modal" }
   .modal-dialog
     .modal-content
       - if commentable.comment_lock.blank?

--- a/src/api/spec/features/webui/comment_locks_spec.rb
+++ b/src/api/spec/features/webui/comment_locks_spec.rb
@@ -25,14 +25,16 @@ RSpec.describe 'CommentLocks', :vcr do
         end
 
         it 'checks comments are unlocked' do
-          find_button('Lock comments')
-          expect(page).to have_no_text('Commenting on this is locked. You can remove the lock by clicking on the button below.')
+          click_link_or_button('Actions') if mobile?
+          expect(page).to have_link('Lock Comments')
+          expect(page).to have_no_text('Commenting on this is locked.')
         end
 
         it 'locks comments' do
-          find_button('Lock comments').click
+          click_link_or_button('Actions') if mobile?
+          find_link('Lock Comments').click
           find_button('Lock').click
-          expect(page).to have_text('Commenting on this is locked. You can remove the lock by clicking on the button below.')
+          expect(page).to have_text('Commenting on this is locked.')
         end
       end
 
@@ -43,11 +45,15 @@ RSpec.describe 'CommentLocks', :vcr do
         end
 
         it 'cannot lock comments' do
-          expect(page).to have_no_button('Lock comments')
+          if mobile?
+            expect(page).to have_no_link('Actions')
+          else
+            expect(page).to have_no_link('Lock Comments')
+          end
         end
 
         it 'can comment' do
-          expect(page).to have_no_text('Commenting on this is locked')
+          expect(page).to have_no_text('Commenting on this is locked.')
           fill_in 'new_comment_body', with: 'Comment Body'
           find_button('Add comment')
         end
@@ -65,14 +71,16 @@ RSpec.describe 'CommentLocks', :vcr do
 
         it 'checks comments are locked' do
           expect(bs_request.comment_lock).not_to be_nil
-          find_button('Unlock comments')
-          expect(page).to have_text('Commenting on this is locked. You can remove the lock by clicking on the button below.')
+          click_link_or_button('Actions') if mobile?
+          expect(page).to have_link('Unlock Comments')
+          expect(page).to have_text('Commenting on this is locked.')
         end
 
         it 'unlocks comments' do
-          find_button('Unlock comments').click
+          click_link_or_button('Actions') if mobile?
+          find_link('Unlock Comments').click
           find_button('Unlock').click
-          expect(page).to have_no_text('Commenting on this is locked. You can remove the lock by clicking on the button below.')
+          expect(page).to have_no_text('Commenting on this is locked.')
         end
       end
 
@@ -82,13 +90,17 @@ RSpec.describe 'CommentLocks', :vcr do
           visit request_show_path(bs_request)
         end
 
-        it 'cannot unlock comments' do
-          expect(page).to have_no_button('Unlock comments')
+        it 'cannot unlock comments' do # rubocop:disable RSpec/ExampleLength
+          if mobile?
+            expect(page).to have_no_link('Actions')
+          else
+            expect(page).to have_no_link('Unlock Comments')
+          end
           expect(page).to have_no_text('You can remove the lock by clicking on the button below.')
         end
 
         it 'cannot comment' do
-          expect(page).to have_text('Commenting on this is locked')
+          expect(page).to have_text('Commenting on this is locked.')
           expect(page).to have_no_button('Add comment')
         end
       end


### PR DESCRIPTION
Also tries to address:
- https://github.com/openSUSE/open-build-service/pull/15031#discussion_r1351960786
- https://github.com/openSUSE/open-build-service/pull/15031#discussion_r1354568799

### Before

![Screenshot from 2024-08-30 16-07-54](https://github.com/user-attachments/assets/3d71ce1c-e746-4bd2-a36b-81cf0dca3335)


### After

![Screenshot from 2024-08-30 16-08-31](https://github.com/user-attachments/assets/8bd7f4ac-e8ac-4991-9f95-a63ed7258b67)