### PR TITLE
Request accept buttons into dropdown

### DIFF
--- a/src/api/app/components/request_decision_component.html.haml
+++ b/src/api/app/components/request_decision_component.html.haml
@@ -27,35 +27,71 @@
                             rows: 4, class: 'w-100 form-control mb-2 message-field')
           .tab-pane.fade{ id: 'preview_new_comment', role: 'tabpanel', 'aria-labelledby': 'preview-message-tab' }
             .comment-preview.message-preview.border-bottom.border-gray-300.my-3
-      - if single_action_request && @is_target_maintainer && @bs_request.state.in?([:new, :review])
-        - if show_add_submitter_as_maintainer_option?
-          .form-check.mb-2.mt-2
-            = check_box_tag('add_submitter_as_maintainer_0', "#{@action.target_project}_#_#{@action.target_package}",
-                            false,
-                            class: 'form-check-input')
-            %label.form-check-label{ for: 'add_submitter_as_maintainer_0' }
-              Add #{link_to(@bs_request.creator, user_path(@bs_request.creator))} as maintainer for
-              #{helpers.project_or_package_link(project: @action.target_project, package: @action.target_package, short: true)}
-        - if @action.type == 'submit'
-          - @action.forward.each_with_index do |forward, index|
-            .form-check.mb-2
-              = check_box_tag("forward-#{index}", "#{forward[:project]}_#_#{forward[:package]}", true, class: 'form-check-input')
-              %label.form-check-label{ for: "forward-#{index}" }
-                Forward submit request to
-                #{helpers.project_or_package_link(project: forward[:project], package: forward[:package], short: true)}
       .mt-2
+        - if policy(Comment.new(commentable:@bs_request)).create?
+          = submit_tag 'Add comment', class: 'btn btn-primary me-2', data: { disable_with: 'Creating comment...' }, name: 'commented'
         - if policy(@bs_request).revoke_request?
           = submit_tag 'Revoke request', name: 'revoked', class: 'btn btn-danger me-2', data: other_decision_confirmation('revoke')
+        - if policy(@bs_request).decline_request?
+          = submit_tag('Decline request', name: 'declined', class: 'btn btn-danger me-2', data: other_decision_confirmation('decline'),
+                        title: 'Decline the request, as the author of the request you can reopen it again.')
+        - if policy(@bs_request).accept_request?
+          -# Hidden checkbox input to flag make_maintainer option
+          - if accept_with_options_allowed? && show_add_submitter_as_maintainer_option?
+            .form-check.mb-2.mt-2.d-none
+              = check_box_tag('add_submitter_as_maintainer_0', "#{@action.target_project}_#_#{@action.target_package}",
+                              false, class: 'form-check-input')
+          -# Accept buttons
+          %span.dropdown.me-2
+            = button_tag('Accept', type: 'button', role: 'button', id: 'decision-buttons-group', class: 'btn btn-secondary dropdown-toggle',
+                          data: { 'bs-toggle': 'dropdown'}, aria: { 'haspopup': 'true', 'expanded': 'false' })
+            .dropdown-menu{ aria: { labelledby: 'decision-buttons-group' } }
+              -# Simple Accept request submit
+              = submit_tag('Accept request', name: 'accepted', class: 'btn-link dropdown-item', data: confirmation,
+                            title: 'Accept the request, this will apply the changes on the target.')
+              -# Accept and make maintainer submit
+              - if accept_with_options_allowed? && show_add_submitter_as_maintainer_option?
+                = submit_tag("Accept and make #{@bs_request.creator} maintainer of #{make_maintainer_of}",
+                            name: 'accepted',
+                            class: 'btn-link dropdown-item', data: confirmation,
+                            title: 'Accept the request. this will apply the changes on the target.',
+                            id: 'accept-and-make-maintainer')
+          -# Accept and forward buttons
+          - if forward_allowed?
+            %span.dropdown.me-2
+              = button_tag('Accept and Forward', type: 'button', role: 'button', id: 'decision-forward-buttons-group',
+                            class: 'btn btn-secondary dropdown-toggle',
+                            data: { 'bs-toggle': 'dropdown'}, aria: { 'haspopup': 'true', 'expanded': 'false' })
+              .dropdown-menu{ aria: { labelledby: 'decision-forward-buttons-group' } }
+                - @action.forward.each_with_index do |forward, index|
+                  .form-check.m-2
+                    = check_box_tag("forward-#{index}", "#{forward[:project]}_#_#{forward[:package]}", true,
+                                    class: 'form-check-input forward-check-inputs')
+                    %label.form-check-label{ for: "forward-#{index}" }
+                      Forward submit request to
+                      #{helpers.project_or_package_link(project: forward[:project], package: forward[:package], short: true)}
+                %hr.dropdown-divider
+                -# Accept and forward submit
+                = submit_tag('Accept and forward request to the selected projects ', name: 'accepted', class: 'btn-link dropdown-item',
+                              data: confirmation, title: 'Accept the request. this will apply the changes on the target.',
+                              id: 'accept-and-forward')
+                -# Accept and make maintainer and forward submit
+                - if show_add_submitter_as_maintainer_option?
+                  = submit_tag("Accept and make #{@bs_request.creator} maintainer of #{make_maintainer_of} and forward request to the selected projects",
+                                name: 'accepted', class: 'btn-link dropdown-item', data: confirmation,
+                                title: 'Accept the request. this will apply the changes on the target.',
+                                id: 'accept-and-make-maintainer-and-forward')
+
         - if policy(@bs_request).reopen_request?
           = submit_tag 'Reopen request', name: 'new', class: 'btn btn-warning me-2', data: other_decision_confirmation('reopen')
-        - if policy(@bs_request).accept_request?
-          - if policy(@bs_request).decline_request?
-            = submit_tag('Decline request', name: 'declined', title: 'Decline the request, as the author of the request you can reopen it again.',
-                        class: 'btn btn-danger me-2', data: other_decision_confirmation('decline'))
-          = submit_tag('Accept request', name: 'accepted', title: 'Accept the request, this will apply the changes on the target.',
-                      class: 'btn btn-primary me-2', data: confirmation)
-        - if policy(Comment.new(commentable:@bs_request)).create?
-          = submit_tag 'Add comment', class: 'btn btn-secondary me-2', data: { disable_with: 'Creating comment...' }, name: 'commented'
 
 :javascript
   attachPreviewMessageOnCommentBoxes();
+
+  // Check the proper checkbox behind the scene on different type of accept submit
+  $('#accept-and-make-maintainer').on('click', function(){
+    $('input[name=add_submitter_as_maintainer_0]').prop('checked', 'checked');
+  });
+  $('#accept-and-make-maintainer-and-forward').on('click', function(){
+    $('input[name=add_submitter_as_maintainer_0]').prop('checked', 'checked');
+  });

--- a/src/api/app/components/request_decision_component.html.haml
+++ b/src/api/app/components/request_decision_component.html.haml
@@ -51,7 +51,7 @@
                             title: 'Accept the request, this will apply the changes on the target.')
               -# Accept and make maintainer submit
               - if accept_with_options_allowed? && show_add_submitter_as_maintainer_option?
-                = submit_tag("Accept and make #{@bs_request.creator} maintainer of #{make_maintainer_of}",
+                = submit_tag("Accept and make #{@creator} maintainer of #{make_maintainer_of}",
                             name: 'accepted',
                             class: 'btn-link dropdown-item', data: confirmation,
                             title: 'Accept the request. this will apply the changes on the target.',
@@ -72,7 +72,7 @@
                               id: 'accept-and-forward')
                 -# Accept and make maintainer and forward submit
                 - if show_add_submitter_as_maintainer_option?
-                  = submit_tag("Accept and make #{@bs_request.creator} maintainer of #{make_maintainer_of} and forward request to the selected projects",
+                  = submit_tag("Accept and make #{@creator} maintainer of #{make_maintainer_of} and forward request to the selected projects",
                                 name: 'accepted', class: 'btn-link dropdown-item', data: confirmation,
                                 title: 'Accept the request. this will apply the changes on the target.',
                                 id: 'accept-and-make-maintainer-and-forward')

--- a/src/api/app/components/request_decision_component.html.haml
+++ b/src/api/app/components/request_decision_component.html.haml
@@ -64,18 +64,6 @@
                             class: 'btn-link dropdown-item', data: confirmation,
                             title: 'Accept the request. this will apply the changes on the target.',
                             id: 'accept-and-make-maintainer')
-              -# Accept and forward buttons
-              - if @forward_allowed
-                -# Accept and forward submit
-                = submit_tag('Accept and forward request to the selected projects ', name: 'accepted', class: 'btn-link dropdown-item',
-                              data: confirmation, title: 'Accept the request. this will apply the changes on the target.',
-                              id: 'accept-and-forward')
-                -# Accept and make maintainer and forward submit
-                - if show_add_submitter_as_maintainer_option?
-                  = submit_tag("Accept and make #{@creator} maintainer of #{make_maintainer_of} and forward request to the selected projects",
-                                name: 'accepted', class: 'btn-link dropdown-item', data: confirmation,
-                                title: 'Accept the request. this will apply the changes on the target.',
-                                id: 'accept-and-make-maintainer-and-forward')
 
         - if policy(@bs_request).reopen_request?
           = submit_tag 'Reopen request', name: 'new', class: 'btn btn-warning me-2', data: other_decision_confirmation('reopen')

--- a/src/api/app/components/request_decision_component.html.haml
+++ b/src/api/app/components/request_decision_component.html.haml
@@ -28,7 +28,7 @@
           .tab-pane.fade{ id: 'preview_new_comment', role: 'tabpanel', 'aria-labelledby': 'preview-message-tab' }
             .comment-preview.message-preview.border-bottom.border-gray-300.my-3
       .mt-2
-        - if forward_allowed?
+        - if @forward_allowed
           - @action.forward.each_with_index do |forward, index|
             .form-check.m-2
               = check_box_tag("forward-#{index}", "#{forward[:project]}_#_#{forward[:package]}", true,
@@ -65,7 +65,7 @@
                             title: 'Accept the request. this will apply the changes on the target.',
                             id: 'accept-and-make-maintainer')
               -# Accept and forward buttons
-              - if forward_allowed?
+              - if @forward_allowed
                 -# Accept and forward submit
                 = submit_tag('Accept and forward request to the selected projects ', name: 'accepted', class: 'btn-link dropdown-item',
                               data: confirmation, title: 'Accept the request. this will apply the changes on the target.',

--- a/src/api/app/components/request_decision_component.html.haml
+++ b/src/api/app/components/request_decision_component.html.haml
@@ -28,6 +28,14 @@
           .tab-pane.fade{ id: 'preview_new_comment', role: 'tabpanel', 'aria-labelledby': 'preview-message-tab' }
             .comment-preview.message-preview.border-bottom.border-gray-300.my-3
       .mt-2
+        - if forward_allowed?
+          - @action.forward.each_with_index do |forward, index|
+            .form-check.m-2
+              = check_box_tag("forward-#{index}", "#{forward[:project]}_#_#{forward[:package]}", true,
+                              class: 'form-check-input forward-check-inputs')
+              %label.form-check-label{ for: "forward-#{index}" }
+                Forward submit request to
+                #{helpers.project_or_package_link(project: forward[:project], package: forward[:package], short: true)}
         - if policy(Comment.new(commentable:@bs_request)).create?
           = submit_tag 'Add comment', class: 'btn btn-primary me-2', data: { disable_with: 'Creating comment...' }, name: 'commented'
         - if policy(@bs_request).revoke_request?
@@ -58,14 +66,6 @@
                             id: 'accept-and-make-maintainer')
               -# Accept and forward buttons
               - if forward_allowed?
-                - @action.forward.each_with_index do |forward, index|
-                  .form-check.m-2
-                    = check_box_tag("forward-#{index}", "#{forward[:project]}_#_#{forward[:package]}", true,
-                                    class: 'form-check-input forward-check-inputs')
-                    %label.form-check-label{ for: "forward-#{index}" }
-                      Forward submit request to
-                      #{helpers.project_or_package_link(project: forward[:project], package: forward[:package], short: true)}
-                %hr.dropdown-divider
                 -# Accept and forward submit
                 = submit_tag('Accept and forward request to the selected projects ', name: 'accepted', class: 'btn-link dropdown-item',
                               data: confirmation, title: 'Accept the request. this will apply the changes on the target.',

--- a/src/api/app/components/request_decision_component.html.haml
+++ b/src/api/app/components/request_decision_component.html.haml
@@ -56,13 +56,8 @@
                             class: 'btn-link dropdown-item', data: confirmation,
                             title: 'Accept the request. this will apply the changes on the target.',
                             id: 'accept-and-make-maintainer')
-          -# Accept and forward buttons
-          - if forward_allowed?
-            %span.dropdown.me-2
-              = button_tag('Accept and Forward', type: 'button', role: 'button', id: 'decision-forward-buttons-group',
-                            class: 'btn btn-secondary dropdown-toggle',
-                            data: { 'bs-toggle': 'dropdown'}, aria: { 'haspopup': 'true', 'expanded': 'false' })
-              .dropdown-menu{ aria: { labelledby: 'decision-forward-buttons-group' } }
+              -# Accept and forward buttons
+              - if forward_allowed?
                 - @action.forward.each_with_index do |forward, index|
                   .form-check.m-2
                     = check_box_tag("forward-#{index}", "#{forward[:project]}_#_#{forward[:package]}", true,

--- a/src/api/app/components/request_decision_component.rb
+++ b/src/api/app/components/request_decision_component.rb
@@ -38,4 +38,16 @@ class RequestDecisionComponent < ApplicationComponent
   def show_add_submitter_as_maintainer_option?
     @action.type == 'submit' && !@action.creator_is_target_maintainer
   end
+
+  def accept_with_options_allowed?
+    single_action_request && @is_target_maintainer && @bs_request.state.in?(%i[new review])
+  end
+
+  def forward_allowed?
+    @action.type == 'submit' && @action.forward.any?
+  end
+
+  def make_maintainer_of
+    @action.target_project + ("/#{@action.target_package}" if @action.target_package)
+  end
 end

--- a/src/api/app/components/request_decision_component.rb
+++ b/src/api/app/components/request_decision_component.rb
@@ -6,6 +6,7 @@ class RequestDecisionComponent < ApplicationComponent
     @is_target_maintainer = is_target_maintainer
     @action = action
     @package_maintainers = package_maintainers
+    @creator = bs_request.creator
 
     return unless render? && show_project_maintainer_hint
 

--- a/src/api/app/components/request_decision_component.rb
+++ b/src/api/app/components/request_decision_component.rb
@@ -7,6 +7,7 @@ class RequestDecisionComponent < ApplicationComponent
     @action = action
     @package_maintainers = package_maintainers
     @creator = bs_request.creator
+    @forward_allowed = forward_allowed?
 
     return unless render? && show_project_maintainer_hint
 
@@ -45,7 +46,7 @@ class RequestDecisionComponent < ApplicationComponent
   end
 
   def forward_allowed?
-    @action.type == 'submit' && @action.forward.any?
+    @action.type == 'submit' && policy(@bs_request).accept_request? && @action.forward.any?
   end
 
   def make_maintainer_of

--- a/src/api/spec/features/beta/webui/maintenance_workflow_spec.rb
+++ b/src/api/spec/features/beta/webui/maintenance_workflow_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe 'MaintenanceWorkflow', :js, :vcr do
         visit request_show_path(bs_request)
         fill_in('reason', with: 'really? ok')
 
+        click_button('Accept')
         click_button('Accept request')
       end
 
@@ -96,6 +97,7 @@ RSpec.describe 'MaintenanceWorkflow', :js, :vcr do
         visit request_show_path(bs_request)
         fill_in('reason', with: 'really? ok')
 
+        click_button('Accept')
         click_button('Accept request')
       end
 


### PR DESCRIPTION
The proposal is about keeping separated all the different decision actions, but grouping the `accept request` ones. Accepting request can be made like:

1. Accept
2. Accept & make the submitter a maintainer of the target project/package

Due to the fact that the forward can be submitted to multiple choices, they requires checkboxes to be visible and selectable. The forwarding destinations are shown as checkboxes above the buttons

![image](https://github.com/user-attachments/assets/6e60179c-909a-43ca-b532-28aa66ceb769)
