### PR TITLE
No comments and logout: drop login warning, show simpler text instead

### DIFF
--- a/src/api/app/views/webui/comment/_comment_list.html.haml
+++ b/src/api/app/views/webui/comment/_comment_list.html.haml
@@ -1,9 +1,17 @@
-- commentable = commentable.bs_request if commentable.is_a?(BsRequestAction)
-- if commentable.is_a?(BsRequest)
-  - Comment.without_parent.on_actions_for_request(commentable).includes(:user).each do |comment|
+:ruby
+  commentable = commentable.bs_request if commentable.is_a?(BsRequestAction)
+  comments_without_parent_on_actions = Comment.without_parent.on_actions_for_request(commentable).includes(:user)
+  comments_without_parent_on_commentable = commentable.comments.without_parent.includes(:user)
+
+- if comments_without_parent_on_actions.empty? && comments_without_parent_on_commentable.empty?
+  .ps-2.pt-2
+    %i No comments available
+- else
+  - if commentable.is_a?(BsRequest)
+    - comments_without_parent_on_actions.each do |comment|
+      = render partial: 'webui/comment/content', locals: { comment: comment, commentable: commentable, level: 1 }
+  - comments_without_parent_on_commentable.each do |comment|
     = render partial: 'webui/comment/content', locals: { comment: comment, commentable: commentable, level: 1 }
-- commentable.comments.without_parent.includes(:user).each do |comment|
-  = render partial: 'webui/comment/content', locals: { comment: comment, commentable: commentable, level: 1 }
 
 .comment_new.mt-3
   = render partial: 'webui/comment/new', locals: { commentable: commentable }

--- a/src/api/app/views/webui/comment/_new.html.haml
+++ b/src/api/app/views/webui/comment/_new.html.haml
@@ -10,11 +10,3 @@
   - if policy(Comment.new(commentable:)).create?
     = render(partial: 'webui/comment/comment_field',
       locals: { form_method: :post, comment: Comment.new, commentable: commentable, element_suffix: 'new_comment', has_cancel: false })
-- else
-  .alert.alert-warning{ role: 'alert' }
-    Login required, please
-    = link_to('login', new_session_url)
-    - if can_register?
-      or
-      = link_to('signup', new_user_url)
-    in order to comment


### PR DESCRIPTION
## Before
![image](https://github.com/user-attachments/assets/2ad0ba70-8093-4b4b-aa5e-6c7cda1d9906)



## After
![image](https://github.com/user-attachments/assets/d639304f-9171-4111-acbf-8832a2b1ecca)
