### PR TITLE
Handle external report bug links properly

### DIFF
--- a/src/api/app/views/webui/package/show_actions/_bugzilla_owner.html.haml
+++ b/src/api/app/views/webui/package/show_actions/_bugzilla_owner.html.haml
@@ -2,3 +2,4 @@
   = link_to(url, class: 'nav-link', title: 'Report Bug') do
     %i.fas.fa-bug.fa-lg.me-2
     %span.nav-item-name Report Bug
+    %i.fa-solid.fa-arrow-up-right-from-square.fa-xs

--- a/src/api/app/views/webui/project/show_actions/_report_bug.html.haml
+++ b/src/api/app/views/webui/project/show_actions/_report_bug.html.haml
@@ -2,3 +2,4 @@
   = link_to(url, class: 'nav-link', title: 'Report Bug') do
     %i.fas.fa-bug.fa-lg.me-2
     %span.nav-item-name Report Bug
+    %i.fa-solid.fa-arrow-up-right-from-square.fa-xs


### PR DESCRIPTION
This is how it looks like:

![Screenshot from 2024-09-20 10-07-58](https://github.com/user-attachments/assets/de145a99-b9d9-4117-927b-18438cc12e9b)
