### PR TITLE
Don't override `find_by_title!` in roles

### DIFF
--- a/src/api/app/models/role.rb
+++ b/src/api/app/models/role.rb
@@ -1,13 +1,7 @@
-require 'api_error'
-
 # The Role class represents a role in the database. Roles can have permissions
 # associated with themselves. Roles can assigned be to roles and groups.
 
 class Role < ApplicationRecord
-  class NotFound < APIError
-    setup 404
-  end
-
   validates :title,
             format: { with: /\A\w*\z/,
                       message: 'must not contain invalid characters' }
@@ -46,10 +40,6 @@ class Role < ApplicationRecord
 
   def delete_hashed_cache
     Rails.cache.delete('hashed_roles')
-  end
-
-  def self.find_by_title!(title)
-    find_by_title(title) || raise(NotFound, "Couldn't find Role '#{title}'")
   end
 
   def self.local_roles

--- a/src/api/spec/models/role_spec.rb
+++ b/src/api/spec/models/role_spec.rb
@@ -34,20 +34,6 @@ RSpec.describe Role do
     end
   end
 
-  describe '::find_by_title!' do
-    context 'called for an existing record' do
-      it 'returns the queried role' do
-        expect(Role.find_by_title!(role.title)).to eq(role)
-      end
-    end
-
-    context 'called for a non-existing record' do
-      it 'raises an APIError' do
-        expect { Role.find_by_title!('foobar') }.to raise_error(Role::NotFound, "Couldn't find Role 'foobar'")
-      end
-    end
-  end
-
   describe '#to_param' do
     it { expect(role.to_param).to eq(role.title) }
   end


### PR DESCRIPTION
We should handle exceptions of not found records in the controllers involving roles instead of in the Role model.