### PR TITLE
Add `enabled` column to `tokens` table

### DIFF
--- a/src/api/app/components/card_component.html.haml
+++ b/src/api/app/components/card_component.html.haml
@@ -1,7 +1,6 @@
 .card
   .card-header.d-flex.justify-content-between
-    %div
-      = header
+    = header
     - if delete_button?
       .ms-4
         = delete_button

--- a/src/api/app/components/token_card_component.html.haml
+++ b/src/api/app/components/token_card_component.html.haml
@@ -14,12 +14,15 @@
       Last trigger on #{@token.triggered_at}
 
   - component.with_header do
-    = link_to token_path(@token) do
+    %h5.card-title
+      - unless @token.enabled
+        .pb-3
+          .fas.fa-ban.text-danger
+          %span.text-warning Disabled
       - if @token.description.present?
-        %h5.card-title
-          = @token.description
+        = link_to @token.description, token_path(@token)
       - else
-        %h5.card-title.fst-italic No description
+        = link_to 'No description', token_path(@token), class: 'fst-italic'
 
   - if policy(@token).destroy?
     - component.with_delete_button do

--- a/src/api/app/models/token.rb
+++ b/src/api/app/models/token.rb
@@ -91,6 +91,7 @@ end
 #
 #  id                          :integer          not null, primary key
 #  description                 :string(64)       default("")
+#  enabled                     :boolean          default(TRUE), not null
 #  scm_token                   :string(255)      indexed
 #  string                      :string(255)      indexed
 #  triggered_at                :datetime

--- a/src/api/app/models/token/rebuild.rb
+++ b/src/api/app/models/token/rebuild.rb
@@ -24,6 +24,7 @@ end
 #
 #  id                          :integer          not null, primary key
 #  description                 :string(64)       default("")
+#  enabled                     :boolean          default(TRUE), not null
 #  scm_token                   :string(255)      indexed
 #  string                      :string(255)      indexed
 #  triggered_at                :datetime

--- a/src/api/app/models/token/release.rb
+++ b/src/api/app/models/token/release.rb
@@ -64,6 +64,7 @@ end
 #
 #  id                          :integer          not null, primary key
 #  description                 :string(64)       default("")
+#  enabled                     :boolean          default(TRUE), not null
 #  scm_token                   :string(255)      indexed
 #  string                      :string(255)      indexed
 #  triggered_at                :datetime

--- a/src/api/app/models/token/service.rb
+++ b/src/api/app/models/token/service.rb
@@ -17,6 +17,7 @@ end
 #
 #  id                          :integer          not null, primary key
 #  description                 :string(64)       default("")
+#  enabled                     :boolean          default(TRUE), not null
 #  scm_token                   :string(255)      indexed
 #  string                      :string(255)      indexed
 #  triggered_at                :datetime

--- a/src/api/app/models/token/workflow.rb
+++ b/src/api/app/models/token/workflow.rb
@@ -87,6 +87,7 @@ end
 #
 #  id                          :integer          not null, primary key
 #  description                 :string(64)       default("")
+#  enabled                     :boolean          default(TRUE), not null
 #  scm_token                   :string(255)      indexed
 #  string                      :string(255)      indexed
 #  triggered_at                :datetime

--- a/src/api/app/views/webui/users/tokens/show.html.haml
+++ b/src/api/app/views/webui/users/tokens/show.html.haml
@@ -5,6 +5,9 @@
   .card-body
     %h3.mb-3
       = @pagetitle
+      - unless @token.enabled
+        .fas.fa-ban.text-danger
+        %span.text-warning Disabled
 
     .row
       .col-12.col-md-10.col-lg-8

--- a/src/api/db/migrate/20250211133315_add_enabled_to_token.rb
+++ b/src/api/db/migrate/20250211133315_add_enabled_to_token.rb
@@ -1,0 +1,5 @@
+class AddEnabledToToken < ActiveRecord::Migration[7.0]
+  def change
+    add_column :tokens, :enabled, :boolean, default: true, null: false
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_01_29_110812) do
+ActiveRecord::Schema[7.0].define(version: 2025_02_11_133315) do
   create_table "active_storage_attachments", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -1176,6 +1176,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_01_29_110812) do
     t.datetime "triggered_at", precision: nil
     t.string "workflow_configuration_path", default: ".obs/workflows.yml"
     t.string "workflow_configuration_url", limit: 8192
+    t.boolean "enabled", default: true, null: false
     t.index ["executor_id"], name: "user_id"
     t.index ["package_id"], name: "package_id"
     t.index ["scm_token"], name: "index_tokens_on_scm_token"


### PR DESCRIPTION
Add a column `enabled` to the table `tokens` as the first step to implement token authorization circuit breaker.

Also, modify the list and show views for the tokens of a user to indicate when a token is disabled.

## After

**Note:** I used the rails console to modify the `enabled` field of the tokens to create these screenshots. The pull requests to add the enable/disable functionality will come after this one gets approved and merged.

### List of tokens

![Screenshot From 2025-02-11 17-11-49](https://github.com/user-attachments/assets/be7cf799-0054-47f0-a004-a73b310bef31)

### Token's show page

![Screenshot From 2025-02-11 17-12-14](https://github.com/user-attachments/assets/eb35cb1e-825f-49ba-befd-a5234d45adc2)
