### PR TITLE
Use only one `opts` hash

### DIFF
--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -487,7 +487,7 @@ class BsRequest < ApplicationRecord
 
   def permission_check_change_state!(opts)
     checker = BsRequestPermissionCheck.new(self, opts)
-    checker.cmd_changestate_permissions(opts)
+    checker.cmd_changestate_permissions
 
     # check target write permissions
     return unless opts[:newstate] == 'accepted'
@@ -1237,7 +1237,7 @@ class BsRequest < ApplicationRecord
     # none of them is supposed to be crucial wrt. permission checking)
     my_opts = opts.merge(newstate: 'accepted', force: true)
     checker = BsRequestPermissionCheck.new(self, my_opts)
-    checker.cmd_changestate_permissions(my_opts)
+    checker.cmd_changestate_permissions
     check_bs_request_actions!(skip_source: true)
 
     self.approver = new_approver

--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -466,7 +466,7 @@ class BsRequest < ApplicationRecord
 
   def permission_check_change_review!(params)
     checker = BsRequestPermissionCheck.new(self, params)
-    checker.cmd_changereviewstate_permissions(params)
+    checker.cmd_changereviewstate_permissions
   end
 
   def permission_check_setincident!(incident)

--- a/src/api/app/models/bs_request_permission_check.rb
+++ b/src/api/app/models/bs_request_permission_check.rb
@@ -139,7 +139,7 @@ class BsRequestPermissionCheck
     req.bs_request_actions.each do |action|
       set_permissions_for_action(action, accept_check ? 'accepted' : opts[:newstate])
 
-      check_newstate_action!(action, opts)
+      check_newstate_action!(action)
 
       # TODO: Get the relevant project attribute, from the target project or target package. Retrieve the accepter and check if it's the same person than the creator. And fail if true
       target_package = Package.get_by_project_and_name(action.target_project, action.target_package) if Package.exists_by_project_and_name(action.target_project, action.target_package)
@@ -276,7 +276,7 @@ class BsRequestPermissionCheck
   end
 
   # check if the action can change state - or throw an APIError if not
-  def check_newstate_action!(action, opts)
+  def check_newstate_action!(action)
     # relaxed checks for final exit states
     return if opts[:newstate].in?(%w[declined revoked superseded])
 

--- a/src/api/app/models/bs_request_permission_check.rb
+++ b/src/api/app/models/bs_request_permission_check.rb
@@ -186,7 +186,7 @@ class BsRequestPermissionCheck
     # maintenance_release accept check
     if action.action_type == :maintenance_release
       # compare with current sources
-      check_maintenance_release_accept(action, opts)
+      check_maintenance_release_accept(action)
     end
 
     # target must exist
@@ -249,7 +249,7 @@ class BsRequestPermissionCheck
     end
   end
 
-  def check_maintenance_release_accept(action, opts = {})
+  def check_maintenance_release_accept(action)
     if action.source_rev
       # FIXME2.4 we have a directory model
       c = Backend::Api::Sources::Package.files(action.source_project, action.source_package, expand: 1)

--- a/src/api/app/models/bs_request_permission_check.rb
+++ b/src/api/app/models/bs_request_permission_check.rb
@@ -167,7 +167,7 @@ class BsRequestPermissionCheck
 
   private
 
-  def check_accepted_action(action, opts)
+  def check_accepted_action(action)
     raise NotExistingTarget, "Unable to process project #{action.target_project}; it does not exist." unless @target_project
 
     check_action_target(action)
@@ -281,7 +281,7 @@ class BsRequestPermissionCheck
     return if opts[:newstate].in?(%w[declined revoked superseded])
 
     if opts[:newstate] == 'accepted' || opts[:cmd] == 'approve'
-      check_accepted_action(action, opts)
+      check_accepted_action(action)
     else # only check the target is sane
       check_action_target(action)
     end

--- a/src/api/app/models/bs_request_permission_check.rb
+++ b/src/api/app/models/bs_request_permission_check.rb
@@ -194,7 +194,7 @@ class BsRequestPermissionCheck
       raise NotExistingTarget, "Unable to process package #{action.target_project}/#{action.target_package}; it does not exist."
     end
 
-    check_delete_accept(action, opts) if action.action_type == :delete
+    check_delete_accept(action) if action.action_type == :delete
 
     return unless action.makeoriginolder && Package.exists_by_project_and_name(action.target_project, action.target_package)
 
@@ -235,7 +235,7 @@ class BsRequestPermissionCheck
     raise TargetNotMaintenance, "The target project is not of type maintenance or incident but #{@target_project.kind}"
   end
 
-  def check_delete_accept(action, opts)
+  def check_delete_accept(action)
     if @target_package
       return if opts.include?(:force) && opts[:force].in?([nil, '1'])
 

--- a/src/api/app/models/bs_request_permission_check.rb
+++ b/src/api/app/models/bs_request_permission_check.rb
@@ -55,7 +55,7 @@ class BsRequestPermissionCheck
     require_permissions_in_target_or_source
   end
 
-  def cmd_changereviewstate_permissions(opts)
+  def cmd_changereviewstate_permissions
     # Basic validations of given parameters
     by_user = User.find_by_login!(opts[:by_user]) if opts[:by_user]
     by_group = Group.find_by_title!(opts[:by_group]) if opts[:by_group]

--- a/src/api/app/models/bs_request_permission_check.rb
+++ b/src/api/app/models/bs_request_permission_check.rb
@@ -83,7 +83,7 @@ class BsRequestPermissionCheck
     raise ReviewChangeStateNoPermission, "review state change for project #{opts[:by_project]} is not permitted for #{User.session!.login}"
   end
 
-  def cmd_changestate_permissions(opts)
+  def cmd_changestate_permissions
     # We do not support to revert changes from accepted requests (yet)
     raise PostRequestNoPermission, 'change state from an accepted state is not allowed.' if req.state == :accepted
 


### PR DESCRIPTION
`opts` is defined as a reader attribute for `BsRequestPermissionCheck`. Passing the `opts` parameter to all these methods is redundant.

Noticed after working on solving #16832.