### PR TITLE
Fix bs_request_actions nullify data migration

### DIFF
--- a/src/api/db/data/20250131094818_nullify_targets_on_bs_request_actions.rb
+++ b/src/api/db/data/20250131094818_nullify_targets_on_bs_request_actions.rb
@@ -8,7 +8,7 @@ class NullifyTargetsOnBsRequestActions < ActiveRecord::Migration[7.0]
       batch.find_each do |action|
         target_project = Project.find_by(name: action.target_project)
         if target_project.nil?
-          action.update_attribute(:target_project_id, nil)
+          action.update_columns(target_project_id: nil)
         end
       end
     end
@@ -18,14 +18,13 @@ class NullifyTargetsOnBsRequestActions < ActiveRecord::Migration[7.0]
       batch.find_each do |action|
         target_project = Project.find_by(name: action.target_project)
         if target_project.nil?
-          action.update_attribute(:target_project_id, nil)
-          action.update_attribute(:target_package_id, nil)
+          action.update_columns(target_project_id: nil, target_package_id: nil)
           next
         end
 
         target_package = Package.find_by_project_and_name(action.target_project, action.target_package)
         if target_package.nil?
-          action.update_attribute(:target_package_id, nil)
+          action.update_columns(target_package_id: nil)
         end
       end
     end


### PR DESCRIPTION
Prevent from updating bs_requests when updating bs_request_actions.

Related to #17324.