### PR TITLE
Remove not implemented `withhistory` parameter from the API

### DIFF
--- a/src/api/app/controllers/source_controller.rb
+++ b/src/api/app/controllers/source_controller.rb
@@ -961,7 +961,8 @@ class SourceController < ApplicationController
     path = @package.source_path
     path << build_query_from_hash(params, %i[cmd rev user comment oproject opackage orev expand
                                              keeplink repairlink linkrev olinkrev requestid
-                                             withvrev noservice dontupdatesource withhistory])
+                                             withvrev noservice dontupdatesource])
+
     pass_to_backend(path)
 
     @package.sources_changed

--- a/src/api/public/apidocs/paths/source_project_name_package_name_cmd_copy.yaml
+++ b/src/api/public/apidocs/paths/source_project_name_package_name_cmd_copy.yaml
@@ -2,7 +2,7 @@ post:
   summary: Copy packages.
   description: |
     Copy packages. 
-    Additionally you can copy the binaries and/or the commit history.
+    Additionally you can copy the binaries.
     The copy can be done synchronously or asynchronously.
     You can leave a comment in the package revision.
   security:
@@ -60,14 +60,6 @@ post:
           - 1
           - 0
       description: Set to '1' to do the copying synchronously. By default the copying is done asynchronously.
-    - in: query
-      name: withhistory
-      schema:
-        type: string
-        enum:
-          - 1
-          - 0
-      description: Set to '1' to copy the package commit history.
     - in: query
       name: noservice
       schema:


### PR DESCRIPTION
This parameter is implemented and passed directly to the backend for copying projects. But for the case of copying packages, it is not implemented.

See allowed parameters for that endpoint in the backend: https://github.com/openSUSE/open-build-service/blob/8467b52747940f80e6759f6c671cff968f0d0493/src/backend/bs_srcserver#L7784

### Before

Passing `withhistory=1` throws an error:

```
> curl -u Admin:opensuse -H 'accept: application/xml; charset=utf-8' -X POST 'http://localhost:3000/source/home:Admin/test?cmd=copy&package=test2&rev=upload&withhistory=1'

<status code="400" origin="backend">
  <summary>unknown parameter 'withhistory'</summary>
</status>
```

### After

Passing `withhistory=1` is simply ignored:

```
> curl -u Admin:opensuse -H 'accept: application/xml; charset=utf-8' -X POST 'http://localhost:3000/source/home:Admin/test?cmd=copy&package=test2&rev=upload&withhistory=1'

<revision rev="upload">
  <srcmd5>9d906406954b53ffbd6b12c2f15a9c0a</srcmd5>
</revision>
```