### PR TITLE
Change 400 to 501 Not Implemented response

### DIFF
--- a/src/api/app/controllers/source_attribute_controller.rb
+++ b/src/api/app/controllers/source_attribute_controller.rb
@@ -4,7 +4,7 @@ class SourceAttributeController < SourceController
   before_action :find_attribute_container
 
   class RemoteProject < APIError
-    setup 400, 'Attribute access to remote project is not yet supported'
+    setup 501, 'Attribute access to remote project is not yet supported'
   end
 
   class InvalidAttribute < APIError

--- a/src/api/public/apidocs/paths/source_project_name_attribute.yaml
+++ b/src/api/public/apidocs/paths/source_project_name_attribute.yaml
@@ -47,8 +47,12 @@ get:
                 14 (Admin        2023-03-13 15:14:21     7)     <value>Development</value>
                 14 (Admin        2023-03-13 15:14:21     8)   </attribute>
                 10 (Admin        2023-03-09 11:46:01     9) </attributes>
-    '400':
-      description: Bad Request.
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '404':
+      $ref: '../components/responses/unknown_project.yaml'
+    '501':
+      description: Not Implemented.
       content:
         application/xml; charset=utf-8:
           schema:
@@ -56,9 +60,5 @@ get:
           example:
               code: remote_project
               summary: Attribute access to remote project is not yet supported
-    '401':
-      $ref: '../components/responses/unauthorized.yaml'
-    '404':
-      $ref: '../components/responses/unknown_project.yaml'
   tags:
     - Sources - Projects

--- a/src/api/public/apidocs/paths/source_project_name_package_name_attribute.yaml
+++ b/src/api/public/apidocs/paths/source_project_name_package_name_attribute.yaml
@@ -60,8 +60,12 @@ get:
                 14 (Admin        2023-03-13 15:14:21     7)     <value>Development</value>
                 14 (Admin        2023-03-13 15:14:21     8)   </attribute>
                 10 (Admin        2023-03-09 11:46:01     9) </attributes>
-    '400':
-      description: Bad Request.
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '404':
+      $ref: '../components/responses/unknown_project_or_package.yaml'
+    '501':
+      description: Not Implemented.
       content:
         application/xml; charset=utf-8:
           schema:
@@ -71,10 +75,6 @@ get:
               value:
                 code: remote_project
                 summary: Attribute access to remote project is not yet supported
-    '401':
-      $ref: '../components/responses/unauthorized.yaml'
-    '404':
-      $ref: '../components/responses/unknown_project_or_package.yaml'
   tags:
     - Sources - Packages
 

--- a/src/api/test/functional/attributes_test.rb
+++ b/src/api/test/functional/attributes_test.rb
@@ -349,7 +349,7 @@ ription</description>
 
     # via remote link
     get '/source/RemoteInstance:home:tom/_attribute/OBS:Maintained'
-    assert_response :bad_request
+    assert_response :not_implemented
 
     # via group
     login_adrian


### PR DESCRIPTION
Instead of return a response code 400, return a 501 Not Implemented response code for source attribute endpoints dealing with remote projects.

Fixes #16944.