### PR TITLE
[backend] bs_publish: also publish mkosi .img files

### DIFF
--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -1264,7 +1264,7 @@ sub createrepo_staticlinks {
         my $profile = $3 || "";
         $link = "$1$profile$5";
         $link = "$1-$2$profile$5" if $versioned;
-      } elsif (/^(.*)_([^_]*)\.(manifest|efi|vmlinuz|initrd|tar|cpio|raw|verity|roothash|roothash\.p7s|usrhash|usrhash\.p7s)(?:\.(?:gz|bz2|xz|zst|zstd))?$/s) {
+      } elsif (/^(.*)_([^_]*)\.(manifest|efi|vmlinuz|initrd|tar|cpio|img|raw|verity|roothash|roothash\.p7s|usrhash|usrhash\.p7s)(?:\.(?:gz|bz2|xz|zst|zstd))?$/s) {
         # mkosi appliance
         $link = "$1.$3";
         $link = "${1}_$2.$3" if $versioned;
@@ -2506,7 +2506,7 @@ sub publish {
 	    BSPublisher::Helm::readhelminfo($r, "$1.helminfo");
 	    $p = $bin;
           };
-	} elsif ($bin =~ /\.(manifest|efi|vmlinuz|initrd|cpio|verity|roothash|roothash\.p7s|usrhash|usrhash\.p7s)(?:\.(?:gz|bz2|xz|zst|zstd))?(?:\.sha[0-9]*(?:\.asc)?)?$/) {
+	} elsif ($bin =~ /\.(manifest|img|efi|vmlinuz|initrd|cpio|verity|roothash|roothash\.p7s|usrhash|usrhash\.p7s)(?:\.(?:gz|bz2|xz|zst|zstd))?(?:\.sha[0-9]*(?:\.asc)?)?$/) {
 	  # split dm-verity/EFI artifacts from mkosi, or image manifest file
 	  $p = "$bin";
 	} elsif ($bin =~ /^SHA[0-9]*SUMS(?:\.gpg|\.asc)?$/) {


### PR DESCRIPTION
The UEFI spec for http boot requires that either a file has MIME type of a particular value, which we can't do on published repos, or the image has a '.img' suffix. Mkosi just added support for building UKIs with this suffix, as an option, for this use case.