### PR TITLE
Special-case SLFO maintenance patchinfos when displaying staging requests

### DIFF
--- a/src/api/app/helpers/webui/staging/workflow_helper.rb
+++ b/src/api/app/helpers/webui/staging/workflow_helper.rb
@@ -69,7 +69,7 @@ module Webui::Staging::WorkflowHelper
     css = 'review' if request[:missing_reviews].present?
     css = 'obsolete' if request[:state].in?(BsRequest::OBSOLETE_STATES)
     css += ' delete' if request[:request_type] == 'delete'
-    link_content = [request[:package]]
+    link_content = [request[:package].match?(/patchinfo\.\d+\.\d+/) ? 'patchinfo' : request[:package]]
     link_content << reviewers_icon(request, users_hash, groups_hash) if request[:missing_reviews].present?
     tag.span(class: "badge state-#{css}") do
       link_to(request_show_path(request[:number]), class: 'request') do


### PR DESCRIPTION
These patchinfos are named "patchinfo.ABC.XYZ" where "ABC" and "XYZ" are sequences of integers, and this naming scheme is considered an implementation detail (to avoid collisions when several maintenance coordinators are working on updates targeting the same codestream).

The numbers are irrelevant for display, the only relevant information is that these packages are patchinfos, so this change rewrites the package name to just "patchinfo" in such cases.