### PR TITLE
Move rubocop-performance from `require:` to `plugins:`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,11 +1,11 @@
 inherit_from: .rubocop_todo.yml
 
 plugins:
+  - rubocop-performance
   - rubocop-rspec
 
 require:
   - rubocop-capybara
-  - rubocop-performance
   - rubocop-rspec_rails
 
 AllCops:

--- a/src/api/.rubocop.yml
+++ b/src/api/.rubocop.yml
@@ -1,10 +1,10 @@
 plugins:
+  - rubocop-performance
   - rubocop-rspec
 
 require:
   - rubocop-capybara
   - rubocop-factory_bot
-  - rubocop-performance
   - rubocop-rails
   - rubocop-rspec_rails
   - ./lib/rubocop/cop/view_component/avoid_global_state.rb


### PR DESCRIPTION
Follow up to #17391.

Prevents from throwing a warning about `rubocop-performance` supporting extension plugin.

See: https://docs.rubocop.org/rubocop/plugin_migration_guide.html