### PR TITLE
Improve performance of checking for notifications query

### DIFF
--- a/src/api/app/views/webui/users/notifications/_notifications_list.html.haml
+++ b/src/api/app/views/webui/users/notifications/_notifications_list.html.haml
@@ -1,4 +1,4 @@
-- if notifications.empty?
+- if notifications.total_count == 0
   .card
     .card-body
       %p


### PR DESCRIPTION
Instead of perfoming another query for checking for empty notifications, use the already cached `total_count` query result.

Related to #17046.