### PR TITLE
Make sure only user's own canned responses show up

### DIFF
--- a/src/api/app/components/reports_modal_component.rb
+++ b/src/api/app/components/reports_modal_component.rb
@@ -11,6 +11,6 @@ class ReportsModalComponent < ApplicationComponent
   end
 
   def canned_responses
-    CannedResponsePolicy::Scope.new(user, CannedResponse).resolve.order(:decision_type, :title)
+    user.canned_responses.order(:decision_type, :title)
   end
 end

--- a/src/api/app/views/webui/comment/_comment_field.html.haml
+++ b/src/api/app/views/webui/comment/_comment_field.html.haml
@@ -21,7 +21,7 @@ data: { preview_message_url: preview_comments_path, message_body_param: 'comment
                                        'data-canned-controller': '' }
         - if Flipper.enabled?(:content_moderation, User.session)
           .d-flex.justify-content-end
-            = render CannedResponsesDropdownComponent.new(policy_scope(CannedResponse).where(decision_type: nil).order(:title))
+            = render CannedResponsesDropdownComponent.new(User.session.canned_responses.where(decision_type: nil).order(:title))
         ~ f.text_area :body, id: "#{element_suffix}_body", rows: '4',
         placeholder: 'Write your comment here... (Markdown markup is supported)', required: true,
         class: 'w-100 form-control comment-field message-field'


### PR DESCRIPTION
Right now everyone's canned responses are visible in the dropdown