### PR TITLE
Use request state badge as a component

### DIFF
--- a/src/api/app/helpers/webui/request_helper.rb
+++ b/src/api/app/helpers/webui/request_helper.rb
@@ -195,63 +195,7 @@ module Webui::RequestHelper
     end
   end
 
-  # TODO: find a way to DRY the code related to state badge (used on notifications)
-
-  def bs_request_state_badge(state)
-    content_tag(
-      :span,
-      icon_state_tag(state).concat(state),
-      class: ['badge', "text-bg-#{decode_state_color(state)}", 'ms-1']
-    )
-  end
-
   private
-
-  def decode_state_color(state)
-    case state
-    when :review, :new
-      'secondary'
-    when :declined
-      'danger'
-    when :superseded
-      'warning'
-    when :accepted
-      'success'
-    when :revoked
-      'dismissed'
-    else
-      'dark'
-    end
-  end
-
-  def decode_state_icon(state)
-    case state
-    when :new
-      'code-branch'
-    when :review, :declined, :revoked
-      'code-pull-request'
-    when :superseded
-      'code-compare'
-    when :accepted
-      'code-merge'
-    else
-      'code-fork'
-    end
-  end
-
-  def icon_state_tag(state)
-    if %i[declined revoked].include?(state)
-      content_tag(
-        :span,
-        tag.i(class: 'fas fa-code-pull-request').concat(
-          tag.i(class: 'fas fa-times fa-xs')
-        ),
-        class: 'fa-custom-pr-closed me-1'
-      )
-    else
-      tag.i(class: "fas fa-#{decode_state_icon(state)} me-1")
-    end
-  end
 
   def action_type_icon(type)
     case type

--- a/src/api/app/views/webui/users/notifications/_notification.html.haml
+++ b/src/api/app/views/webui/users/notifications/_notification.html.haml
@@ -17,7 +17,7 @@
           %small.text-nowrap
             = render TimeComponent.new(time: notification.created_at)
           - if notification.notifiable_type == 'BsRequest'
-            = bs_request_state_badge(notification.notifiable.state)
+            = render BsRequestStateBadgeComponent.new(state: notification.notifiable.state)
           - if notification.notifiable_type == 'WorkflowRun'
             = render WorkflowRunStatusBadgeComponent.new(status: notification.notifiable.status, css_class: 'ms-1')
           - if notification.notifiable_type == 'Report' && count_of_additional_reports_for_reportable(notification) >= 1


### PR DESCRIPTION
There was an attempt to move it to a helper, but it makes sense to keep it as a ViewComponent, which is re-used from around seven other parts of the code: watchlist, notifications, request page, filters...

## Testing tips

- Go to the Notifications page
- Filter by notifications about requests
- Check the state badges look good