### PR TITLE
Adapt inline comments to avoid overflow

### DIFF
--- a/src/api/app/assets/stylesheets/webui/diff.scss
+++ b/src/api/app/assets/stylesheets/webui/diff.scss
@@ -47,6 +47,16 @@
         margin-left: calc(2 * (var(--line-index-digits) + 2rem + var(--bs-border-width)) + 0.5rem + var(--bs-border-width) - var(--additional-padding));
         margin-top: -1.75rem !important;
       }
+      // TODO: This is hard-coding 65% of the viewport width. Find a proper solution once the code is refactored.
+      .line-comment {
+        width: 65vw;
+      }
+      // TODO: This is hard-coding 75% of the viewport width. Find a proper solution once the code is refactored.
+      @include media-breakpoint-between(xs,sm) {
+        .line-comment {
+          width: 75vw;
+        }
+      }
       .line-comment .fa-comment {
         display: none;
       }


### PR DESCRIPTION
Fixes #16088

Check the following screenshots. They show the comment in different viewport sizes.

The solution is not ideal as it hard-codes a width of 65% of the viewport. But after a lot of trials and conversations, the proper solution is going to require a bigger refactoring that includes wrapping each line (something that should be done after this [card](https://trello.com/c/E160LMhR) is implemented).
 

![Screenshot 2024-09-04 at 20-16-20 Request 1 - Open Build Service](https://github.com/user-attachments/assets/e692b03a-fb9b-4426-848d-48e9912d7d5f)

![Screenshot 2024-09-04 at 20-16-09 Request 1 - Open Build Service](https://github.com/user-attachments/assets/193633de-73d6-459c-a1b1-cf7473c304be)

![Screenshot 2024-09-04 at 20-15-50 Request 1 - Open Build Service](https://github.com/user-attachments/assets/002acc54-8a50-4b6c-a31b-a39cd4ea41a2)

![Screenshot 2024-09-05 at 11-08-07 Request 1 - Open Build Service](https://github.com/user-attachments/assets/2fdca6bc-455a-4147-b6a4-3b463ef6d891)



