### PR TITLE
Skip if line in nil

### DIFF
--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -165,6 +165,7 @@ Metrics/ClassLength:
     - 'app/models/user_ldap_strategy.rb'
     - 'app/models/workflow/step/branch_package_step.rb'
     - 'app/services/user_service/involved.rb'
+    - 'app/services/diff_parser.rb'
     - 'db/migrate/20230727110437_migrate_to_utf8mb4.rb'
     - 'lib/xpath_engine.rb'
     - 'test/functional/attributes_test.rb'


### PR DESCRIPTION
Fixes https://github.com/openSUSE/open-build-service/issues/16997

When _the change_ content is an added **empty** line, the resulting diff is just `''`. This was breaking in the previous code, fixed now by skipping the case when the line change content is `nil`, indeed.
This specific corner case does not affect nor break the rest of the diff though.