### PR TITLE
Fix capybara session errors

### DIFF
--- a/src/api/spec/support/capybara.rb
+++ b/src/api/spec/support/capybara.rb
@@ -14,6 +14,7 @@ Capybara.register_driver :desktop do |app|
   Capybara::Selenium::Driver.load_selenium
   browser_options = Selenium::WebDriver::Chrome::Options.new
   browser_options.args << '--disable-gpu'
+  browser_options.args << '--disable-dev-shm-usage'
   browser_options.args << '--headless'
   browser_options.args << '--no-sandbox' # to run in docker
   browser_options.args << '--window-size=1280,1024'
@@ -24,6 +25,7 @@ Capybara.register_driver :mobile do |app|
   Capybara::Selenium::Driver.load_selenium
   browser_options = Selenium::WebDriver::Chrome::Options.new
   browser_options.args << '--disable-gpu'
+  browser_options.args << '--disable-dev-shm-usage'
   browser_options.args << '--headless'
   browser_options.args << '--no-sandbox' # to run in docker
   browser_options.add_emulation(device_metrics: { width: 320, height: 568, pixelRatio: 1, touch: true })


### PR DESCRIPTION
When running feature specs some errors pop up:

  1.3) Failure/Error: Unable to infer file and line number from backtrace

    Selenium::WebDriver::Error::InvalidSessionIdError:
      invalid session id

Disabling the use of shared memory seems to fix those errors.