### PR TITLE
Speed up test: trigger submit form instead of waiting for the timeout

### DIFF
--- a/src/api/spec/features/beta/webui/requests_index_spec.rb
+++ b/src/api/spec/features/beta/webui/requests_index_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe 'Requests Index' do
       find_by_id('requests-dropdown-trigger').click if mobile? # open the filter dropdown
       within('#content-selector-filters') do
         check('Maintenance Release')
-        sleep 2 # there is a timeout before firing the filtering
+        page.execute_script('submitFilters()') # autosubmit form
       end
 
       within('#requests') do
@@ -126,7 +126,7 @@ RSpec.describe 'Requests Index' do
         find('.ui-menu-item-wrapper', match: :first).click
         # Remove focus from autocomplete search to allow the autosubmit
         find(:xpath, '//*[@id="request-creator-dropdown"]/div/div/span/i').click
-        sleep 2
+        page.execute_script('submitFilters()') # autosubmit form
       end
 
       if mobile?
@@ -139,7 +139,7 @@ RSpec.describe 'Requests Index' do
         find('.ui-menu-item-wrapper', match: :first).click
         # Remove focus from autocomplete search to allow the autosubmit
         find(:xpath, '//*[@id="request-creator-dropdown"]/div/div/span/i').click
-        sleep 2
+        page.execute_script('submitFilters()') # autosubmit form
       end
     end
 
@@ -158,7 +158,7 @@ RSpec.describe 'Requests Index' do
 
       within('#content-selector-filters') do
         uncheck("creators[#{receiver.login}]")
-        sleep 2
+        page.execute_script('submitFilters()') # autosubmit form
       end
 
       expect(page).to have_no_link(href: "/request/show/#{outgoing_request.number}")
@@ -188,7 +188,7 @@ RSpec.describe 'Requests Index' do
         # filter from yesterday to tomorrow
         fill_in 'created_at_from', with: DateTime.now - 1.day
         fill_in 'created_at_to', with: DateTime.now + 1.day
-        sleep 2 # there is a timeout before firing the filtering
+        page.execute_script('submitFilters()') # autosubmit form
       end
 
       within('#requests') do
@@ -213,7 +213,7 @@ RSpec.describe 'Requests Index' do
         find('.ui-menu-item-wrapper', match: :first).click
         # Remove focus from autocomplete search to allow the autosubmit
         find(:xpath, '//*[@id="request-reviewer-dropdown"]/div/div/span/i').click
-        sleep 2
+        page.execute_script('submitFilters()') # autosubmit form
       end
     end
 


### PR DESCRIPTION
https://trello.com/c/Ur7ALglM

On local setup:
`time rspec ./spec/features/beta/webui/requests_index_spec.rb`

**Before**
real    0m59.635s
user    0m43.092s
sys     0m7.101s

**After**
real    0m41.460s
user    0m42.139s
sys     0m6.736s