### PR TITLE
Reload page when maintainer permissions are removed

### DIFF
--- a/src/api/app/assets/javascripts/webui/users_groups.js
+++ b/src/api/app/assets/javascripts/webui/users_groups.js
@@ -41,6 +41,11 @@ function changeUserRole(obj) { // jshint ignore:line
     },
     complete: function() {
       spinner.addClass('d-none');
+    },
+    success: function() {
+      if (!obj.is(':checked') && obj.data('role') === 'maintainer') {
+        window.location.reload();
+      }
     }
   });
 }


### PR DESCRIPTION
Prevent users who may have revoked their own maintainer permissions from continuing to access a page with links they should no longer use. The page will now reload to reflect the updated permission status, ensuring proper access control.

### For reviewers

In your development environment, or in the review-app:
- As user `User1`:
  - Create a package `package1`
  - Give Maintainer and Bugowner roles to `User2` to `package1`
- As user `User2`:
  - Remove Maintainer role for user `User2` in users of the package `package1`
  
After following the steps mentioned above:
- before: `User2` could click on more checkboxes or access more links. This should not be allowed.
- after: the page is reload and `User2` is not able to click on unpermitted links.

This not only happens for packages but also for projects.

Fixes #16433.

When a user is in this scenario:

![Screenshot From 2024-12-05 20-29-54](https://github.com/user-attachments/assets/c6718bec-9a02-422a-945e-f235eaaa4b3e)

After clicking on the "Maintainer" checkbox...

**Before**

![Screenshot From 2024-12-05 20-30-49](https://github.com/user-attachments/assets/d94b7297-d0eb-440e-913c-e7f46ed12394)

**After**

![Screenshot From 2024-12-05 20-30-04](https://github.com/user-attachments/assets/943de1e5-2cb8-46e2-8280-175f4d740eb3)

