### PR TITLE
Fix anonymous bind to LDAP server

### DIFF
--- a/src/api/app/models/user_ldap_strategy.rb
+++ b/src/api/app/models/user_ldap_strategy.rb
@@ -174,6 +174,10 @@ class UserLdapStrategy
       # implicitly turn array into string
       user_name = [user_name].flatten.join
 
+      # LDAP bind quietly dies when user_name or password is nil
+      # password can be nil in case of passwordless authentication or anonymous bind
+      password ||= ''
+
       Rails.logger.debug { "UserLdapStrategy: Connecting to server '#{server}' as user '#{user_name}'" }
       port = ldap_port
 
@@ -191,7 +195,7 @@ class UserLdapStrategy
         Rails.logger.info("UserLdapStrategy: Failed to bind as user '#{user_name}': #{con.err2string(con.err)}")
         return
       end
-      Rails.logger.debug { "UserLdapStrategy: Bound as #{user_name}" }
+      Rails.logger.debug { "UserLdapStrategy: Bound as '#{user_name}'" }
       con
     end
 


### PR DESCRIPTION
Fix for #16806 

Currently when no `ldap_search_user` and `ldap_search_auth` are provided `try_ldap_con` quietly died.

```log
D, [2024-09-05T02:49:58.019231 #14706] DEBUG -- : [f70496f7-1c56-4935-818b-961930039bb5] [14706:25.37] Using LDAP to find testuser
D, [2024-09-05T02:49:58.019326 #14706] DEBUG -- : [f70496f7-1c56-4935-818b-961930039bb5] [14706:25.37] Looking for testuser using ldap
D, [2024-09-05T02:49:58.020230 #14706] DEBUG -- : [f70496f7-1c56-4935-818b-961930039bb5] [14706:25.37] Connecting to ldap.example.com as ''
D, [2024-09-05T02:49:58.020405 #14706] DEBUG -- : [f70496f7-1c56-4935-818b-961930039bb5] [14706:25.37] testuser not found in LDAP.
```

After these changes:
 * in case of `ldap_search_user` and `ldap_search_auth` are set
  ```log
D, [2024-09-05T03:47:19.464541 #21206] DEBUG -- : [69eb8e8e-0fb8-4528-b3ec-166c5009d419] [21206:0.10] Using LDAP to find testuser
D, [2024-09-05T03:47:19.464688 #21206] DEBUG -- : [69eb8e8e-0fb8-4528-b3ec-166c5009d419] [21206:0.10] Looking for testuser using ldap
D, [2024-09-05T03:47:19.465540 #21206] DEBUG -- : [69eb8e8e-0fb8-4528-b3ec-166c5009d419] [21206:0.10] Connecting to ad-ldap.example.com as 'CN=OBS Server,OU=Other Mailboxes,OU=Sunnyvale,DC=example,DC=com'
D, [2024-09-05T03:47:19.540883 #21206] DEBUG -- : [69eb8e8e-0fb8-4528-b3ec-166c5009d419] [21206:0.17] Bound as CN=OBS Server,OU=Other Mailboxes,OU=Sunnyvale,DC=example,DC=com
D, [2024-09-05T03:47:19.541287 #21206] DEBUG -- : [69eb8e8e-0fb8-4528-b3ec-166c5009d419] [21206:0.17] Search for DC=example,DC=com (sAMAccountName=testuser)
D, [2024-09-05T03:47:19.556977 #21206] DEBUG -- : [69eb8e8e-0fb8-4528-b3ec-166c5009d419] [21206:0.19] Connecting to ad-ldap.example.com as 'CN=User,OU=Contractors,OU=Sunnyvale,DC=example,DC=com'
D, [2024-09-05T03:47:19.612602 #21206] DEBUG -- : [69eb8e8e-0fb8-4528-b3ec-166c5009d419] [21206:0.24] Bound as CN=User,OU=Contractors,OU=Sunnyvale,DC=example,DC=com
D, [2024-09-05T03:47:19.627020 #21206] DEBUG -- : [69eb8e8e-0fb8-4528-b3ec-166c5009d419] [21206:0.26] login success for checking with ldap server
D, [2024-09-05T03:47:19.650192 #21206] DEBUG -- : [69eb8e8e-0fb8-4528-b3ec-166c5009d419] [21206:0.28] Authenticated as user 'testuser'
  ```
   * In case when either `ldap_search_user` or `ldap_search_auth` aren't set
   ```log
D, [2024-09-05T03:41:37.156723 #20529] DEBUG -- : [9ce62093-97a9-4c9e-b8ba-52526295c610] [20529:4.81] Using LDAP to find testuser
D, [2024-09-05T03:41:37.156857 #20529] DEBUG -- : [9ce62093-97a9-4c9e-b8ba-52526295c610] [20529:4.81] Looking for testuser using ldap
D, [2024-09-05T03:41:37.157878 #20529] DEBUG -- : [9ce62093-97a9-4c9e-b8ba-52526295c610] [20529:4.81] Connecting to ldap.inca.example.com as ''
D, [2024-09-05T03:41:37.187821 #20529] DEBUG -- : [9ce62093-97a9-4c9e-b8ba-52526295c610] [20529:4.84] Bound as ''
D, [2024-09-05T03:41:37.188108 #20529] DEBUG -- : [9ce62093-97a9-4c9e-b8ba-52526295c610] [20529:4.84] Search for DC=example,DC=com (uid=testuser)
D, [2024-09-05T03:41:37.274616 #20529] DEBUG -- : [9ce62093-97a9-4c9e-b8ba-52526295c610] [20529:4.92] Connecting to ldap.example.com as 'uid=testuser,ou=People,dc=example,dc=com'
D, [2024-09-05T03:41:37.286745 #20529] DEBUG -- : [9ce62093-97a9-4c9e-b8ba-52526295c610] [20529:4.94] Bound as uid=testuser,ou=People,dc=example,dc=com
D, [2024-09-05T03:41:37.377719 #20529] DEBUG -- : [9ce62093-97a9-4c9e-b8ba-52526295c610] [20529:5.03] login success for checking with ldap server
D, [2024-09-05T03:41:37.391150 #20529] DEBUG -- : [9ce62093-97a9-4c9e-b8ba-52526295c610] [20529:5.04] Authenticated as user 'testuser'   
   ```