### PR TITLE
Skip retrieval of gpg key if container signing is not configured

### DIFF
--- a/src/backend/BSPublisher/Container.pm
+++ b/src/backend/BSPublisher/Container.pm
@@ -178,8 +178,12 @@ sub upload_all_containers {
     $isdelete = 1;
     $containers = {};
   } else {
-    my ($pubkey, $signargs) = get_notary_pubkey($projid, $data->{'pubkey'}, $data->{'signargs'}, $data->{'signflavor'});
-    $data = { %$data, 'pubkey' => $pubkey, 'signargs' => $signargs };
+    if ($BSConfig::sign_project && $BSConfig::sign) {
+      my ($pubkey, $signargs) = get_notary_pubkey($projid, $data->{'pubkey'}, $data->{'signargs'}, $data->{'signflavor'});
+      $data = { %$data, 'pubkey' => $pubkey, 'signargs' => $signargs };
+    } else {
+      $data = {};
+    }
   }
 
   my $notary_uploads = {};


### PR DESCRIPTION
If the tool or signing project is not configured, skip all together searching for a pubkey, as that will then die and the container publishing will not proceed further. If configured just behave correctly as before.