### PR TITLE
Remove unnecesary retrying on creating events

### DIFF
--- a/src/api/app/models/update_notification_events.rb
+++ b/src/api/app/models/update_notification_events.rb
@@ -14,20 +14,8 @@ class UpdateNotificationEvents
         e.elements('data') do |d|
           data[d['key']] = d['_content']
         end
-        retries = 10
-        begin
-          event = Event::Factory.new_from_type(type, data)
-          event.save!
-        rescue ActiveRecord::StatementInvalid => e
-          retries -= 1
-          if retries.positive?
-            Airbrake.notify("Failed to create Event : #{type.inspect}: #{data} #{e}")
-            retry
-          end
-          Airbrake.notify("Failed to create Event : #{type.inspect}: #{data} #{e}")
-        rescue StandardError => e
-          Airbrake.notify("Failed to create Event : #{type.inspect}: #{data} #{e}")
-        end
+        event = Event::Factory.new_from_type(type, data)
+        event.save!
       end
     end
 


### PR DESCRIPTION
Also unifies the way database errors are reported. Fixes #16953.

This PR is the first of a group of pull requests:
1. **Remove unnecesary retrying on creating events**
1. #16956
1. #16957