### PR TITLE
Remove package_kinds association from projects

### DIFF
--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -45,7 +45,6 @@ class Project < ApplicationRecord
   end
   has_many :patchinfos, -> { with_kind('patchinfo') }, class_name: 'Package'
 
-  has_many :package_kinds, through: :packages
   has_many :issues, through: :packages
   has_many :attribs, dependent: :destroy do
     def embargo_date


### PR DESCRIPTION
Package kinds are always use from the package model.