### PR TITLE
Catch generic server exceptions when connecting to GitHub

### DIFF
--- a/src/api/app/services/scm_exception_handler.rb
+++ b/src/api/app/services/scm_exception_handler.rb
@@ -22,10 +22,12 @@ class SCMExceptionHandler
               Octokit::UnverifiedEmail,
               Octokit::InvalidRepository,
               Octokit::PathDiffTooLarge,
-              Octokit::ServiceUnavailable,
-              Octokit::InternalServerError,
               Octokit::UnprocessableEntity,
-              Octokit::BadGateway do |exception|
+              Octokit::InternalServerError,       # 500
+              Octokit::NotImplemented,            # 501
+              Octokit::BadGateway,                # 502
+              Octokit::ServiceUnavailable,        # 503
+              Octokit::ServerError do |exception| # 500..599
     log_to_workflow_run(exception, 'GitHub') if @workflow_run.present?
   end
 

--- a/src/api/app/services/scm_exception_message.rb
+++ b/src/api/app/services/scm_exception_message.rb
@@ -38,14 +38,18 @@ class SCMExceptionMessage
       'Use the user/repo (String) format, or the repository ID (Integer), or a hash containing :repo and :user keys. Example: sferik/octokit.',
     Octokit::PathDiffTooLarge =>
       'Action can not be performed. File too large.',
-    Octokit::ServiceUnavailable =>
-      'Service is unavailable. Please try again later.',
-    Octokit::InternalServerError =>
-      'Internal error. Please try again later.',
     Octokit::UnprocessableEntity =>
       'Server is unable to process the contained instructions. Please modify your request and try again.',
-    Octokit::BadGateway =>
-      'Bad gateway. Please try again later.'
+    Octokit::InternalServerError => # 500
+      'Internal error. Please try again later.',
+    Octokit::NotImplemented =>      # 501
+      'The server does not support the functionality required to fulfill the request. Please modify your request and try again.',
+    Octokit::BadGateway =>          # 502
+      'Bad gateway. Please try again later.',
+    Octokit::ServiceUnavailable =>  # 503
+      'Service is unavailable. Please try again later.',
+    Octokit::ServerError =>         # 500..599
+      'Generic server error. Please try again later.'
   }.freeze
 
   GITLAB_EXCEPTIONS = {


### PR DESCRIPTION
Exceptions with code 504 were not catched.

Rescuing from generic exceptions in the range of 500..599 with Octokit::ServerError prevents from crashing without notifying back OBS.

See #16691. Related to #12661.

To see exceptions supported by Octokit: https://github.com/octokit/octokit.rb/blob/71e3d209400ff29440d87581db90314b6272355b/lib/octokit/error.rb#L19-L37

Octokit::ServerError exceptions: https://github.com/octokit/octokit.rb/blob/71e3d209400ff29440d87581db90314b6272355b/lib/octokit/error.rb#L343-L356