### PR TITLE
Add data migration to backfill source fields on `bs_request_actions`

### DIFF
--- a/src/api/db/data/20250131143734_backfill_sources_on_bs_request_actions.rb
+++ b/src/api/db/data/20250131143734_backfill_sources_on_bs_request_actions.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class BackfillSourcesOnBsRequestActions < ActiveRecord::Migration[7.0]
+  # rubocop:disable Rails/SkipsModelValidations
+  def up
+    bs_request_actions = BsRequestAction.where(source_project_id: nil, source_package_id: nil).where.not(source_project: nil)
+    bs_request_actions.in_batches do |batch|
+      batch.find_each do |action|
+        if action.source_package.present?
+          source_package = Package.find_by_project_and_name(action.source_project, action.source_package)
+          if source_package
+            action.update_attribute(:source_project_id, source_package.project.id)
+            action.update_attribute(:source_package_id, source_package.id)
+          end
+          next
+        end
+
+        source_project = Project.find_by(name: action.source_project)
+        if source_project
+          action.update_attribute(:source_project_id, source_project.id)
+        end
+      end
+    end
+  end
+  # rubocop:enable Rails/SkipsModelValidations
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/src/api/db/data_schema.rb
+++ b/src/api/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20250131094818)
+DataMigrate::Data.define(version: 20250131143734)


### PR DESCRIPTION
Backfill `target_project_id` and `target_package_id` in `bs_request_actions` if they were `NULL` and the project or/and package exist.

Follow up to #17335.