### PR TITLE
Add data migration to nullify target fields on bs_request_actions

### DIFF
--- a/src/api/db/data/20250131094818_nullify_targets_on_bs_request_actions.rb
+++ b/src/api/db/data/20250131094818_nullify_targets_on_bs_request_actions.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class NullifyTargetsOnBsRequestActions < ActiveRecord::Migration[7.0]
+  # rubocop:disable Rails/SkipsModelValidations
+  def up
+    bs_request_actions = BsRequestAction.where('target_project_id IS NOT NULL AND target_package_id IS NULL')
+    bs_request_actions.in_batches do |batch|
+      batch.find_each do |action|
+        target_project = Project.find_by(name: action.target_project)
+        if target_project.nil?
+          action.update_attribute(:target_project_id, nil)
+        end
+      end
+    end
+
+    bs_request_actions = BsRequestAction.where('target_project_id IS NOT NULL AND target_package_id IS NOT NULL')
+    bs_request_actions.in_batches do |batch|
+      batch.find_each do |action|
+        target_project = Project.find_by(name: action.target_project)
+        if target_project.nil?
+          action.update_attribute(:target_project_id, nil)
+          action.update_attribute(:target_package_id, nil)
+          next
+        end
+
+        target_package = Package.find_by_project_and_name(action.target_project, action.target_package)
+        if target_package.nil?
+          action.update_attribute(:target_package_id, nil)
+        end
+      end
+    end
+  end
+  # rubocop:enable Rails/SkipsModelValidations
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/src/api/db/data_schema.rb
+++ b/src/api/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20241017123303)
+DataMigrate::Data.define(version: 20250131094818)


### PR DESCRIPTION
Nullify `target_project_id` and `target_package_id` in `bs_request_actions` if the project or/and package no longer exist.

Follow-up to #17310.