### PR TITLE
Do not allow local urls for the report bug link

### DIFF
--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -104,6 +104,7 @@ class Package < ApplicationRecord
   validates :url, length: { maximum: 255 }
   validates :description, length: { maximum: 65_535 }
   validates :report_bug_url, length: { maximum: 8192 }
+  validate :report_bug_url_is_external
   validates :project_id, uniqueness: {
     scope: :name,
     message: lambda do |object, _data|
@@ -1367,6 +1368,12 @@ class Package < ApplicationRecord
     package_kinds.delete_all
     BackendPackage.where(package_id: id).delete_all
     decline_requests_with_self_as_target("The package '#{project.name} / #{name}' is now maintained at #{scmsync}")
+  end
+
+  def report_bug_url_is_external
+    return true unless report_bug_url
+
+    errors.add(:report_bug_url, 'Local urls are not allowed') if report_bug_url.include?(Configuration.obs_url)
   end
 end
 # rubocop: enable Metrics/ClassLength

--- a/src/api/spec/models/package_spec.rb
+++ b/src/api/spec/models/package_spec.rb
@@ -783,32 +783,35 @@ RSpec.describe Package, :vcr do
   end
 
   describe '#report_bug_url' do
-    # Locally the configuration returns https://unconfigured.openbuildservice.org
-    # as host so we use a better host
-    before { allow(Configuration).to receive(:obs_url).and_return('https://localhost:3000') }
+    before do
+      # Locally the configuration returns https://unconfigured.openbuildservice.org
+      # as host so we use a better host
+      allow(Configuration).to receive(:obs_url).and_return('https://localhost:3000')
+      package.valid?
+    end
 
     context 'url is external' do
       let(:package) { build(:package, report_bug_url: 'https://example.com') }
 
-      it { expect(package).to be_valid }
+      it { expect(package.errors).to be_empty }
     end
 
     context 'url is relative' do
       let(:package) { build(:package, report_bug_url: '/about') }
 
-      it { expect(package).not_to(be_valid) }
+      it { expect(package.errors[:report_bug_url]).to eql(['Local urls are not allowed']) }
     end
 
     context 'url has no protocol' do
       let(:package) { build(:package, report_bug_url: 'example.com') }
 
-      it { expect(package).to be_valid }
+      it { expect(package.errors).to be_empty }
     end
 
     context 'local url has no protocol' do
       let(:package) { build(:package, report_bug_url: 'localhost:3000/about') }
 
-      it { expect(package).not_to(be_valid) }
+      it { expect(package.errors[:report_bug_url]).to eql(['Local urls are not allowed']) }
     end
   end
 end

--- a/src/api/spec/models/package_spec.rb
+++ b/src/api/spec/models/package_spec.rb
@@ -781,4 +781,34 @@ RSpec.describe Package, :vcr do
       it { expect { subject }.to raise_error(Package::CycleError) }
     end
   end
+
+  describe '#report_bug_url' do
+    # Locally the configuration returns https://unconfigured.openbuildservice.org
+    # as host so we use a better host
+    before { allow(Configuration).to receive(:obs_url).and_return('https://localhost:3000') }
+
+    context 'url is external' do
+      let(:package) { build(:package, report_bug_url: 'https://example.com') }
+
+      it { expect(package).to be_valid }
+    end
+
+    context 'url is relative' do
+      let(:package) { build(:package, report_bug_url: '/about') }
+
+      it { expect(package).not_to(be_valid) }
+    end
+
+    context 'url has no protocol' do
+      let(:package) { build(:package, report_bug_url: 'example.com') }
+
+      it { expect(package).to be_valid }
+    end
+
+    context 'local url has no protocol' do
+      let(:package) { build(:package, report_bug_url: 'localhost:3000/about') }
+
+      it { expect(package).not_to(be_valid) }
+    end
+  end
 end


### PR DESCRIPTION
This is how it looks like when the url is local
![Screenshot from 2024-09-20 11-20-42](https://github.com/user-attachments/assets/946c426a-4b3d-49fe-b383-97ef79e1a984)

And this is how it looks like when the url is not local
![Screenshot from 2024-09-20 11-53-31](https://github.com/user-attachments/assets/c3a949da-44d8-4695-adb1-9efefa20fe91)

