### PR TITLE
[backend] bs_worker: fix cache handling in _buildenv builds

### DIFF
--- a/src/backend/BSPublisher/Diffnotify.pm
+++ b/src/backend/BSPublisher/Diffnotify.pm
@@ -91,7 +91,7 @@ sub is_unchanged {
 }
 
 sub create_notification {
-  my ($data, $oldstate, $newstate) = @_;
+  my ($notify, $data, $oldstate, $newstate) = @_;
 
   my $n = {};
   $n->{'dag_run_id'} = "$data->{'publishid'}";
@@ -108,7 +108,7 @@ sub create_notification {
     }
     push @{$n->{'conf'}->{'binaries'}}, $b;
   }
-  my $registries = $newstate->{'registries'};
+  my $registries = $notify->{'no_registries'} ? {} : $newstate->{'registries'};
   for my $gunprefix (sort keys %$registries) {
     my $rdiff = diffdata((($oldstate->{'registries'} || {})->{$gunprefix} || {})->{'tags'}, $registries->{$gunprefix}->{'tags'}, 'tag');
     for $b (@$rdiff) {
@@ -225,7 +225,7 @@ sub notification {
   };
 
   # create and send notification
-  my $n = create_notification($data, $oldstate, $newstate);
+  my $n = create_notification($notify, $data, $oldstate, $newstate);
   my $n_json = JSON::XS->new->utf8->canonical->encode($n);
   my $param = {
     'uri' => $notify->{'uri'}, 

--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -2566,14 +2566,13 @@ sub getbinaries_buildenv {
 	  my $id = Build::queryhdrmd5("$dir/$bv->{'name'}");
 	  if ($id eq $bv->{'hdrmd5'}) {
 	    push @cacheold, [$cacheid, $s[7]];
+	    die unless $bv->{'name'} =~ /(.*)\.rpm$/;
+	    $used{$needed} = { 'name' => $1, 'project' => $projid, 'repository' => $repoid, 'hdrmd5' => $id };
 	    delete $needed{$needed};
 	    last;
           }
-	  die unless $bv->{'name'} =~ /(.*)\.rpm$/;
-	  $used{$needed} = { 'name' => $1, 'project' => $projid, 'repository' => $repoid, 'hdrmd5' => $id };
-	} else {
-	  unlink("$dir/$bv->{'name'}");
 	}
+	unlink("$dir/$bv->{'name'}");
       }
     }
   }
@@ -2643,8 +2642,9 @@ sub getbinaries_buildenv {
   my $outbdep = ($buildinfo->{'outbuildinfo'} || {})->{'bdep'};
   if ($outbdep) {
     for (@bdeps) {
-      my $obdep = $used{"$_->{'name'}.$_->{'hdrmd5'}"};
-      die("did not use package $_?\n") unless $obdep;
+      my $needed = "$_->{'name'}.$_->{'hdrmd5'}";
+      my $obdep = $used{$needed};
+      die("did not use package $needed?\n") unless $obdep;
       push @$outbdep, $obdep;
     }
   }


### PR DESCRIPTION
The code did not set the "used" hash, leading to a crash when the outgoing buildenv was created.