### PR TITLE
Show package name in breadcrumbs of Request page

### DIFF
--- a/src/api/app/views/webui/requests_listing/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui/requests_listing/_breadcrumb_items.html.haml
@@ -6,6 +6,6 @@
   - if @package
     %li.breadcrumb-item.text-word-break-all
       %i.fa.fa-archive
-      = link_to @project, package_show_path(@project, @package)
+      = link_to @package, package_show_path(@project, @package)
   %li.breadcrumb-item.active{ 'aria-current' => 'page' }
     Requests


### PR DESCRIPTION
Before, the project name was shown twice.