### PR TITLE
[backend] bs_dodup: make sure the old entries are valid

### DIFF
--- a/src/backend/BSRepServer/Registry.pm
+++ b/src/backend/BSRepServer/Registry.pm
@@ -191,6 +191,7 @@ sub construct_containerinfo {
     'tags' => \@tags,
     'file' => "$pkgname.tar",
   };
+  $containerinfo->{'imageid'} =~ s/^sha256://;	# like in Containertar.pm
   $containerinfo->{'release'} = $data->{'release'} if defined $data->{'release'};
   my ($tar) = BSRepServer::Containertar::construct_container_tar($dir, $containerinfo);
   ($containerinfo->{'tar_md5sum'}, $containerinfo->{'tar_sha256sum'}, $containerinfo->{'tar_size'}) = BSContar::checksum_tar($tar);

--- a/src/backend/bs_dodup
+++ b/src/backend/bs_dodup
@@ -565,8 +565,17 @@ sub dod_registry {
     my $oldentry;
     $oldentry = $oldcache->{$resource} if $olddodresources{$resource};
     my ($olddigest, $oldfatdigest);
-    ($olddigest, $oldfatdigest) = ($oldentry->{'version'}, $oldentry->{'fatdigest'}) if $oldentry;
+    ($olddigest, $oldfatdigest) = ($oldentry->{'digest'}, $oldentry->{'fatdigest'}) if $oldentry;
     $oldfatdigest = $oldfatmissing->{$resource} if !$oldentry;
+    eval {
+      registry_valid_digest("olddigest of $resource", $olddigest) if $olddigest;
+      registry_valid_digest("oldfatdigest of $resource", $oldfatdigest) if $oldfatdigest;
+    };
+    if ($@) {
+      warn($@);
+      undef $olddigest;
+      undef $oldfatdigest;
+    }
     my ($blobs, $digest, $fatdigest);
     eval { ($blobs, $digest, $fatdigest) = registry_fetch_manifest($url, $arch, $repo, $tag, $olddigest, $oldfatdigest) };
     if ($@) {
@@ -615,6 +624,7 @@ sub dod_registry {
       'registry_refname' => ($urldomain =~ /docker\.io/ ? '' : "$urldomain/") . $refname,
       'registry_digest' => $digest,
     };
+    $annotation->{'binaryid'} =~ s/^sha256://;	# like with Containertar.pm
     $annotation->{'registry_fatdigest'} = $fatdigest if $fatdigest;
     $pkg->{'annotation'} = BSUtil::toxml($annotation, $BSXML::binannotation);
     $cache->{$resource} = $pkg;


### PR DESCRIPTION
Some of our digest entries had a missing "sha256:" prefix