### PR TITLE
Provide details about an invalid label template's color

### DIFF
--- a/src/api/app/models/label_template.rb
+++ b/src/api/app/models/label_template.rb
@@ -18,7 +18,12 @@ class LabelTemplate < ApplicationRecord
 
   #### Validations macros
   validates :name, length: { maximum: 255 }, presence: true
-  validates :color, length: { maximum: 7 }, presence: true, format: { with: /\A#[0-9a-f]{6}\z/i, message: 'enter color in valid hex format (#FFFFFF)' }
+  validates :color, length: { maximum: 7 }, presence: true, format: {
+    with: /\A#[0-9a-f]{6}\z/i,
+    message: lambda do |_, data|
+      "'#{data[:value]}' is not a valid color. It should be formatted as hex (#FFFFFF)"
+    end
+  }
 
   #### Class methods using self. (public and then private)
 


### PR DESCRIPTION
This will be useful for debugging flaky tests on CircleCI about invalid colors... See https://app.circleci.com/pipelines/github/openSUSE/open-build-service/21480/workflows/5149ba31-8ef0-4a37-8be4-f673846cfab2/jobs/205382/tests