### PR TITLE
Use the right project for filtering the requests

### DIFF
--- a/src/api/app/controllers/webui/packages/bs_requests_controller.rb
+++ b/src/api/app/controllers/webui/packages/bs_requests_controller.rb
@@ -27,8 +27,8 @@ module Webui
       private
 
       def filter_by_involvement(filter_by_involvement)
-        target = BsRequest.with_actions.where(bs_request_actions: { target_project: @project.name, target_package: @package.name })
-        source = BsRequest.with_actions.where(bs_request_actions: { source_project: @project.name, source_package: @package.name })
+        target = BsRequest::FindFor::Project.new({ project: @project.name, package: @package.name, source_or_target: 'target' }).all
+        source = BsRequest::FindFor::Project.new({ project: @project.name, package: @package.name, source_or_target: 'source' }).all
         case filter_by_involvement
         when 'all'
           target.or(source)

--- a/src/api/app/controllers/webui/projects/bs_requests_controller.rb
+++ b/src/api/app/controllers/webui/projects/bs_requests_controller.rb
@@ -26,8 +26,8 @@ module Webui
       private
 
       def filter_by_involvement(filter_by_involvement)
-        target = BsRequest.with_actions.where(bs_request_actions: { target_project: @project.name })
-        source = BsRequest.with_actions.where(bs_request_actions: { source_project: @project.name })
+        target = BsRequest::FindFor::Project.new({ project: @project.name, source_or_target: 'target' }).all
+        source = BsRequest::FindFor::Project.new({ project: @project.name, source_or_target: 'source' }).all
         case filter_by_involvement
         when 'all'
           target.or(source)

--- a/src/api/app/models/bs_request/find_for/base.rb
+++ b/src/api/app/models/bs_request/find_for/base.rb
@@ -64,6 +64,10 @@ class BsRequest
       def creator
         @parameters[:creator]
       end
+
+      def source_or_target
+        @parameters[:source_or_target]
+      end
     end
   end
 end

--- a/src/api/app/models/bs_request/find_for/project.rb
+++ b/src/api/app/models/bs_request/find_for/project.rb
@@ -7,8 +7,12 @@ class BsRequest
         @where_conditions = []
         @where_values = []
 
-        bs_request_actions_conditions('source')
-        bs_request_actions_conditions('target')
+        if source_or_target.present?
+          bs_request_actions_conditions(source_or_target)
+        else
+          bs_request_actions_conditions('source')
+          bs_request_actions_conditions('target')
+        end
 
         reviews_conditions
 
@@ -18,18 +22,18 @@ class BsRequest
 
       private
 
-      def bs_request_actions_conditions(source_or_target)
-        return unless roles.empty? || roles.include?(source_or_target)
+      def bs_request_actions_conditions(type)
+        return unless roles.empty? || roles.include?(type)
 
         bs_request_actions_filters = []
         if project_name.present?
           bs_request_actions_filters << if subprojects.blank?
-                                          ["bs_request_actions.#{source_or_target}_project = ?", project_name]
+                                          ["bs_request_actions.#{type}_project = ?", project_name]
                                         else
-                                          ["bs_request_actions.#{source_or_target}_project like ?", "#{project_name}:%"]
+                                          ["bs_request_actions.#{type}_project like ?", "#{project_name}:%"]
                                         end
         end
-        bs_request_actions_filters << ["bs_request_actions.#{source_or_target}_package = ?", package_name] if package_name.present?
+        bs_request_actions_filters << ["bs_request_actions.#{type}_package = ?", package_name] if package_name.present?
 
         @where_conditions << bs_request_actions_filters.pluck(0).join(' and ')
         @where_values << bs_request_actions_filters.pluck(1)


### PR DESCRIPTION
When we're looking for requests for a staging project, the project we get as filter is the staged one, instead of the main project.

This fix checks if we're using staging projects, if so, use the main project as filter.

Fixes #17096