### PR TITLE
2.10 scmsync compability

### DIFF
--- a/ReleaseNotes-2.10.24
+++ b/ReleaseNotes-2.10.24
@@ -1,0 +1,24 @@
+#
+# Open Build Service 2.10.24
+#
+
+Please read the README.md file for initial installation
+instructions or use the OBS Appliance from
+
+  http://openbuildservice.org/download/
+
+The dist/README.UPDATERS file has information for people updating
+from a previous OBS release.
+
+This is a compability release to support changes of upcoming
+OBS 2.11.
+
+Compability
+===========
+
+* Support usage of scmsync source from remote OBS instances
+* Fix linking of remote backend only packages
+* Handle "manual" source service modes
+* bs_worker: export cpu features as flags (for s390)
+* Update kiwi schema to current state
+

--- a/docs/api/api/obs.rng
+++ b/docs/api/api/obs.rng
@@ -86,12 +86,13 @@
 
   <define ns="" name="service-modes">
     <choice>
-                                   <!-- DEFAULT: the attribute is not used, service running on server and locally on build time -->
+                                   <!-- DEFAULT: the attribute is not used, service running on server and locally before starting a build -->
       <value>trylocal</value>      <!-- try on local clients and merge result, but run also on server side -->
-      <value>localonly</value>     <!-- never run on server side, but on the clients (not enforced) -->
+      <value>localonly</value>     <!-- never run on server side, but on the clients before commit or build -->
       <value>serveronly</value>    <!-- run on server side, but not on the clients by default -->
-      <value>buildtime</value>     <!-- run during build time, pulls in services as build dependencies -->
-      <value>disabled</value>      <!-- never run, except user explicit starts it locally -->
+      <value>buildtime</value>     <!-- run during build time inside build env, pulls in services as build dependencies -->
+      <value>manual</value>        <!-- never run, except user explicit starts it locally -->
+      <value>disabled</value>      <!-- never run, except user explicit starts it locally (old termonology) -->
     </choice>
   </define>
 

--- a/docs/api/api/package.rng
+++ b/docs/api/api/package.rng
@@ -53,13 +53,17 @@
         <attribute name="updated"/>
       </optional>
 
-      <element ns="" name="title">
-        <text/>
-      </element>
+      <optional>
+        <element ns="" name="title">
+          <text/>
+        </element>
+      </optional>
 
-      <element ns="" name="description">
-        <text/>
-      </element>
+      <optional>
+        <element ns="" name="description">
+          <text/>
+        </element>
+      </optional>
 
 <interleave>
 

--- a/src/api/test/functional/source_controller_test.rb
+++ b/src/api/test/functional/source_controller_test.rb
@@ -268,6 +268,23 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     assert_xml_tag(tag: 'comment', content: 'fixtures')
   end
 
+  def test_put_minimal_package_meta
+    login_tom
+    # ensure that api and backend takes this minimal meta
+    raw_put '/source/home:tom/MINIMAL/_meta', '<package name="MINIMAL"/>'
+    assert_response :success
+
+    # check created package in api and backend
+    get '/source/home:tom/MINIMAL/_meta'
+    assert_response :success
+    get '/source/home:tom/MINIMAL'
+    assert_response :success
+
+    # cleanup
+    delete '/source/home:tom/MINIMAL'
+    assert_response :success
+  end
+
   def test_get_package_meta_from_hidden_project
     login_tom
     get '/source/HiddenProject/pack/_meta'

--- a/src/backend/BSXML.pm
+++ b/src/backend/BSXML.pm
@@ -141,6 +141,7 @@ our $proj = [
         'title',
         'description',
         'url',
+        'scmsync',
 	'config',	# for 'withconfig' option
      [[	'link' =>
 	    'project',
@@ -166,6 +167,7 @@ our $pack = [
         'title',
         'description',
         'releasename',
+        'scmsync',
       [ 'devel' =>
 	    'project',
 	    'package',

--- a/src/backend/bs_service
+++ b/src/backend/bs_service
@@ -157,7 +157,7 @@ sub run_source_update {
     for my $service (@{$serviceinfo->{'service'}}) {
       my $name = $service->{'name'};
       BSVerify::verify_filename($name);
-      if (defined($service->{'mode'}) && ($service->{'mode'} eq 'localonly' || $service->{'mode'} eq 'disabled' || $service->{'mode'} eq 'buildtime')) {
+      if (defined($service->{'mode'}) && ($service->{'mode'} eq 'localonly' || $service->{'mode'} eq 'disabled' || $service->{'mode'} eq 'manual' || $service->{'mode'} eq 'buildtime')) {
         print "Skip $name\n";
         next;
       }


### PR DESCRIPTION
Allow to reference remote project or package instance which get fed via scmsync git. The source content is transparent for older OBS instances, but they need to accept the additional xml element.

@DimStar77 could you test if a linkpac to a remote using scmsync is working with this?