### PR TITLE
Don't error when checking user roles on a project

### DIFF
--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -352,9 +352,10 @@ class Webui::RequestController < Webui::WebuiController
   end
 
   def any_project_maintained_by_current_user?
-    projects = @actions.select(:target_project).distinct.pluck(:target_project)
-    maintainer_role = Role.find_by_title('maintainer')
-    projects.any? { |project| Project.find_by_name(project).user_has_role?(User.possibly_nobody, maintainer_role) }
+    projects = Project.where(name: @actions.select(:target_project)).distinct
+    user = User.possibly_nobody
+
+    Relationship.maintainers.where(project: projects, user: user).or(Relationship.where(group: [user.groups.unscope(:order)])).any?
   end
 
   def new_state


### PR DESCRIPTION
Substitute the call to the overwritten `Project.find_by_name` finder method with plain ActiveRecord finder methods.

Fix #17176.