### PR TITLE
fix #17015; patch for strange situation where @package is nil

### DIFF
--- a/src/api/app/controllers/webui/webui_controller.rb
+++ b/src/api/app/controllers/webui/webui_controller.rb
@@ -133,6 +133,7 @@ class Webui::WebuiController < ActionController::Base
 
     begin
       @package = Package.get_by_project_and_name(@project.name, @package_name, follow_multibuild: true)
+      raise APIError unless @package
     # why it's not found is of no concern
     rescue APIError
       raise Package::UnknownObjectError, "Package not found: #{@project.name}/#{@package_name}"


### PR DESCRIPTION
Hey folks,
this is just a one line hot fix for the issue #17015 .

For what i could replicate, i understood that in the specific situation of the issue, for some reason, this (https://github.com/openSUSE/open-build-service/blob/11c90d45673d684b2176900020242a8e5facde03/src/api/app/models/package.rb#L193) function returns `nil` (using row 205/ 218 (probably)/ 232.
In the meanwhile the webui_controller.rb only catches `APIError` exceptions, not the `@package == nil` situation so the meaning of this patch.