### PR TITLE
Remove unnecesary retrying on updating a package

### DIFF
--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -460,18 +460,8 @@ class Package < ApplicationRecord
     if opts[:wait_for_update]
       update_if_dirty
     else
-      retries = 10
-      begin
-        # NOTE: Its important that this job run in queue 'default' in order to avoid concurrency
-        PackageUpdateIfDirtyJob.perform_later(id)
-      rescue ActiveRecord::StatementInvalid => e
-        # mysql lock errors in delayed job handling... we need to retry
-        retries -= 1
-        if retries.positive?
-          Airbrake.notify("Failed while running PackageUpdateIfDirtyJob: retries left: #{retries}, package_id: #{id}, #{e}")
-          retry
-        end
-      end
+      # NOTE: Its important that this job run in queue 'default' in order to avoid concurrency
+      PackageUpdateIfDirtyJob.perform_later(id)
     end
   end
 


### PR DESCRIPTION
Follow up to #16956.

We want to deploy these pull requests separately.

This PR is the third of a group of pull requests:

1. #16954
1. #16956
1. **Remove unnecesary retrying on updating a package**