### PR TITLE
Fix the notice about the confirmation when creating a project with the same name as a deleted project.

### DIFF
--- a/src/api/app/views/webui/project/new.html.haml
+++ b/src/api/app/views/webui/project/new.html.haml
@@ -16,7 +16,7 @@
         %p
           A project with the same name existed in the past. You can restore the old state instead of starting from scratch.
           = link_to 'Click here', projects_restore_path(project: @project.name), method: :post
-          if you want to restore the project. If you want to start from scratch, click the 'Create Project' button again.
+          if you want to restore the project. If you want to start from scratch, click the 'Accept' button below.
           %strong (Be aware that starting from scratch would mean that you'd delete the old state of the project and it can never get restored again!)
     = form_for(@project, url: projects_create_path, method: :post) do |form|
       - locals = { form: form, configuration: @configuration, show_restore_message: @show_restore_message }


### PR DESCRIPTION
I noticed this when I was working on some side projects.

![Screenshot From 2025-02-22 01-19-52](https://github.com/user-attachments/assets/270c749a-52df-48fe-a7d5-55300af8a38e)
