### PR TITLE
Move requests' json routes to the webui router file

### DIFF
--- a/src/api/config/routes/api.rb
+++ b/src/api/config/routes/api.rb
@@ -196,10 +196,6 @@ constraints(RoutesHelper::APIMatcher) do
   end
 
   resources :image_templates, constraints: cons, only: [:index], controller: 'webui/image_templates'
-
-  ### /projects
-  get 'projects/:project/requests' => 'webui/projects/bs_requests#index', constraints: cons, as: 'projects_requests'
-  get 'projects/:project/packages/:package/requests' => 'webui/packages/bs_requests#index', constraints: cons, as: 'packages_requests'
 end
 
 # StagingWorkflow API

--- a/src/api/config/routes/webui.rb
+++ b/src/api/config/routes/webui.rb
@@ -365,6 +365,9 @@ constraints(RoutesHelper::WebuiMatcher) do
     end
   end
 
+  get 'projects/:project/requests' => 'webui/projects/bs_requests#index', constraints: cons, as: 'projects_requests'
+  get 'projects/:project/packages/:package/requests' => 'webui/packages/bs_requests#index', constraints: cons, as: 'packages_requests'
+
   controller 'webui/search' do
     get 'search' => :index
     get 'search/owner' => :owner


### PR DESCRIPTION
Those routes are used in the our web ui, even if they serve json they are not specific to the API.