### PR TITLE
Prevent the linktobranch command to work when there is no @package

### DIFF
--- a/src/api/app/controllers/source_controller.rb
+++ b/src/api/app/controllers/source_controller.rb
@@ -1068,6 +1068,10 @@ class SourceController < ApplicationController
 
   # POST /source/<project>/<package>?cmd=linktobranch
   def package_command_linktobranch
+    if @target_package_name.in?(%w[_project _pattern])
+      render_error status: 400, message: "cannot turn a #{@target_package_name} package into a branch"
+      return
+    end
     pkg_rev = params[:rev]
     pkg_linkrev = params[:linkrev]
 


### PR DESCRIPTION
When the package name is `_pattern` the code does not set the `@package` variable. So we need to avoid calling the command if we have no package to work on.

Fixes #17305