### PR TITLE
Handle project sources in a consistent fashion

### DIFF
--- a/src/api/app/controllers/source_project_controller.rb
+++ b/src/api/app/controllers/source_project_controller.rb
@@ -22,10 +22,9 @@ class SourceProjectController < SourceController
     @project = Project.find_by_name(project_name)
     raise Project::UnknownObjectError, "Project not found: #{project_name}" unless @project
 
-    if @project.scmsync.present?
-      pass_to_backend
-      return
-    end
+    pass_to_backend
+
+    return if @project.scmsync.present?
 
     # we let the backend list the packages after we verified the project is visible
     if params.key?(:view)

--- a/src/api/app/controllers/source_project_controller.rb
+++ b/src/api/app/controllers/source_project_controller.rb
@@ -4,7 +4,7 @@ class SourceProjectController < SourceController
   # GET /source/:project
   def show
     project_name = params[:project]
-    if params.key?(:deleted)
+    if params[:deleted] == '1'
       unless Project.find_by_name(project_name) || Project.is_remote_project?(project_name)
         # project is deleted or not accessible
         validate_visibility_of_deleted_project(project_name)

--- a/src/api/app/controllers/source_project_controller.rb
+++ b/src/api/app/controllers/source_project_controller.rb
@@ -22,6 +22,11 @@ class SourceProjectController < SourceController
     @project = Project.find_by_name(project_name)
     raise Project::UnknownObjectError, "Project not found: #{project_name}" unless @project
 
+    if @project.scmsync.present?
+      pass_to_backend
+      return
+    end
+
     # we let the backend list the packages after we verified the project is visible
     if params.key?(:view)
       case params[:view]
@@ -52,7 +57,8 @@ class SourceProjectController < SourceController
   end
 
   def render_project_packages
-    @packages = params.key?(:expand) ? @project.expand_all_packages : @project.packages.pluck(:name)
+    # TODO: Display multibuild flavors when passing the expand param
+    @packages = params.key?(:expand) ? @project.expand_all_packages : @project.packages.sort_by(&:name)
     render locals: { expand: params.key?(:expand) }, formats: [:xml]
   end
 

--- a/src/api/app/views/source_project/show.xml.builder
+++ b/src/api/app/views/source_project/show.xml.builder
@@ -1,9 +1,14 @@
 xml.directory(count: @packages.count) do
-  @packages.map do |name, project|
+  @packages.map do |package, project|
     if expand
-      xml.entry(name: name, originproject: project)
+      xml.entry(name: package, originproject: project)
+    elsif package.multibuild?
+      xml.entry(name: package.name)
+      package.multibuild_flavors.each do |flavor|
+        xml.entry(name: "#{package.name}:#{flavor}", originpackage: package.name)
+      end
     else
-      xml.entry(name: name)
+      xml.entry(name: package)
     end
   end
 end

--- a/src/api/test/functional/channel_maintenance_test.rb
+++ b/src/api/test/functional/channel_maintenance_test.rb
@@ -266,6 +266,10 @@ class ChannelMaintenanceTests < ActionDispatch::IntegrationTest
     get '/source/' + incident_project + '/pack2.BaseDistro2.0_LinkedUpdateProject/_meta'
     assert_response :success
     assert_xml_tag tag: 'releasename', content: 'pack2'
+    put '/source/' + incident_project + '/pack2.linked.BaseDistro2.0_LinkedUpdateProject/_multibuild', params: '<multibuild><flavor>A</flavor></multibuild>'
+    assert_response :success
+    get '/source/' + incident_project + '/pack2.linked.BaseDistro2.0_LinkedUpdateProject/_multibuild'
+    assert_response :success
     get '/source/' + incident_project + '/pack2.linked.BaseDistro2.0_LinkedUpdateProject/_meta'
     assert_response :success
     assert_xml_tag tag: 'releasename', content: 'pack2.linked'


### PR DESCRIPTION
There was a consistency gap between sources coming from local projects and sources coming from remote projects. Multibuild flavors were only shown for remote projects. Now the multibuild flavors are shown in both cases.

deleted=0 will no longer be valid, only deleted=1 will trigger the desired behaviour. 

Fixes #9715
Fixes #16911