### PR TITLE
Move reads from the `diff_ref` column to the new `diff_*` columns

### DIFF
--- a/src/api/app/components/bs_request_activity_timeline_component.rb
+++ b/src/api/app/components/bs_request_activity_timeline_component.rb
@@ -23,11 +23,10 @@ class BsRequestActivityTimelineComponent < ApplicationComponent
   end
 
   def diff_for_ref(comment)
-    return unless (ref = comment.diff_ref&.match(/diff_([0-9]+)/))
+    return unless comment.diff_file_index
 
-    file_index = ref.captures.first
     sourcediff = @commented_actions.find(comment.commentable.id).first.webui_sourcediff(rev: comment.source_rev, orev: comment.target_rev).first
-    filename = sourcediff.dig('filenames', file_index.to_i)
+    filename = sourcediff.dig('filenames', comment.diff_file_index)
     sourcediff.dig('files', filename)
   end
 end

--- a/src/api/app/components/bs_request_comment_component.html.haml
+++ b/src/api/app/components/bs_request_comment_component.html.haml
@@ -19,15 +19,13 @@
                             class: 'dropdown-item', remote: true, form_class: 'moderate-form', params: { moderation_state: !comment.moderated? })
             - if policy(Report.new(reportable: comment)).create?
               = link_to('#', class: 'dropdown-item', id: "js-comment-#{comment.id}",
-                        data: { 'bs-toggle': 'modal',
-                                'bs-target': '#report-modal',
+                        data: { 'bs-toggle': 'modal', 'bs-target': '#report-modal',
                                 'modal-title': "Report comment from #{comment.user}",
                                 'reportable-type': comment.class.name,
                                 'reportable-id': comment.id }) do
                 Report
             - if policy(comment).destroy?
-              = link_to('#', data: { 'bs-toggle': 'modal',
-                  'bs-target': '#delete-comment-modal',
+              = link_to('#', data: { 'bs-toggle': 'modal', 'bs-target': '#delete-comment-modal',
                   confirmation_text: 'Please confirm deletion of comment',
                   action: comment_path(comment) },
                   class: 'dropdown-item delete_link', title: 'Delete comment') do
@@ -47,14 +45,15 @@
           - helpers.comment_user_role_titles(comment).each do |title|
             %span.badge.border.border-secondary.text-secondary.text-capitalize
               = title
-      - if comment.diff_ref
+      - if comment.diff_file_index
         .comment-diff
           - if diff
             - action = comment.commentable
+            - anchor = "diff_#{comment.diff_file_index}_n#{comment.diff_line_number}"
             .px-3.pt-3.pb-2
               = link_to(action.uniq_key, request_show_path(number: action.bs_request, request_action_id: action))
               >
-              = link_to request_changes_path(number: action.bs_request, request_action_id: action, anchor: comment.diff_ref) do
+              = link_to request_changes_path(number: action.bs_request, request_action_id: action, anchor:) do
                 = render(DiffSubjectComponent.new(state: diff['state'], old_filename: diff.dig('old', 'name'), new_filename: diff.dig('new', 'name')))
               - if comment.outdated?
                 %span.badge.text-bg-warning Outdated

--- a/src/api/app/components/bs_request_comment_component.rb
+++ b/src/api/app/components/bs_request_comment_component.rb
@@ -16,7 +16,7 @@ class BsRequestCommentComponent < ApplicationComponent
   end
 
   def range
-    line_index = @comment.diff_ref.match(/diff_[0-9]+_n([0-9]+)/).captures.first
-    ((line_index.to_i - 4).clamp(0..)..(line_index.to_i - 1))
+    line_index = @comment.diff_line_number
+    ((line_index - 4).clamp(0..)..(line_index - 1))
   end
 end

--- a/src/api/app/components/comment_component.rb
+++ b/src/api/app/components/comment_component.rb
@@ -22,7 +22,7 @@ class CommentComponent < ApplicationComponent
   end
 
   def body
-    return inline_comment_body if comment.commentable.is_a?(BsRequestAction) && comment.diff_ref.present?
+    return inline_comment_body if comment.commentable.is_a?(BsRequestAction) && comment.diff_file_index
 
     comment.body.delete("\u0000")
   end
@@ -37,9 +37,8 @@ class CommentComponent < ApplicationComponent
     return comment.body if sourcediff[:error]
 
     target = "#{comment.commentable.target_project}/#{comment.commentable.target_package}"
-    file_index, line_number = comment.diff_ref.match(/diff_([0-9]+)_n([0-9]+)/).captures
-    filename = sourcediff['filenames'][file_index.to_i]
+    filename = sourcediff['filenames'][comment.diff_file_index]
 
-    "Inline comment for target: '#{target}', file: '#{filename}', and line: #{line_number}:\n\n#{comment.body}"
+    "Inline comment for target: '#{target}', file: '#{filename}', and line: #{comment.diff_line_number}:\n\n#{comment.body}"
   end
 end

--- a/src/api/app/components/diff_component.html.haml
+++ b/src/api/app/components/diff_component.html.haml
@@ -40,8 +40,9 @@
                 = sanitize line.content[1..]
         - if commentable
           .line-comment{ id: "comment#{id}" }
-            - if commented_lines.include?(id)
-              - commentable.comments.where(diff_ref: id, source_rev: [source_rev, nil], target_rev: [target_rev, nil]).each do |comment|
+            - if commented_lines.include?([file_index, line.index])
+              - commentable.comments.where(diff_file_index: file_index, diff_line_number: line.index,
+                                           source_rev: [source_rev, nil], target_rev: [target_rev, nil]).each do |comment|
                 .diff-comments
                   .comments-thread
                     = render BsRequestCommentComponent.new(comment: comment, level: 1, commentable: commentable)

--- a/src/api/app/components/diff_list_component.rb
+++ b/src/api/app/components/diff_list_component.rb
@@ -8,7 +8,7 @@ class DiffListComponent < ApplicationComponent
     @diff_list = diff_list
     @view_id = view_id
     @commentable = commentable
-    @commented_lines = commentable ? commentable.comments.where.not(diff_ref: nil).select(:diff_ref).distinct.pluck(:diff_ref) : []
+    @commented_lines = commentable ? commentable.comments.where.not(diff_file_index: nil).select(:diff_file_index, :diff_line_number).distinct.pluck(:diff_file_index, :diff_line_number) : []
     @source_package = source_package
     @target_package = target_package
     @source_rev = source_rev

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -283,8 +283,9 @@ class Webui::RequestController < Webui::WebuiController
   end
 
   def inline_comment
-    @line = params[:line]
-    @file_index, @line_number = @line.match(/diff_([0-9]+)_n([0-9]+)/).captures
+    @file_index = params[:diff_file_index]
+    @line_number = params[:diff_line_number]
+    @line = "diff_#{@file_index}_n#{@line_number}"
     @source_rev = params[:source_rev]
     @target_rev = params[:target_rev]
     respond_to do |format|

--- a/src/api/app/models/comment.rb
+++ b/src/api/app/models/comment.rb
@@ -108,7 +108,7 @@ class Comment < ApplicationRecord
     when 'BsRequest'
       Event::CommentForRequest.create(event_parameters)
     when 'BsRequestAction'
-      Event::CommentForRequest.create(event_parameters.merge({ id: id, diff_ref: diff_ref }))
+      Event::CommentForRequest.create(event_parameters.merge({ id: id, diff_file_index: diff_file_index, diff_line_number: diff_line_number, diff_ref: diff_ref }))
     end
   end
 

--- a/src/api/app/models/event/comment_for_request.rb
+++ b/src/api/app/models/event/comment_for_request.rb
@@ -3,7 +3,7 @@ module Event
     include CommentEvent
     self.message_bus_routing_key = 'request.comment'
     self.description = 'New comment for request created'
-    payload_keys :request_number, :diff_ref
+    payload_keys :request_number, :diff_file_index, :diff_line_number, :diff_ref
     receiver_roles :source_maintainer, :target_maintainer, :creator, :reviewer, :source_project_watcher, :target_project_watcher,
                    :source_package_watcher, :target_package_watcher, :request_watcher
 
@@ -25,7 +25,7 @@ module Event
     end
 
     def metric_tags
-      { diff_ref: payload['diff_ref'].present? }
+      { diff_ref: payload['diff_file_index'].present? }
     end
 
     def metric_fields

--- a/src/api/app/views/webui/comment/_comment_field.html.haml
+++ b/src/api/app/views/webui/comment/_comment_field.html.haml
@@ -3,7 +3,7 @@ class: "#{form_method}-comment-form write-and-preview" },
 data: { preview_message_url: preview_comments_path, message_body_param: 'comment[body]' }) do |f|
   = hidden_field_tag :commentable_type, commentable.class.name, { id: "#{element_suffix}_commentable_type" }
   = hidden_field_tag :commentable_id, commentable.id, { id: "#{element_suffix}_commentable_id" }
-  - if defined?(line)
+  - if defined?(file_index)
     = f.hidden_field :diff_ref, value: line, id: "#{element_suffix}_diff_ref"
     = f.hidden_field :diff_file_index, value: file_index, id: "#{element_suffix}_diff_file_index"
     = f.hidden_field :diff_line_number, value: line_number, id: "#{element_suffix}_diff_line_number"

--- a/src/api/app/views/webui/comment/_content.html.haml
+++ b/src/api/app/views/webui/comment/_content.html.haml
@@ -19,10 +19,9 @@
       - unless sourcediff[:error]
         :ruby
           target = "#{comment.commentable.target_project}/#{comment.commentable.target_package}"
-          file_index, line_number = comment.diff_ref.match(/diff_([0-9]+)_n([0-9]+)/).captures
-          filename = sourcediff['filenames'][file_index.to_i]
+          filename = sourcediff['filenames'][comment.diff_file_index.to_i]
         %p
-          %i Inline comment for target: '#{target}', file: '#{filename}', and line: #{line_number}.
+          %i Inline comment for target: '#{target}', file: '#{filename}', and line: #{comment.diff_line_number}.
     = render ReportsNoticeComponent.new(reportable: comment, user: User.session)
     = render_as_markdown(comment)
     = render partial: 'webui/comment/reply', locals: { comment: comment, level: 0, commentable: comment.commentable }

--- a/src/api/app/views/webui/request/_add_inline_comment.html.haml
+++ b/src/api/app/views/webui/request/_add_inline_comment.html.haml
@@ -1,5 +1,6 @@
 - if User.session
-  = link_to(request_inline_comment_path(commentable.bs_request, request_action_id: commentable, line: diff_ref, source_rev:, target_rev:),
+  = link_to(request_inline_comment_path(commentable.bs_request, request_action_id: commentable,
+                                        diff_file_index:, diff_line_number:, source_rev:, target_rev:),
             class: 'btn btn-sm btn-primary line-new-comment', remote: true, title: 'Add comment') do
     %i.fas.fa-comment-medical
     .visually-hidden

--- a/src/api/app/views/webui/request/_inline_comment.html.haml
+++ b/src/api/app/views/webui/request/_inline_comment.html.haml
@@ -1,4 +1,5 @@
-- commentable.comments.where(diff_ref:, source_rev: [source_rev, nil], target_rev: [target_rev, nil]).each do |comment|
+- commentable.comments.where(diff_file_index: file_index, diff_line_number: line_number,
+                             source_rev: [source_rev, nil], target_rev: [target_rev, nil]).each do |comment|
   .comments-thread
     = render BsRequestCommentComponent.new(comment: comment, level: 1, commentable: commentable)
 .comments-thread

--- a/src/api/app/views/webui/request/inline_comment.js.erb
+++ b/src/api/app/views/webui/request/inline_comment.js.erb
@@ -2,5 +2,5 @@ $('#flash').empty();
 $('#comment<%= @line %> .diff-comments').html("<%= escape_javascript(render(partial: 'webui/request/inline_comment', locals: { comment: @comment, commentable: @action, diff_ref: @line, file_index: @file_index, line_number: @line_number, source_rev: @source_rev, target_rev: @target_rev })) %>");
 $("#comment<%= @line %> .diff-comments textarea").focus();
 $("#comment<%= @line %>").on('click', '.cancel-comment', function (e) {
-  $('#comment<%= @line %> .diff-comments').html("<%= escape_javascript(render(partial: 'webui/request/add_inline_comment', locals: { commentable: @action, diff_ref: @line, source_rev: @source_rev, target_rev: @target_rev })) %>");
+  $('#comment<%= @line %> .diff-comments').html("<%= escape_javascript(render(partial: 'webui/request/add_inline_comment', locals: { commentable: @action, diff_file_index: @file_index, diff_line_number: @line_number, source_rev: @source_rev, target_rev: @target_rev })) %>");
 });

--- a/src/api/config/routes/webui.rb
+++ b/src/api/config/routes/webui.rb
@@ -348,7 +348,7 @@ constraints(RoutesHelper::WebuiMatcher) do
     post 'request/set_bugowner_request' => :set_bugowner_request
     get 'request/:number/request_action/:id' => :request_action, as: 'request_action'
     get 'request/:number/request_action/:id/changes' => :request_action_changes, as: 'request_action_changes'
-    get 'request/:number/request_action/:request_action_id/inline_comment/:line' => :inline_comment, constraints: cons, as: 'request_inline_comment'
+    get 'request/:number/request_action/:request_action_id/inline_comment' => :inline_comment, constraints: cons, as: 'request_inline_comment'
     get 'request/:number/chart_build_results' => :chart_build_results, as: 'request_chart_build_results', constraints: cons
     get 'request/:number/complete_build_results' => :complete_build_results, as: 'request_complete_build_results', constraints: cons
   end

--- a/src/api/spec/controllers/comments_controller_spec.rb
+++ b/src/api/spec/controllers/comments_controller_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe CommentsController do
     context 'of a bs_request_action (inline comment)', :vcr do
       let(:submit_request) { create(:bs_request_with_submit_action) }
       let(:object) { create(:bs_request_action_submit_with_diff, bs_request: submit_request) }
-      let(:comment) { create(:comment, commentable: object, diff_ref: 'diff_0_n1') }
+      let(:comment) { create(:comment, commentable: object, diff_file_index: 0, diff_line_number: 1) }
 
       before do
         login user

--- a/src/api/spec/features/webui/requests/diff_comments_spec.rb
+++ b/src/api/spec/features/webui/requests/diff_comments_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Comments with diff', :js, :vcr do
            source_package: source_package)
   end
 
-  let!(:comment) { create(:comment, commentable: bs_request.bs_request_actions.first, diff_ref: 'diff_0_n1', user: admin) }
+  let!(:comment) { create(:comment, commentable: bs_request.bs_request_actions.first, diff_file_index: 0, diff_line_number: 1, user: admin) }
 
   context 'reply comment' do
     describe 'when under the beta program' do

--- a/src/api/spec/features/webui/requests/submissions_spec.rb
+++ b/src/api/spec/features/webui/requests/submissions_spec.rb
@@ -186,7 +186,7 @@ RSpec.describe 'Requests_Submissions', :js, :vcr do
                  source_project: source_project,
                  source_package: source_package)
         end
-        let!(:comment) { create(:comment, commentable: bs_request.bs_request_actions.first, diff_ref: 'diff_0_n1') }
+        let!(:comment) { create(:comment, commentable: bs_request.bs_request_actions.first, diff_file_index: 0, diff_line_number: 1) }
 
         it 'displays the comment in the timeline' do
           login submitter
@@ -204,7 +204,7 @@ RSpec.describe 'Requests_Submissions', :js, :vcr do
                  source_project: source_project,
                  source_package: source_package)
         end
-        let!(:comment) { create(:comment, commentable: bs_request, diff_ref: '') }
+        let!(:comment) { create(:comment, commentable: bs_request) }
 
         it 'displays the comment in the timeline' do
           login submitter


### PR DESCRIPTION
Follow up to #16969.

This PR belongs to a series to avoid downtime. The steps are:

1. Add new columns
1. Write to all three columns
2. Backfill data from the old column to the new columns
3. Move reads from the old column to the new columns :arrow_left:
4. Stop writing to the old column
5. Drop the old column
