### PR TITLE
Fix request filter from API

### DIFF
--- a/src/api/app/models/bs_request/find_for/project.rb
+++ b/src/api/app/models/bs_request/find_for/project.rb
@@ -13,6 +13,7 @@ class BsRequest
         reviews_conditions
 
         @relation = @relation.where("(#{@where_conditions.join(') or (')})", *@where_values.flatten) if @where_conditions.present?
+        @relation
       end
 
       private


### PR DESCRIPTION
When filtering by both roles and user, the code crashed as we set the @relation to nil by mistake. When there aren't new conditions to add to the relation, we should return the relation as it was before, not nil.

Fixes #16692

## Testing Tips

With the data generated by the `test_data` task, you can try the following, which will crash without the change proposed in this PR:

```
curl -H 'accept: application/xml' -u Admin:opensuse -X GET "http://localhost:3000/request?view=collection&user=Admin&roles=creator&project=home:Admin"
```

This is the endpoint documentation: https://api.opensuse.org/apidocs/index#/Requests/get_request_view_collection



