### PR TITLE
Remove case sensitiveness from architecture's name uniqueness validation

### DIFF
--- a/src/api/.database_consistency.todo.yml
+++ b/src/api/.database_consistency.todo.yml
@@ -1,16 +1,10 @@
 ---
 Architecture:
-  arch_name_index:
-    UniqueIndexChecker:
-      enabled: false
   available:
     ThreeStateBooleanChecker:
       enabled: false
   id:
     PrimaryKeyTypeChecker:
-      enabled: false
-  lower(name):
-    MissingUniqueIndexChecker:
       enabled: false
   name:
     LengthConstraintChecker:

--- a/src/api/app/models/architecture.rb
+++ b/src/api/app/models/architecture.rb
@@ -19,7 +19,7 @@ class Architecture < ApplicationRecord
   scope :unavailable, -> { where(available: 0) }
 
   #### Validations macros
-  validates :name, uniqueness: { case_sensitive: false }
+  validates :name, uniqueness: true
   validates :name, presence: true
 
   #### Class methods using self. (public and then private)


### PR DESCRIPTION
Architectures table has a collation of `utf8mb4_unicode_ci`. the `_ci` part means case insensitive, so then it makes no sense that the validation we have on the Architecture model regarding uniqueness of the name to be case sensitive.