### PR TITLE
Refactor package requests under packages/bs_request controller

### DIFF
--- a/src/api/app/controllers/webui/packages/bs_requests_controller.rb
+++ b/src/api/app/controllers/webui/packages/bs_requests_controller.rb
@@ -3,10 +3,22 @@ module Webui
     class BsRequestsController < Webui::WebuiController
       before_action :set_project
       before_action :require_package
+      include Webui::RequestsFilter
 
       def index
         if Flipper.enabled?(:request_index, User.session)
-          redirect_to project_package_requests_beta_path(@project, @package, action_type: params[:action_type], state: params[:state])
+          set_filter_involvement
+          set_filter_state
+          set_filter_action_type
+          set_filter_creators
+
+          filter_requests
+          set_selected_filter
+
+          @url = packages_requests_path(@project, @package)
+          @bs_requests = @bs_requests.order('number DESC').page(params[:page])
+          @bs_requests = @bs_requests.includes(:bs_request_actions, :comments, :reviews)
+          @bs_requests = @bs_requests.includes(:labels) if Flipper.enabled?(:labels, User.session)
         else
           parsed_params = BsRequest::DataTable::ParamsParserWithStateAndType.new(params).parsed_params
           requests_query = BsRequest::DataTable::FindForPackageQuery.new(@project, @package, parsed_params)
@@ -15,6 +27,41 @@ module Webui
           respond_to do |format|
             format.json { render 'webui/shared/bs_requests/index' }
           end
+        end
+      end
+
+      private
+
+      def filter_requests
+        if params[:requests_search_text].present?
+          initial_bs_requests = filter_by_text(params[:requests_search_text])
+          params[:ids] = filter_by_involvement(@filter_involvement).ids
+        else
+          initial_bs_requests = filter_by_involvement(@filter_involvement)
+        end
+
+        params[:creator] = @filter_creators if @filter_creators.present?
+        params[:states] = @filter_state if @filter_state.present?
+        params[:types] = @filter_action_type if @filter_action_type.present?
+
+        @bs_requests = BsRequest::FindFor::Query.new(params, initial_bs_requests).all
+      end
+
+      def set_selected_filter
+        @selected_filter = { involvement: @filter_involvement, action_type: @filter_action_type, search_text: params[:requests_search_text],
+                             state: @filter_state, creators: @filter_creators }
+      end
+
+      def filter_by_involvement(filter_by_involvement)
+        target = BsRequest.with_actions.where(bs_request_actions: { target_project: @project.name, target_package: @package.name })
+        source = BsRequest.with_actions.where(bs_request_actions: { source_project: @project.name, source_package: @package.name })
+        case filter_by_involvement
+        when 'all'
+          target.or(source)
+        when 'incoming'
+          target
+        when 'outgoing'
+          source
         end
       end
     end

--- a/src/api/app/views/webui/packages/bs_requests/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui/packages/bs_requests/_breadcrumb_items.html.haml
@@ -1,6 +1,9 @@
 - if Flipper.enabled?(:request_index, User.session)
   %li.breadcrumb-item.text-word-break-all
     %i.fa.fa-archive
+    = link_to @project, project_show_path(@project)
+  %li.breadcrumb-item.text-word-break-all
+    %i.fa.fa-archive
     = link_to @package, package_show_path(@project, @package)
   %li.breadcrumb-item.active{ 'aria-current' => 'page' }
     Requests

--- a/src/api/app/views/webui/packages/bs_requests/index.html.haml
+++ b/src/api/app/views/webui/packages/bs_requests/index.html.haml
@@ -1,0 +1,9 @@
+- @pagetitle = requests_listing_pagetitle(@package)
+
+.row
+  .px-0.px-md-3.mb-3
+    .card
+      = render(partial: 'webui/package/tabs', locals: { project: @project, package: @package })
+
+= render(partial: 'webui/shared/bs_requests/form',
+         locals: { selected_filter: @selected_filter, bs_requests_creators: @bs_requests_creators, url: @url, bs_requests: @bs_requests })


### PR DESCRIPTION
Depends on #17145.

This PR is moving all the logic related to package/requests from `requests_listing_controller` to `packages/bs_requests` controller.