### PR TITLE
Refactoring of action mailers

### DIFF
--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -679,13 +679,6 @@ Rails/ApplicationController:
   Exclude:
     - 'app/controllers/webui/webui_controller.rb'
 
-# Offense count: 2
-# This cop supports unsafe autocorrection (--autocorrect-all).
-Rails/ApplicationMailer:
-  Exclude:
-    - 'app/mailers/admin_mailer.rb'
-    - 'app/mailers/event_mailer.rb'
-
 # Offense count: 70
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: EnforcedStyle.

--- a/src/api/app/mailers/admin_mailer.rb
+++ b/src/api/app/mailers/admin_mailer.rb
@@ -1,16 +1,13 @@
 class AdminMailer < ActionMailer::Base
-  # avoiding the event mechanism for this, since it might be the actual problem
+  default Precedence: 'bulk',
+          'X-Mailer': 'OBS Administrator Notification',
+          'X-OBS-URL': ActionDispatch::Http::URL.url_for(controller: :main, action: :index, only_path: false, host: @host),
+          'Auto-Submitted': 'auto-generated',
+          'Return-Path': mail_sender,
+          Sender: mail_sender
 
-  def set_headers
+  def set_host
     @host = ::Configuration.obs_url
-    return unless @host
-
-    headers['Precedence'] = 'bulk'
-    headers['X-Mailer'] = 'OBS Administrator Notification'
-    headers['X-OBS-URL'] = ActionDispatch::Http::URL.url_for(controller: :main, action: :index, only_path: false, host: @host)
-    headers['Auto-Submitted'] = 'auto-generated'
-    headers['Return-Path'] = mail_sender
-    headers['Sender'] = mail_sender
   end
 
   def mail_sender
@@ -22,7 +19,7 @@ class AdminMailer < ActionMailer::Base
   end
 
   def warning(message, level = 'Warning')
-    set_headers
+    set_host
     return unless @host
 
     # FIXME/to be implemented:

--- a/src/api/app/mailers/admin_mailer.rb
+++ b/src/api/app/mailers/admin_mailer.rb
@@ -6,14 +6,6 @@ class AdminMailer < ActionMailer::Base
           'Return-Path': mail_sender,
           Sender: mail_sender
 
-  def set_host
-    @host = ::Configuration.obs_url
-  end
-
-  def mail_sender
-    "OBS Admin Notification <#{::Configuration.admin_email}>"
-  end
-
   def error(message)
     warning(message, 'ERROR')
   end
@@ -35,6 +27,16 @@ class AdminMailer < ActionMailer::Base
          from: ::Configuration.admin_email,
          date: Time.now,
          body: message)
+  end
+
+  private
+
+  def set_host
+    @host = ::Configuration.obs_url
+  end
+
+  def mail_sender
+    "OBS Admin Notification <#{::Configuration.admin_email}>"
   end
 
   def admins

--- a/src/api/app/mailers/admin_mailer.rb
+++ b/src/api/app/mailers/admin_mailer.rb
@@ -1,7 +1,7 @@
 class AdminMailer < ApplicationMailer
-  default 'X-Mailer': 'OBS Administrator Notification',
-          'Return-Path': mail_sender,
-          Sender: mail_sender
+  before_action :set_admin_headers
+
+  default 'X-Mailer': 'OBS Administrator Notification'
 
   def error(message)
     warning(message, 'ERROR')
@@ -26,6 +26,11 @@ class AdminMailer < ApplicationMailer
   end
 
   private
+
+  def set_admin_headers
+    headers 'Return-Path': mail_sender,
+            Sender: mail_sender
+  end
 
   def mail_sender
     "OBS Admin Notification <#{::Configuration.admin_email}>"

--- a/src/api/app/mailers/admin_mailer.rb
+++ b/src/api/app/mailers/admin_mailer.rb
@@ -5,8 +5,6 @@ class AdminMailer < ActionMailer::Base
     @host = ::Configuration.obs_url
     return unless @host
 
-    @configuration = ::Configuration.fetch
-
     headers['Precedence'] = 'bulk'
     headers['X-Mailer'] = 'OBS Administrator Notification'
     headers['X-OBS-URL'] = ActionDispatch::Http::URL.url_for(controller: :main, action: :index, only_path: false, host: @host)

--- a/src/api/app/mailers/admin_mailer.rb
+++ b/src/api/app/mailers/admin_mailer.rb
@@ -1,4 +1,6 @@
 class AdminMailer < ActionMailer::Base
+  before_action :set_host
+
   default Precedence: 'bulk',
           'X-Mailer': 'OBS Administrator Notification',
           'X-OBS-URL': ActionDispatch::Http::URL.url_for(controller: :main, action: :index, only_path: false, host: @host),
@@ -11,7 +13,6 @@ class AdminMailer < ActionMailer::Base
   end
 
   def warning(message, level = 'Warning')
-    set_host
     return unless @host
 
     # FIXME/to be implemented:

--- a/src/api/app/mailers/admin_mailer.rb
+++ b/src/api/app/mailers/admin_mailer.rb
@@ -1,10 +1,5 @@
-class AdminMailer < ActionMailer::Base
-  before_action :set_host
-
-  default Precedence: 'bulk',
-          'X-Mailer': 'OBS Administrator Notification',
-          'X-OBS-URL': ActionDispatch::Http::URL.url_for(controller: :main, action: :index, only_path: false, host: @host),
-          'Auto-Submitted': 'auto-generated',
+class AdminMailer < ApplicationMailer
+  default 'X-Mailer': 'OBS Administrator Notification',
           'Return-Path': mail_sender,
           Sender: mail_sender
 
@@ -31,10 +26,6 @@ class AdminMailer < ActionMailer::Base
   end
 
   private
-
-  def set_host
-    @host = ::Configuration.obs_url
-  end
 
   def mail_sender
     "OBS Admin Notification <#{::Configuration.admin_email}>"

--- a/src/api/app/mailers/application_mailer.rb
+++ b/src/api/app/mailers/application_mailer.rb
@@ -1,8 +1,8 @@
 class ApplicationMailer < ActionMailer::Base
   before_action :set_host
+  before_action :set_application_headers
 
   default Precedence: 'bulk',
-          'X-OBS-URL': ActionDispatch::Http::URL.url_for(controller: :main, action: :index, only_path: false, host: @host),
           'Auto-Submitted': 'auto-generated'
 
   private
@@ -11,5 +11,9 @@ class ApplicationMailer < ActionMailer::Base
     # FIXME: This if for the view. Use action_mailer.default_url_options instead
     # https://guides.rubyonrails.org/action_mailer_basics.html#generating-urls-in-action-mailer-views
     @host = ::Configuration.obs_url
+  end
+
+  def set_application_headers
+    headers['X-OBS-URL'] = ActionDispatch::Http::URL.url_for(controller: :main, action: :index, only_path: false, host: @host)
   end
 end

--- a/src/api/app/mailers/application_mailer.rb
+++ b/src/api/app/mailers/application_mailer.rb
@@ -1,0 +1,15 @@
+class ApplicationMailer < ActionMailer::Base
+  before_action :set_host
+
+  default Precedence: 'bulk',
+          'X-OBS-URL': ActionDispatch::Http::URL.url_for(controller: :main, action: :index, only_path: false, host: @host),
+          'Auto-Submitted': 'auto-generated'
+
+  private
+
+  def set_host
+    # FIXME: This if for the view. Use action_mailer.default_url_options instead
+    # https://guides.rubyonrails.org/action_mailer_basics.html#generating-urls-in-action-mailer-views
+    @host = ::Configuration.obs_url
+  end
+end

--- a/src/api/app/mailers/consistency_mailer.rb
+++ b/src/api/app/mailers/consistency_mailer.rb
@@ -1,6 +1,6 @@
 class ConsistencyMailer < AdminMailer
   def errors(errors)
-    set_headers
+    set_host
     return unless @host
 
     @errors = errors

--- a/src/api/app/mailers/consistency_mailer.rb
+++ b/src/api/app/mailers/consistency_mailer.rb
@@ -1,6 +1,5 @@
 class ConsistencyMailer < AdminMailer
   def errors(errors)
-    set_host
     return unless @host
 
     @errors = errors

--- a/src/api/app/mailers/event_mailer.rb
+++ b/src/api/app/mailers/event_mailer.rb
@@ -5,9 +5,15 @@ class EventMailer < ActionMailer::Base
   before_action :set_configuration_title
   before_action :set_host
   before_action :set_recipients
-  before_action :set_default_headers
   before_action :set_event
   before_action :set_event_headers
+
+  default Precedence: 'bulk',
+          'X-Mailer': 'OBS Notification System',
+          'X-OBS-URL': ActionDispatch::Http::URL.url_for(controller: :main, action: :index, only_path: false, host: @host),
+          'Auto-Submitted': 'auto-generated',
+          Sender: email_address_with_name(::Configuration.admin_email, 'OBS Notification'),
+          'Message-ID': message_id
 
   def notification_email
     return if @recipients.blank? || @event.blank?
@@ -38,15 +44,6 @@ class EventMailer < ActionMailer::Base
     return unless params[:subscribers]
 
     @recipients = params[:subscribers].map(&:display_name).compact_blank.sort
-  end
-
-  def set_default_headers
-    headers['Precedence'] = 'bulk'
-    headers['X-Mailer'] = 'OBS Notification System'
-    headers['X-OBS-URL'] = ActionDispatch::Http::URL.url_for(controller: :main, action: :index, only_path: false, host: @host)
-    headers['Auto-Submitted'] = 'auto-generated'
-    headers['Sender'] = email_address_with_name(::Configuration.admin_email, 'OBS Notification')
-    headers['Message-ID'] = message_id
   end
 
   def set_event

--- a/src/api/app/mailers/event_mailer.rb
+++ b/src/api/app/mailers/event_mailer.rb
@@ -8,8 +8,7 @@ class EventMailer < ApplicationMailer
   before_action :set_event_headers
 
   default 'X-Mailer': 'OBS Notification System',
-          Sender: email_address_with_name(::Configuration.admin_email, 'OBS Notification'),
-          'Message-ID': message_id
+          Sender: email_address_with_name(::Configuration.admin_email, 'OBS Notification')
 
   def notification_email
     return if @recipients.blank? || @event.blank?
@@ -43,7 +42,9 @@ class EventMailer < ApplicationMailer
   def set_event_headers
     return unless @event
 
-    headers['X-OBS-event-type'] = @event.template_name
+    headers 'Message-ID': message_id,
+            'X-OBS-event-type': @event.template_name
+
     headers(@event.custom_headers)
   end
 

--- a/src/api/app/mailers/event_mailer.rb
+++ b/src/api/app/mailers/event_mailer.rb
@@ -1,17 +1,13 @@
-class EventMailer < ActionMailer::Base
+class EventMailer < ApplicationMailer
   helper 'webui/markdown'
   helper 'webui/reportables'
 
   before_action :set_configuration_title
-  before_action :set_host
   before_action :set_recipients
   before_action :set_event
   before_action :set_event_headers
 
-  default Precedence: 'bulk',
-          'X-Mailer': 'OBS Notification System',
-          'X-OBS-URL': ActionDispatch::Http::URL.url_for(controller: :main, action: :index, only_path: false, host: @host),
-          'Auto-Submitted': 'auto-generated',
+  default 'X-Mailer': 'OBS Notification System',
           Sender: email_address_with_name(::Configuration.admin_email, 'OBS Notification'),
           'Message-ID': message_id
 
@@ -32,12 +28,6 @@ class EventMailer < ActionMailer::Base
 
   def set_configuration_title
     @configuration_title = ::Configuration.title
-  end
-
-  def set_host
-    # FIXME: This if for the view. Use action_mailer.default_url_options instead
-    # https://guides.rubyonrails.org/action_mailer_basics.html#generating-urls-in-action-mailer-views
-    @host = ::Configuration.obs_url
   end
 
   def set_recipients

--- a/src/api/app/views/layouts/event_mailer.html.haml
+++ b/src/api/app/views/layouts/event_mailer.html.haml
@@ -4,6 +4,6 @@
 %br/
 Configure notifications at #{link_to(*[url_for(controller: 'webui/users/subscriptions', action: :index, only_path: false, host: @host)] * 2)}
 %br/
-= @configuration['title']
+= @configuration_title
 (#{link_to(*[url_for(controller: 'webui/main', action: :index, only_path: false, host: @host)] * 2)})
 %br/

--- a/src/api/app/views/layouts/event_mailer.text.erb
+++ b/src/api/app/views/layouts/event_mailer.text.erb
@@ -2,4 +2,4 @@
 
 -- 
 Configure notifications at <%= url_for(controller: 'webui/users/subscriptions', action: :index, only_path: false, host: @host) %>
-<%= @configuration.title %> (<%= url_for(controller: 'webui/main', action: :index, only_path: false, host: @host) %>)
+<%= @configuration_title %> (<%= url_for(controller: 'webui/main', action: :index, only_path: false, host: @host) %>)

--- a/src/api/test/fixtures/event_mailer/repo_delete_request
+++ b/src/api/test/fixtures/event_mailer/repo_delete_request
@@ -7,16 +7,16 @@ Mime-Version: 1.0
 Content-Type: text/plain;
  charset=UTF-8
 Content-Transfer-Encoding: 7bit
-Precedence: bulk
-X-Mailer: OBS Notification System
 X-OBS-URL: http://localhost
-Auto-Submitted: auto-generated
 X-OBS-event-type: request_create
 X-OBS-Request-Creator: Iggy
 X-OBS-Request-Id: REQUESTID
 X-OBS-Request-State: new
 X-OBS-Request-Action-type: delete
 X-OBS-Request-Action-target: home:coolo/standard
+Precedence: bulk
+Auto-Submitted: auto-generated
+X-Mailer: OBS Notification System
 
 Visit http://localhost/request/show/REQUESTID
 

--- a/src/api/test/fixtures/event_mailer/request_event
+++ b/src/api/test/fixtures/event_mailer/request_event
@@ -7,16 +7,16 @@ Mime-Version: 1.0
 Content-Type: text/plain;
  charset=UTF-8
 Content-Transfer-Encoding: 7bit
-Precedence: bulk
-X-Mailer: OBS Notification System
 X-OBS-URL: http://localhost
-Auto-Submitted: auto-generated
 X-OBS-event-type: request_create
 X-OBS-Request-Creator: Iggy
 X-OBS-Request-Id: REQUESTID
 X-OBS-Request-State: new
 X-OBS-Request-Action-type: add_role
 X-OBS-Request-Action-target: home:tom
+Precedence: bulk
+Auto-Submitted: auto-generated
+X-Mailer: OBS Notification System
 
 Visit http://localhost/request/show/REQUESTID
 

--- a/src/api/test/fixtures/event_mailer/set_bugowner_event
+++ b/src/api/test/fixtures/event_mailer/set_bugowner_event
@@ -7,16 +7,16 @@ Mime-Version: 1.0
 Content-Type: text/plain;
  charset=UTF-8
 Content-Transfer-Encoding: 7bit
-Precedence: bulk
-X-Mailer: OBS Notification System
 X-OBS-URL: http://localhost
-Auto-Submitted: auto-generated
 X-OBS-event-type: request_create
 X-OBS-Request-Creator: Iggy
 X-OBS-Request-Id: REQUESTID
 X-OBS-Request-State: new
 X-OBS-Request-Action-type: set_bugowner
 X-OBS-Request-Action-target: home:tom
+Precedence: bulk
+Auto-Submitted: auto-generated
+X-Mailer: OBS Notification System
 
 Visit http://localhost/request/show/REQUESTID
 

--- a/src/api/test/fixtures/event_mailer/tom_declined
+++ b/src/api/test/fixtures/event_mailer/tom_declined
@@ -9,16 +9,16 @@ Mime-Version: 1.0
 Content-Type: text/plain;
  charset=UTF-8
 Content-Transfer-Encoding: 7bit
-Precedence: bulk
-X-Mailer: OBS Notification System
 X-OBS-URL: http://localhost
-Auto-Submitted: auto-generated
 X-OBS-event-type: request_statechange
 X-OBS-Request-Creator: Iggy
 X-OBS-Request-Id: REQUESTID
 X-OBS-Request-State: declined
 X-OBS-Request-Action-type: set_bugowner
 X-OBS-Request-Action-target: home:tom
+Precedence: bulk
+Auto-Submitted: auto-generated
+X-Mailer: OBS Notification System
 
 Visit http://localhost/request/show/REQUESTID
 

--- a/src/api/test/fixtures/event_mailer/tom_gets_mail_too
+++ b/src/api/test/fixtures/event_mailer/tom_gets_mail_too
@@ -9,16 +9,16 @@ Mime-Version: 1.0
 Content-Type: text/plain;
  charset=UTF-8
 Content-Transfer-Encoding: 7bit
-Precedence: bulk
-X-Mailer: OBS Notification System
 X-OBS-URL: http://localhost
-Auto-Submitted: auto-generated
 X-OBS-event-type: request_create
 X-OBS-Request-Creator: Iggy
 X-OBS-Request-Id: REQUESTID
 X-OBS-Request-State: new
 X-OBS-Request-Action-type: add_role
 X-OBS-Request-Action-target: kde4/kdelibs
+Precedence: bulk
+Auto-Submitted: auto-generated
+X-Mailer: OBS Notification System
 
 Visit http://localhost/request/show/REQUESTID
 


### PR DESCRIPTION
- Organize common parts of action mailers on an application mailer:
   - This is the recommended way of organizing mailers proposed by the Action Mailer Basics guide: https://guides.rubyonrails.org/action_mailer_basics.html
   - Solve the `Rails/ApplicationMailer` RuboCop offenses
- Get rid of this unneded assignment: `@configuration = ::Configuration.fetch`
- Prepare for a further refactoring to get rid of the `@host` variable and use `action_mailer.default_url_options` instead.