### PR TITLE
Show request creator text in request index

### DIFF
--- a/src/api/app/components/bs_request_action_description_component.rb
+++ b/src/api/app/components/bs_request_action_description_component.rb
@@ -46,7 +46,7 @@ class BsRequestActionDescriptionComponent < ApplicationComponent
                     { target_repository: target_repository, target_container: target_container }
                   when 'add_role', 'set_bugowner'
                     '%{creator} wants %{requester} to %{task} for %{target_container}' % {
-                      creator: user_with_realname_and_icon(creator),
+                      creator: text_only ? creator : user_with_realname_and_icon(creator),
                       requester: requester_str(creator, action.person_name, action.group_name),
                       task: creator_intentions(action.role),
                       target_container: target_container


### PR DESCRIPTION
Fixes https://trello.com/c/cWOnuYAW/88-add-role-requests-overflow

Prevent this from happening:

![Screenshot From 2025-02-03 12-02-26](https://github.com/user-attachments/assets/ef8e2404-ff29-41c2-b459-c917d6f14e30)
