### PR TITLE
Switch user requests path to my requests

### DIFF
--- a/src/api/app/views/layouts/webui/_places.html.haml
+++ b/src/api/app/views/layouts/webui/_places.html.haml
@@ -10,7 +10,7 @@
           Profile
     - if Flipper.enabled?(:request_index, User.session)
       %li.nav-item
-        = link_to(user_requests_path(User.session, involvement: 'incoming', state: %w[new review]), class: 'nav-link', title: 'Requests') do
+        = link_to(my_requests_path(involvement: 'incoming', state: %w[new review]), class: 'nav-link', title: 'Requests') do
           %i.fas.fa-code-pull-request.fa-lg.me-2
           %span.nav-item-name Requests
     - else

--- a/src/api/app/views/webui/users/tasks/index.html.haml
+++ b/src/api/app/views/webui/users/tasks/index.html.haml
@@ -11,7 +11,7 @@
 
   .card-body
     .tab-content#reviews-in
-      = render(partial: 'webui/shared/requests_table', locals: { id: 'reviews_in_table', source_url: user_requests_path(User.session),
+      = render(partial: 'webui/shared/requests_table', locals: { id: 'reviews_in_table', source_url: my_requests_path,
                page_length: 10 })
 
 .card.mt-3#requests
@@ -47,16 +47,16 @@
   .card-body
     .tab-content
       .tab-pane.fade#requests-in{ role: 'tabpanel', 'aria-labelledby': 'requests-in-tab' }
-        = render(partial: 'webui/shared/requests_table', locals: { id: 'requests_in_table', source_url: user_requests_path(User.session),
+        = render(partial: 'webui/shared/requests_table', locals: { id: 'requests_in_table', source_url: my_requests_path,
                  page_length: 10 })
       .tab-pane.fade#requests-out{ role: 'tabpanel', 'aria-labelledby': 'requests-out-tab' }
-        = render(partial: 'webui/shared/requests_table', locals: { id: 'requests_out_table', source_url: user_requests_path(User.session),
+        = render(partial: 'webui/shared/requests_table', locals: { id: 'requests_out_table', source_url: my_requests_path,
                  page_length: 10 })
       .tab-pane.fade#requests-declined{ role: 'tabpanel', 'aria-labelledby': 'requests-declined-tab' }
-        = render(partial: 'webui/shared/requests_table', locals: { id: 'requests_declined_table', source_url: user_requests_path(User.session),
+        = render(partial: 'webui/shared/requests_table', locals: { id: 'requests_declined_table', source_url: my_requests_path,
                  page_length: 10 })
       .tab-pane.fade#all-requests{ role: 'tabpanel', 'aria-labelledby': 'all-requests-tab' }
-        = render(partial: 'webui/shared/requests_table', locals: { id: 'all_requests_table', source_url: user_requests_path(User.session),
+        = render(partial: 'webui/shared/requests_table', locals: { id: 'all_requests_table', source_url: my_requests_path,
                  page_length: 10 })
 
 - number_of_involved_patchinfos = User.session.involved_patchinfos.size

--- a/src/api/config/routes/webui.rb
+++ b/src/api/config/routes/webui.rb
@@ -375,7 +375,6 @@ constraints(RoutesHelper::WebuiMatcher) do
   end
 
   resources :users, controller: 'webui/users', param: :login, constraints: cons do
-    resources :requests, only: [:index], controller: 'webui/users/bs_requests'
     collection do
       get 'autocomplete'
       get 'tokens'
@@ -391,6 +390,7 @@ constraints(RoutesHelper::WebuiMatcher) do
 
   scope :my do
     resources :tasks, only: [:index], controller: 'webui/users/tasks', as: :my_tasks
+    resources :requests, only: [:index], controller: 'webui/users/bs_requests', as: :my_requests
 
     resources :notifications, only: [:index], controller: 'webui/users/notifications', as: :my_notifications do
       collection do

--- a/src/api/spec/features/beta/webui/requests_index_spec.rb
+++ b/src/api/spec/features/beta/webui/requests_index_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'Requests Index' do
   before do
     Flipper.enable(:request_index)
     login receiver
-    visit user_requests_path(receiver)
+    visit my_requests_path
   end
 
   it 'lists all requests by default' do

--- a/src/api/spec/routing/webui/users/requests_spec.rb
+++ b/src/api/spec/routing/webui/users/requests_spec.rb
@@ -1,8 +1,6 @@
-RSpec.describe '/users/:user/requests routes' do
-  let(:user) { Faker::Name.first_name }
-
+RSpec.describe '/my/requests routes' do
   it do
-    expect(get("/users/#{user}/requests"))
-      .to route_to('webui/users/bs_requests#index', user_login: user)
+    expect(get('/my/requests'))
+      .to route_to('webui/users/bs_requests#index')
   end
 end


### PR DESCRIPTION
Moving this since you can currently access a page like https://build.opensuse.org/users/dimstar/requests, which still displays your own requests, which makes no sense