### PR TITLE
Add `diff_file_index` and `diff_line_number` columns to table `comments`

### DIFF
--- a/src/api/app/models/comment.rb
+++ b/src/api/app/models/comment.rb
@@ -138,6 +138,8 @@ end
 #  id               :integer          not null, primary key
 #  body             :text(65535)
 #  commentable_type :string(255)      indexed => [commentable_id]
+#  diff_file_index  :integer
+#  diff_line_number :integer
 #  diff_ref         :string(255)
 #  moderated_at     :datetime
 #  created_at       :datetime

--- a/src/api/db/migrate/20241016135555_add_diff_columns_to_comments.rb
+++ b/src/api/db/migrate/20241016135555_add_diff_columns_to_comments.rb
@@ -1,0 +1,6 @@
+class AddDiffColumnsToComments < ActiveRecord::Migration[7.0]
+  def change
+    add_column :comments, :diff_file_index, :integer
+    add_column :comments, :diff_line_number, :integer
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_09_16_121900) do
+ActiveRecord::Schema[7.0].define(version: 2024_10_16_135555) do
   create_table "active_storage_attachments", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -373,6 +373,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_09_16_121900) do
     t.string "diff_ref"
     t.datetime "moderated_at"
     t.integer "moderator_id"
+    t.integer "diff_file_index"
+    t.integer "diff_line_number"
     t.index ["commentable_type", "commentable_id"], name: "index_comments_on_commentable_type_and_commentable_id"
     t.index ["moderator_id"], name: "moderated_comments_fk"
     t.index ["parent_id"], name: "parent_id"


### PR DESCRIPTION
The final goal is to split the `diff_ref` column into the `diff_file_index` and `diff_line_number` columns. See: https://github.com/openSUSE/open-build-service/pull/16962#issuecomment-2416875280

This PR belongs to a series to avoid downtime. The steps are:

1. Add new columns :arrow_left:
1. Write to all three columns
2. Backfill data from the old column to the new columns
3. Move reads from the old column to the new columns
4. Stop writing to the old column
5. Drop the old column

