### PR TITLE
Don't pass not needed arguments to WatchlistIconComponent

### DIFF
--- a/src/api/app/views/webui/package/show.html.haml
+++ b/src/api/app/views/webui/package/show.html.haml
@@ -24,10 +24,7 @@
           = render WatchlistIconComponent.new(user: User.session,
                                               package: @package,
                                               project: @project,
-                                              current_object: @package,
-                                              bs_requests: @watched_requests,
-                                              packages: @watched_packages,
-                                              projects: @watched_projects)
+                                              current_object: @package)
     .row
       .col-md-8
         .mb-3

--- a/src/api/app/views/webui/project/show.html.haml
+++ b/src/api/app/views/webui/project/show.html.haml
@@ -18,10 +18,7 @@
         .d-inline.ms-1#watchlist-icon-wrapper
           = render WatchlistIconComponent.new(user: User.session,
                                               project: @project,
-                                              current_object: @project,
-                                              bs_requests: @watched_requests,
-                                              packages: @watched_packages,
-                                              projects: @watched_projects)
+                                              current_object: @project)
     .row
       .col-md-8
         = render partial: 'basic_info', locals: { project: @project }

--- a/src/api/app/views/webui/request/_request_header.html.haml
+++ b/src/api/app/views/webui/request/_request_header.html.haml
@@ -15,10 +15,7 @@
     .d-inline.align-bottom.ms-1#watchlist-icon-wrapper
       = render WatchlistIconComponent.new(user: User.session,
                                           bs_request: bs_request,
-                                          current_object: bs_request,
-                                          bs_requests: bs_requests,
-                                          packages: packages,
-                                          projects: projects)
+                                          current_object: bs_request)
 
 -# author + datetime + (if superseding -> "Superseds something")
 .card-text.px-4.pb-4

--- a/src/api/app/views/webui/request/_show_overview.html.haml
+++ b/src/api/app/views/webui/request/_show_overview.html.haml
@@ -6,10 +6,7 @@
     .d-inline.ms-2#watchlist-icon-wrapper
       = render WatchlistIconComponent.new(user: User.session,
                                           bs_request: bs_request,
-                                          current_object: bs_request,
-                                          bs_requests: bs_requests,
-                                          packages: packages,
-                                          projects: projects)
+                                          current_object: bs_request)
 
 #description-text
   - if bs_request.description.present?

--- a/src/api/app/views/webui/request/beta_show.html.haml
+++ b/src/api/app/views/webui/request/beta_show.html.haml
@@ -11,8 +11,7 @@
     = render partial: 'request_header',
         locals: { bs_request: @bs_request, staging_status: @staging_status, action: @action,
                   prev_action: @prev_action, next_action: @next_action, actions: @actions,
-                  diff_to_superseded_id: @diff_to_superseded_id, page_name: '',
-                  bs_requests: @watched_requests, packages: @watched_packages, projects: @watched_projects }
+                  diff_to_superseded_id: @diff_to_superseded_id, page_name: '' }
     = render partial: 'request_tabs',
         locals: { bs_request: @bs_request, action: @action, issues: @issues,
                   actions_count: @actions.count, active_tab: @active_tab }

--- a/src/api/app/views/webui/request/show.html.haml
+++ b/src/api/app/views/webui/request/show.html.haml
@@ -20,10 +20,7 @@
     .row
       .col-md-8#overview
         = render partial: 'show_overview', locals: { bs_request: @bs_request,
-                                                     can_add_reviews: @can_add_reviews,
-                                                     bs_requests: @watched_requests,
-                                                     packages: @watched_packages,
-                                                     projects: @watched_projects }
+                                                     can_add_reviews: @can_add_reviews }
       .col-md-4#side-links
         = render partial: 'show_side_links', locals: { bs_request: @bs_request, package_maintainers: @package_maintainers }
       = render partial: 'actions', locals: { bs_request: @bs_request, can_add_reviews: @can_add_reviews }

--- a/src/api/app/views/webui/watched_items/toggle_watched_item.js.erb
+++ b/src/api/app/views/webui/watched_items/toggle_watched_item.js.erb
@@ -1,6 +1,6 @@
 $("#delete-item-from-watchlist-modal").modal('hide');
 $('#flash').html("<%= escape_javascript(render(partial: 'layouts/webui/flash'))%>")
 $('.watchlist-collapse').html("<%= escape_javascript(render WatchlistComponent.new(user: User.session, bs_request: @bs_request, package: @package, project: @project, current_object: @current_object, bs_requests: @watched_requests, packages: @watched_packages, projects: @watched_projects)) %>");
-$('#watchlist-icon-wrapper').html("<%= escape_javascript(render WatchlistIconComponent.new(user: User.session, bs_request: @bs_request, package: @package, project: @project, current_object: @current_object, bs_requests: @watched_requests, packages: @watched_packages, projects: @watched_projects)) %>");
+$('#watchlist-icon-wrapper').html("<%= escape_javascript(render WatchlistIconComponent.new(user: User.session, bs_request: @bs_request, package: @package, project: @project, current_object: @current_object)) %>");
 
 collectDeleteConfirmationModalsAndSetValues();


### PR DESCRIPTION
`WatchlistIconComponent` inherits from `WatchlistComponent`. However, that doesn't mean we should pass all the parameters. In fact, `WatchlistIconComponent` never uses the following parameters: `projects`,
`packages` and `bs_requests`.