### PR TITLE
Unify request description of list page and detail page

### DIFF
--- a/src/api/app/components/bs_request_action_description_component.rb
+++ b/src/api/app/components/bs_request_action_description_component.rb
@@ -1,35 +1,51 @@
 # This component renders the request action description based on the type of the action
 
 class BsRequestActionDescriptionComponent < ApplicationComponent
-  attr_reader :action
+  attr_reader :action, :text_only
 
   delegate :project_or_package_link, to: :helpers
   delegate :user_with_realname_and_icon, to: :helpers
   delegate :requester_str, to: :helpers
   delegate :creator_intentions, to: :helpers
 
-  def initialize(action:)
+  def initialize(action:, text_only: false)
     super
     @action = action
+    @text_only = text_only
   end
 
   # rubocop:disable Metrics/CyclomaticComplexity
+  # rubocop:disable Metrics/PerceivedComplexity
   # rubocop:disable Rails/OutputSafety
   # rubocop:disable Style/FormatString
   def description
     creator = action.bs_request.creator
+
     source_project_hash = { project: action.source_project, package: action.source_package, trim_to: nil }
     target_project_hash = { project: action.target_project, package: action.target_package, trim_to: nil }
 
-    source_container = project_or_package_link(source_project_hash)
-    target_container = project_or_package_link(target_project_hash)
+    source_and_target_component = BsRequestActionSourceAndTargetComponent.new(action.bs_request)
+
+    source_text = source_and_target_component.source
+    target_text = source_and_target_component.target
+    source_and_target_text = source_and_target_component.call
+
+    source_container = text_only ? source_text : project_or_package_link(source_project_hash)
+    target_container = text_only ? target_text : project_or_package_link(target_project_hash)
+    source_and_target_container = if text_only
+                                    source_and_target_text
+                                  else
+                                    tag.span(source_container)
+                                       .concat(tag.i(nil, class: 'fas fa-long-arrow-alt-right text-info mx-2'))
+                                       .concat(tag.span(target_container))
+                                  end
 
     description = case action.type
                   when 'submit'
-                    'Submit %{source_container} to %{target_container}' %
-                    { source_container: source_container, target_container: target_container }
+                    'Submit %{source_and_target_container}' % { source_and_target_container: source_and_target_container }
                   when 'delete'
-                    target_repository = "repository #{link_to(action.target_repository, repositories_path(target_project_hash))} for " if action.target_repository
+                    repository_content = text_only ? action.target_repository : link_to(action.target_repository, repositories_path(target_project_hash))
+                    target_repository = "repository #{repository_content} for " if action.target_repository
 
                     'Delete %{target_repository}%{target_container}' %
                     { target_repository: target_repository, target_container: target_container }
@@ -44,14 +60,14 @@ class BsRequestActionDescriptionComponent < ApplicationComponent
                     'Set %{source_container} to be devel project/package of %{target_container}' %
                     { source_container: source_container, target_container: target_container }
                   when 'maintenance_incident'
-                    'Submit update from %{source_container} to %{target_container}' %
-                    { source_container: source_container, target_container: target_container }
+                    'Submit update from %{source_and_target_container}' %
+                    { source_and_target_container: source_and_target_container }
                   when 'maintenance_release'
-                    'Maintenance release %{source_container} to %{target_container}' %
-                    { source_container: source_container, target_container: target_container }
+                    'Maintenance release %{source_and_target_container}' %
+                    { source_and_target_container: source_and_target_container }
                   when 'release'
-                    'Release %{source_container} to %{target_container}' %
-                    { source_container: source_container, target_container: target_container }
+                    'Release %{source_and_target_container}' %
+                    { source_and_target_container: source_and_target_container }
                   end
 
     # HACK: this is just a porting of the already existing way of passing the string to the view
@@ -59,6 +75,7 @@ class BsRequestActionDescriptionComponent < ApplicationComponent
     description.html_safe
   end
   # rubocop:enable Metrics/CyclomaticComplexity
+  # rubocop:enable Metrics/PerceivedComplexity
   # rubocop:enable Rails/OutputSafety
   # rubocop:enable Style/FormatString
 end

--- a/src/api/app/components/bs_request_action_description_component.rb
+++ b/src/api/app/components/bs_request_action_description_component.rb
@@ -15,7 +15,6 @@ class BsRequestActionDescriptionComponent < ApplicationComponent
   end
 
   # rubocop:disable Metrics/CyclomaticComplexity
-  # rubocop:disable Metrics/PerceivedComplexity
   # rubocop:disable Rails/OutputSafety
   # rubocop:disable Style/FormatString
   def description
@@ -24,21 +23,19 @@ class BsRequestActionDescriptionComponent < ApplicationComponent
     source_project_hash = { project: action.source_project, package: action.source_package, trim_to: nil }
     target_project_hash = { project: action.target_project, package: action.target_package, trim_to: nil }
 
-    source_and_target_component = BsRequestActionSourceAndTargetComponent.new(action.bs_request)
+    if text_only
+      source_and_target_component = BsRequestActionSourceAndTargetComponent.new(action.bs_request)
 
-    source_text = source_and_target_component.source
-    target_text = source_and_target_component.target
-    source_and_target_text = source_and_target_component.call
-
-    source_container = text_only ? source_text : project_or_package_link(source_project_hash)
-    target_container = text_only ? target_text : project_or_package_link(target_project_hash)
-    source_and_target_container = if text_only
-                                    source_and_target_text
-                                  else
-                                    tag.span(source_container)
+      source_container = source_and_target_component.source
+      target_container = source_and_target_component.target
+      source_and_target_container = source_and_target_component.call
+    else
+      source_container = project_or_package_link(source_project_hash)
+      target_container = project_or_package_link(target_project_hash)
+      source_and_target_container = tag.span(source_container)
                                        .concat(tag.i(nil, class: 'fas fa-long-arrow-alt-right text-info mx-2'))
                                        .concat(tag.span(target_container))
-                                  end
+    end
 
     description = case action.type
                   when 'submit'
@@ -75,7 +72,6 @@ class BsRequestActionDescriptionComponent < ApplicationComponent
     description.html_safe
   end
   # rubocop:enable Metrics/CyclomaticComplexity
-  # rubocop:enable Metrics/PerceivedComplexity
   # rubocop:enable Rails/OutputSafety
   # rubocop:enable Style/FormatString
 end

--- a/src/api/app/components/bs_request_action_description_component.rb
+++ b/src/api/app/components/bs_request_action_description_component.rb
@@ -23,19 +23,17 @@ class BsRequestActionDescriptionComponent < ApplicationComponent
     source_project_hash = { project: action.source_project, package: action.source_package, trim_to: nil }
     target_project_hash = { project: action.target_project, package: action.target_package, trim_to: nil }
 
-    if text_only
-      source_and_target_component = BsRequestActionSourceAndTargetComponent.new(action.bs_request)
+    source_and_target_component = BsRequestActionSourceAndTargetComponent.new(action.bs_request)
 
+    if text_only
       source_container = source_and_target_component.source
       target_container = source_and_target_component.target
-      source_and_target_container = source_and_target_component.call
     else
       source_container = project_or_package_link(source_project_hash)
       target_container = project_or_package_link(target_project_hash)
-      source_and_target_container = tag.span(source_container)
-                                       .concat(tag.i(nil, class: 'fas fa-long-arrow-alt-right text-info mx-2'))
-                                       .concat(tag.span(target_container))
     end
+
+    source_and_target_container = source_and_target_component.combine(source_container, target_container)
 
     description = case action.type
                   when 'submit'

--- a/src/api/app/components/bs_request_action_source_and_target_component.rb
+++ b/src/api/app/components/bs_request_action_source_and_target_component.rb
@@ -18,8 +18,6 @@ class BsRequestActionSourceAndTargetComponent < ApplicationComponent
     end
   end
 
-  private
-
   def source
     @source ||= if number_of_bs_request_actions > 1
                   ''

--- a/src/api/app/components/bs_request_action_source_and_target_component.rb
+++ b/src/api/app/components/bs_request_action_source_and_target_component.rb
@@ -9,13 +9,7 @@ class BsRequestActionSourceAndTargetComponent < ApplicationComponent
   end
 
   def call
-    capture do
-      if source.present?
-        concat(tag.span(source))
-        concat(tag.i(nil, class: 'fas fa-long-arrow-alt-right text-info mx-2'))
-      end
-      concat(tag.span(target))
-    end
+    combine(source, target)
   end
 
   def source
@@ -30,5 +24,15 @@ class BsRequestActionSourceAndTargetComponent < ApplicationComponent
     return bs_request_action.target_project if number_of_bs_request_actions > 1
 
     [bs_request_action.target_project, bs_request_action.target_package].compact.join(' / ')
+  end
+
+  def combine(source, target)
+    capture do
+      if source.present?
+        concat(tag.span(source))
+        concat(tag.i(nil, class: 'fas fa-long-arrow-alt-right text-info mx-2'))
+      end
+      concat(tag.span(target))
+    end
   end
 end

--- a/src/api/app/views/webui/shared/bs_requests/_request_item.html.haml
+++ b/src/api/app/views/webui/shared/bs_requests/_request_item.html.haml
@@ -20,9 +20,13 @@
         .mb-1
           = render partial: 'webui/shared/label', collection: bs_request.labels, as: :label
       .mb-1
-        = render BsRequestActionSourceAndTargetComponent.new(bs_request)
-      .mb-2.request-index-description.text-truncate
-        = bs_request.description
+        - if bs_request_actions_count != 1
+          = render BsRequestActionSourceAndTargetComponent.new(bs_request)
+        - else
+          .mb-2.request-index-description.text-truncate
+            = render BsRequestActionDescriptionComponent.new(action: bs_request.bs_request_actions.first, text_only: true)
+        .mb-2.request-index-description.text-truncate
+          = bs_request.description
       .text-end
         %span
           = render AvatarComponent.new(name: bs_request.creator, email: User.find_by_login(bs_request.creator).email, custom_css: 'align-text-bottom')

--- a/src/api/spec/components/previews/bs_request_action_description_component_preview.rb
+++ b/src/api/spec/components/previews/bs_request_action_description_component_preview.rb
@@ -5,8 +5,33 @@ class BsRequestActionDescriptionComponentPreview < ViewComponent::Preview
     render(BsRequestActionDescriptionComponent.new(action: action))
   end
 
+  def submit_preview_text_only
+    action = BsRequestAction.where(type: :submit).last
+    render(BsRequestActionDescriptionComponent.new(action: action, text_only: true))
+  end
+
+  def delete_preview
+    action = BsRequestAction.where(type: :delete).last
+    render(BsRequestActionDescriptionComponent.new(action: action))
+  end
+
+  def delete_preview_text_only
+    action = BsRequestAction.where(type: :delete).last
+    render(BsRequestActionDescriptionComponent.new(action: action, text_only: true))
+  end
+
   def add_role_preview
     action = BsRequestAction.where(type: :add_role).first
     render(BsRequestActionDescriptionComponent.new(action: action))
+  end
+
+  def change_devel_preview
+    action = BsRequestAction.where(type: :change_devel).first
+    render(BsRequestActionDescriptionComponent.new(action: action))
+  end
+
+  def change_devel_preview_text_only
+    action = BsRequestAction.where(type: :change_devel).first
+    render(BsRequestActionDescriptionComponent.new(action: action, text_only: true))
   end
 end


### PR DESCRIPTION
This PR adapts the `BsRequestActionDescriptionComponent` output in order to return the same value shaped in html or text only format.

This addresses all `bs_request` types but only when it is a _single action request_. In case of a _multi action_ one it requires some different customization which is out of this PR scope.

# Before
![before-description](https://github.com/user-attachments/assets/cd8d8c2e-8849-4b8f-bcd6-58787aa2adff)


# After
![image](https://github.com/user-attachments/assets/e4d8375a-65aa-4360-aff1-d8fccce6f618)
