### PR TITLE
Remove unnecesary retrying on updates of packages' issues 

### DIFF
--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -1032,8 +1032,6 @@ class Package < ApplicationRecord
   # just make sure the backend_package is there
   def update_if_dirty
     backend_package
-  rescue Mysql2::Error
-    # the delayed job might have jumped in and created the entry just before us
   end
 
   def linking_packages

--- a/src/api/app/models/package_issue.rb
+++ b/src/api/app/models/package_issue.rb
@@ -5,33 +5,24 @@ class PackageIssue < ApplicationRecord
   after_save :populate_to_sphinx
 
   def self.sync_relations(package, issues)
-    retries = 10
-    begin
-      PackageIssue.transaction do
-        allissues = []
-        issues.map { |h| allissues += h.last }
+    PackageIssue.transaction do
+      allissues = []
+      issues.map { |h| allissues += h.last }
 
-        # drop not anymore existing relations
-        PackageIssue.where('package_id = ? AND NOT issue_id IN (?)', package, allissues).lock(true).delete_all
+      # drop not anymore existing relations
+      PackageIssue.where('package_id = ? AND NOT issue_id IN (?)', package, allissues).lock(true).delete_all
 
-        # create missing in an efficient way
-        sql = ApplicationRecord.connection
-        (allissues - package.issues.to_ary).each do |i|
-          sql.execute("INSERT INTO `package_issues` (`package_id`, `issue_id`) VALUES (#{package.id},#{i.id})")
-        end
-
-        # set change value for all
-        issues.each do |pair|
-          # rubocop:disable Rails/SkipsModelValidations
-          PackageIssue.where(package: package, issue: pair.last).lock(true).update_all(change: pair.first)
-          # rubocop:enable Rails/SkipsModelValidations
-        end
+      # create missing in an efficient way
+      sql = ApplicationRecord.connection
+      (allissues - package.issues.to_ary).each do |i|
+        sql.execute("INSERT INTO `package_issues` (`package_id`, `issue_id`) VALUES (#{package.id},#{i.id})")
       end
-    rescue ActiveRecord::StatementInvalid, Mysql2::Error => e
-      retries -= 1
-      if retries.positive?
-        Airbrake.notify("Failed to update PackageIssue : retries left: #{retries}, #{e}, package: #{package.inspect}")
-        retry
+
+      # set change value for all
+      issues.each do |pair|
+        # rubocop:disable Rails/SkipsModelValidations
+        PackageIssue.where(package: package, issue: pair.last).lock(true).update_all(change: pair.first)
+        # rubocop:enable Rails/SkipsModelValidations
       end
     end
   end


### PR DESCRIPTION
Follow up to #16954.

We want to deploy these pull requests separately.

This PR is the second of a group of pull requests:
1. #16954
1. **Remove unnecesary retrying on updates of packages' issues**
1. #16957