### PR TITLE
Track retries of failed database queries

### DIFF
--- a/src/api/app/models/package_issue.rb
+++ b/src/api/app/models/package_issue.rb
@@ -27,9 +27,12 @@ class PackageIssue < ApplicationRecord
           # rubocop:enable Rails/SkipsModelValidations
         end
       end
-    rescue ActiveRecord::StatementInvalid, Mysql2::Error
+    rescue ActiveRecord::StatementInvalid, Mysql2::Error => e
       retries -= 1
-      retry if retries.positive?
+      if retries.positive?
+        Airbrake.notify("Failed to update PackageIssue : retries left: #{retries}, package: #{package.inspect}, issues: #{issues.inspect}, #{e}")
+        retry
+      end
     end
   end
 

--- a/src/api/app/models/update_notification_events.rb
+++ b/src/api/app/models/update_notification_events.rb
@@ -20,15 +20,12 @@ class UpdateNotificationEvents
           event.save!
         rescue ActiveRecord::StatementInvalid => e
           retries -= 1
-          retry if retries.positive?
+          if retries.positive?
+            Airbrake.notify("Failed to create Event : #{type.inspect}: #{data} #{e}")
+            retry
+          end
           Airbrake.notify("Failed to create Event : #{type.inspect}: #{data} #{e}")
         rescue StandardError => e
-          if Rails.env.test?
-            # make debug output useful in test suite, not just showing backtrace to Airbrake
-            Rails.logger.error "ERROR: #{e.inspect}: #{e.backtrace}"
-            Rails.logger.info e.inspect
-            Rails.logger.info e.backtrace
-          end
           Airbrake.notify("Failed to create Event : #{type.inspect}: #{data} #{e}")
         end
       end


### PR DESCRIPTION
We want to have an idea on how often retries of queries are triggered. Then we could take a decision on removing retries or not. See #16954.