### PR TITLE
Introduce Package/BsRequest -> EventSubscription association

### DIFF
--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -67,6 +67,7 @@ class BsRequest < ApplicationRecord
   has_many :notifications, as: :notifiable, dependent: :delete_all
   has_many :watched_items, as: :watchable, dependent: :destroy
   has_many :reports, as: :reportable, dependent: :nullify
+  has_many :event_subscriptions, dependent: :destroy
   has_many :labels, as: :labelable
   accepts_nested_attributes_for :labels, allow_destroy: true
 

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -57,6 +57,8 @@ class Package < ApplicationRecord
   has_many :source_of_bs_request_actions, class_name: 'BsRequestAction', foreign_key: 'source_package_id', dependent: :nullify
   has_many :source_of_bs_requests, through: :source_of_bs_request_actions, source: :bs_request
 
+  has_many :event_subscription, dependent: :destroy
+
   has_many :watched_items, as: :watchable, dependent: :destroy
   has_many :reports, as: :reportable, dependent: :nullify
   has_many :labels, as: :labelable


### PR DESCRIPTION
The other way around this is there since a long time. Although exclusively for the `scm` channel.

If a Package/BsRequest is destroyed, the subscription should go too. As there will be no events about this anymore...