### PR TITLE
Bugfix: missing default filters on direct request index link

### DIFF
--- a/src/api/app/views/webui/project/side_links/_requests.html.haml
+++ b/src/api/app/views/webui/project/side_links/_requests.html.haml
@@ -4,12 +4,12 @@
              request_show_path(requests.first)
            elsif package
              if Flipper.enabled?(:request_index, User.session)
-              packages_requests_path(project, package)
+              packages_requests_path(project, package, state: %w[new review])
              else
               package_requests_path(project, package)
              end
            elsif Flipper.enabled?(:request_index, User.session)
-             projects_requests_path(project)
+             projects_requests_path(project, state: %w[new review])
            else
              project_requests_path(project)
            end


### PR DESCRIPTION
Fix #17318

Note: not adding `direction: incoming` filter parameter here because it comes from a link showing `incoming/outgoing` requests counter, so it makes sense to show both in the landing page.