### PR TITLE
Override the primary key used in the groups table

### DIFF
--- a/src/api/.database_consistency.todo.yml
+++ b/src/api/.database_consistency.todo.yml
@@ -207,9 +207,6 @@ BinaryRelease:
   flavor:
     LengthConstraintChecker:
       enabled: false
-  id:
-    PrimaryKeyTypeChecker:
-      enabled: false
   medium:
     LengthConstraintChecker:
       enabled: false
@@ -837,13 +834,15 @@ Group:
     LengthConstraintChecker:
       enabled: false
   id:
-    PrimaryKeyTypeChecker:
+    NullConstraintChecker:
       enabled: false
   staging_workflow:
     MissingIndexChecker:
       enabled: false
   title:
     MissingUniqueIndexChecker:
+      enabled: false
+    PrimaryKeyTypeChecker:
       enabled: false
 GroupMaintainer:
   group:
@@ -1417,8 +1416,6 @@ MaintenanceIncident:
       enabled: false
 Notification:
   bs_request:
-    ColumnPresenceChecker:
-      enabled: false
     ForeignKeyChecker:
       enabled: false
   bs_request_oldstate:

--- a/src/api/app/controllers/concerns/webui/manage_relationships.rb
+++ b/src/api/app/controllers/concerns/webui/manage_relationships.rb
@@ -40,7 +40,7 @@ module Webui::ManageRelationships
 
     return User.find_by_login!(login) if login
 
-    ::Group.find_by_title!(title)
+    ::Group.find(title)
   end
 
   def remove_role

--- a/src/api/app/controllers/group_controller.rb
+++ b/src/api/app/controllers/group_controller.rb
@@ -34,7 +34,7 @@ class GroupController < ApplicationController
 
   # DELETE for removing it
   def delete
-    group = Group.find_by_title!(params[:title])
+    group = Group.find(params[:title])
     authorize group, :destroy?
     group.destroy
     render_ok
@@ -42,7 +42,7 @@ class GroupController < ApplicationController
 
   # GET for showing the group
   def show
-    @group = Group.find_by_title!(params[:title])
+    @group = Group.find(params[:title])
   end
 
   # PUT for rewriting it completely including defined user list.
@@ -65,7 +65,7 @@ class GroupController < ApplicationController
 
   # POST for editing it, adding or remove users
   def command
-    group = Group.find_by_title!(CGI.unescape(params[:title]))
+    group = Group.find(CGI.unescape(params[:title]))
     authorize group, :update?
 
     user = User.find_by_login!(params[:userid]) if params[:userid]

--- a/src/api/app/controllers/search_controller.rb
+++ b/src/api/app/controllers/search_controller.rb
@@ -85,7 +85,7 @@ class SearchController < ApplicationController
     if params[:user].present?
       User.find_by_login!(params[:user])
     elsif params[:group].present?
-      Group.find_by_title!(params[:group])
+      Group.find(params[:group])
     end
   end
 

--- a/src/api/app/controllers/webui/groups/bs_requests_controller.rb
+++ b/src/api/app/controllers/webui/groups/bs_requests_controller.rb
@@ -13,7 +13,7 @@ module Webui
       private
 
       def set_group
-        @user_or_group = Group.find_by_title!(params[:group_title])
+        @user_or_group = Group.find(params[:group_title])
       end
 
       def request_method

--- a/src/api/app/controllers/webui/groups_controller.rb
+++ b/src/api/app/controllers/webui/groups_controller.rb
@@ -9,8 +9,6 @@ class Webui::GroupsController < Webui::WebuiController
 
   def show
     @group = Group.includes(:users).find_by_title(params[:title])
-
-    # Group.find_by_title! is self implemented and would raise an 500 error
     return if @group
 
     flash[:error] = "Group '#{params[:title]}' does not exist"

--- a/src/api/app/models/attrib_namespace.rb
+++ b/src/api/app/models/attrib_namespace.rb
@@ -38,7 +38,7 @@ class AttribNamespace < ApplicationRecord
 
     new_rule = {}
     new_rule[:user] = User.find_by_login!(node['user']) if node['user']
-    new_rule[:group] = Group.find_by_title!(node['group']) if node['group']
+    new_rule[:group] = Group.find(node['group']) if node['group']
     attrib_namespace_modifiable_bies << AttribNamespaceModifiableBy.new(new_rule)
   end
 

--- a/src/api/app/models/attrib_type.rb
+++ b/src/api/app/models/attrib_type.rb
@@ -125,7 +125,7 @@ class AttribType < ApplicationRecord
 
     new_rule = {}
     new_rule[:user] = User.find_by_login!(node['user']) if node['user']
-    new_rule[:group] = Group.find_by_title!(node['group']) if node['group']
+    new_rule[:group] = Group.find(node['group']) if node['group']
     new_rule[:role] = Role.find_by_title!(node['role']) if node['role']
     attrib_type_modifiable_bies << AttribTypeModifiableBy.new(new_rule)
   end

--- a/src/api/app/models/bs_request/find_for/group.rb
+++ b/src/api/app/models/bs_request/find_for/group.rb
@@ -19,7 +19,7 @@ class BsRequest
       private
 
       def group
-        @group ||= ::Group.find_by_title!(group_title)
+        @group ||= ::Group.find(group_title)
       end
 
       def union_query

--- a/src/api/app/models/bs_request_action.rb
+++ b/src/api/app/models/bs_request_action.rb
@@ -640,7 +640,7 @@ class BsRequestAction < ApplicationRecord
     end
     if group_name
       # validate group object
-      Group.find_by_title!(group_name)
+      Group.find(group_name)
     end
     if self.role
       # validate role object

--- a/src/api/app/models/bs_request_permission_check.rb
+++ b/src/api/app/models/bs_request_permission_check.rb
@@ -58,7 +58,7 @@ class BsRequestPermissionCheck
   def cmd_changereviewstate_permissions
     # Basic validations of given parameters
     by_user = User.find_by_login!(opts[:by_user]) if opts[:by_user]
-    by_group = Group.find_by_title!(opts[:by_group]) if opts[:by_group]
+    by_group = Group.find(opts[:by_group]) if opts[:by_group]
     if opts[:by_project] && opts[:by_package]
       by_package = Package.get_by_project_and_name(opts[:by_project], opts[:by_package])
     elsif opts[:by_project]

--- a/src/api/app/models/concerns/has_relationships.rb
+++ b/src/api/app/models/concerns/has_relationships.rb
@@ -81,7 +81,7 @@ module HasRelationships
   def maintainers
     direct_users = relationships.with_users_and_roles_query.maintainers.pluck('users.login').map! { |user| User.find_by_login(user) }
     users_in_groups = relationships.with_groups_and_roles_query.maintainers.pluck('groups.title')
-                                   .map! { |title| Group.find_by_title!(title).users }.flatten
+                                   .map! { |title| Group.find(title).users }.flatten
     (direct_users + users_in_groups).uniq
   end
 

--- a/src/api/app/models/group.rb
+++ b/src/api/app/models/group.rb
@@ -1,8 +1,10 @@
 # The Group class represents a group record in the database and thus a
 # group model. Groups are arranged in trees and have a title.
 # Groups have an arbitrary number of users assigned to them.
-#
+
 class Group < ApplicationRecord
+  self.primary_key = 'title'
+
   has_one :staging_workflow, class_name: 'Staging::Workflow', foreign_key: :managers_group_id, dependent: :nullify
   has_many :groups_users, inverse_of: :group, dependent: :destroy
   has_many :users, -> { distinct.order(:login) }, through: :groups_users
@@ -39,12 +41,6 @@ class Group < ApplicationRecord
   default_scope { order(:title) }
 
   alias_attribute :name, :title
-
-  def self.find_by_title!(title)
-    find_by!(title: title)
-  rescue ActiveRecord::RecordNotFound => e
-    raise e, "Couldn't find Group '#{title}'", e.backtrace
-  end
 
   def update_from_xml(xmlhash, user_session_login:)
     with_lock do

--- a/src/api/app/models/relationship/add_role.rb
+++ b/src/api/app/models/relationship/add_role.rb
@@ -36,7 +36,7 @@ class Relationship::AddRole
     self.user = User.find_by_login!(user) if user.is_a?(String)
 
     self.group = opts[:group]
-    self.group = Group.find_by_title!(group) if group.is_a?(String)
+    self.group = Group.find(group) if group.is_a?(String)
   end
 
   def check_role!

--- a/src/api/app/models/review.rb
+++ b/src/api/app/models/review.rb
@@ -198,7 +198,7 @@ class Review < ApplicationRecord
 
   def users_and_groups_for_review
     return [User.find_by_login!(by_user)] if by_user
-    return [Group.find_by_title!(by_group)] if by_group
+    return [Group.find(by_group)] if by_group
 
     if by_package
       obj = Package.find_by_project_and_name(by_project, by_package)

--- a/src/api/public/apidocs/paths/group_group_title.yaml
+++ b/src/api/public/apidocs/paths/group_group_title.yaml
@@ -25,7 +25,7 @@ get:
             $ref: '../components/schemas/api_response.yaml'
           example:
             code: not_found
-            summary: Couldn't find Group 'group-testd'
+            summary: Couldn't find Group with 'title'=group-testd
   tags:
     - Groups
 
@@ -85,7 +85,7 @@ post:
             group_not_found:
               value:
                 code: not_found
-                summary: Couldn't find Group 'group-testd'
+                summary: Couldn't find Group with 'title'=group-testd
               summary: Group Not Found
   tags:
     - Groups
@@ -120,7 +120,7 @@ put:
             $ref: '../components/schemas/api_response.yaml'
           example:
             code: not_found
-            summary: Couldn't find Group 'group-testd'
+            summary: Couldn't find Group with 'title'=group-testd
   tags:
     - Groups
 
@@ -144,6 +144,6 @@ delete:
             $ref: '../components/schemas/api_response.yaml'
           example:
             code: not_found
-            summary: Couldn't find Group 'group-testd'
+            summary: Couldn't find Group with 'title'=group-testd
   tags:
     - Groups

--- a/src/api/public/apidocs/paths/search_owner.yaml
+++ b/src/api/public/apidocs/paths/search_owner.yaml
@@ -181,7 +181,7 @@ get:
             Group Not Found:
               value:
                 code: not_found
-                summary: Couldn't find Group 'fake'
+                summary: Couldn't find Group with 'title'=fake
   tags:
     - Search
 

--- a/src/api/spec/models/bs_request/find_for/group_spec.rb
+++ b/src/api/spec/models/bs_request/find_for/group_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe BsRequest::FindFor::Group do
     context 'with a not existing group' do
       subject { klass.new(group: 'not-existent') }
 
-      it { expect { subject.all }.to raise_error(ActiveRecord::RecordNotFound, "Couldn't find Group 'not-existent'") }
+      it { expect { subject.all }.to raise_error(ActiveRecord::RecordNotFound, "Couldn't find Group with 'title'=not-existent") }
     end
 
     context 'with a group maintainer relationship' do

--- a/src/api/spec/shared/examples/features/bootstrap_user_tab.rb
+++ b/src/api/spec/shared/examples/features/bootstrap_user_tab.rb
@@ -166,7 +166,7 @@ RSpec.shared_examples 'bootstrap user tab' do
         click_button('Accept')
       end
 
-      expect(page).to have_text("Couldn't find Group 'unknown group'")
+      expect(page).to have_text("Couldn't find Group with 'title'=unknown group")
     end
 
     it 'Add an existing group' do


### PR DESCRIPTION
Prevent from overriding the main finder method.

See: https://guides.rubyonrails.org/v7.0/active_record_basics.html#overriding-the-naming-conventions