### PR TITLE
[api] increase size limit for binary_releases table

### DIFF
--- a/src/api/app/models/binary_release.rb
+++ b/src/api/app/models/binary_release.rb
@@ -118,7 +118,7 @@ end
 #
 # Table name: binary_releases
 #
-#  id                        :integer          not null, primary key
+#  id                        :bigint           not null, primary key
 #  binary_arch               :string(64)       not null, indexed => [binary_name, binary_epoch, binary_version, binary_release], indexed => [binary_name]
 #  binary_buildtime          :datetime
 #  binary_cpeid              :string(255)
@@ -138,7 +138,7 @@ end
 #  obsolete_time             :datetime
 #  operation                 :string           default("added")
 #  binary_id                 :string(255)      indexed
-#  on_medium_id              :integer
+#  on_medium_id              :bigint
 #  release_package_id        :integer          indexed
 #  repository_id             :integer          not null, indexed => [binary_name]
 #

--- a/src/api/db/migrate/20240916121900_increase_binary_releases_limit.rb
+++ b/src/api/db/migrate/20240916121900_increase_binary_releases_limit.rb
@@ -1,0 +1,11 @@
+class IncreaseBinaryReleasesLimit < ActiveRecord::Migration[7.0]
+  def up
+    safety_assured { change_column :binary_releases, :id, :bigint }
+    safety_assured { change_column :binary_releases, :on_medium_id, :bigint }
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+    # in theory we could implement some complex handling here, but it is unlikely that we revert
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_08_23_084727) do
+ActiveRecord::Schema[7.0].define(version: 2024_09_16_121900) do
   create_table "active_storage_attachments", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -153,7 +153,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_08_23_084727) do
     t.index ["links_to_id"], name: "index_backend_packages_on_links_to_id"
   end
 
-  create_table "binary_releases", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
+  create_table "binary_releases", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "repository_id", null: false
     t.column "operation", "enum('added','removed','modified')", default: "added", collation: "utf8mb3_general_ci"
     t.datetime "obsolete_time", precision: nil
@@ -172,7 +172,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_08_23_084727) do
     t.string "binary_updateinfo"
     t.string "binary_updateinfo_version"
     t.datetime "modify_time", precision: nil
-    t.integer "on_medium_id"
+    t.bigint "on_medium_id"
     t.string "binary_id"
     t.string "flavor"
     t.string "binary_cpeid"


### PR DESCRIPTION
We reached the integer limit meanwhile, going from int to bigint for index