### PR TITLE
Remove never used parameter `attribute` for creating maintenance incidents

### DIFF
--- a/src/api/app/controllers/source_controller.rb
+++ b/src/api/app/controllers/source_controller.rb
@@ -294,15 +294,7 @@ class SourceController < ApplicationController
 
   # POST /source?cmd=createmaintenanceincident
   def global_command_createmaintenanceincident
-    # set defaults
-    at = nil
-    unless params[:attribute]
-      params[:attribute] = 'OBS:MaintenanceProject'
-      at = AttribType.find_by_name!(params[:attribute])
-    end
-
-    # find maintenance project via attribute
-    prj = Project.get_maintenance_project!(at)
+    prj = Project.get_maintenance_project!
     actually_create_incident(prj)
   end
 

--- a/src/api/app/models/concerns/project_maintenance.rb
+++ b/src/api/app/models/concerns/project_maintenance.rb
@@ -18,8 +18,8 @@ module ProjectMaintenance
   end
 
   class_methods do
-    def get_maintenance_project(at = nil)
-      at ||= AttribType.find_by_namespace_and_name!('OBS', 'MaintenanceProject')
+    def get_maintenance_project # rubocop:disable Naming/AccessorMethodName
+      at = AttribType.find_by_namespace_and_name!('OBS', 'MaintenanceProject')
       maintenance_project = Project.joins(:attribs).where(attribs: { attrib_type_id: at.id }).first
 
       return unless maintenance_project&.check_access?
@@ -27,8 +27,8 @@ module ProjectMaintenance
       maintenance_project
     end
 
-    def get_maintenance_project!(at = nil)
-      maintenance_project = get_maintenance_project(at)
+    def get_maintenance_project!
+      maintenance_project = get_maintenance_project
       raise Project::Errors::UnknownObjectError, 'There is no project flagged as maintenance project on server and no target in request defined.' unless maintenance_project
 
       maintenance_project

--- a/src/api/public/apidocs/paths/source_createmaintenanceincident.yaml
+++ b/src/api/public/apidocs/paths/source_createmaintenanceincident.yaml
@@ -1,15 +1,8 @@
 post:
   summary: Create maintenance incident projects
-  description: Create a mainatenance incident project based on attribute search.
+  description: Create a maintenance incident project based on the project defined by the attribute `OBS:MaintenanceProject`.
   security:
     - basic_authentication: []
-  parameters:
-    - in: query
-      name: attribute
-      schema:
-        type: string
-      example: OBS:MaintenanceProject
-      description: attribute used for package search, default is OBS:MaintenanceProject
   responses:
     '200':
       description: ok


### PR DESCRIPTION
Passing a value or not to the `attribute` parameter to the `/source?cmd=createmaintenanceincident` API endpoint has never made a difference.