### PR TITLE
[backend]: support multi-stage signing for mkosi

### DIFF
--- a/src/backend/BSXML.pm
+++ b/src/backend/BSXML.pm
@@ -644,7 +644,8 @@ our $buildinfo = [
      ]],
 	'containerannotation',	# temporary hack
 	'expanddebug',
-	'followupfile',	# for two-stage builds
+	'followupfile',	# for multi-stage builds
+	'signingstage',	# for multi-stage builds, to avoid loops
 	'masterdispatched',	# dispatched through a master dispatcher
 	'nounchanged',	# do not check for "unchanged" builds
       [ 'module' ],	# list of modules to use

--- a/src/backend/bs_signer
+++ b/src/backend/bs_signer
@@ -879,8 +879,8 @@ sub signjob {
     unlink("$jobdir/.checksums");
 
     my $followupfile;
-    # check for followup files
-    if (!$info->{'followupfile'} && ($info->{'file'} || '') ne '_aggregate') {
+    # check for followup files, but don't allow more than 10 stages to avoid loops
+    if ((!$info->{'signingstage'} || $info->{'signingstage'} < 10) && ($info->{'file'} || '') ne '_aggregate') {
       if (grep {/\.rsasign$/} @signfiles) {
         $followupfile = (grep {/\.(spec|dsc)$/} @files)[0];
         @signfiles = grep {/\.rsasign$/} @signfiles if $followupfile;
@@ -1074,6 +1074,12 @@ sub signjob {
       # we need to create a followup job to integrate the signatures
       $info->{'followupfile'} = $followupfile;
       $info->{'readytime'} = time();
+      # to avoid loops keep track of how many stages we have done for this job
+      if (!$info->{'signingstage'}) {
+        $info->{'signingstage'} = 0;
+      } else {
+        $info->{'signingstage'}++;
+      }
       writexml("$jobsdir/$arch/.$job", "$jobsdir/$arch/$job", $info, $BSXML::buildinfo);
       updateredisjobstatus($arch, $job, $info);
       unlink("$jobsdir/$arch/$job:status");


### PR DESCRIPTION
When building UKIs (unified kernel images) with mkosi we need to do multi-stage signing. First the image is built from packages, with the kernel/initrd/etc being put together. The TPM2 policy digests are calculated, and need to be signed.
After the digests signatures are retrived after the first signing stage, they are inserted in the UKI, which itself needs to be signed for secure boot, hence the second consecutive signing stage.

In order to avoid infinite loops, keep a count of consecutive signing stages in the info file, and stop after 10 no matter what.

Tested on an OBS VM. Example project: https://build.opensuse.org/package/live_build_log/home:bluca:branches:home:bluca:systemd/debian-image/Debian_Testing_images/x86_64

In that build we end with:

```
[   41s] OTHER/debian-testing-x86-64_45.5.manifest.gz
[   41s] OTHER/debian-testing-x86-64_45.5.SHA256SUMS
[   41s] OTHER/debian-testing-x86-64_45.5.manifest.gz.sha256
[   41s] OTHER/mkosi.conf.sha256
[   41s] OTHER/debian-testing-x86-64_45.5.efi
[   41s] OTHER/_statistics
[   41s] OTHER/hashes.cpio.rsasign
[   41s] OTHER/debian-testing-x86-64_45.5.efi.sha256
[   41s] OTHER/hashes.cpio.rsasign.sha256
[   41s] OTHER/mkosi.conf
[   41s] OTHER/debian-testing-x86-64_45.5.SHA256SUMS.sha256
```

IE there's another hashes.cpio.rsasign for the next round, but the build terminates. This changes makes it so that another signing round is done, and we can complete the UKI.