### PR TITLE
[backend] bs_service: fix error reporting

### DIFF
--- a/src/backend/bs_service
+++ b/src/backend/bs_service
@@ -143,10 +143,8 @@ sub run_source_update {
   # chdir into a clean temp directory
   my $myworkdir = "$tempdir/$$";
   rm_rf($myworkdir);
-  die("cannot get rid of old work dir\n") if -e $myworkdir;
-  mkdir_p($myworkdir);
-  die("$myworkdir not writable for me") unless -w $myworkdir;
-  mkdir("$myworkdir/src") || die("mkdir $myworkdir/src: $!\n");
+  die("500 cannot get rid of old work dir\n") if -e $myworkdir;
+  mkdir_p("$myworkdir/src") || die("mkdir $myworkdir/src: $!\n");
   chdir("$myworkdir/src") || die("chdir $myworkdir/src: $!\n");
 
   # unpack source data


### PR DESCRIPTION
Include the real reason why the directory setup failed in the error so that the automatic retry code will detect that this is a transient error.