### PR TITLE
Extend Personal Navigation

### DIFF
--- a/src/api/app/views/layouts/webui/_places.html.haml
+++ b/src/api/app/views/layouts/webui/_places.html.haml
@@ -7,20 +7,17 @@
       %li.nav-item
         = link_to(user_path(User.session), id: 'link-to-user-home', class: 'nav-link') do
           = render(AvatarComponent.new(name: User.session.name, email: User.session.email, size: 23, shape: :circle, custom_css: 'me-2'))
-          Profile
-    - if Flipper.enabled?(:request_index, User.session)
-      %li.nav-item
-        = link_to(my_requests_path(direction: 'incoming', state: %w[new review]), class: 'nav-link', title: 'Requests') do
+          Your Profile
+    %li.nav-item
+      = link_to(my_requests_path(direction: 'incoming', state: %w[new review]), class: 'nav-link', title: 'Requests') do
+        - if Flipper.enabled?(:request_index, User.session)
           %i.fas.fa-code-pull-request.fa-lg.me-2
-          %span.nav-item-name Requests
-    - else
-      %li.nav-item
-        - tasks = User.session.tasks
-        = link_to(my_tasks_path, class: 'nav-link', title: 'Tasks') do
+          %span.nav-item-name Your Requests
+        - else
           %i.fas.fa-tasks.fa-lg.me-2
-          %span.nav-item-name Tasks
-          - unless tasks.zero?
-            %span.badge.text-bg-primary.align-text-top= tasks
+          %span.nav-item-name Your Tasks
+          - unless User.session.tasks.zero?
+            %span.badge.text-bg-primary.align-text-top= User.session.tasks
     %li.nav-item
       - if User.session.home_project
         = link_to(project_show_path(User.session.home_project), class: 'nav-link', title: 'Your Home Project') do
@@ -30,6 +27,25 @@
         = link_to(new_project_path(name: User.session.home_project_name), class: 'nav-link', title: 'Create Your Home Project') do
           %i.fas.fa-cubes.fa-lg.me-2
           %span.nav-item-name Create Your Home Project
+    - if navigation != :left
+      %li.nav-item
+        = link_to(my_subscriptions_path, class: 'nav-link') do
+          %i.fas.fa-code-pull-request.me-2
+          Your Subscriptions
+      %li.nav-item
+        = link_to(tokens_path, class: 'nav-link') do
+          %i.fas.fa-key.me-2
+          Your Tokens
+      %li.nav-item
+        = link_to(my_beta_features_path, class: 'nav-link') do
+          %i.fas.fa-flask.me-2
+          Your Beta Features
+      %li.nav-item
+        = link_to(canned_responses_path, class: 'nav-link') do
+          %i.fas.fa-comment-dots.me-2
+          Your Responses
+    %li
+      %hr
     %li.nav-item
       = link_to(projects_path, class: 'nav-link', title: 'All Projects') do
         %i.fas.fa-list.fa-lg.me-2
@@ -51,6 +67,8 @@
           %i.fas.fa-toggle-on.me-2
           %span.nav-item-name Global Feature Toggles
     - if navigation != :left
+      %li
+        %hr
       %li.nav-item
         = link_to(session_path, method: :delete, id: 'logout-link', class: 'nav-link') do
           %i.fas.fa-sign-out-alt.fa-lg.me-2

--- a/src/api/app/views/layouts/webui/_places.html.haml
+++ b/src/api/app/views/layouts/webui/_places.html.haml
@@ -6,80 +6,80 @@
     - if navigation != :left
       %li.nav-item
         = link_to(user_path(User.session), id: 'link-to-user-home', class: 'nav-link') do
-          = render(AvatarComponent.new(name: User.session.name, email: User.session.email, size: 23, shape: :circle, custom_css: 'me-2'))
+          %i.fas.fa-user.fa-fw.me-2
           Your Profile
     %li.nav-item
       = link_to(my_requests_path(direction: 'incoming', state: %w[new review]), class: 'nav-link', title: 'Requests') do
         - if Flipper.enabled?(:request_index, User.session)
-          %i.fas.fa-code-pull-request.fa-lg.me-2
+          %i.fas.fa-code-pull-request.fa-fw.me-2
           %span.nav-item-name Your Requests
         - else
-          %i.fas.fa-tasks.fa-lg.me-2
+          %i.fas.fa-tasks.fa-fw.me-2
           %span.nav-item-name Your Tasks
           - unless User.session.tasks.zero?
             %span.badge.text-bg-primary.align-text-top= User.session.tasks
     %li.nav-item
       - if User.session.home_project
         = link_to(project_show_path(User.session.home_project), class: 'nav-link', title: 'Your Home Project') do
-          %i.fas.fa-cubes.fa-lg.me-2
+          %i.fas.fa-cubes.fa-fw.me-2
           %span.nav-item-name Your Home Project
       - else
         = link_to(new_project_path(name: User.session.home_project_name), class: 'nav-link', title: 'Create Your Home Project') do
-          %i.fas.fa-cubes.fa-lg.me-2
+          %i.fas.fa-cubes.fa-fw.me-2
           %span.nav-item-name Create Your Home Project
     - if navigation != :left
       %li.nav-item
         = link_to(my_subscriptions_path, class: 'nav-link') do
-          %i.fas.fa-code-pull-request.me-2
+          %i.fas.fa-code-pull-request.fa-fw.me-2
           Your Subscriptions
       %li.nav-item
         = link_to(tokens_path, class: 'nav-link') do
-          %i.fas.fa-key.me-2
+          %i.fas.fa-key.fa-fw.me-2
           Your Tokens
       %li.nav-item
         = link_to(my_beta_features_path, class: 'nav-link') do
-          %i.fas.fa-flask.me-2
+          %i.fas.fa-flask.fa-fw.me-2
           Your Beta Features
       %li.nav-item
         = link_to(canned_responses_path, class: 'nav-link') do
-          %i.fas.fa-comment-dots.me-2
+          %i.fas.fa-comment-dots.fa-fw.me-2
           Your Responses
     %li
       %hr
     %li.nav-item
       = link_to(projects_path, class: 'nav-link', title: 'All Projects') do
-        %i.fas.fa-list.fa-lg.me-2
+        %i.fas.fa-list.fa-fw.me-2
         %span.nav-item-name All Projects
     %li.nav-item
       = link_to(monitor_path, class: 'nav-link', title: 'Status Monitor') do
-        %i.fas.fa-heartbeat.fa-lg.me-2
+        %i.fas.fa-heartbeat.fa-fw.me-2
         %span.nav-item-name Status Monitor
     - if User.admin_session?
       %li.nav-item
         = link_to(configuration_path, class: 'nav-link', title: 'Configuration') do
-          %i.fas.fa-cogs.me-2
+          %i.fas.fa-cogs.fa-fw.me-2
           %span.nav-item-name Configuration
     - if User.possibly_nobody.is_staff? && !User.admin_session?
       %li.nav-item
         = link_to("#{root_url}/flipper", class: 'nav-link',
                   title: 'Global Feature Toggles',
                   data: { confirm: 'Do you really want to manage feature toggles globally? This might affect all the users of the application.' }) do
-          %i.fas.fa-toggle-on.me-2
+          %i.fas.fa-toggle-on.fa-fw.me-2
           %span.nav-item-name Global Feature Toggles
     - if navigation != :left
       %li
         %hr
       %li.nav-item
         = link_to(session_path, method: :delete, id: 'logout-link', class: 'nav-link') do
-          %i.fas.fa-sign-out-alt.fa-lg.me-2
+          %i.fas.fa-sign-out-alt.fa-fw.me-2
           Logout
   - else
     %li.nav-item
       = link_to(projects_path, class: 'nav-link', title: 'All Projects') do
-        %i.fas.fa-list.fa-lg.me-2
+        %i.fas.fa-list.fa-fw.me-2
         %span.nav-item-name All Projects
     - unless spider_bot
       %li.nav-item
         = link_to(monitor_path, class: 'nav-link', title: 'Status Monitor') do
-          %i.fas.fa-heartbeat.fa-lg.me-2
+          %i.fas.fa-heartbeat.fa-fw.me-2
           %span.nav-item-name Status Monitor

--- a/src/api/app/views/layouts/webui/_top_navigation.html.haml
+++ b/src/api/app/views/layouts/webui/_top_navigation.html.haml
@@ -16,12 +16,39 @@
           = link_to('#', class: 'nav-link dropdown-toggle text-light', id: 'top-navigation-profile-dropdown', role: 'button',
                     'data-bs-toggle': 'dropdown', aria: { haspopup: true, expanded: false }) do
             = render(AvatarComponent.new(name: User.session.name, email: User.session.email, size: 32, shape: :circle, custom_css: 'me-2'))
-          .dropdown-menu.dropdown-menu-end{ 'aria-labelledby': 'top-navigation-profile-dropdown' }
-            .dropdown-item
+          %ul.dropdown-menu.dropdown-menu-end{ 'aria-labelledby': 'top-navigation-profile-dropdown' }
+            %li.dropdown-item
               = link_to(user_path(User.session), id: 'link-to-user-home', class: 'nav-link text-light p-0 w-100') do
-                = render(AvatarComponent.new(name: User.session.name, email: User.session.email, size: 20, shape: :circle, custom_css: 'me-2'))
+                %i.fas.fa-user.me-2
                 Your profile
-            .dropdown-item
+            %li.dropdown-item
+              = link_to(my_requests_path(direction: 'incoming', state: %w[new review]), class: 'nav-link text-light p-0 w-100') do
+                %i.fas.fa-code-pull-request.me-2
+                Your Requests
+            - if User.session.home_project
+              %li.dropdown-item
+                = link_to(project_show_path(User.session.home_project), class: 'nav-link text-light p-0 w-100') do
+                  %i.fas.fa-cubes.me-2
+                  Your Home Project
+            %li.dropdown-item
+              = link_to(my_subscriptions_path, class: 'nav-link text-light p-0 w-100') do
+                %i.fas.fa-code-pull-request.me-2
+                Your Subscriptions
+            %li.dropdown-item
+              = link_to(tokens_path, class: 'nav-link text-light p-0 w-100') do
+                %i.fas.fa-key.me-2
+                Your Tokens
+            %li.dropdown-item
+              = link_to(my_beta_features_path, class: 'nav-link text-light p-0 w-100') do
+                %i.fas.fa-flask.me-2
+                Your Beta Features
+            %li.dropdown-item
+              = link_to(canned_responses_path, class: 'nav-link text-light p-0 w-100') do
+                %i.fas.fa-comment-dots.me-2
+                Your Responses
+            %li
+              %hr.dropdown-divider
+            %li.dropdown-item
               = link_to(session_path, method: :delete, id: 'logout-link', class: 'nav-link text-light p-0 w-100') do
                 %i.fas.fa-sign-out-alt.fa-lg.me-2
                 Logout

--- a/src/api/app/views/layouts/webui/_top_navigation.html.haml
+++ b/src/api/app/views/layouts/webui/_top_navigation.html.haml
@@ -19,38 +19,38 @@
           %ul.dropdown-menu.dropdown-menu-end{ 'aria-labelledby': 'top-navigation-profile-dropdown' }
             %li.dropdown-item
               = link_to(user_path(User.session), id: 'link-to-user-home', class: 'nav-link text-light p-0 w-100') do
-                %i.fas.fa-user.me-2
+                %i.fas.fa-user.fa-fw.me-2
                 Your profile
             %li.dropdown-item
               = link_to(my_requests_path(direction: 'incoming', state: %w[new review]), class: 'nav-link text-light p-0 w-100') do
-                %i.fas.fa-code-pull-request.me-2
+                %i.fas.fa-code-pull-request.fa-fw.me-2
                 Your Requests
             - if User.session.home_project
               %li.dropdown-item
                 = link_to(project_show_path(User.session.home_project), class: 'nav-link text-light p-0 w-100') do
-                  %i.fas.fa-cubes.me-2
+                  %i.fas.fa-cubes.fa-fw.me-2
                   Your Home Project
             %li.dropdown-item
               = link_to(my_subscriptions_path, class: 'nav-link text-light p-0 w-100') do
-                %i.fas.fa-code-pull-request.me-2
+                %i.fas.fa-code-pull-request.fa-fw.me-2
                 Your Subscriptions
             %li.dropdown-item
               = link_to(tokens_path, class: 'nav-link text-light p-0 w-100') do
-                %i.fas.fa-key.me-2
+                %i.fas.fa-key.fa-fw.me-2
                 Your Tokens
             %li.dropdown-item
               = link_to(my_beta_features_path, class: 'nav-link text-light p-0 w-100') do
-                %i.fas.fa-flask.me-2
+                %i.fas.fa-flask.fa-fw.me-2
                 Your Beta Features
             %li.dropdown-item
               = link_to(canned_responses_path, class: 'nav-link text-light p-0 w-100') do
-                %i.fas.fa-comment-dots.me-2
+                %i.fas.fa-comment-dots.fa-fw.me-2
                 Your Responses
             %li
               %hr.dropdown-divider
             %li.dropdown-item
               = link_to(session_path, method: :delete, id: 'logout-link', class: 'nav-link text-light p-0 w-100') do
-                %i.fas.fa-sign-out-alt.fa-lg.me-2
+                %i.fas.fa-sign-out-alt.fa-fw.me-2
                 Logout
       - else
         = render partial: 'layouts/webui/top_navigation_nobody'


### PR DESCRIPTION
There are a lot of places that are specific to the logged in User. So far they are only reachable through visiting the profile page. Also add them to the personal navigation.

## Before

![Screenshot From 2025-02-05 13-56-40](https://github.com/user-attachments/assets/b8426b5b-bdd8-4448-9ac1-eb07a4cd938c)

![Screenshot From 2025-02-05 13-57-01](https://github.com/user-attachments/assets/063e0035-567f-4188-89a3-6e2813bb7074)

## After

![Screenshot From 2025-02-05 13-55-43](https://github.com/user-attachments/assets/3123626e-a787-4e07-8e41-26dd176cc7dc)

![Screenshot From 2025-02-05 14-02-19](https://github.com/user-attachments/assets/5ade834e-ad5c-4c56-8392-963fa98946dd)
