### PR TITLE
Extract request policies out of RequestDecisionComponent

### DIFF
--- a/src/api/app/components/request_decision_component.html.haml
+++ b/src/api/app/components/request_decision_component.html.haml
@@ -25,7 +25,7 @@
       = submit_tag 'Revoke request', name: 'revoked', class: 'btn btn-danger me-2'
     - if can_reopen_request?
       = submit_tag 'Reopen request', name: 'new', class: 'btn btn-warning me-2'
-    - if can_accept_request?
+    - if policy(@bs_request).accept_request?
       - if policy(@bs_request).decline_request?
         = submit_tag('Decline request', name: 'declined', title: 'Decline the request, as the author of the request you can reopen it again.',
                      class: 'btn btn-danger me-2')

--- a/src/api/app/components/request_decision_component.html.haml
+++ b/src/api/app/components/request_decision_component.html.haml
@@ -23,7 +23,7 @@
               #{helpers.project_or_package_link(project: forward[:project], package: forward[:package], short: true)}
     - if policy(@bs_request).revoke_request?
       = submit_tag 'Revoke request', name: 'revoked', class: 'btn btn-danger me-2'
-    - if can_reopen_request?
+    - if policy(@bs_request).reopen_request?
       = submit_tag 'Reopen request', name: 'new', class: 'btn btn-warning me-2'
     - if policy(@bs_request).accept_request?
       - if policy(@bs_request).decline_request?

--- a/src/api/app/components/request_decision_component.rb
+++ b/src/api/app/components/request_decision_component.rb
@@ -28,8 +28,4 @@ class RequestDecisionComponent < ApplicationComponent
   def show_add_submitter_as_maintainer_option?
     @action.type == 'submit' && !@action.creator_is_target_maintainer
   end
-
-  def can_reopen_request?
-    @bs_request.state == :declined
-  end
 end

--- a/src/api/app/components/request_decision_component.rb
+++ b/src/api/app/components/request_decision_component.rb
@@ -29,11 +29,6 @@ class RequestDecisionComponent < ApplicationComponent
     @action.type == 'submit' && !@action.creator_is_target_maintainer
   end
 
-  # TODO: Move all those "can_*" checks to a pundit policy
-  def can_accept_request?
-    @bs_request.state.in?(%i[new review]) && @is_target_maintainer
-  end
-
   def can_reopen_request?
     @bs_request.state == :declined
   end

--- a/src/api/app/policies/bs_request_policy.rb
+++ b/src/api/app/policies/bs_request_policy.rb
@@ -38,6 +38,11 @@ class BsRequestPolicy < ApplicationPolicy
     !(author? || record.is_source_maintainer?(user))
   end
 
+  def accept_request?
+    is_target_maintainer = record.is_target_maintainer?(user)
+    record.state.in?(%i[new review]) && is_target_maintainer
+  end
+
   private
 
   def author?

--- a/src/api/app/policies/bs_request_policy.rb
+++ b/src/api/app/policies/bs_request_policy.rb
@@ -39,8 +39,11 @@ class BsRequestPolicy < ApplicationPolicy
   end
 
   def accept_request?
-    is_target_maintainer = record.is_target_maintainer?(user)
-    record.state.in?(%i[new review]) && is_target_maintainer
+    record.state.in?(%i[new review]) && record.is_target_maintainer?(user)
+  end
+
+  def reopen_request?
+    record.state == :declined
   end
 
   private

--- a/src/api/spec/policies/bs_request_policy_spec.rb
+++ b/src/api/spec/policies/bs_request_policy_spec.rb
@@ -61,4 +61,42 @@ RSpec.describe BsRequestPolicy, type: :policy do
       it { expect(subject).not_to permit(author, bs_request) }
     end
   end
+
+  permissions :accept_request? do
+    let(:user) { create(:confirmed_user, login: 'iggy') }
+    let(:author) { create(:confirmed_user, login: 'foo') }
+    let(:project) { create(:project, maintainer: user) }
+
+    context 'when the user is not a target maintainer' do
+      let(:bs_request) { create(:bs_request_with_submit_action, state: request_state.to_s, creator: author) }
+
+      context 'when the request state is "new"' do
+        let(:request_state) { 'new' }
+
+        it { expect(subject).not_to permit(user, bs_request) }
+      end
+
+      context 'when the request state is "declined"' do
+        let(:request_state) { 'declined' }
+
+        it { expect(subject).not_to permit(user, bs_request) }
+      end
+    end
+
+    context 'when the user is a target maintainer' do
+      let(:bs_request) { create(:bs_request_with_submit_action, state: request_state.to_s, creator: author, target_project: project) }
+
+      context 'when the request state is "new"' do
+        let(:request_state) { 'new' }
+
+        it { expect(subject).to permit(user, bs_request) }
+      end
+
+      context 'when the request state is "declined"' do
+        let(:request_state) { 'declined' }
+
+        it { expect(subject).not_to permit(user, bs_request) }
+      end
+    end
+  end
 end


### PR DESCRIPTION
This will make easier to reuse the request policies outside of [RequestDecisionComponent](https://github.com/openSUSE/open-build-service/blob/d0c3746758f71cbc458a970d23283298e01b869c/src/api/app/components/request_decision_component.rb#L32)