### PR TITLE
Backfill `diff_file_index` and `diff_line_number` columns on table `comments`

### DIFF
--- a/src/api/db/data/20241017123303_backfill_diff_fields_on_comments.rb
+++ b/src/api/db/data/20241017123303_backfill_diff_fields_on_comments.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class BackfillDiffFieldsOnComments < ActiveRecord::Migration[7.0]
+  def up
+    Comment.where.not(diff_ref: nil).where(diff_file_index: nil).in_batches do |batch|
+      batch.find_each do |comment|
+        diff_file_index, diff_line_number = comment.diff_ref.match(/diff_([0-9]+)_n([0-9]+)/).captures
+
+        comment.update!(diff_file_index:, diff_line_number:)
+      end
+    end
+  end
+
+  def down
+    Comment.where.not(diff_file_index: nil).in_batches do |batch|
+      batch.find_each do |comment|
+        comment.update!(diff_file_index: nil, diff_line_number: nil)
+      end
+    end
+  end
+end

--- a/src/api/db/data_schema.rb
+++ b/src/api/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20240814142031)
+DataMigrate::Data.define(version: 20241017123303)


### PR DESCRIPTION
Follow up to #16966.

This PR belongs to a series to avoid downtime. The steps are:

1. Add new columns
1. Write to all three columns
2. Backfill data from the old column to the new columns :arrow_left:
3. Move reads from the old column to the new columns
4. Stop writing to the old column
5. Drop the old column

