### PR TITLE
Ignore comments with empty strings in diff_ref

### DIFF
--- a/src/api/db/data/20241017123303_backfill_diff_fields_on_comments.rb
+++ b/src/api/db/data/20241017123303_backfill_diff_fields_on_comments.rb
@@ -2,7 +2,7 @@
 
 class BackfillDiffFieldsOnComments < ActiveRecord::Migration[7.0]
   def up
-    Comment.where.not(diff_ref: nil).where(diff_file_index: nil).in_batches do |batch|
+    Comment.where.not(diff_ref: [nil, '']).where(diff_file_index: nil).in_batches do |batch|
       batch.find_each do |comment|
         diff_file_index, diff_line_number = comment.diff_ref.match(/diff_([0-9]+)_n([0-9]+)/).captures
 


### PR DESCRIPTION
This migration was introduced in #16969 and it did not consider comments with empty strings in `diff _ref`. We have some comments in production with empty strings in diff_ref