### PR TITLE
Show available creator filter options after filter is applied

### DIFF
--- a/src/api/app/controllers/webui/requests_listing_controller.rb
+++ b/src/api/app/controllers/webui/requests_listing_controller.rb
@@ -10,10 +10,14 @@ class Webui::RequestsListingController < Webui::WebuiController
     set_filter_action_type
     set_filter_creators
 
-    filter_requests
+    filter_requests_by_static_values
+    # we have to set the creators before filtering by them in order to keep showing
+    # the complete list of creators in the filter dropdown after the filter is applied
+    @bs_requests_creators = @bs_requests.distinct.pluck(:creator)
+    filter_creators
+
     set_selected_filter
 
-    @bs_requests_creators = @bs_requests.distinct.pluck(:creator)
     @bs_requests = @bs_requests.order('number DESC').page(params[:page])
     @bs_requests = @bs_requests.includes(:bs_request_actions, :comments, :reviews)
     @bs_requests = @bs_requests.includes(:labels) if Flipper.enabled?(:labels, User.session)
@@ -26,13 +30,18 @@ class Webui::RequestsListingController < Webui::WebuiController
     @url = requests_path
   end
 
-  def filter_requests
+  # apply filters that are based on constant values and not dynamically based on
+  # the available requests
+  def filter_requests_by_static_values
     params[:ids] = filter_by_involvement(@filter_involvement).ids
-    params[:creator] = @filter_creators if @filter_creators.present?
     params[:states] = @filter_state if @filter_state.present?
     params[:types] = @filter_action_type if @filter_action_type.present?
 
     @bs_requests = BsRequest::FindFor::Query.new(params, filter_by_text(params[:requests_search_text])).all
+  end
+
+  def filter_creators
+    @bs_requests = @bs_requests.where(creator: @filter_creators) if @filter_creators.present?
   end
 
   def set_selected_filter


### PR DESCRIPTION
Before after filtering by a creator, the rest of the available creators disappeared from the filter dropdown and only the selected one's remained in the list.
This happend because the list of creators in the filter dropdown was basedon the requests where the creator filter was already applied. We have to set the available creators before applying the filter it self in order to keep the list complete.

Before: 
![image](https://github.com/user-attachments/assets/cbb18d1c-7c2c-4906-a143-1aa376d626c3)

After:
![image](https://github.com/user-attachments/assets/6df9b2b3-4b0d-404e-8505-fed5aba17ece)
