### PR TITLE
Airbrake Bunny::Exception

### DIFF
--- a/src/api/config/initializers/airbrake.rb
+++ b/src/api/config/initializers/airbrake.rb
@@ -100,14 +100,14 @@ def ignore_by_backend_400_message?(message)
 end
 
 def ignore_by_class?(notice)
-  exceptions_to_ignore = ['AMQ::Protocol::EmptyResponseError', 'AbstractController::ActionNotFound',
+  exceptions_to_ignore = ['AbstractController::ActionNotFound',
                           'ActionController::BadRequest', 'ActionController::InvalidAuthenticityToken',
                           'ActionController::UnknownAction', 'ActionController::UnknownFormat',
                           'ActionDispatch::Http::MimeNegotiation::InvalidType',
                           'ActiveRecord::RecordNotFound', 'Backend::NotFoundError',
-                          'Bunny::TCPConnectionFailedForAllHosts', 'CGI::Session::CookieStore::TamperedWithCookie',
-                          'Errno::ECONNRESET', 'Interrupt', 'Net::HTTPBadResponse',
-                          'RoutesHelper::WebuiMatcher::InvalidRequestFormat', 'Timeout::Error']
+                          'CGI::Session::CookieStore::TamperedWithCookie',
+                          'Interrupt', 'Net::HTTPBadResponse',
+                          'RoutesHelper::WebuiMatcher::InvalidRequestFormat']
 
   notice[:errors].pluck(:type).intersect?(exceptions_to_ignore)
 end

--- a/src/api/config/options.yml.example
+++ b/src/api/config/options.yml.example
@@ -198,6 +198,7 @@ default: &default
   #   user: guest
   #   pass: guest
   #   vhost: vhost
+  #   recovery_attempts: 75
   #
   # Exchange options -> http://rubybunny.info/articles/exchanges.html
   # amqp_exchange_name: pubsub

--- a/src/api/lib/rabbitmq_bus.rb
+++ b/src/api/lib/rabbitmq_bus.rb
@@ -4,16 +4,8 @@ class RabbitmqBus
   def self.send_to_bus(channel, data)
     channel = "#{Configuration.amqp_namespace}.#{channel}"
     publish(channel, data)
-    self.failed = false
-  rescue Bunny::ConnectionClosedError
-    # if bunny can't recover itself, we need to reset the connection
-    self.exchange = nil
-    unless failed
-      self.failed = true
-      publish(channel, data)
-    end
-  rescue StandardError => e
-    Rails.logger.error "Publishing to RabbitMQ failed: #{e.message}"
+  rescue Bunny::Exception => e
+    Rails.logger.error "Publishing to AMQP failed, automatic recovery too: #{e.message}"
     Airbrake.notify(e)
   end
 

--- a/src/api/spec/lib/rabbitmq_bus_spec.rb
+++ b/src/api/spec/lib/rabbitmq_bus_spec.rb
@@ -3,15 +3,4 @@ RSpec.describe RabbitmqBus, rabbitmq: '#' do
     RabbitmqBus.send_to_bus('metrics', 'hallo')
     expect_message('opensuse.obs.metrics', 'hallo')
   end
-
-  context 'with exceptions' do
-    before do
-      allow_any_instance_of(BunnyMock::Queue).to receive(:publish).and_raise(Net::ReadTimeout)
-    end
-
-    it 'disconnects on errors' do
-      RabbitmqBus.send_to_bus('metrics', 'hallo')
-      expect_no_message
-    end
-  end
 end


### PR DESCRIPTION
Bunny has automatic connection recovery by default, also from server initiated close.

http://rubybunny.info/articles/error_handling.html

We should know when that fails instead of swallowing that problem. By default automatic recovery will try every 4 seconds forever, let's limit this to roughly 5 minutes: (75 * 4 / 60)