### PR TITLE
Link to beta view for project requests

### DIFF
--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -222,9 +222,8 @@ class Webui::ProjectController < Webui::WebuiController
                                              collapsed_repositories: params.fetch(:collapsedRepositories, {}) }
   end
 
+  # TODO: Remove this once request_index beta is rolled out
   def requests
-    redirect_to project_requests_beta_path(@project, involvement: 'incoming', state: %w[new review]) if Flipper.enabled?(:request_index, User.session)
-
     @default_request_type = params[:type] if params[:type]
     @default_request_state = params[:state] if params[:state]
   end

--- a/src/api/app/controllers/webui/projects/bs_requests_controller.rb
+++ b/src/api/app/controllers/webui/projects/bs_requests_controller.rb
@@ -4,12 +4,16 @@ module Webui
       before_action :set_project
 
       def index
-        parsed_params = BsRequest::DataTable::ParamsParserWithStateAndType.new(params).parsed_params
-        requests_query = BsRequest::DataTable::FindForProjectQuery.new(@project, parsed_params)
-        @requests_data_table = BsRequest::DataTable::Table.new(requests_query, params[:draw])
+        if Flipper.enabled?(:request_index, User.session)
+          redirect_to project_requests_beta_path(@project, action_type: params[:action_type], state: params[:state])
+        else
+          parsed_params = BsRequest::DataTable::ParamsParserWithStateAndType.new(params).parsed_params
+          requests_query = BsRequest::DataTable::FindForProjectQuery.new(@project, parsed_params)
+          @requests_data_table = BsRequest::DataTable::Table.new(requests_query, params[:draw])
 
-        respond_to do |format|
-          format.json { render 'webui/shared/bs_requests/index' }
+          respond_to do |format|
+            format.json { render 'webui/shared/bs_requests/index' }
+          end
         end
       end
     end

--- a/src/api/app/views/webui/project/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui/project/_breadcrumb_items.html.haml
@@ -17,6 +17,9 @@
   - elsif current_page?(project_monitor_path(@project))
     %li.breadcrumb-item.active{ 'aria-current' => 'page' }
       Monitor
+  - elsif current_page?(project_requests_beta_path(@project))
+    %li.breadcrumb-item.active{ 'aria-current' => 'page' }
+      Requests
   - elsif current_page?(project_requests_path(@project))
     %li.breadcrumb-item.active{ 'aria-current' => 'page' }
       Requests

--- a/src/api/app/views/webui/project/_tabs.html.haml
+++ b/src/api/app/views/webui/project/_tabs.html.haml
@@ -10,7 +10,10 @@
       - unless project.defines_remote_instance? || project.is_maintenance?
         = tab_link('Repositories', repositories_path(project), 'scrollable-tab-link')
         = tab_link('Monitor', project_monitor_path(project), 'scrollable-tab-link')
-      = tab_link('Requests', project_requests_path(project), 'scrollable-tab-link', active: controller_name == 'requests_listing')
+      - if Flipper.enabled?(:request_index, User.session)
+        = tab_link('Requests', projects_requests_path(project), 'scrollable-tab-link', active: controller_name == 'requests_listing')
+      - else
+        = tab_link('Requests', project_requests_path(project), 'scrollable-tab-link', active: controller_name == 'requests_listing')
       - unless project.defines_remote_instance?
         = tab_link('Users', project_users_path(project), 'scrollable-tab-link')
       - unless project.defines_remote_instance? || project.is_maintenance?

--- a/src/api/app/views/webui/project/side_links/_incident_project.html.haml
+++ b/src/api/app/views/webui/project/side_links/_incident_project.html.haml
@@ -8,6 +8,8 @@
     :ruby
       path = if open_release_requests.length == 1
                request_show_path(open_release_requests.first)
+             elsif Flipper.enabled?(:request_index, User.session)
+               projects_requests_path(project, action_type: ['maintenance_release'])
              else
                project_requests_path(project, type: 'maintenance_release')
              end

--- a/src/api/app/views/webui/project/side_links/_requests.html.haml
+++ b/src/api/app/views/webui/project/side_links/_requests.html.haml
@@ -4,6 +4,8 @@
              request_show_path(requests.first)
            elsif package
              package_requests_path(project, package)
+           elsif Flipper.enabled?(:request_index, User.session)
+             projects_requests_path(project)
            else
              project_requests_path(project)
            end

--- a/src/api/app/views/webui/projects/pulse/_pulse_list_requests_box.html.haml
+++ b/src/api/app/views/webui/projects/pulse/_pulse_list_requests_box.html.haml
@@ -27,5 +27,9 @@
               %br
               in #{state}
     - else
-      = link_to(project_requests_path(project)) do
-        No requests have been sent to this project.
+      - if Flipper.enabled?(:request_index, User.session)
+        = link_to(projects_requests_path(project)) do
+          No requests have been sent to this project.
+      - else
+        = link_to(project_requests_path(project)) do
+          No requests have been sent to this project.

--- a/src/api/app/views/webui/staging/workflows/_infos.html.haml
+++ b/src/api/app/views/webui/staging/workflows/_infos.html.haml
@@ -13,8 +13,12 @@
       %dt= link_to('Backlog:', group_path(staging_workflow.managers_group, anchor: 'reviews-in'))
       %dd= render 'requests_list', requests: unassigned_requests, more_requests: more_unassigned_requests
 
-      %dt= link_to('Ready:', project_requests_path(staging_workflow.project, state: :new))
-      %dd= render 'requests_list', requests: ready_requests, more_requests: more_ready_requests
+      - if Flipper.enabled?(:request_index, User.session)
+        %dt= link_to('Ready:', projects_requests_path(staging_workflow.project, state: ['new']))
+        %dd= render 'requests_list', requests: ready_requests, more_requests: more_ready_requests
+      - else
+        %dt= link_to('Ready:', project_requests_path(staging_workflow.project, state: :new))
+        %dd= render 'requests_list', requests: ready_requests, more_requests: more_ready_requests
 
       %dt= link_to('Excluded:', excluded_requests_path(staging_workflow.project))
       %dd= render 'requests_list', requests: excluded_requests, more_requests: more_excluded_requests, excluded: true


### PR DESCRIPTION
In order to refactor the request listing controller, and
to move the logic to the appropriate bs_request_controller
we first have to change the paths and redirect to the old
one inside the controller. This enables us to do the changes
in smaller chunks.