### PR TITLE
Make delete parameter to behave properly

### DIFF
--- a/src/api/app/controllers/source_project_controller.rb
+++ b/src/api/app/controllers/source_project_controller.rb
@@ -4,7 +4,7 @@ class SourceProjectController < SourceController
   # GET /source/:project
   def show
     project_name = params[:project]
-    if params.key?(:deleted)
+    if params[:deleted] == '1'
       unless Project.find_by_name(project_name) || Project.is_remote_project?(project_name)
         # project is deleted or not accessible
         validate_visibility_of_deleted_project(project_name)


### PR DESCRIPTION
This way `?deleted=0` and `?` behaves consistently, and only `?deleted=1` activates the behavior for deleted projects

Fixes #9715 and possibly #16911