### PR TITLE
Only start loading the build results after the request page loads

### DIFF
--- a/src/api/app/views/webui/request/beta_show.html.haml
+++ b/src/api/app/views/webui/request/beta_show.html.haml
@@ -107,8 +107,10 @@
 
               .chart_build_results_wrapper{ data: { url: request_chart_build_results_path } }
               :javascript
-                updateChartBuildResults();
-                setInterval(updateChartBuildResults, 60000);
+                $(document).ready(function(){
+                  updateChartBuildResults();
+                  setInterval(updateChartBuildResults, 60000);
+                });
 
               - if policy(@bs_request).handle_request? && @bs_request.can_be_reopened?
                 = render partial: 'accordion_reviews', locals: { accepted_reviews: @request_reviews.accepted,


### PR DESCRIPTION
Waiting until the page is loaded until we start loading the chart with build results, otherwise the browser will wait for the execution of this