### PR TITLE
Display multibuild flavors when asking for local project sources

### DIFF
--- a/src/api/app/controllers/source_project_controller.rb
+++ b/src/api/app/controllers/source_project_controller.rb
@@ -52,7 +52,8 @@ class SourceProjectController < SourceController
   end
 
   def render_project_packages
-    @packages = params.key?(:expand) ? @project.expand_all_packages : @project.packages.pluck(:name)
+    # TODO: Display multibuild flavors when passing the expand param
+    @packages = params.key?(:expand) ? @project.expand_all_packages : @project.packages.sort_by(&:name)
     render locals: { expand: params.key?(:expand) }, formats: [:xml]
   end
 

--- a/src/api/app/views/source_project/show.xml.builder
+++ b/src/api/app/views/source_project/show.xml.builder
@@ -1,9 +1,14 @@
 xml.directory(count: @packages.count) do
-  @packages.map do |name, project|
+  @packages.map do |package, project|
     if expand
-      xml.entry(name: name, originproject: project)
+      xml.entry(name: package, originproject: project)
+    elsif package.multibuild?
+      xml.entry(name: package.name)
+      package.multibuild_flavors.each do |flavor|
+        xml.entry(name: "#{package.name}:#{flavor}", originpackage: package.name)
+      end
     else
-      xml.entry(name: name)
+      xml.entry(name: package)
     end
   end
 end


### PR DESCRIPTION
There was a consistency gap between sources coming from local projects and sources coming from remote projects. Multibuild flavors were only shown for remote projects. Now the multibuild flavors are shown in both cases.

Fixes #16911