### PR TITLE
Fix decision box border

### DIFF
--- a/src/api/app/assets/stylesheets/webui/bootstrap_variables/options.scss
+++ b/src/api/app/assets/stylesheets/webui/bootstrap_variables/options.scss
@@ -1,1 +1,2 @@
 $enable-smooth-scroll: false;
+$enable-negative-margins: true;

--- a/src/api/app/components/request_decision_component.html.haml
+++ b/src/api/app/components/request_decision_component.html.haml
@@ -1,4 +1,4 @@
-.request-decision
+.request-decision.mt-n1
   = form_tag({ action: 'changerequest' }, id: 'request_handle_form', class: 'write-and-preview',
     data: { preview_message_url: preview_comments_path, message_body_param: 'comment[body]' }) do
     = hidden_field_tag(:number, @bs_request.number)
@@ -8,7 +8,7 @@
           Commenting on this is locked.
           - if CommentLockPolicy.new(User.session, @bs_request).create?
             = helpers.comment_lock_alert(@bs_request)
-      .card.rounded-0.rounded-bottom
+      .card
         %ul.card-header.nav.nav-tabs.px-3.pt-2.pb-0.disable-link-generation{ role: 'tablist' }
           %li.nav-item
             = link_to('Write', "#write_new_comment", class: 'nav-link active', data: { 'bs-toggle': 'tab' },


### PR DESCRIPTION
Rebased on top of https://github.com/openSUSE/open-build-service/pull/16960

It may happen that the upper "Pending Review" orange box and its content is not there, so the following box for the comment would have not rounded corners on top. This PR fixes it using rounded borders and moving upper with negative margin the comment box closer to the upper box, otherwise the side borders would be detached to the rounded comment box ones.

## Before
![image](https://github.com/user-attachments/assets/51a37489-bb22-455e-934b-0215c51b4f3d)

## After
![image](https://github.com/user-attachments/assets/1ad29823-9314-464e-8e23-d4165036ab17)
