### PR TITLE
Allow to disable or enable a token from the web UI

### DIFF
--- a/src/api/app/controllers/webui/users/tokens_controller.rb
+++ b/src/api/app/controllers/webui/users/tokens_controller.rb
@@ -92,7 +92,7 @@ class Webui::Users::TokensController < Webui::WebuiController
   end
 
   def update_parameters
-    params.require(:token).except(:string_readonly).permit(:description, :scm_token, :workflow_configuration_path, :workflow_configuration_url)
+    params.require(:token).except(:string_readonly).permit(:description, :enabled, :scm_token, :workflow_configuration_path, :workflow_configuration_url)
           .reject! { |k, v| k == 'scm_token' && (@token.type != 'Token::Workflow' || v.empty?) }
   end
 

--- a/src/api/app/views/webui/users/tokens/edit.html.haml
+++ b/src/api/app/views/webui/users/tokens/edit.html.haml
@@ -23,6 +23,9 @@
               .mb-3
                 = f.label(:type, 'Operation:')
                 = @token.token_name.capitalize
+              .mb-3.form-check.form-switch
+                = f.check_box(:enabled, class: 'form-check-input')
+                = f.label(:enabled, 'Enabled', class: 'form-check-label')
               .mb-3
                 = f.label(:description, 'Description:')
                 %span.d-none#original-token-description

--- a/src/api/spec/controllers/webui/users/tokens_controller_spec.rb
+++ b/src/api/spec/controllers/webui/users/tokens_controller_spec.rb
@@ -108,13 +108,14 @@ RSpec.describe Webui::Users::TokensController do
 
     context 'updates a workflow token belonging to the logged-in user' do
       let(:token) { create(:workflow_token, executor: user, scm_token: 'something') }
-      let(:update_parameters) { { id: token.id, token: { description: 'My first token', scm_token: 'something_else' } } }
+      let(:update_parameters) { { id: token.id, token: { description: 'My first token', enabled: false, scm_token: 'something_else' } } }
 
       include_examples 'check for flashing a success'
 
       it { is_expected.to redirect_to(tokens_path) }
       it { expect { subject }.to change { token.reload.scm_token }.from('something').to('something_else') }
       it { expect { subject }.to change { token.reload.description }.from('').to('My first token') }
+      it { expect { subject }.to change { token.reload.enabled }.from(true).to(false) }
     end
 
     context 'updates the token string of a token belonging to the logged-in user' do


### PR DESCRIPTION
Follow up to #17363.

## After

Enabled | Disabled
:-------------------------:|:-------------------------:
![Screenshot From 2025-02-12 11-49-17](https://github.com/user-attachments/assets/9621c64d-9b29-4ad2-86d2-2300b367df41) | ![Screenshot From 2025-02-12 11-49-27](https://github.com/user-attachments/assets/c09d857b-457a-4eee-982e-2c712fc682a4)
