### PR TITLE
Show notification toolbar for missed notification types

### DIFF
--- a/src/api/app/controllers/webui/appeals_controller.rb
+++ b/src/api/app/controllers/webui/appeals_controller.rb
@@ -2,12 +2,12 @@ class Webui::AppealsController < Webui::WebuiController
   include Webui::NotificationsHandler
 
   after_action :verify_authorized
-  before_action :handle_notification, only: :show
 
   def show
     @appeal = Appeal.find(params[:id])
 
     authorize @appeal
+    @current_notification = handle_notification
   end
 
   def new

--- a/src/api/app/controllers/webui/packages/build_log_controller.rb
+++ b/src/api/app/controllers/webui/packages/build_log_controller.rb
@@ -10,9 +10,9 @@ module Webui
       before_action :set_repository
       before_action :set_architecture
       before_action :set_object_to_authorize
-      before_action :handle_notification, only: :live_build_log
 
       def live_build_log
+        @current_notification = handle_notification
         @offset = 0
         @status = get_status(@project, @package_name, @repository, @architecture)
         @what_depends_on = Package.what_depends_on(@project, @package_name, @repository, @architecture)

--- a/src/api/app/controllers/webui/workflow_runs_controller.rb
+++ b/src/api/app/controllers/webui/workflow_runs_controller.rb
@@ -1,8 +1,6 @@
 class Webui::WorkflowRunsController < Webui::WebuiController
   include Webui::NotificationsHandler
 
-  before_action :handle_notification, only: :show
-
   def index
     # TODO: The pull/merge request dropdown should accept multiple selections
 
@@ -27,6 +25,7 @@ class Webui::WorkflowRunsController < Webui::WebuiController
     @workflow_run = WorkflowRun.find(params[:id])
     authorize @workflow_run, policy_class: WorkflowRunPolicy
 
+    @current_notification = handle_notification
     @token = @workflow_run.token
   end
 


### PR DESCRIPTION
The missed notification types are:
- Build Failures
- Workflow Runs
- Appealed Decisions

~Solves most of~ Fixes #17012.