### PR TITLE
Make sure ansi escape codes get parsed

### DIFF
--- a/src/api/app/mixins/build_log_support.rb
+++ b/src/api/app/mixins/build_log_support.rb
@@ -11,7 +11,7 @@ module BuildLogSupport
     log.encode!(invalid: :replace, undef: :replace, cr_newline: true)
     log = CGI.escapeHTML(log)
     log.scrub! # Remove invalid byte sequences in UTF-8
-    log = ansi_escaped(log, theend - start + 1)
+    log = ansi_escaped(log, log.length + 1)
     log.gsub(%r{([^a-zA-Z0-9&;<>/\n\r \t()])}) do |c|
       if c.ord < 32
         ''


### PR DESCRIPTION
After doing `CGI.escapeHTML` lines before, the length of the log might have changed from `theend - start`, so we can't use it anymore