### PR TITLE
Introduce the `enabled` token attribute into the tokens' API endoints

### DIFF
--- a/docs/api/api/token.rng
+++ b/docs/api/api/token.rng
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar ns="http://buildservice.org/api"
+         xmlns="http://relaxng.org/ns/structure/1.0"
+         datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"
+         xmlns:a="http://www.example.com/annotation">
+
+  <include href="obs.rng" />
+
+  <start>
+   <ref name="token-element"/>
+  </start>
+
+  <define name="token-element">
+   <element ns="" name="token">
+    <a:documentation>
+     Token
+    </a:documentation>
+
+    <optional>
+     <attribute name="id">
+      <data type="nonNegativeInteger"/>
+      <a:documentation>
+       The unique id of this token.
+      </a:documentation>
+     </attribute>
+    </optional>
+
+    <optional>
+     <attribute name="string">
+      <a:documentation>
+       The token secret. This string can be used instead of the password to
+       authenticate the user or to trigger service runs via the
+       `POST /trigger/runservice` route.
+      </a:documentation>
+      <data type="string"/>
+     </attribute>
+    </optional>
+
+    <optional>
+     <attribute name="description">
+      <a:documentation>
+       It helps to identify a token from the rest of the tokens of a user.
+      </a:documentation>
+      <data type="string"/>
+     </attribute>
+    </optional>
+
+    <optional>
+     <attribute name="enabled">
+      <a:documentation>
+       Indicates whether a token can accept trigger requests or not.
+      </a:documentation>
+      <data type="boolean"/>
+     </attribute>
+    </optional>
+
+    <optional>
+     <attribute name="project">
+      <a:documentation>
+       Project name. Should be provided, together with the package query
+       parameter, to limit the token to a specific package.
+      </a:documentation>
+      <data type="string"/>
+     </attribute>
+     <attribute name="package">
+      <a:documentation>
+       Package name. Should be provided, together with the project query
+       parameter, to limit the token to a specific package.
+      </a:documentation>
+      <data type="string"/>
+     </attribute>
+    </optional>
+
+    <optional>
+     <attribute name="kind">
+      <a:documentation>
+       This attribute indicates the kind of token. When operation is not
+       specified, 'runservice' is the default value.
+       - rss: used to retrieve the notification RSS feed
+       - rebuild: trigger rebuilds of packages
+       - release: trigger project releases
+       - runservice: run a service via the POST /trigger/runservice route
+       - workflow: trigger SCM/CI workflows, see
+         https://openbuildservice.org/help/manuals/obs-user-guide/cha-obs-scm-ci-workflow-integration
+      </a:documentation>
+      <ref name="token-kind"/>
+     </attribute>
+    </optional>
+
+    <optional>
+     <attribute name="scm_token">
+      <a:documentation>
+       SCM token used in OBS workflows to report back the workflow status, when
+       the operation is workflow. It's normally possible to generate SCM tokens
+       directly on the SCM's website like GitHub or GitLab.
+      </a:documentation>
+      <data type="string"/>
+     </attribute>
+    </optional>
+
+    <optional>
+     <attribute name="workflow_configuration_path">
+      <a:documentation>
+       The default path is '.obs/workflows.yml'.
+      </a:documentation>
+      <data type="string"/>
+     </attribute>
+    </optional>
+
+    <optional>
+     <attribute name="workflow_configuration_url">
+      <a:documentation>
+       When the URL is given, the path will be ignored. The URL should be accessible for the OBS instance.
+      </a:documentation>
+      <data type="string"/>
+     </attribute>
+    </optional>
+
+    <optional>
+     <attribute name="triggered_at">
+      <a:documentation>
+       The date and time a token got triggered the last time.
+      </a:documentation>
+      <data type="string"/>
+     </attribute>
+    </optional>
+   </element>
+  </define>
+</grammar>

--- a/docs/api/api/token.xml
+++ b/docs/api/api/token.xml
@@ -1,0 +1,1 @@
+<token id="18" enabled="true" string="thisIsASuperSecretValue" kind="rss" triggered_at="2021-10-28 12:32:18 UTC"/>

--- a/docs/api/api/tokenlist.rng
+++ b/docs/api/api/tokenlist.rng
@@ -56,6 +56,16 @@
        </attribute>
       </optional>
 
+     <attribute name="enabled">
+      <a:documentation>
+       Indicates whether a token can accept trigger requests or not. A token is
+       created with the `enabled` attribute set to `true`, but this attribute may
+       be automatically set to `false` depending on the number of failed trigger
+       requests associated with the token.
+      </a:documentation>
+      <data type="boolean"/>
+     </attribute>
+
       <optional>
        <attribute name="project">
         <a:documentation>

--- a/docs/api/api/tokenlist.xml
+++ b/docs/api/api/tokenlist.xml
@@ -1,5 +1,5 @@
 <directory count="3">
-  <entry id="18" string="thisIsASuperSecretValue" kind="rss" triggered_at="2021-10-28 12:32:18 UTC"/>
-  <entry id="265" string="thisIsAnotherSuperSecretValue" kind="runservice" description="Runservice without package" triggered_at="2021-10-28 12:32:18 UTC"/>
-  <entry id="267" string="aSuperSecretValue" kind="release" triggered_at="2021-10-28 12:32:18 UTC" project="devel:libraries:c_c++" package="notmuch"/>
+  <entry id="18" enabled="true" string="thisIsASuperSecretValue" kind="rss" triggered_at="2021-10-28 12:32:18 UTC"/>
+  <entry id="265" enabled="true" string="thisIsAnotherSuperSecretValue" kind="runservice" description="Runservice without package" triggered_at="2021-10-28 12:32:18 UTC"/>
+  <entry id="267" enabled="false" string="aSuperSecretValue" kind="release" triggered_at="2021-10-28 12:32:18 UTC" project="devel:libraries:c_c++" package="notmuch"/>
 </directory>

--- a/src/api/app/models/token.rb
+++ b/src/api/app/models/token.rb
@@ -12,6 +12,7 @@ class Token < ApplicationRecord
   end
 
   validates :description, length: { maximum: 64 }
+  validates :enabled, inclusion: { in: [true, false], message: "must be 'true' or 'false'." }
   validates :string, uniqueness: { case_sensitive: false }
   validates :scm_token, absence: true, if: -> { type != 'Token::Workflow' }
 

--- a/src/api/app/views/person/token/index.xml.builder
+++ b/src/api/app/views/person/token/index.xml.builder
@@ -1,7 +1,7 @@
 xml.directory(count: @list.length) do |dir|
   @list.each do |token|
     token_name = token.token_name.sub('service', 'runservice') # To make token naming consistent: we create the token as runservice
-    p = { id: token.id, string: token.string, kind: token_name, description: token.description, triggered_at: token.triggered_at }
+    p = { id: token.id, string: token.string, kind: token_name, description: token.description, enabled: token.enabled, triggered_at: token.triggered_at }
     if token.package
       p[:project] = token.package.project.name
       p[:package] = token.package.name

--- a/src/api/config/routes/api.rb
+++ b/src/api/config/routes/api.rb
@@ -15,6 +15,7 @@ constraints(RoutesHelper::APIMatcher) do
   get 'person/:login/token' => 'person/token#index', constraints: cons
   post 'person/:login/token' => 'person/token#create', constraints: cons
   delete 'person/:login/token/:id' => 'person/token#delete', constraints: cons
+  put 'person/:login/token/:id' => 'person/token#update', constraints: cons
 
   # FIXME3.0: this is no clean namespace, a person "register" or "changepasswd" could exist ...
   #           remove these for OBS 3.0

--- a/src/api/public/apidocs/components/schemas/person_tokens.yaml
+++ b/src/api/public/apidocs/components/schemas/person_tokens.yaml
@@ -17,6 +17,10 @@ properties:
           type: string
           xml:
             attribute: true
+        enabled:
+          type: string
+          xml:
+            attribute: true
         string:
           type: string
           xml:

--- a/src/api/public/apidocs/components/schemas/token.yaml
+++ b/src/api/public/apidocs/components/schemas/token.yaml
@@ -1,0 +1,37 @@
+type: object
+properties:
+  id:
+    type: string
+    xml:
+      attribute: true
+  description:
+    type: string
+    xml:
+      attribute: true
+  enabled:
+    type: string
+    xml:
+      attribute: true
+  string:
+    type: string
+    xml:
+      attribute: true
+  kind:
+    type: string
+    xml:
+      attribute: true
+  triggered_at:
+    type: string
+    format: date-time
+    xml:
+      attribute: true
+  project:
+    type: string
+    xml:
+      attribute: true
+  package:
+    type: string
+    xml:
+      attribute: true
+xml:
+  name: token

--- a/src/api/public/apidocs/paths/person_login_token.yaml
+++ b/src/api/public/apidocs/paths/person_login_token.yaml
@@ -19,11 +19,13 @@ get:
             count: 2
             entry:
               - id: 3
+                enabled: true
                 string: FK49K39DKK
                 kind: rss
                 triggered_at: '2021-10-28 12:32:18 UTC'
               - id: 25
                 description: Release ghcz
+                enabled: false
                 string: 4T04JGI691
                 kind: release
                 triggered_at: '2021-09-21 11:12:18 UTC'

--- a/src/api/public/apidocs/paths/person_login_token_id.yaml
+++ b/src/api/public/apidocs/paths/person_login_token_id.yaml
@@ -1,6 +1,90 @@
+put:
+  summary: Update a token of a person.
+  description: |
+    Update a specified token of a person.
+
+    The only token attribute which can be updated is `enabled`. A token is
+    created with this attribute set to `true`. However, this attribute may be
+    automatically set to `false` depending on the number of failed trigger
+    requests associated with the token.
+  security:
+    - basic_authentication: []
+  parameters:
+    - $ref: '../components/parameters/login.yaml'
+    - in: path
+      name: id
+      schema:
+        type: string
+      required: true
+      description: Id of the token to be removed.
+      example: 3
+  requestBody:
+    description: |
+      Token definition.
+
+      XML Schema used for token validation: [token.rng](../schema/token.rng)
+    required: true
+    content:
+      application/xml; charset=utf-8:
+        schema:
+          $ref: '../components/schemas/token.yaml'
+  responses:
+    '200':
+      description: |
+        OK. The request has succeeded.
+
+        XML Schema used for body validation: [status.rng](../schema/status.rng)
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          example:
+            code: ok
+            summary: Ok
+    '400':
+      description: |
+        Bad Request.
+
+        XML Schema used for body validation: [status.rng](../schema/status.rng)
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          example:
+            code: validation_failed
+            summary: 'token validation error: 1:0: ERROR: Invalid attribute enabled for element token'
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '403':
+      description: |
+        Forbidden.
+
+        XML Schema used for body validation: [status.rng](../schema/status.rng)
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          example:
+            code: update_user_not_authorized
+            summary: 'You are not authorized to update this User.'
+    '404':
+      description: |
+        Not Found.
+
+        XML Schema used for body validation: [status.rng](../schema/status.rng)
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          example:
+            code: not_found
+            summary: Couldn't find Token with 'id'=33
+  tags:
+    - Person
+
 delete:
   summary: Delete a token of a person.
-  description: Delete a token of the specified person.
+  description: Delete a specific token of a person.
   security:
     - basic_authentication: []
   parameters:

--- a/src/api/test/functional/backend_test.rb
+++ b/src/api/test/functional/backend_test.rb
@@ -15,7 +15,7 @@ class BackendTests < ActionDispatch::IntegrationTest
                           productlist binary_released check required_checks status_report
                           staged_requests remove_staged_requests status_ok staging_project
                           staging_projects create_staging_workflow update_staging_workflow accept_staging_projects
-                          excluded_requests create_excluded_requests delete_excluded_requests create_staging_projects backlog tokenlist]
+                          excluded_requests create_excluded_requests delete_excluded_requests create_staging_projects backlog token tokenlist]
 
     Dir.entries(dir).each do |f|
       next unless /.*.xml\z/.match?(f)


### PR DESCRIPTION
For reviewers:

- Create a token in your development environment with the user Admin.
- Test the endpoint:
   - with `osc`: `osc -A http://localhost:3000 api -X PUT '/person/Admin/token/$TOKEN_ID?enabled=false'`, or
   - with `curl`: `curl -u Admin:$PASSWORD -H 'Content-Type: application/octet-stream' -H 'accept: application/xml' -X PUT 'http://localhost:3000/person/Admin/token/$TOKEN_ID?enabled=false'`
   
You can check the new documented endpoint in the review-app, with this [link](https://obs-reviewlab.opensuse.org/eduardoj-featureworkflow_token_circuit_breaker_api/apidocs/index#/Person/put_person__login__token__id_).
