### PR TITLE
Write to `diff_file_index` and `diff_line_number` columns

### DIFF
--- a/src/api/app/controllers/webui/comments_controller.rb
+++ b/src/api/app/controllers/webui/comments_controller.rb
@@ -146,7 +146,7 @@ class Webui::CommentsController < Webui::WebuiController
   private
 
   def permitted_params
-    params.require(:comment).permit(:body, :parent_id, :diff_ref, :source_rev, :target_rev)
+    params.require(:comment).permit(:body, :parent_id, :diff_ref, :diff_file_index, :diff_line_number, :source_rev, :target_rev)
   end
 
   # FIXME: Use this function for the rest of the actions

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -279,6 +279,7 @@ class Webui::RequestController < Webui::WebuiController
 
   def inline_comment
     @line = params[:line]
+    @file_index, @line_number = @line.match(/diff_([0-9]+)_n([0-9]+)/).captures
     @source_rev = params[:source_rev]
     @target_rev = params[:target_rev]
     respond_to do |format|

--- a/src/api/app/views/webui/comment/_comment_field.html.haml
+++ b/src/api/app/views/webui/comment/_comment_field.html.haml
@@ -5,6 +5,8 @@ data: { preview_message_url: preview_comments_path, message_body_param: 'comment
   = hidden_field_tag :commentable_id, commentable.id, { id: "#{element_suffix}_commentable_id" }
   - if defined?(line)
     = f.hidden_field :diff_ref, value: line, id: "#{element_suffix}_diff_ref"
+    = f.hidden_field :diff_file_index, value: file_index, id: "#{element_suffix}_diff_file_index"
+    = f.hidden_field :diff_line_number, value: line_number, id: "#{element_suffix}_diff_line_number"
   - if defined?(source_rev) && defined?(target_rev)
     = f.hidden_field :source_rev, value: source_rev, id: "#{element_suffix}_source_rev"
     = f.hidden_field :target_rev, value: target_rev, id: "#{element_suffix}_target_rev"

--- a/src/api/app/views/webui/request/_inline_comment.html.haml
+++ b/src/api/app/views/webui/request/_inline_comment.html.haml
@@ -4,4 +4,5 @@
 .comments-thread
   = render(partial: 'webui/comment/comment_field',
   locals: { form_method: :post, comment: Comment.new, commentable: commentable,
-            line: diff_ref, source_rev:, target_rev:, element_suffix: "new_comment_#{diff_ref}", has_cancel: true })
+            line: diff_ref, file_index:, line_number:, source_rev:, target_rev:,
+            element_suffix: "new_comment_#{diff_ref}", has_cancel: true })

--- a/src/api/app/views/webui/request/inline_comment.js.erb
+++ b/src/api/app/views/webui/request/inline_comment.js.erb
@@ -1,5 +1,5 @@
 $('#flash').empty();
-$('#comment<%= @line %> .diff-comments').html("<%= escape_javascript(render(partial: 'webui/request/inline_comment', locals: { comment: @comment, commentable: @action, diff_ref: @line, source_rev: @source_rev, target_rev: @target_rev })) %>");
+$('#comment<%= @line %> .diff-comments').html("<%= escape_javascript(render(partial: 'webui/request/inline_comment', locals: { comment: @comment, commentable: @action, diff_ref: @line, file_index: @file_index, line_number: @line_number, source_rev: @source_rev, target_rev: @target_rev })) %>");
 $("#comment<%= @line %> .diff-comments textarea").focus();
 $("#comment<%= @line %>").on('click', '.cancel-comment', function (e) {
   $('#comment<%= @line %> .diff-comments').html("<%= escape_javascript(render(partial: 'webui/request/add_inline_comment', locals: { commentable: @action, diff_ref: @line, source_rev: @source_rev, target_rev: @target_rev })) %>");


### PR DESCRIPTION
Follow up to #16965.

This PR belongs to a series to avoid downtime. The steps are:

1. Add new columns
1. Write to all three columns :arrow_left:
2. Backfill data from the old column to the new columns
3. Move reads from the old column to the new columns
4. Stop writing to the old column
5. Drop the old column

