### PR TITLE
Show multibuild flavor in Repository State pages

### DIFF
--- a/src/api/app/assets/stylesheets/webui/breadcrumbs-component.scss
+++ b/src/api/app/assets/stylesheets/webui/breadcrumbs-component.scss
@@ -4,7 +4,7 @@ ol.breadcrumb {
   & li {
     font-size: 0.9rem;
 
-    &.active {
+    .active, &.active {
       color: var(--breadcrumbs-item-text-color);
       font-weight: bold;
     }

--- a/src/api/app/controllers/webui/packages/binaries_controller.rb
+++ b/src/api/app/controllers/webui/packages/binaries_controller.rb
@@ -12,6 +12,7 @@ module Webui
 
       before_action :set_project
       before_action :set_package
+      before_action :set_multibuild_flavor
       before_action :set_repository
       before_action :set_architecture, only: %i[show dependency filelist]
       before_action :set_dependant_project, only: :dependency
@@ -115,6 +116,10 @@ module Webui
       def set_filename
         # Ensure it really is just a file name, no '/..', etc.
         @filename = File.basename(params[:binary_filename] || params[:filename])
+      end
+
+      def set_multibuild_flavor
+        @multibuild_flavor = @package_name.gsub(/.*:/, '') if @package_name.present? && @package_name.include?(':')
       end
 
       # Get an URL to a binary produced by the build.

--- a/src/api/app/views/webui/package/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui/package/_breadcrumb_items.html.haml
@@ -7,7 +7,11 @@
 - else
   %li.breadcrumb-item.text-word-break-all
     %i.fa.fa-archive
-    = link_to(@package, package_show_path(@project, @package))
+    = precede link_to(@package, package_show_path(@project, @package)) do
+      - if @multibuild_flavor.present?
+        %span.active :#{@multibuild_flavor}
+      - else
+        = nil
   - if current_page?(package_view_revisions_path(@project, @package))
     %li.breadcrumb-item.active{ 'aria-current' => 'page' }
       Revisions


### PR DESCRIPTION
Add the multibuild flavor to the breadcrumbs as text.

Fixes partially #16234.

### Before

![Screenshot From 2024-12-17 18-22-22](https://github.com/user-attachments/assets/202851c5-40c3-4e51-bafb-6085470598cf)

### After

![Screenshot From 2024-12-17 18-20-07](https://github.com/user-attachments/assets/75803d88-d210-41ac-bc4c-bb8f1292ebe7)
