### PR TITLE
Remove no longer used scopes in model PackageIssue

### DIFF
--- a/src/api/app/models/package_issue.rb
+++ b/src/api/app/models/package_issue.rb
@@ -4,11 +4,6 @@ class PackageIssue < ApplicationRecord
 
   after_save :populate_to_sphinx
 
-  scope :open_issues_of_owner, ->(owner_id) { joins(:issue).where(issues: { state: 'OPEN', owner_id: owner_id }) }
-  scope :with_patchinfo, lambda {
-    joins('LEFT JOIN package_kinds ON package_kinds.package_id = package_issues.package_id').where('package_kinds.kind = "patchinfo"')
-  }
-
   def self.sync_relations(package, issues)
     retries = 10
     begin


### PR DESCRIPTION
These scopes were introduced in #2497, and substituted by Active Record queries in #10973.