### PR TITLE
Fixup font awesome classes for the action menu

### DIFF
--- a/src/api/app/assets/stylesheets/webui/layout.scss
+++ b/src/api/app/assets/stylesheets/webui/layout.scss
@@ -56,19 +56,6 @@
   z-index: $zindex-fixed;
 }
 
-#left-navigation-area, #bottom-navigation-area {
-  .fa-stack {
-    width: 1.9rem;
-
-    .top-icon {
-      font-size: 0.9rem;
-      padding-left: 1rem;
-      padding-top: 0.5rem;
-      text-shadow: -1.5px 0 $dark, 0 1.5px $dark, 1.5px 0 $dark, 0 -1.5px $dark;
-    }
-  }
-}
-
 // BREADCRUMBS
 
 .breadcrumb {

--- a/src/api/app/views/webui/cloud/upload_jobs/index.html.haml
+++ b/src/api/app/views/webui/cloud/upload_jobs/index.html.haml
@@ -3,7 +3,7 @@
 - content_for :actions do
   %li.nav-item
     = link_to(cloud_configuration_index_path, title: 'Cloud Configuration', class: 'nav-link') do
-      %i.fas.fa-lg.me-2.fa-cogs
+      %i.fas.fa-fw.me-2.fa-cogs
       %span.nav-item-name Cloud Configuration
 
 .card

--- a/src/api/app/views/webui/kiwi/images/_actions.html.haml
+++ b/src/api/app/views/webui/kiwi/images/_actions.html.haml
@@ -1,14 +1,14 @@
 - content_for :actions do
   %li.nav-item
     = link_to(package_show_path(package.project, package), class: 'nav-link', title: 'View Package') do
-      %i.fa.fa-archive.fa-lg.me-2
+      %i.fa.fa-archive.fa-fw.me-2
       %span.nav-item-name View Package
   %li.nav-item#link-edit-details{ class: "#{'d-none' unless is_edit_details_action}" }
     = link_to('#', class: 'nav-link', data: { 'bs-target': '#description-edit', 'bs-toggle': 'modal' }, title: 'Edit Details') do
-      %i.fa.fa-edit.fa-lg.me-2
+      %i.fa.fa-edit.fa-fw.me-2
       %span.nav-item-name Edit Details
   - if User.session
     %li.nav-item
       = link_to(cloud_upload_index_path, class: 'nav-link', id: 'cloud-upload', title: 'Cloud Upload') do
-        %i.fas.fa-cloud-upload-alt.fa-lg.me-2
+        %i.fas.fa-cloud-upload-alt.fa-fw.me-2
         %span.nav-item-name Cloud Upload

--- a/src/api/app/views/webui/main/_index_actions.html.haml
+++ b/src/api/app/views/webui/main/_index_actions.html.haml
@@ -2,9 +2,9 @@
   - if User.session
     %li.nav-item
       = link_to(new_project_path, class: 'nav-link', title: 'Create Project') do
-        %i.fas.fa-plus-circle.fa-lg.me-2
+        %i.fas.fa-plus-circle.fa-fw.me-2
         %span.nav-item-name Create Project
     %li.nav-item
       = link_to(image_templates_path, class: 'nav-link', title: 'New Image') do
-        %i.fas.fa-compact-disc.fa-lg.me-2
+        %i.fas.fa-compact-disc.fa-fw.me-2
         %span.nav-item-name New Image

--- a/src/api/app/views/webui/package/show_actions/_branch_package.html.haml
+++ b/src/api/app/views/webui/package/show_actions/_branch_package.html.haml
@@ -1,5 +1,5 @@
 %li.nav-item
   = link_to(new_package_branches_path(project: project, package_name: package, revision: revision),
             class: 'nav-link', title: 'Branch Package') do
-    %i.fas.fa-code-branch.fa-lg.me-2
+    %i.fas.fa-code-branch.fa-fw.me-2
     %span.nav-item-name Branch Package

--- a/src/api/app/views/webui/package/show_actions/_bugzilla_owner.html.haml
+++ b/src/api/app/views/webui/package/show_actions/_bugzilla_owner.html.haml
@@ -1,5 +1,5 @@
 - if url.present?
   = link_to(url, class: 'nav-link', title: 'Report Bug') do
-    %i.fas.fa-bug.fa-lg.me-2
+    %i.fas.fa-bug.fa-fw.me-2
     %span.nav-item-name Report Bug
     %i.fa-solid.fa-arrow-up-right-from-square.fa-xs

--- a/src/api/app/views/webui/package/show_actions/_cloud_upload.html.haml
+++ b/src/api/app/views/webui/package/show_actions/_cloud_upload.html.haml
@@ -1,4 +1,4 @@
 %li.nav-item
   = link_to(cloud_upload_index_path, id: 'cloud-upload', class: 'nav-link', title: 'Cloud Upload') do
-    %i.fas.fa-cloud-upload-alt.fa-lg.me-2
+    %i.fas.fa-cloud-upload-alt.fa-fw.me-2
     %span.nav-item-name Cloud Upload

--- a/src/api/app/views/webui/package/show_actions/_delete_package.html.haml
+++ b/src/api/app/views/webui/package/show_actions/_delete_package.html.haml
@@ -1,4 +1,4 @@
 %li.nav-item
   = link_to('#', class: 'nav-link', data: { 'bs-toggle': 'modal', 'bs-target': '#delete-modal' }, title: 'Delete Package') do
-    %i.fas.fa-times-circle.fa-lg.me-2
+    %i.fas.fa-times-circle.fa-fw.me-2
     %span.nav-item-name Delete Package

--- a/src/api/app/views/webui/package/show_actions/_report_package.html.haml
+++ b/src/api/app/views/webui/package/show_actions/_report_package.html.haml
@@ -6,5 +6,5 @@
                   'modal-title': "Report package from #{package.name}",
                   'reportable-type': package.class.name,
                   'reportable-id': package.id }) do
-      %i.fas.fa-regular.fa-flag.fa-lg.me-2
+      %i.fas.fa-regular.fa-flag.fa-fw.me-2
       %span.nav-item-name Report Package

--- a/src/api/app/views/webui/package/show_actions/_request_deletion.html.haml
+++ b/src/api/app/views/webui/package/show_actions/_request_deletion.html.haml
@@ -1,4 +1,4 @@
 %li.nav-item
   = link_to(new_project_package_deletion_path(project, package), class: 'nav-link', title: 'Request Deletion') do
-    %i.fas.fa-times-circle.fa-lg.me-2
+    %i.fas.fa-times-circle.fa-fw.me-2
     %span.nav-item-name Request Deletion

--- a/src/api/app/views/webui/package/show_actions/_request_devel_project_change.html.haml
+++ b/src/api/app/views/webui/package/show_actions/_request_devel_project_change.html.haml
@@ -1,5 +1,5 @@
 %li.nav-item
   = link_to(new_project_package_devel_project_change_path(package.project, package), class: 'nav-link',
             title: 'Request Devel Project Change') do
-    %i.fas.fa-exchange-alt.fa-lg.me-2
+    %i.fas.fa-exchange-alt.fa-fw.me-2
     %span.nav-item-name Request Devel Project Change

--- a/src/api/app/views/webui/package/show_actions/_request_role_addition.html.haml
+++ b/src/api/app/views/webui/package/show_actions/_request_role_addition.html.haml
@@ -1,4 +1,4 @@
 %li.nav-item
   = link_to(new_project_package_role_addition_path(project, package), class: 'nav-link', title: 'Request Role Addition') do
-    %i.fas.fa-plus-circle.fa-lg.me-2
+    %i.fas.fa-plus-circle.fa-fw.me-2
     %span.nav-item-name Request Role Addition

--- a/src/api/app/views/webui/package/show_actions/_submit_package.html.haml
+++ b/src/api/app/views/webui/package/show_actions/_submit_package.html.haml
@@ -1,5 +1,5 @@
 %li.nav-item
   = link_to(new_project_package_submission_path(project, package, revision: revision), class: 'nav-link',
             title: 'Submit Package') do
-    %i.fas.fa-share-square.fa-lg.me-2
+    %i.fas.fa-share-square.fa-fw.me-2
     %span.nav-item-name Submit Package

--- a/src/api/app/views/webui/package/show_actions/_trigger_services.html.haml
+++ b/src/api/app/views/webui/package/show_actions/_trigger_services.html.haml
@@ -1,5 +1,5 @@
 %li.nav-item
   = link_to(services_project_package_trigger_path(project_name: project, package_name: package), method: :post, class: 'nav-link',
             title: 'Trigger Services') do
-    %i.fas.fa-project-diagram.fa-lg.me-2
+    %i.fas.fa-project-diagram.fa-fw.me-2
     %span.nav-item-name Trigger Services

--- a/src/api/app/views/webui/package/show_actions/_view_kiwi.html.haml
+++ b/src/api/app/views/webui/package/show_actions/_view_kiwi.html.haml
@@ -1,4 +1,4 @@
 %li.nav-item
   = link_to(import_kiwi_image_path(package_id), id: 'edit-kiwi', class: 'nav-link', title: 'View Image') do
-    %i.fas.fa-compact-disc.fa-lg.me-2
+    %i.fas.fa-compact-disc.fa-fw.me-2
     %span.nav-item-name View Image

--- a/src/api/app/views/webui/project/_show_actions.html.haml
+++ b/src/api/app/views/webui/project/_show_actions.html.haml
@@ -18,7 +18,7 @@
   - if User.session
     %li.nav-item
       = link_to(image_templates_path, class: 'nav-link', title: 'New Image') do
-        %i.fas.fa-compact-disc.fa-lg.me-2
+        %i.fas.fa-compact-disc.fa-fw.me-2
         %span.nav-item-name New Image
 
   = render partial: 'webui/shared/lock_unlock_comment', locals: { commentable: project }

--- a/src/api/app/views/webui/project/_subprojects_actions.html.haml
+++ b/src/api/app/views/webui/project/_subprojects_actions.html.haml
@@ -1,5 +1,5 @@
 - content_for :actions do
   - if User.possibly_nobody.can_modify?(project)
     = link_to(new_project_path(namespace: project), class: 'nav-link', title: 'Create Subproject') do
-      %i.fas.fa-plus-circle.fa-lg.me-2
+      %i.fas.fa-plus-circle.fa-fw.me-2
       %span.nav-item-name Create Subproject

--- a/src/api/app/views/webui/project/index.html.haml
+++ b/src/api/app/views/webui/project/index.html.haml
@@ -31,7 +31,7 @@
         - content_for :actions do
           %li.nav-item
             = link_to(new_project_path, class: 'nav-link', title: 'Create Project') do
-              %i.fas.fa-lg.me-2.fa-plus-circle
+              %i.fas.fa-fw.me-2.fa-plus-circle
               %span.nav-item-name Create Project
 
     %table.responsive.table.table-sm.table-bordered.table-hover.w-100#projects-datatable{ data: { source: projects_path(format: :json),

--- a/src/api/app/views/webui/project/show_actions/_delete_project.html.haml
+++ b/src/api/app/views/webui/project/show_actions/_delete_project.html.haml
@@ -4,5 +4,5 @@
             title: 'Delete Project',
             data: { 'bs-toggle': 'modal',
                     'bs-target': '#delete-project-modal' }) do
-    %i.fas.fa-times-circle.fa-lg.me-2
+    %i.fas.fa-times-circle.fa-fw.me-2
     %span.nav-item-name Delete Project

--- a/src/api/app/views/webui/project/show_actions/_patchinfo.html.haml
+++ b/src/api/app/views/webui/project/show_actions/_patchinfo.html.haml
@@ -1,7 +1,5 @@
 - unless has_patchinfo
   %li.nav-item
     = link_to(patchinfo_path(project: project), method: :post, class: 'nav-link', title: 'Create Patchinfo') do
-      %span.fa-stack
-        %i.fas.fa-band-aid.fa-lg.fa-stack-1x
-        %i.fas.fa-plus-circle.fa-stack-1x.top-icon
+      %i.fas.fa-band-aid.fa-fw.me-2
       %span.nav-item-name Create Patchinfo

--- a/src/api/app/views/webui/project/show_actions/_report_bug.html.haml
+++ b/src/api/app/views/webui/project/show_actions/_report_bug.html.haml
@@ -1,5 +1,5 @@
 - if url.present?
   = link_to(url, class: 'nav-link', title: 'Report Bug') do
-    %i.fas.fa-bug.fa-lg.me-2
+    %i.fas.fa-bug.fa-fw.me-2
     %span.nav-item-name Report Bug
     %i.fa-solid.fa-arrow-up-right-from-square.fa-xs

--- a/src/api/app/views/webui/project/show_actions/_report_project.html.haml
+++ b/src/api/app/views/webui/project/show_actions/_report_project.html.haml
@@ -5,5 +5,5 @@
                 'modal-title': "Report #{project.name}",
                 'reportable-type': project.class.name,
                 'reportable-id': project.id }) do
-    %i.fas.fa-regular.fa-flag.fa-lg.me-2
+    %i.fas.fa-regular.fa-flag.fa-fw.me-2
     %span.nav-item-name Report Project

--- a/src/api/app/views/webui/project/show_actions/_request_role_addition_and_deletion.html.haml
+++ b/src/api/app/views/webui/project/show_actions/_request_role_addition_and_deletion.html.haml
@@ -1,8 +1,8 @@
 %li.nav-item
   = link_to(new_project_role_addition_path(project), class: 'nav-link', title: 'Request Role Addition') do
-    %i.fas.fa-plus-circle.fa-lg.me-2
+    %i.fas.fa-plus-circle.fa-fw.me-2
     %span.nav-item-name Request Role Addition
 %li.nav-item
   = link_to(new_project_deletion_path(project), class: 'nav-link', title: 'Request Deletion') do
-    %i.fas.fa-times-circle.fa-lg.me-2
+    %i.fas.fa-times-circle.fa-fw.me-2
     %span.nav-item-name Request Deletion

--- a/src/api/app/views/webui/project/show_actions/_request_to_release.html.haml
+++ b/src/api/app/views/webui/project/show_actions/_request_to_release.html.haml
@@ -1,4 +1,4 @@
 %li.nav-item
   = link_to(project_release_request_path(project), class: 'nav-link', title: 'Request to Release') do
-    %i.fas.fa-share-square.fa-lg.me-2
+    %i.fas.fa-share-square.fa-fw.me-2
     %span.nav-item-name Request to Release

--- a/src/api/app/views/webui/project/show_actions/_submit_as_update.html.haml
+++ b/src/api/app/views/webui/project/show_actions/_submit_as_update.html.haml
@@ -1,5 +1,5 @@
 - if !project.is_maintenance_incident? && release_targets.present?
   %li.nav-item
     = link_to(new_project_maintenance_incident_request_path(project), class: 'nav-link', title: 'Submit as Update') do
-      %i.fas.fa-share-square.fa-lg.me-2
+      %i.fas.fa-share-square.fa-fw.me-2
       %span.nav-item-name Submit as Update

--- a/src/api/app/views/webui/project/show_actions/_unlock_project.html.haml
+++ b/src/api/app/views/webui/project/show_actions/_unlock_project.html.haml
@@ -1,4 +1,4 @@
 %li.nav-item
   = link_to('#', class: 'nav-link', data: { 'bs-toggle': 'modal', 'bs-target': '#unlock-project-modal' }, title: 'Unlock Project') do
-    %i.fas.fa-unlock.fa-lg.me-2
+    %i.fas.fa-unlock.fa-fw.me-2
     %span.nav-item-name Unlock Project

--- a/src/api/app/views/webui/request/_actions.html.haml
+++ b/src/api/app/views/webui/request/_actions.html.haml
@@ -4,5 +4,5 @@
   - if can_add_reviews
     %li.nav-item
       = link_to('#', data: { 'bs-toggle': 'modal', 'bs-target': '#add-reviewer-modal' }, class: 'nav-link', title: 'Add a Review') do
-        %i.fas.fa-plus-circle.fa-lg.me-2
+        %i.fas.fa-plus-circle.fa-fw.me-2
         %span.nav-item-name Add a Review

--- a/src/api/app/views/webui/request/_report_request.html.haml
+++ b/src/api/app/views/webui/request/_report_request.html.haml
@@ -5,5 +5,5 @@
                 'modal-title': "Report #{bs_request.number}",
                 'reportable-type': bs_request.class.name,
                 'reportable-id': bs_request.number }) do
-    %i.fas.fa-regular.fa-flag.fa-lg.me-2
+    %i.fas.fa-regular.fa-flag.fa-fw.me-2
     %span.nav-item-name Report Request

--- a/src/api/app/views/webui/staging/workflows/edit.html.haml
+++ b/src/api/app/views/webui/staging/workflows/edit.html.haml
@@ -2,7 +2,7 @@
 - content_for :actions do
   %li.nav-item
     = link_to('#', class: 'nav-link', data: { 'bs-toggle': 'modal', 'bs-target': '#staging-managers-group-modal' }, title: 'Change Managers') do
-      %i.fas.fa-lg.me-2.fa-users
+      %i.fas.fa-fw.me-2.fa-users
       %span.nav-item-name Change Managers
 
 .row

--- a/src/api/app/views/webui/staging/workflows/show.html.haml
+++ b/src/api/app/views/webui/staging/workflows/show.html.haml
@@ -11,13 +11,13 @@
             - content_for(:actions) do
               %li.nav-item
                 = link_to(edit_staging_workflow_path(@staging_workflow.project), title: 'Edit Staging', class: 'nav-link') do
-                  %i.fas.fa-edit.fa-lg.me-2
+                  %i.fas.fa-edit.fa-fw.me-2
                   %span.nav-item-name Edit Staging
           - if policy(@staging_workflow).destroy?
             - content_for(:actions) do
               %li.nav-item
                 = link_to('#', title: 'Delete Staging', data: { 'bs-toggle': 'modal', 'bs-target': '#delete-staging-workflow' }, class: 'nav-link') do
-                  %i.fas.fa-lg.me-2.fa-times-circle
+                  %i.fas.fa-fw.me-2.fa-times-circle
                   %span.nav-item-name Delete Staging
         - if policy(@staging_workflow).destroy? # This is outside of the h3 to prevent the font in the modal to be oversized
           = render(partial: 'delete', locals: { staging_workflow: @staging_workflow, project: @project })

--- a/src/api/app/views/webui/user/index_actions/_change_notifications.haml
+++ b/src/api/app/views/webui/user/index_actions/_change_notifications.haml
@@ -1,4 +1,4 @@
 %li.nav-item
   = link_to(my_subscriptions_path, class: 'nav-link', title: 'Manage Your Notifications') do
-    %i.fas.fa-lg.me-2.fa-bell
+    %i.fas.fa-fw.me-2.fa-bell
     %span.nav-item-name Manage Your Notifications

--- a/src/api/app/views/webui/user/index_actions/_change_password.haml
+++ b/src/api/app/views/webui/user/index_actions/_change_password.haml
@@ -1,4 +1,4 @@
 %li.nav-item
   = link_to('#', data: { 'bs-toggle': 'modal', 'bs-target': '#password-modal' }, class: 'nav-link', title: 'Change Your Password') do
-    %i.fas.fa-lg.me-2.fa-exchange-alt
+    %i.fas.fa-fw.me-2.fa-exchange-alt
     %span.nav-item-name Change Your Password

--- a/src/api/app/views/webui/user/index_actions/_edit_account.html.haml
+++ b/src/api/app/views/webui/user/index_actions/_edit_account.html.haml
@@ -1,5 +1,5 @@
 -# Behind a proxy or not, we go to the edit account form.
 %li.nav-item
   = link_to(edit_account_user_path(user), class: 'nav-link', remote: true, title: 'Edit Your Account') do
-    %i.fas.fa-lg.me-2.fa-user-edit
+    %i.fas.fa-fw.me-2.fa-user-edit
     %span.nav-item-name Edit Your Account

--- a/src/api/app/views/webui/user/index_actions/_manage_beta_features.haml
+++ b/src/api/app/views/webui/user/index_actions/_manage_beta_features.haml
@@ -1,4 +1,4 @@
 %li.nav-item
   = link_to(my_beta_features_path, class: 'nav-link', title: 'Manage Beta Features') do
-    %i.fas.fa-lg.me-2.fa-flask
+    %i.fas.fa-fw.me-2.fa-flask
     %span.nav-item-name Manage Beta Features

--- a/src/api/app/views/webui/user/index_actions/_manage_canned_responses.haml
+++ b/src/api/app/views/webui/user/index_actions/_manage_canned_responses.haml
@@ -1,4 +1,4 @@
 %li.nav-item
   = link_to(canned_responses_path, class: 'nav-link', title: 'Manage Canned Responses') do
-    %i.fas.fa-lg.me-2.fa-comment-dots
+    %i.fas.fa-fw.me-2.fa-comment-dots
     %span.nav-item-name Manage Canned Responses

--- a/src/api/app/views/webui/user/index_actions/_manage_tokens.haml
+++ b/src/api/app/views/webui/user/index_actions/_manage_tokens.haml
@@ -1,4 +1,4 @@
 %li.nav-item
   = link_to(tokens_path, class: 'nav-link', title: 'Manage Your Tokens') do
-    %i.fas.fa-lg.me-2.fa-key
+    %i.fas.fa-fw.me-2.fa-key
     %span.nav-item-name Manage Your Tokens

--- a/src/api/app/views/webui/users/notifications/_index_actions.html.haml
+++ b/src/api/app/views/webui/users/notifications/_index_actions.html.haml
@@ -1,5 +1,5 @@
 - content_for :actions do
   %li.nav-item
     = link_to(my_subscriptions_path, class: 'nav-link', title: 'Manage Your Notifications') do
-      %i.fas.fa-edit.fa-lg.me-2
+      %i.fas.fa-edit.fa-fw.me-2
       %span.nav-item-name Manage Your Notifications


### PR DESCRIPTION
The action menu used relative sizing for some icons (`fa-lg`) instead of using a
fixed width (fa-fw) for all icons to align them horizontally.

## before
![Screenshot From 2025-02-11 11-20-58](https://github.com/user-attachments/assets/f6974f43-86de-4fb9-8ace-07663c346f47)
![Screenshot From 2025-02-11 11-21-43](https://github.com/user-attachments/assets/3c356e31-96ad-4091-bf1f-74d13a490e29)

## After

![Screenshot From 2025-02-11 11-22-17](https://github.com/user-attachments/assets/f3cb7783-ef77-423f-a3b6-cda5448a9a85)
![Screenshot From 2025-02-11 11-22-01](https://github.com/user-attachments/assets/51761b45-12ae-40b1-bfa0-bb83427df9f3)



Follow up to #17341 