### PR TITLE
Move overlooked reads from the `diff_ref` column to the new `diff_*`  columns

### DIFF
--- a/src/api/app/models/comment.rb
+++ b/src/api/app/models/comment.rb
@@ -84,7 +84,7 @@ class Comment < ApplicationRecord
   end
 
   def revisions?
-    return false if diff_ref.blank?
+    return false if diff_file_index.nil?
     return false if source_rev.nil? || target_rev.nil?
 
     true
@@ -108,7 +108,8 @@ class Comment < ApplicationRecord
     when 'BsRequest'
       Event::CommentForRequest.create(event_parameters)
     when 'BsRequestAction'
-      Event::CommentForRequest.create(event_parameters.merge({ id: id, diff_file_index: diff_file_index, diff_line_number: diff_line_number, diff_ref: diff_ref }))
+      Event::CommentForRequest.create(event_parameters.merge({ id: id, diff_file_index: diff_file_index, diff_line_number: diff_line_number,
+                                                               diff_ref: "diff_#{diff_file_index}_n#{diff_line_number}" }))
     end
   end
 


### PR DESCRIPTION
These changes, somehow, got overlooked. They should have been included in #16971, in this step:

4. Move reads from the old column to the new columns

I noticed this while working on the next step:

5. Stop writing to the old column