### PR TITLE
Show priority labels

### DIFF
--- a/src/api/app/components/bs_request_priority_badge_component.rb
+++ b/src/api/app/components/bs_request_priority_badge_component.rb
@@ -1,5 +1,5 @@
 class BsRequestPriorityBadgeComponent < ApplicationComponent
-  attr_reader :priority, :css_class, :overview
+  attr_reader :css_class, :overview
 
   def initialize(priority:, css_class: nil, overview: false)
     super
@@ -10,15 +10,15 @@ class BsRequestPriorityBadgeComponent < ApplicationComponent
   end
 
   def call
-    return if overview && priority == 'moderate'
+    return if overview && @priority == 'moderate'
 
-    priority = "#{priority} priority" if overview && priority == 'low'
+    @priority = "#{@priority} priority" if overview && @priority == 'low'
 
-    content_tag(:span, priority, class: ['badge', "text-bg-#{decode_priority_color}", css_class])
+    content_tag(:span, @priority, class: ['badge', "text-bg-#{decode_priority_color}", css_class])
   end
 
   def decode_priority_color
-    case priority
+    case @priority
     when 'moderate'
       'success'
     when 'important'


### PR DESCRIPTION
After last changes, showing labels in the priority filter was broken.

![Screenshot From 2025-01-28 12-34-27](https://github.com/user-attachments/assets/bb75109f-23d4-4fa8-9d5d-9deee81bb54c)

Thanks @ncounter for reporting it.