### PR TITLE
Update brakeman ignore file

### DIFF
--- a/src/api/config/brakeman.ignore
+++ b/src/api/config/brakeman.ignore
@@ -160,6 +160,25 @@
       "note": ""
     },
     {
+      "warning_type": "Unmaintained Dependency",
+      "warning_code": 123,
+      "fingerprint": "715ee6d743a8af33c7b930d728708ce19c765fb40e2ad9d2b974db04d92dc7d1",
+      "check_name": "EOLRuby",
+      "message": "Support for Ruby 3.1.6 ends on 2025-03-31",
+      "file": ".ruby-version",
+      "line": 1,
+      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
+      "code": null,
+      "render_path": null,
+      "location": null,
+      "user_input": null,
+      "confidence": "Weak",
+      "cwe_id": [
+        1104
+      ],
+      "note": ""
+    },
+    {
       "warning_type": "Weak Cryptography",
       "warning_code": 126,
       "fingerprint": "755ce94e0c9b9218dcd5ca3c2d9dca58acdcb61c7484cd76abe3b283749ab48d",
@@ -212,7 +231,7 @@
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "app/controllers/source_controller.rb",
-      "line": 426,
+      "line": 418,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
       "code": "@project.lock(params[:comment])",
       "render_path": null,
@@ -388,6 +407,6 @@
       "note": "We track this with a comment in the code"
     }
   ],
-  "updated": "2024-07-18 14:14:29 +0000",
-  "brakeman_version": "5.4.0"
+  "updated": "2025-01-30 14:05:08 +0000",
+  "brakeman_version": "6.2.1"
 }


### PR DESCRIPTION
We want to ignore the warning regarding Ruby 3.1.6 EOL for the time being (see [this](https://github.com/openSUSE/open-build-service/actions/runs/13050288201/job/36408851351?pr=17315). Once we have Ruby 3.2 set, we'll revisit this again.

We'll track this ignore in [here](https://trello.com/c/Tg04a4YW/212-ignore-the-brakeman-warning-regarding-ruby-316-eol)