### PR TITLE
Fix creators options for listing requests

### DIFF
--- a/src/api/app/controllers/webui/requests_listing_controller.rb
+++ b/src/api/app/controllers/webui/requests_listing_controller.rb
@@ -13,8 +13,8 @@ class Webui::RequestsListingController < Webui::WebuiController
     filter_requests
     set_selected_filter
 
-    @bs_requests = @bs_requests.order('number DESC').page(params[:page])
     @bs_requests_creators = @bs_requests.distinct.pluck(:creator)
+    @bs_requests = @bs_requests.order('number DESC').page(params[:page])
     @bs_requests = @bs_requests.includes(:bs_request_actions, :comments, :reviews)
     @bs_requests = @bs_requests.includes(:labels) if Flipper.enabled?(:labels, User.session)
   end


### PR DESCRIPTION
Previously, only the creators of a certain page of requests were listed.