### PR TITLE
Inform of an outdated inline comment

### DIFF
--- a/src/api/app/components/bs_request_comment_component.html.haml
+++ b/src/api/app/components/bs_request_comment_component.html.haml
@@ -47,16 +47,20 @@
           - helpers.comment_user_role_titles(comment).each do |title|
             %span.badge.border.border-secondary.text-secondary.text-capitalize
               = title
-      - if comment.diff_ref && diff
-        - action = comment.commentable
+      - if comment.diff_ref
         .comment-diff
-          .px-3.pt-3.pb-2
-            = link_to request_show_path(number: action.bs_request, request_action_id: action) do
-              = action.uniq_key
-            >
-            = link_to request_changes_path(number: action.bs_request, request_action_id: action, anchor: comment.diff_ref) do
-              = render(DiffSubjectComponent.new(state: diff['state'], old_filename: diff.dig('old', 'name'), new_filename: diff.dig('new', 'name')))
-          = render(DiffComponent.new(diff: diff.dig('diff', '_content'), range:))
+          - if diff
+            - action = comment.commentable
+            .px-3.pt-3.pb-2
+              = link_to request_show_path(number: action.bs_request, request_action_id: action) do
+                = action.uniq_key
+              >
+              = link_to request_changes_path(number: action.bs_request, request_action_id: action, anchor: comment.diff_ref) do
+                = render(DiffSubjectComponent.new(state: diff['state'], old_filename: diff.dig('old', 'name'), new_filename: diff.dig('new', 'name')))
+            = render(DiffComponent.new(diff: diff.dig('diff', '_content'), range:))
+          - else
+            %p.border-bottom.fst-italic.px-3.pt-3.pb-2
+              The following comment was attached to a line that is outdated.
       .comment-bubble-content{ id: "comment-#{comment.id}-body" }
         = render ReportsNoticeComponent.new(reportable: comment, user: User.session)
         = helpers.render_as_markdown(comment)


### PR DESCRIPTION
A comment on a line of a diff of a submit request can be outdated when, for example, the source package gets removed.

In those cases, show a message informing that the attachment point of the comment is outdated.

### Before

![Screenshot from 2024-10-10 15-48-15](https://github.com/user-attachments/assets/0d756d10-ada3-4324-b76e-692bb541dae2)


### After

![Screenshot from 2024-10-10 15-47-02](https://github.com/user-attachments/assets/cea5765c-b7a8-409a-ad76-c233eadf3102)