### PR TITLE
Make xargs to ignore commands if stdin is empty

### DIFF
--- a/.github/workflows/create_diffend_io_links.yml
+++ b/.github/workflows/create_diffend_io_links.yml
@@ -18,8 +18,8 @@ jobs:
         run: |
           # Receive added and removed file names from the git diff, filter out everything besides the gem files and receive
           # the basename without the gem file extension
-          ADDED_GEMS=( $(git diff --name-only --diff-filter=A origin/${GITHUB_BASE_REF} $GITHUB_SHA | grep .gem$ | xargs basename -s .gem) )
-          REMOVED_GEMS=( $(git diff --name-only --diff-filter=D origin/${GITHUB_BASE_REF} $GITHUB_SHA | grep .gem$ | xargs basename -s .gem) )
+          ADDED_GEMS=( $(git diff --name-only --diff-filter=A origin/${GITHUB_BASE_REF} $GITHUB_SHA | grep .gem$ | xargs -r basename -s .gem) )
+          REMOVED_GEMS=( $(git diff --name-only --diff-filter=D origin/${GITHUB_BASE_REF} $GITHUB_SHA | grep .gem$ | xargs -r basename -s .gem) )
 
           COMMENT_TEXT="Please see the links listed bellow to review the changes applied to the gems:"$'\n'
 


### PR DESCRIPTION
When we added a new gem, REMOVED_GEMS was empty, and the `basename` command crashed. Not anymore.

When there is nothing coming from ADDED_GEMS (because we remove the gem) or REMOVED_GEMS (because we add a new gem) `xargs` will not crash anymore.