### PR TITLE
Improve message for failed database queries

### DIFF
--- a/src/api/app/models/package_issue.rb
+++ b/src/api/app/models/package_issue.rb
@@ -30,7 +30,7 @@ class PackageIssue < ApplicationRecord
     rescue ActiveRecord::StatementInvalid, Mysql2::Error => e
       retries -= 1
       if retries.positive?
-        Airbrake.notify("Failed to update PackageIssue : retries left: #{retries}, package: #{package.inspect}, issues: #{issues.inspect}, #{e}")
+        Airbrake.notify("Failed to update PackageIssue : retries left: #{retries}, #{e}, package: #{package.inspect}")
         retry
       end
     end


### PR DESCRIPTION
Before, the message got truncated because of too much data of the packages' issues.

Related to #16959.