### PR TITLE
Show workflow run repository link only when necessary

### DIFF
--- a/src/api/app/components/workflow_run_row_component.html.haml
+++ b/src/api/app/components/workflow_run_row_component.html.haml
@@ -5,7 +5,6 @@
   - if hook_action
     %span.ms-2.badge.text-bg-primary= hook_action.humanize
 .col.text-start
-  = link_to_if repository_url, repository_name, repository_url
   - if event_source_name
     - popover_content = render partial: 'webui/workflow_runs/event_links', locals: { hook_event: hook_event,
                                                                                      formatted_event_source_name: formatted_event_source_name,

--- a/src/api/app/views/webui/users/tokens/show.html.haml
+++ b/src/api/app/views/webui/users/tokens/show.html.haml
@@ -46,6 +46,15 @@
                 = link_to(@token.executor.login, user_path(@token.executor))
 
         - if @token.type == 'Token::Workflow'
+          - if (unique_repository = @token.workflow_runs.where.not(response_url: nil).first)
+            .row
+              .col
+                .mb-3
+                  %label.fw-bold
+                    Workflow Repository:
+                  %span
+                    = link_to unique_repository.repository_full_name, unique_repository.repository_url
+
           .row
             .col
               .mb-3


### PR DESCRIPTION
Prevents displaying the workflow run repository in the index listing, to avoid visual clutter if possible. The full list of repositories that were ever used is also listed in token show page