### PR TITLE
Mark data migration as executed after replacing rake task is performed

### DIFF
--- a/src/api/lib/tasks/data_backfill.rake
+++ b/src/api/lib/tasks/data_backfill.rake
@@ -29,6 +29,12 @@ namespace :data do
         end
       end
       # rubocop:enable Rails/SkipsModelValidations
+
+      # this rake task replaces the 20250131143734_backfill_sources_on_bs_request_actions.rb data migration
+      # after this task has been performed, we need to mark the data migration as executed
+      if DataMigrate::DatabaseTasks.pending_data_migrations.find { |data_migration| data_migration[:version] == 20_250_131_143_734 }.present?
+        DataMigrate::DataSchemaMigration.create_version('20250131143734')
+      end
     end
   end
 end


### PR DESCRIPTION
The rake task is a replacement for a data migration. After running it, there is no requirement to perform the data migration. For this reason, we have to mark the data migration as performed after the task has been performed.