### PR TITLE
Wait for obssrcserver and obsrepserver to be running

### DIFF
--- a/dist/systemd/obspublisher.service
+++ b/dist/systemd/obspublisher.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=OBS repository publisher
-After=network-online.target
+After=network-online.target obssrcserver.service obsrepserver.service
 
 [Service]
 OOMPolicy=continue


### PR DESCRIPTION
Hey there,
I've noticed that the `obspublisher` service doesn't start automatically because its systemd call is not scheduled after `obssrcserver` and `obsrepserver`.
Solution: Add `obssrcserver.service` and `obsrepserver.service` To After section in `obspublisher.service`