### PR TITLE
Remove _open_requests partial

### DIFF
--- a/src/api/app/views/webui/shared/_open_requests.html.haml
+++ b/src/api/app/views/webui/shared/_open_requests.html.haml
@@ -1,6 +1,0 @@
-- if requests.present?
-  - path = package ? package_requests_path(project, package) : project_requests_path(project)
-  - path = request_show_path(requests[0]) if requests.size == 1
-  %li
-    %i.fas.fa-info-circle.text-info
-    = link_to(pluralize(requests.size, 'open request'), path)


### PR DESCRIPTION
While adapting a link inside, I realized that this partial is nowhere used.