### PR TITLE
Change the link of a package with a multibuild flavor

### DIFF
--- a/src/api/app/assets/javascripts/webui/project_monitor.js
+++ b/src/api/app/assets/javascripts/webui/project_monitor.js
@@ -60,7 +60,8 @@ function initializeMonitorDataTable() {
         data: null,
         render: function (packageName) {
           if (scmsync !== undefined) return packageName;
-          var url = '/package/show/' + projectName + '/' + packageName;
+          var packageNameWithoutMultibuildFlavor = packageName.replace(/:\w+$/, '');
+          var url = '/package/show/' + projectName + '/' + packageNameWithoutMultibuildFlavor;
           return '<a href="' + url + '">' + packageName + '</a>';
         }
       },


### PR DESCRIPTION
Instead of linking to a package show page with the form `package_name:multibuild_flavor`, link to `package_name`, without multibuild flavor. Package's show pages for multibuild flavors don't exist as such.

Fix #16234.