### PR TITLE
Show an error message for statistics of a package of a scmsync project

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -1,5 +1,6 @@
 class Webui::PackageController < Webui::WebuiController
   include ParsePackageDiff
+  include ScmsyncChecker
   include Webui::PackageHelper
   include Webui::ManageRelationships
   include Webui::NotificationsHandler
@@ -10,6 +11,8 @@ class Webui::PackageController < Webui::WebuiController
                                        new branch_diff_info rdiff create remove
                                        save_person save_group remove_role view_file
                                        buildresult rpmlint_result rpmlint_log files]
+
+  before_action :check_scmsync, only: :statistics
 
   before_action :require_package, only: %i[edit update show requests statistics revisions
                                            branch_diff_info rdiff remove

--- a/src/api/spec/controllers/webui/package_controller_spec.rb
+++ b/src/api/spec/controllers/webui/package_controller_spec.rb
@@ -388,6 +388,17 @@ RSpec.describe Webui::PackageController, :vcr do
 
       it { expect(assigns(:statistics)).to be_nil }
     end
+
+    context 'the project is an scmsync project' do
+      let(:scmsync_project) { create(:project, name: 'lorem', scmsync: 'https://github.com/example/scmsync-project.git') }
+
+      before do
+        get :statistics, params: { project: scmsync_project.name, package: source_package.name, arch: 'i586', repository: repository.name }
+      end
+
+      it { expect(flash[:error]).to eq('The project lorem is configured through scmsync. This is not supported by the OBS frontend') }
+      it { expect(response).to redirect_to(project_show_path(scmsync_project)) }
+    end
   end
 
   describe '#rpmlint_result' do


### PR DESCRIPTION
Avoid throwing a 500 error.

Fixes #16855.

Related to #16857.