### PR TITLE
[backend] accept _scmsync.obsinfo in patchinfo's

### DIFF
--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -699,7 +699,7 @@ sub addrev {
   }
 
   if ($files->{'_patchinfo'}) {
-    die("bad files in patchinfo container\n") if grep {$_ ne '_patchinfo'} keys %$files;
+    die("bad files in patchinfo container\n") if grep {$_ ne '_patchinfo' && $_ ne '_scmsync.obsinfo'} keys %$files;
     my $p = BSRevision::revreadxml({'project' => $projid, 'package' => $packid}, '_patchinfo', $files->{'_patchinfo'}, $BSXML::patchinfo);
     BSVerify::verify_patchinfo($p);
   }


### PR DESCRIPTION
patchinfo containers may contain _scmsync.obsinfo files. we must not complain about them when they get comitted.

Esp. after a bugfix in the scm bridge this happens regulary now.