### PR TITLE
Handle group's email from web UI

### DIFF
--- a/src/api/app/controllers/webui/groups_controller.rb
+++ b/src/api/app/controllers/webui/groups_controller.rb
@@ -44,6 +44,6 @@ class Webui::GroupsController < Webui::WebuiController
   private
 
   def group_params
-    params.require(:group).permit(:title, :members)
+    params.require(:group).permit(:title, :email, :members)
   end
 end

--- a/src/api/app/controllers/webui/groups_controller.rb
+++ b/src/api/app/controllers/webui/groups_controller.rb
@@ -21,6 +21,11 @@ class Webui::GroupsController < Webui::WebuiController
     authorize Group.new, :create?
   end
 
+  def edit
+    @group = Group.find_by(title: params[:title])
+    authorize @group, :update?
+  end
+
   def create
     group = Group.new(title: group_params[:title])
     authorize group, :create?
@@ -34,6 +39,18 @@ class Webui::GroupsController < Webui::WebuiController
     redirect_to controller: :groups, action: :index
   rescue ActiveRecord::RecordInvalid
     redirect_back_or_to root_path, error: "Group can't be saved: #{group.errors.full_messages.to_sentence}"
+  end
+
+  def update
+    @group = Group.find_by(title: params[:title])
+    authorize @group, :update?
+
+    if @group.update(email: group_params[:email])
+      flash[:success] = 'Group email successfully updated'
+      redirect_to groups_path
+    else
+      flash[:error] = "Couldn't update group: #{@group.errors.full_messages.to_sentence}"
+    end
   end
 
   def autocomplete

--- a/src/api/app/controllers/webui/groups_controller.rb
+++ b/src/api/app/controllers/webui/groups_controller.rb
@@ -1,6 +1,6 @@
 class Webui::GroupsController < Webui::WebuiController
   before_action :require_login, except: %i[show autocomplete]
-  after_action :verify_authorized, except: %i[show autocomplete]
+  after_action :verify_authorized, except: %i[show autocomplete edit update]
 
   def index
     authorize Group.new, :index?
@@ -23,7 +23,13 @@ class Webui::GroupsController < Webui::WebuiController
 
   def edit
     @group = Group.find_by(title: params[:title])
-    authorize @group, :update?
+
+    if @group
+      authorize(@group, :update?)
+    else
+      flash[:error] = "The group doesn't exist"
+      redirect_to(groups_path)
+    end
   end
 
   def create
@@ -43,6 +49,12 @@ class Webui::GroupsController < Webui::WebuiController
 
   def update
     @group = Group.find_by(title: params[:title])
+
+    unless @group
+      flash[:error] = "The group doesn't exist"
+      redirect_to(groups_path) && return
+    end
+
     authorize @group, :update?
 
     if @group.update(email: group_params[:email])

--- a/src/api/app/models/group.rb
+++ b/src/api/app/models/group.rb
@@ -31,6 +31,11 @@ class Group < ApplicationRecord
   validates :title,
             uniqueness: { case_sensitive: true, message: 'is the name of an already existing group' }
 
+  validates :email,
+            format: { with: /\A([\w\-.\#$%&!?*'+=(){}|~]+)@([0-9a-zA-Z\-.\#$%&!?*'=(){}|~]+)+\z/,
+                      message: 'must be a valid email address',
+                      allow_blank: true }
+
   default_scope { order(:title) }
 
   alias_attribute :name, :title

--- a/src/api/app/views/webui/groups/edit.html.haml
+++ b/src/api/app/views/webui/groups/edit.html.haml
@@ -1,0 +1,13 @@
+- @pagetitle = 'Edit Group'
+
+.card.mb-3
+  .card-body
+    %h3 Edit Group #{@group}
+    .col-lg-6.ps-0
+      = form_for(@group) do |form|
+        .mb-3
+          = form.label(:email) do
+            Email
+            %small.form-text (not required for groups)
+          = form.email_field(:email, class: 'form-control')
+        = form.submit('Update', class: 'btn btn-primary', data: { disable_with: 'Updating...' })

--- a/src/api/app/views/webui/groups/index.html.haml
+++ b/src/api/app/views/webui/groups/index.html.haml
@@ -21,6 +21,9 @@
             %td
               = link_to(edit_group_path(title: group.title)) do
                 %i.fas.fa-edit.text-secondary.pe-1{ title: 'Edit Group\'s Email' }
+              - if group.email.present?
+                = mail_to(group.email) do
+                  %i.fas.fa-envelope.text-secondary.pe-1{ title: 'Send Email to Group' }
     .pt-4
       = link_to(new_group_path, title: 'Create Group') do
         %i.fas.fa-plus-circle.text-primary

--- a/src/api/app/views/webui/groups/index.html.haml
+++ b/src/api/app/views/webui/groups/index.html.haml
@@ -10,6 +10,7 @@
         %tr
           %th Group Name
           %th Members
+          %th Actions
       %tbody
         - @groups.each do |group|
           %tr
@@ -17,7 +18,9 @@
               = link_to(group, group_path(title: group))
             %td
               = safe_join(group.users.map { |user| link_to(truncate(user.login, length: 20), user_path(user), title: user.login) }, ', ')
-
+            %td
+              = link_to(edit_group_path(title: group.title)) do
+                %i.fas.fa-edit.text-secondary.pe-1{ title: 'Edit Group\'s Email' }
     .pt-4
       = link_to(new_group_path, title: 'Create Group') do
         %i.fas.fa-plus-circle.text-primary

--- a/src/api/app/views/webui/groups/new.html.haml
+++ b/src/api/app/views/webui/groups/new.html.haml
@@ -10,6 +10,11 @@
           %abbr.text-danger{ title: 'required' } *
           = form.text_field(:title, class: 'form-control', required: true, autofocus: true)
         .mb-3
+          = form.label(:email) do
+            Email
+            %small.form-text (not required for groups)
+          = form.email_field(:email, class: 'form-control')
+        .mb-3
           = label_tag(:members)
           = text_field_tag('group[members]', @members, id: 'group-members', class: 'form-control tag-input',
                                                        data: { source: autocomplete_users_path })

--- a/src/api/config/routes/webui.rb
+++ b/src/api/config/routes/webui.rb
@@ -422,7 +422,7 @@ constraints(RoutesHelper::WebuiMatcher) do
 
   resource :session, only: %i[new create destroy], controller: 'webui/session'
 
-  resources :groups, only: %i[index show new create], param: :title, constraints: cons, controller: 'webui/groups' do
+  resources :groups, only: %i[index show new create edit update], param: :title, constraints: cons, controller: 'webui/groups' do
     resources :user, only: %i[create destroy update], param: :user_login, constraints: cons, controller: 'webui/groups/users'
     resources :requests, only: [:index], controller: 'webui/groups/bs_requests'
 

--- a/src/api/spec/controllers/webui/groups_controller_spec.rb
+++ b/src/api/spec/controllers/webui/groups_controller_spec.rb
@@ -89,4 +89,73 @@ RSpec.describe Webui::GroupsController do
       end
     end
   end
+
+  describe 'GET #edit' do
+    before do
+      login(login_as)
+      get :edit, params: { title: group.title }
+    end
+
+    context 'as a normal user' do
+      let(:login_as) { create(:user) }
+
+      it 'does not allow to edit the group' do
+        expect(flash[:error]).to eq('Sorry, you are not authorized to update this group.')
+      end
+    end
+
+    context 'as an admin' do
+      let(:login_as) { create(:admin_user) }
+
+      it { expect(assigns(:group)).to eq(group) }
+    end
+  end
+
+  describe 'PUT #update' do
+    before do
+      login(login_as)
+      put :update, params: { title: group.title, group: { email: email } }
+    end
+
+    context 'as a normal user' do
+      let(:login_as) { create(:user) }
+      let(:email) { 'new_email@example.com' }
+
+      it 'does not allow to update the group' do
+        expect(flash[:error]).to eq('Sorry, you are not authorized to update this group.')
+        expect(group.reload.email).not_to eq(email)
+      end
+    end
+
+    context 'as an admin' do
+      let(:login_as) { create(:admin_user) }
+
+      context 'when the email is empty' do
+        let(:email) { nil }
+
+        it 'updates the email' do
+          expect(flash[:success]).to eq('Group email successfully updated')
+          expect(group.reload.email).to be_empty
+        end
+      end
+
+      context 'when the email is not empty' do
+        let(:email) { 'new_email@example.com' }
+
+        it 'updates the email' do
+          expect(response).to redirect_to(groups_path)
+          expect(flash[:success]).to eq('Group email successfully updated')
+          expect(group.reload.email).to eq(email)
+        end
+      end
+
+      context 'when the email have the wrong format' do
+        let(:email) { 'is_not_an_email' }
+
+        it 'is not updated' do
+          expect(flash[:error]).to eq("Couldn't update group: Email must be a valid email address")
+        end
+      end
+    end
+  end
 end

--- a/src/api/spec/controllers/webui/groups_controller_spec.rb
+++ b/src/api/spec/controllers/webui/groups_controller_spec.rb
@@ -91,9 +91,11 @@ RSpec.describe Webui::GroupsController do
   end
 
   describe 'GET #edit' do
+    let(:title) { group.title }
+
     before do
       login(login_as)
-      get :edit, params: { title: group.title }
+      get :edit, params: { title: title }
     end
 
     context 'as a normal user' do
@@ -108,13 +110,23 @@ RSpec.describe Webui::GroupsController do
       let(:login_as) { create(:admin_user) }
 
       it { expect(assigns(:group)).to eq(group) }
+
+      context 'which an inexistent group' do
+        let(:title) { 'no_real_title' }
+
+        it 'does not allow to edit the group' do
+          expect(flash[:error]).to eq("The group doesn't exist")
+        end
+      end
     end
   end
 
   describe 'PUT #update' do
+    let(:title) { group.title }
+
     before do
       login(login_as)
-      put :update, params: { title: group.title, group: { email: email } }
+      put :update, params: { title: title, group: { email: email } }
     end
 
     context 'as a normal user' do
@@ -129,6 +141,15 @@ RSpec.describe Webui::GroupsController do
 
     context 'as an admin' do
       let(:login_as) { create(:admin_user) }
+
+      context 'which an inexistent group' do
+        let(:title) { 'no_real_title' }
+        let(:email) { 'new_email@example.com' }
+
+        it 'does not allow to edit the group' do
+          expect(flash[:error]).to eq("The group doesn't exist")
+        end
+      end
 
       context 'when the email is empty' do
         let(:email) { nil }


### PR DESCRIPTION
In order to improve the group subscriptions to different types of notifications, we start with providing a way to handle groups emails from the UI. Something that was only possible[ through API](https://api.opensuse.org/apidocs/index#/Groups/post_group__group_title_) so far.

Create:

![Screenshot 2024-10-03 at 16-40-23 Create Group - Open Build Service](https://github.com/user-attachments/assets/a98e43a7-62df-45f7-ad02-30cf09ce5fed)

Update email:

![Screenshot 2024-10-03 at 16-39-58 Edit Group - Open Build Service](https://github.com/user-attachments/assets/639cc2c7-3864-48e3-9265-47c42b576004)

Actions column (mail_to and edit emails):

![Screenshot 2024-10-03 at 16-39-36 Manage Groups - Open Build Service](https://github.com/user-attachments/assets/d984a99e-13a9-41fc-a201-25bdcdfaa9c7)
