### PR TITLE
Check for `total_count` instead of `blank?`

### DIFF
--- a/src/api/app/views/webui/requests_listing/index.html.haml
+++ b/src/api/app/views/webui/requests_listing/index.html.haml
@@ -28,7 +28,7 @@
       .card
         .card-body.list-group.list-group-flush.p-3#requests
           .text-center.mb-3
-            - if @bs_requests.blank?
+            - if @bs_requests.total_count == 0
               %p There are no requests available
             - else
               %span.ms-3= page_entries_info(@bs_requests, entry_name: 'request')


### PR DESCRIPTION
Prevent from performing a COUNT on a query with `includes` and sorted elements. This will improve the performance of the first query, the one which counts the number of elements.

### Before, with `blank?`
```
SELECT DISTINCT `bs_requests`.`priority` AS alias_0, `bs_requests`.`id` AS alias_1, number AS
 alias_2, `bs_requests`.`id` FROM `bs_requests` INNER JOIN `bs_request_actions` ON `bs_request_actions`.`bs_request_id` = `bs_requests`.`id` LEFT OUTER JOIN `comments` ON `comments`.`commenta
ble_type` = 'BsRequest' AND `comments`.`commentable_id` = `bs_requests`.`id` LEFT OUTER JOIN `reviews` ON `reviews`.`bs_request_id` = `bs_requests`.`id` LEFT OUTER JOIN `labels` ON `labels`.`
labelable_type` = 'BsRequest' AND `labels`.`labelable_id` = `bs_requests`.`id` WHERE `bs_requests`.`state` = 'new' AND (`bs_requests`.`id` IN (SELECT `bs_request_actions`.`bs_request_id` FROM
 `bs_request_actions` WHERE `bs_request_actions`.`target_project_id` IN (2, 20, 25, 27)) OR `bs_requests`.`id` IN (SELECT `bs_request_actions`.`bs_request_id` FROM `bs_request_actions` WHERE 
1=0)) ORDER BY `bs_requests`.`priority` ASC, `bs_requests`.`id` DESC, number DESC LIMIT 25 OFFSET 0
```

### After, with `total_count`
```
BsRequest Count (1.2ms)  SELECT COUNT(DISTINCT `bs_requests`.`id`) FROM `bs_requests` INNER JOIN `bs_reque
st_actions` ON `bs_request_actions`.`bs_request_id` = `bs_requests`.`id` WHERE `bs_requests`.`state` = 'new' AND (`bs_requests`.`id` IN (SELECT `bs_request_actions`.`bs_request_id` FROM `bs_r
equest_actions` WHERE `bs_request_actions`.`target_project_id` IN (2, 20, 25, 27)) OR `bs_requests`.`id` IN (SELECT `bs_request_actions`.`bs_request_id` FROM `bs_request_actions` WHERE 1=0))
```


See these commits from Kaminari:
- `includes`: https://github.com/kaminari/kaminari/commit/b68068bd5ad050b5bbbc2c1e7ee155b5ec55946a
- `order`: https://github.com/kaminari/kaminari/commit/c9e6f6a12a48e6f28982a05b5fd14069f3778f62