### PR TITLE
Add missing "release" action to submit actions mailer

### DIFF
--- a/src/api/app/views/event_mailer/_actions.text.erb
+++ b/src/api/app/views/event_mailer/_actions.text.erb
@@ -1,6 +1,6 @@
 Actions:
 <% event['actions'].each do |a| -%>
-<% if %w(submit maintenance_incident maintenance_release).include? a['type'] -%>
+<% if %w(submit maintenance_incident maintenance_release release).include? a['type'] -%>
 <%= render partial: 'event_mailer/submit_action', locals: { a: a } -%>
 <% else -%>
 <%= render partial: "event_mailer/#{a['type']}_action", locals: { a: a } -%>


### PR DESCRIPTION
Prevent from throwing errors like:

```
ActionView::Template::Error
delayed_job#SendEventEmailsJob
Missing partial event_mailer/_release_action with {:locale=>[:en], :formats=>[[Truncated]
```