### PR TITLE
[backend] bs_sched: disable early publishing if archsync is configured

### DIFF
--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -2196,7 +2196,7 @@ sub publish {
       $lastchange++ if $as->{'lastcheck'} && $as->{'lastcheck'} == $lastchange;
     }
     if (@bad) {
-      print "    delaying publishing as archirectures ".join(',', @bad)." are not ready\n";
+      print "    delaying publishing as architectures ".join(',', @bad)." are not ready\n";
       for my $a (@bad) {
 	# hack: use the .archsync.new file to signal the scheduler that we are waiting
 	eval { BSUtil::touch("$reporoot/$prp/$a/:repo/.archsync.new") };

--- a/src/backend/bs_sched
+++ b/src/backend/bs_sched
@@ -1084,9 +1084,10 @@ eval {
     BSSched::DoD::dodfetch($ctx) if $ctx->{'doddownloads'};
 
     # we always publish some build types right away...
-    my $noearlypublish = $bconf->{'publishflags:noearlypublish'} || $bconf->{'publishflags:noearlykiwipublish'};
-    if ($isfinished || (!$noearlypublish &&
-                        ($ctx->{'prptype'} eq 'kiwi' || $ctx->{'prptype'} eq 'productcompose'))) {
+    my $earlypublish = $ctx->{'prptype'} eq 'kiwi' || $ctx->{'prptype'} eq 'productcompose';
+    $earlypublish = 0 if $bconf->{'publishflags:noearlypublish'} || $bconf->{'publishflags:noearlykiwipublish'};
+    $earlypublish = 0 if $bconf->{'publishflags:archsync'};
+    if ($isfinished || $earlypublish) {
       my ($pubstate, $pubdetails) = $ctx->publish();
       if ($pubstate && $pubstate eq 'delayed') {
 	$details = $pubdetails if $isfinished && $pubdetails;


### PR DESCRIPTION
Early publishing breaks the archsync check done by the publisher.