### PR TITLE
Stop writing to the `diff_ref` column

### DIFF
--- a/src/api/app/controllers/webui/comments_controller.rb
+++ b/src/api/app/controllers/webui/comments_controller.rb
@@ -143,7 +143,7 @@ class Webui::CommentsController < Webui::WebuiController
   private
 
   def permitted_params
-    params.require(:comment).permit(:body, :parent_id, :diff_ref, :diff_file_index, :diff_line_number, :source_rev, :target_rev)
+    params.require(:comment).permit(:body, :parent_id, :diff_file_index, :diff_line_number, :source_rev, :target_rev)
   end
 
   # FIXME: Use this function for the rest of the actions

--- a/src/api/app/models/comment.rb
+++ b/src/api/app/models/comment.rb
@@ -108,8 +108,7 @@ class Comment < ApplicationRecord
     when 'BsRequest'
       Event::CommentForRequest.create(event_parameters)
     when 'BsRequestAction'
-      Event::CommentForRequest.create(event_parameters.merge({ id: id, diff_file_index: diff_file_index, diff_line_number: diff_line_number,
-                                                               diff_ref: "diff_#{diff_file_index}_n#{diff_line_number}" }))
+      Event::CommentForRequest.create(event_parameters.merge({ id: id, diff_file_index: diff_file_index, diff_line_number: diff_line_number }))
     end
   end
 

--- a/src/api/app/models/event/comment_for_request.rb
+++ b/src/api/app/models/event/comment_for_request.rb
@@ -3,7 +3,7 @@ module Event
     include CommentEvent
     self.message_bus_routing_key = 'request.comment'
     self.description = 'New comment for request created'
-    payload_keys :request_number, :diff_file_index, :diff_line_number, :diff_ref
+    payload_keys :request_number, :diff_file_index, :diff_line_number
     receiver_roles :source_maintainer, :target_maintainer, :creator, :reviewer, :source_project_watcher, :target_project_watcher,
                    :source_package_watcher, :target_package_watcher, :request_watcher
 

--- a/src/api/app/views/webui/comment/_comment_field.html.haml
+++ b/src/api/app/views/webui/comment/_comment_field.html.haml
@@ -4,7 +4,6 @@ data: { preview_message_url: preview_comments_path, message_body_param: 'comment
   = hidden_field_tag :commentable_type, commentable.class.name, { id: "#{element_suffix}_commentable_type" }
   = hidden_field_tag :commentable_id, commentable.id, { id: "#{element_suffix}_commentable_id" }
   - if defined?(file_index)
-    = f.hidden_field :diff_ref, value: line, id: "#{element_suffix}_diff_ref"
     = f.hidden_field :diff_file_index, value: file_index, id: "#{element_suffix}_diff_file_index"
     = f.hidden_field :diff_line_number, value: line_number, id: "#{element_suffix}_diff_line_number"
   - if defined?(source_rev) && defined?(target_rev)

--- a/src/api/app/views/webui/request/_inline_comment.html.haml
+++ b/src/api/app/views/webui/request/_inline_comment.html.haml
@@ -5,5 +5,5 @@
 .comments-thread
   = render(partial: 'webui/comment/comment_field',
   locals: { form_method: :post, comment: Comment.new, commentable: commentable,
-            line: diff_ref, file_index:, line_number:, source_rev:, target_rev:,
+            file_index:, line_number:, source_rev:, target_rev:,
             element_suffix: "new_comment_#{diff_ref}", has_cancel: true })


### PR DESCRIPTION
Follow up to #16971 and overlooked changes in #16992.

This PR belongs to a series to avoid downtime. The steps are:

1. Add new columns
1. Write to all three columns
2. Backfill data from the old column to the new columns
3. Move reads from the old column to the new columns
4. Stop writing to the old column :arrow_left:
5. Drop the old column
