### PR TITLE
Return a 401 when there are no @actions loaded

### DIFF
--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -177,6 +177,8 @@ class Webui::RequestController < Webui::WebuiController
   end
 
   def request_action_changes
+    return head :unauthorized unless @actions
+
     @action = @actions.where(id: params['id'].to_i).first
 
     cache_diff_data


### PR DESCRIPTION
This only happens when the request_action_changes method is being called and the request_show_redesign flag is off, as the `set_actions` method that fills `@actions` is not called.

One way to trigger this is via curl, simulating an AJAX call to /request/<number>/request_action/<action_id>/changes.

This makes sense as the data collected on those errors presents mostly no User-Agent header.

Fixes #16054