### PR TITLE
[backend] bs_publish: do not use arch-specific directory for mkosi artifacts and publish mkosi .asc signatures for all files

### DIFF
--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -2504,10 +2504,10 @@ sub publish {
           };
 	} elsif ($bin =~ /\.(manifest|efi|verity|roothash|roothash\.p7s|usrhash|usrhash\.p7s)(?:\.(?:gz|bz2|xz|zst|zstd))?(?:\.sha[0-9]*)?$/) {
 	  # split dm-verity/EFI artifacts from mkosi, or image manifest file
-	  $p = "$arch/$bin";
+	  $p = "$bin";
 	} elsif ($bin =~ /^SHA[0-9]*SUMS(?:\.gpg)?$/) {
 	  # list of hashes (possibly signed) from mkosi
-	  $p = "$arch/$bin";
+	  $p = "$bin";
 	} elsif ($bin =~ /^mkosi\./) {
 	  # mkosi recipe file
 	  $p = "$bin";

--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -2502,10 +2502,10 @@ sub publish {
 	    BSPublisher::Helm::readhelminfo($r, "$1.helminfo");
 	    $p = $bin;
           };
-	} elsif ($bin =~ /\.(manifest|efi|verity|roothash|roothash\.p7s|usrhash|usrhash\.p7s)(?:\.(?:gz|bz2|xz|zst|zstd))?(?:\.sha[0-9]*)?$/) {
+	} elsif ($bin =~ /\.(manifest|efi|verity|roothash|roothash\.p7s|usrhash|usrhash\.p7s)(?:\.(?:gz|bz2|xz|zst|zstd))?(?:\.sha[0-9]*(?:\.asc)?)?$/) {
 	  # split dm-verity/EFI artifacts from mkosi, or image manifest file
 	  $p = "$bin";
-	} elsif ($bin =~ /^SHA[0-9]*SUMS(?:\.gpg)?$/) {
+	} elsif ($bin =~ /^SHA[0-9]*SUMS(?:\.gpg|\.asc)?$/) {
 	  # list of hashes (possibly signed) from mkosi
 	  $p = "$bin";
 	} elsif ($bin =~ /^mkosi\./) {


### PR DESCRIPTION
mkosi DDIs (.raw) and recipe are already published in the main repo directory.
Publishing in a per-arch subdirectory breaks 'Repotype: checksumsfile' which
is needed to publish a SHA256SUMS signed file, so that systemd-sysupdate can
download images from OBS.

mkosi artifacts can be created with the architecture in the filename with a
simple option in the recipe anyway, so there's no clash if that is used.

Manifests, UKIs and more also get an individual shasum file, and it gets
signed, so publish those signatures too. And also publish the ascii signature
for the SHA256SUMS file.