### PR TITLE
Don't pluck always involved requests' ids

### DIFF
--- a/src/api/app/controllers/concerns/webui/requests_filter.rb
+++ b/src/api/app/controllers/concerns/webui/requests_filter.rb
@@ -24,8 +24,6 @@ module Webui::RequestsFilter
   end
 
   def filter_by_text(text)
-    return BsRequest.all if text.blank?
-
     if BsRequest.search_count(text) > TEXT_SEARCH_MAX_RESULTS
       flash[:error] = 'Your text search pattern matches too many results. Please, try again with a more restrictive search pattern.'
       return BsRequest.none

--- a/src/api/app/controllers/webui/requests_listing_controller.rb
+++ b/src/api/app/controllers/webui/requests_listing_controller.rb
@@ -27,12 +27,17 @@ class Webui::RequestsListingController < Webui::WebuiController
   end
 
   def filter_requests
-    params[:ids] = filter_by_involvement(@filter_involvement).ids
+    if params[:requests_search_text].present?
+      initial_bs_requests = filter_by_text(params[:requests_search_text])
+      params[:ids] = filter_by_involvement(@filter_involvement).ids
+    else
+      initial_bs_requests = filter_by_involvement(@filter_involvement)
+    end
     params[:creator] = @filter_creators if @filter_creators.present?
     params[:states] = @filter_state if @filter_state.present?
     params[:types] = @filter_action_type if @filter_action_type.present?
 
-    @bs_requests = BsRequest::FindFor::Query.new(params, filter_by_text(params[:requests_search_text])).all
+    @bs_requests = BsRequest::FindFor::Query.new(params, initial_bs_requests).all
   end
 
   def set_selected_filter


### PR DESCRIPTION
Only when also searching by text.