### PR TITLE
Extend docs about package/_history

### DIFF
--- a/src/api/public/apidocs/components/parameters/package_meta.yaml
+++ b/src/api/public/apidocs/components/parameters/package_meta.yaml
@@ -1,0 +1,10 @@
+in: query
+name: meta
+schema:
+  type: string
+  enum:
+  - 1
+  - 0
+  default: 0
+description: If set to `1`, show information about history of the package meta file instead of info on the package sources.
+example: 1

--- a/src/api/public/apidocs/paths/build_project_name_repository_name_architecture_name_package_name_history.yaml
+++ b/src/api/public/apidocs/paths/build_project_name_repository_name_architecture_name_package_name_history.yaml
@@ -46,5 +46,8 @@ post:
     - $ref: '../components/parameters/repository_name.yaml'
     - $ref: '../components/parameters/architecture_name.yaml'
     - $ref: '../components/parameters/package_name.yaml'
+    - $ref: '../components/parameters/diff_rev.yaml'
+    - $ref: '../components/parameters/limit.yaml'
+    - $ref: '../components/parameters/package_meta.yaml'
   tags:
     - Build


### PR DESCRIPTION
I found these 3 undocumented parameters in `bs_srcserver:2442`

note: you can test these params with:
```bash
osc api '/source/openSUSE:Factory/bash/_history?limit=1&meta=1&rev=64'
```