### PR TITLE
Make sure seen_by_user only gets queried once for action details

### DIFF
--- a/src/api/app/components/action_seen_by_user_component.rb
+++ b/src/api/app/components/action_seen_by_user_component.rb
@@ -1,18 +1,15 @@
 class ActionSeenByUserComponent < ApplicationComponent
-  def initialize(action:, user:, render_only: false)
+  def initialize(action:, user:, seen_by_user: nil, render_only: false)
     super
 
     @action = action
     @user = user
     @render_only = render_only
-  end
-
-  def seen_by_user
-    @action.seen_by_users.exists?({ id: @user.id })
+    @seen_by_user = seen_by_user || @action.seen_by_users.exists?({ id: @user.id })
   end
 
   def render_icon_status
-    if seen_by_user
+    if @seen_by_user
       tag.i(nil, class: 'fa-regular fa-square-check')
     else
       tag.i(nil, class: 'fa-regular fa-square')

--- a/src/api/app/views/webui/request/_action_text.html.haml
+++ b/src/api/app/views/webui/request/_action_text.html.haml
@@ -2,7 +2,7 @@
 .d-flex.align-items-center
   - if (user = User.session)
     .ms-1.me-3{ id: "action-seen-by-user-wrapper-in-select-#{action.id}" }
-      = render ActionSeenByUserComponent.new(action: action, user: user, render_only: true)
+      = render ActionSeenByUserComponent.new(action: action, user: user, seen_by_user: seen_by_user, render_only: true)
 
   .d-block.w-100
     -# TODO: Load the revision details after the initial page load, otherwise this is very slow with many actions

--- a/src/api/app/views/webui/request/_actions_details.html.haml
+++ b/src/api/app/views/webui/request/_actions_details.html.haml
@@ -20,9 +20,11 @@
                 %span Seen
               %span Action
               %span.float-end Revision
+          - seen_by_user = BsRequestActionsSeenByUser.where(user: User.session, bs_request_action: actions).pluck(:bs_request_action_id)
           - actions.each_with_index do |action_item, action_index|
             %li.border-top
-              = link_to((render partial: 'action_text', locals: { action: action_item, action_index: action_index }),
+              = link_to((render partial: 'action_text', locals: { action: action_item, action_index: action_index,
+                                                                  seen_by_user: seen_by_user.include?(action_item.id) }),
                                                         next_prev_path(number: bs_request.number,
                                                                        request_action_id: action_item.id,
                                                                        diff_to_superseded: diff_to_superseded_id, page_name: page_name),

--- a/src/api/app/views/webui/request/_actions_details.html.haml
+++ b/src/api/app/views/webui/request/_actions_details.html.haml
@@ -20,11 +20,11 @@
                 %span Seen
               %span Action
               %span.float-end Revision
-          - seen_by_user = BsRequestActionsSeenByUser.where(user: User.session, bs_request_action: actions).pluck(:bs_request_action_id)
+          - actions_seen_by_user = BsRequestActionsSeenByUser.where(user: User.session, bs_request_action: actions).pluck(:bs_request_action_id)
           - actions.each_with_index do |action_item, action_index|
             %li.border-top
               = link_to((render partial: 'action_text', locals: { action: action_item, action_index: action_index,
-                                                                  seen_by_user: seen_by_user.include?(action_item.id) }),
+                                                                  seen_by_user: actions_seen_by_user.include?(action_item.id) }),
                                                         next_prev_path(number: bs_request.number,
                                                                        request_action_id: action_item.id,
                                                                        diff_to_superseded: diff_to_superseded_id, page_name: page_name),


### PR DESCRIPTION
Reduces the amount of queries to the database for `bs_request_action_seen_by_user` from `bs_request_actions.count` to 1