### PR TITLE
[backend] Add anchor to fix extraction from the disturl

### DIFF
--- a/src/backend/BSPublisher/Diffnotify.pm
+++ b/src/backend/BSPublisher/Diffnotify.pm
@@ -163,7 +163,7 @@ sub diffdata {
         ($r->{'package'}, $r->{'flavor'}) = ($1, $2);
       }
       # hack: try to get flavor from disturl for aggregated containers
-      $r->{'flavor'} = $1 if $r->{'flavor'} eq '' && $r->{'disturl'} && $r->{'disturl'} =~ /:([^:\/]+)/;
+      $r->{'flavor'} = $1 if $r->{'flavor'} eq '' && $r->{'disturl'} && $r->{'disturl'} =~ /:([^:\/]+)$/;
     }
     push @ret, $r;
   }


### PR DESCRIPTION
Without that, it returns the first match, which is some component of the project name. we actually want the last match, if any.