### PR TITLE
[api] release action: support specification of source repository

### DIFF
--- a/docs/api/api/request.rng
+++ b/docs/api/api/request.rng
@@ -89,6 +89,11 @@
 		<data type="string" />
               </attribute>
             </optional>
+            <optional>
+              <attribute name="repository">
+		<data type="string" />
+              </attribute>
+            </optional>
             <empty/>
           </element>
 	</optional>

--- a/src/api/app/models/bs_request_action.rb
+++ b/src/api/app/models/bs_request_action.rb
@@ -121,6 +121,7 @@ class BsRequestAction < ApplicationRecord
       self.source_package = source.delete('package')
       self.source_project = source.delete('project')
       self.source_rev = source.delete('rev')
+      self.source_repository = source.delete('repository')
 
       raise ArgumentError, "too much information #{source.inspect}" if source.present?
     end
@@ -224,6 +225,7 @@ class BsRequestAction < ApplicationRecord
     ret[:sourceproject] = source_project
     ret[:sourcepackage] = source_package
     ret[:sourcerevision] = source_rev
+    ret[:sourcerepository] = source_repository
     ret[:person] = person_name
     ret[:group] = group_name
     ret[:role] = role
@@ -1026,6 +1028,7 @@ class BsRequestAction < ApplicationRecord
   def render_xml_source(node)
     attributes = xml_package_attributes('source')
     attributes[:rev] = source_rev if source_rev.present?
+    attributes[:repository] = source_repository if source_repository.present?
     node.source(attributes)
   end
 
@@ -1056,6 +1059,7 @@ end
 #  role                  :string(255)
 #  source_package        :string(255)      indexed
 #  source_project        :string(255)      indexed
+#  source_repository     :string(255)
 #  source_rev            :string(255)
 #  sourceupdate          :string(255)
 #  target_package        :string(255)      indexed

--- a/src/api/app/models/bs_request_action_add_role.rb
+++ b/src/api/app/models/bs_request_action_add_role.rb
@@ -73,6 +73,7 @@ end
 #  role                  :string(255)
 #  source_package        :string(255)      indexed
 #  source_project        :string(255)      indexed
+#  source_repository     :string(255)
 #  source_rev            :string(255)
 #  sourceupdate          :string(255)
 #  target_package        :string(255)      indexed

--- a/src/api/app/models/bs_request_action_change_devel.rb
+++ b/src/api/app/models/bs_request_action_change_devel.rb
@@ -52,6 +52,7 @@ end
 #  role                  :string(255)
 #  source_package        :string(255)      indexed
 #  source_project        :string(255)      indexed
+#  source_repository     :string(255)
 #  source_rev            :string(255)
 #  sourceupdate          :string(255)
 #  target_package        :string(255)      indexed

--- a/src/api/app/models/bs_request_action_delete.rb
+++ b/src/api/app/models/bs_request_action_delete.rb
@@ -108,6 +108,7 @@ end
 #  role                  :string(255)
 #  source_package        :string(255)      indexed
 #  source_project        :string(255)      indexed
+#  source_repository     :string(255)
 #  source_rev            :string(255)
 #  sourceupdate          :string(255)
 #  target_package        :string(255)      indexed

--- a/src/api/app/models/bs_request_action_maintenance_incident.rb
+++ b/src/api/app/models/bs_request_action_maintenance_incident.rb
@@ -228,6 +228,7 @@ end
 #  role                  :string(255)
 #  source_package        :string(255)      indexed
 #  source_project        :string(255)      indexed
+#  source_repository     :string(255)
 #  source_rev            :string(255)
 #  sourceupdate          :string(255)
 #  target_package        :string(255)      indexed

--- a/src/api/app/models/bs_request_action_maintenance_release.rb
+++ b/src/api/app/models/bs_request_action_maintenance_release.rb
@@ -186,6 +186,7 @@ end
 #  role                  :string(255)
 #  source_package        :string(255)      indexed
 #  source_project        :string(255)      indexed
+#  source_repository     :string(255)
 #  source_rev            :string(255)
 #  sourceupdate          :string(255)
 #  target_package        :string(255)      indexed

--- a/src/api/app/models/bs_request_action_release.rb
+++ b/src/api/app/models/bs_request_action_release.rb
@@ -40,7 +40,20 @@ class BsRequestActionRelease < BsRequestAction
     # have a unique time stamp for release
     opts[:acceptTimeStamp] ||= Time.zone.now
 
-    release_package(pkg, Project.get_by_name(target_project), target_package, { action: self, manual: true })
+    if source_repository.present?
+      source_repo = Repository.find_by_project_and_name(source_project, source_repository)
+      raise RepositoryMissing, "Source Repository is missing #{source_project} #{source_repository}" if source_repo.empty?
+      flags[:filter_source_repository] = source_repo
+    end
+    target = if target_repository.present? and source_repository.present?
+               # only when source and target repos are defined
+               Repository.find_by_project_and_name(target_project, target_repository)
+             else
+               # otherwise let the release_package code do the release target definition filtering
+               Project.get_by_name(target_project)
+             end
+
+    release_package(pkg, target, target_package, { action: self, manual: true })
   end
 
   def check_permissions!
@@ -89,6 +102,10 @@ class BsRequestActionRelease < BsRequestAction
     manual_targets = prj.repositories.includes(:release_targets).where(release_targets: { trigger: 'manual' })
     raise RepositoryWithoutReleaseTarget, "Release target definition is missing in #{prj.name}" unless manual_targets.any?
 
+    if source_repository.present?
+      raise RepositoryMissing, "Source Repository is missing #{source_project} #{source_repository}" if Repository.find_by_project_and_name(source_project, source_repository).nil?
+    end
+
     manual_targets.each do |repo|
       raise RepositoryWithoutArchitecture, "Repository has no architecture #{prj.name} / #{repo.name}" if repo.architectures.empty?
 
@@ -112,6 +129,7 @@ end
 #  role                  :string(255)
 #  source_package        :string(255)      indexed
 #  source_project        :string(255)      indexed
+#  source_repository     :string(255)
 #  source_rev            :string(255)
 #  sourceupdate          :string(255)
 #  target_package        :string(255)      indexed

--- a/src/api/app/models/bs_request_action_set_bugowner.rb
+++ b/src/api/app/models/bs_request_action_set_bugowner.rb
@@ -66,6 +66,7 @@ end
 #  role                  :string(255)
 #  source_package        :string(255)      indexed
 #  source_project        :string(255)      indexed
+#  source_repository     :string(255)
 #  source_rev            :string(255)
 #  sourceupdate          :string(255)
 #  target_package        :string(255)      indexed

--- a/src/api/app/models/bs_request_action_submit.rb
+++ b/src/api/app/models/bs_request_action_submit.rb
@@ -184,6 +184,7 @@ end
 #  role                  :string(255)
 #  source_package        :string(255)      indexed
 #  source_project        :string(255)      indexed
+#  source_repository     :string(255)
 #  source_rev            :string(255)
 #  sourceupdate          :string(255)
 #  target_package        :string(255)      indexed

--- a/src/api/db/migrate/20240924121900_add_source_repository_action.rb
+++ b/src/api/db/migrate/20240924121900_add_source_repository_action.rb
@@ -1,0 +1,5 @@
+class AddSourceRepositoryAction < ActiveRecord::Migration[7.0]
+  def change
+    add_column :bs_request_actions, :source_repository, :string, collation: 'utf8_unicode_ci'
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_08_23_084727) do
+ActiveRecord::Schema[7.0].define(version: 2024_09_24_121900) do
   create_table "active_storage_attachments", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -226,6 +226,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_08_23_084727) do
     t.boolean "makeoriginolder", default: false
     t.integer "target_package_id"
     t.integer "target_project_id"
+    t.string "source_repository", collation: "utf8mb3_unicode_ci"
     t.index ["bs_request_id", "target_package_id"], name: "index_bs_request_actions_on_bs_request_id_and_target_package_id"
     t.index ["bs_request_id", "target_project_id"], name: "index_bs_request_actions_on_bs_request_id_and_target_project_id"
     t.index ["bs_request_id"], name: "bs_request_id"


### PR DESCRIPTION
It is required to support any combination of releasing source and binaries from any given repository to any other via a request.

This is esp. needed when release targets can not be specified as they would differ by flavor or architecture.