### PR TITLE
Change default value for available column from architectures table to false

### DIFF
--- a/src/api/.database_consistency.todo.yml
+++ b/src/api/.database_consistency.todo.yml
@@ -1,8 +1,5 @@
 ---
 Architecture:
-  available:
-    ThreeStateBooleanChecker:
-      enabled: false
   id:
     PrimaryKeyTypeChecker:
       enabled: false

--- a/src/api/app/models/architecture.rb
+++ b/src/api/app/models/architecture.rb
@@ -71,7 +71,7 @@ end
 # Table name: architectures
 #
 #  id        :integer          not null, primary key
-#  available :boolean          default(FALSE)
+#  available :boolean          default(FALSE), not null
 #  name      :string(255)      not null, indexed
 #
 # Indexes

--- a/src/api/db/data/20250312082028_set_architectures_available_field_to_false.rb
+++ b/src/api/db/data/20250312082028_set_architectures_available_field_to_false.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class SetArchitecturesAvailableFieldToFalse < ActiveRecord::Migration[7.0]
+  def up
+    # rubocop:disable Rails/SkipsModelValidations
+    Architecture.where(available: nil).update_all(available: false)
+    # rubocop:enable Rails/SkipsModelValidations
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/src/api/db/data_schema.rb
+++ b/src/api/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20250131143734)
+DataMigrate::Data.define(version: 20250312082028)

--- a/src/api/db/migrate/20250312082500_add_not_null_to_architectures_available.rb
+++ b/src/api/db/migrate/20250312082500_add_not_null_to_architectures_available.rb
@@ -1,0 +1,5 @@
+class AddNotNullToArchitecturesAvailable < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :architectures, :available, false
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_03_10_164218) do
+ActiveRecord::Schema[7.0].define(version: 2025_03_12_082500) do
   create_table "active_storage_attachments", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -51,7 +51,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_03_10_164218) do
 
   create_table "architectures", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "name", null: false
-    t.boolean "available", default: false
+    t.boolean "available", default: false, null: false
     t.index ["name"], name: "arch_name_index", unique: true
   end
 


### PR DESCRIPTION
That way we stop having three values for that column: true, false and null, and we can get rid of the issue in the
database_consistencty.todo.yml

See https://github.com/djezzzl/database_consistency/wiki/threestatebooleanchecker