### PR TITLE
[backend] fix static links for kiwi appliances

### DIFF
--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -1202,14 +1202,14 @@ sub createrepo_staticlinks {
       } elsif (/^(.*)-Build(?:\d\d\d\d+|\d+(?:\.\d+)+)(-Media\d?)\.iso$/s) {
         # product builds
         $link = "$1$2.iso"; # no support for versioned links
-      } elsif (/^(.*)-Build(?:\d\d\d\d+|\d+(?:\.\d+)+)(|-Source|-Debug)\.iso$/s) {
-        # product-composer builds
-        $link = "$1$2.iso"; # no support for versioned links
       } elsif (/^(.*\.(?:$binarchs)?)-([^-]+)?(-.*?)?-([^-]+)(\.(raw\.install\.raw\.xz|raw\.xz|raw|tar\.xz|box|json|install\.iso|install\.tar|tbz|tgz|vmx|vmdk|vmdk\.xz|appx|vhdx|vhdx\.xz|vdi|vdi\.xz|vhdfixed\.xz|iso|phar|qcow2|qcow2\.xz|ova|ova\.xz|cpio\.tar\.bz2))$/s) {
         # kiwi appliance
         my $profile = $3 || "";
         $link = "$1$profile$5";
         $link = "$1-$2$profile$5" if $versioned;
+      } elsif (/^(.*)-Build(?:\d\d\d\d+|\d+(?:\.\d+)+)(|-Source|-Debug)\.iso$/s) {
+        # product-composer builds
+        $link = "$1$2.iso"; # no support for versioned links
       }
       next unless $link;
       # double match, pick target with latest mtime


### PR DESCRIPTION
Kiwi image appliances need to match first, regexp is more exact then product composer ones