### PR TITLE
Don't show "Decline request" button to the maintainers of the source package

### DIFF
--- a/src/api/app/policies/bs_request_policy.rb
+++ b/src/api/app/policies/bs_request_policy.rb
@@ -35,7 +35,7 @@ class BsRequestPolicy < ApplicationPolicy
   end
 
   def decline_request?
-    !author?
+    !(author? || record.is_source_maintainer?(user))
   end
 
   private


### PR DESCRIPTION
The author of the submit request, or the maintainers of the source package, can already use the "Revoke request" button.