### PR TITLE
Show an error message for build results of an scmsync project

### DIFF
--- a/src/api/app/controllers/webui/packages/build_reason_controller.rb
+++ b/src/api/app/controllers/webui/packages/build_reason_controller.rb
@@ -1,7 +1,10 @@
 module Webui
   module Packages
     class BuildReasonController < Webui::WebuiController
+      include ScmsyncChecker
+
       before_action :set_project
+      before_action :check_scmsync
       before_action :set_package
       before_action :set_repository
       before_action :set_architecture


### PR DESCRIPTION
Avoid throwing a 500 error.

Fixes #16901.