### PR TITLE
Let searchable inputs wait user interaction instead of autosubmit

### DIFF
--- a/src/api/app/assets/javascripts/webui/content-selector-filters.js
+++ b/src/api/app/assets/javascripts/webui/content-selector-filters.js
@@ -27,7 +27,7 @@ function submitFilters() {
 }
 
 let submitFiltersTimeout;
-$(document).on('change keyup', '#content-selector-filters-form input, #content-selector-filters-form select', function() {
+$(document).on('change keyup', '.auto-submit-on-change input, .auto-submit-on-change select', function() {
   // Clear the timeout to prevent the pending submission, if any
   window.clearTimeout(submitFiltersTimeout);
 

--- a/src/api/app/assets/javascripts/webui/content-selector-filters.js
+++ b/src/api/app/assets/javascripts/webui/content-selector-filters.js
@@ -46,6 +46,21 @@ $(document).on('change keyup', '.auto-submit-on-change input, .auto-submit-on-ch
   submitFiltersTimeout = window.setTimeout(submitFilters, 2000);
 });
 
+// NOTE: no need to implement a keypress ENTER event, pressing enter on a form input will submit the form by default
+// Implement a click event on the search icon below
+const autoSubmitOnClickSelector = '#content-selector-filters-form .input-group-text';
+$(document).on('click', autoSubmitOnClickSelector, function() {
+  // Do nothing if there is no search icon inside
+  if ($(this).children('.fa-search').length === 0) {
+    return;
+  }
+  // Clear the timeout to prevent the pending submission, if any
+  window.clearTimeout(submitFiltersTimeout);
+
+  submitFilters();
+});
+
 $(document).ready(function(){
   highlightSelectedFilters();
+  $(autoSubmitOnClickSelector).each(function() {$(this).css('cursor', 'pointer');});
 });

--- a/src/api/app/views/webui/shared/bs_requests/_requests_filter.html.haml
+++ b/src/api/app/views/webui/shared/bs_requests/_requests_filter.html.haml
@@ -1,6 +1,6 @@
 -# haml-lint:disable ViewLength
 .accordion.accordion-flush
-  .mt-2.mb-2.accordion-item.border-0
+  .mt-2.mb-2.accordion-item.border-0.auto-submit-on-change
     .px-3.py-2.accordion-button.no-style{ data: { 'bs-toggle': 'collapse', 'bs-target': '#request-filter-direction' },
                                              aria: { expanded: 'true', controls: 'request-filter-direction' } }
       %b Direction
@@ -15,7 +15,7 @@
                                                               key: 'direction[outgoing]', name: 'direction', value: 'outgoing',
                                                               checked: selected_filter[:direction] == 'outgoing' }
 
-  .mt-2.mb-2.accordion-item.border-0
+  .mt-2.mb-2.accordion-item.border-0.auto-submit-on-change
     .px-3.py-2.accordion-button.no-style{ data: { 'bs-toggle': 'collapse', 'bs-target': '#request-filter-state' },
                                                        aria: { expanded: 'true', controls: 'request-filter-state' } }
       %b State
@@ -27,7 +27,7 @@
                                                               value: state,
                                                               checked: selected_filter[:state]&.include?(state.to_s) }
 
-  .mt-2.mb-2.accordion-item.border-0
+  .mt-2.mb-2.accordion-item.border-0.auto-submit-on-change
     .px-3.py-2.accordion-button.no-style{ data: { 'bs-toggle': 'collapse', 'bs-target': '#request-filter-action' },
                                                        aria: { expanded: 'true', controls: 'request-filter-action' } }
       %b Action Type
@@ -73,7 +73,7 @@
                                                             label_icon: action_type_icon('submit'),
                                                             checked: selected_filter[:action_type]&.include?('submit')}
 
-  .mt-2.mb-2.accordion-item.border-0
+  .mt-2.mb-2.accordion-item.border-0.auto-submit-on-change
     .px-3.py-2.accordion-button.no-style{ data: { 'bs-toggle': 'collapse', 'bs-target': '#request-filter-priority' },
                                                        aria: { expanded: 'true', controls: 'request-filter-priority' } }
       %b Priority
@@ -95,7 +95,7 @@
         = render partial: 'webui/shared/autocomplete', locals: { html_id: 'project_names_search', label: 'Project names:',
                                                                  html_name: 'project_names[]', required: false, with_label: false,
                                                                  data: { source: autocomplete_projects_path } }
-        .scroll-list-wrapper
+        .scroll-list-wrapper.auto-submit-on-change
           - selected_filter[:project_names].each do |project_name|
             .dropdown-item-text
               = render partial: 'webui/shared/check_box', locals: { label: project_name,
@@ -113,7 +113,7 @@
         = render partial: 'webui/shared/autocomplete', locals: { html_id: 'creators_search', label: 'Creators:',
                                                                  html_name: 'creators[]', required: false, with_label: false,
                                                                  data: { source: autocomplete_users_path } }
-        .scroll-list-wrapper
+        .scroll-list-wrapper.auto-submit-on-change
           - if selected_filter[:creators].include?(User.session.login)
             .dropdown-item-text
               = render partial: 'webui/shared/check_box', locals: { label: "#{User.session.login} (me)",
@@ -140,7 +140,7 @@
                                                                  html_name: 'reviewers[]', required: false, with_label: false,
                                                                  data: { source: autocomplete_reviewers_path } }
 
-        .scroll-list-wrapper
+        .scroll-list-wrapper.auto-submit-on-change
           - if selected_filter[:reviewers].include?(User.session.login)
             .dropdown-item-text
               = render partial: 'webui/shared/check_box', locals: { label: "#{User.session.login} (me)",
@@ -173,7 +173,7 @@
                                                                     value: staging_project,
                                                                     checked: selected_filter[:staging_projects]&.include?(staging_project) }
 
-  .mt-2.mb-2.accordion-item.border-0
+  .mt-2.mb-2.accordion-item.border-0.auto-submit-on-change
     .px-3.py-2.accordion-button.no-style{ data: { 'bs-toggle': 'collapse', 'bs-target': '#request-filter-created-at' },
                                                        aria: { expanded: 'true', controls: 'request-filter-created-at' } }
       %b Created datetime


### PR DESCRIPTION
Autosubmit gets triggered after the timeout only on certain filter inputs, the ones with `auto-submit-on-change` wrapper class.
Autocomplete searchable inputs instead wait for the user to press the `enter` key or click on the `fa-search` (AKA the lens icon) of the input field.