### PR TITLE
Request filter staging projects autocomplete

### DIFF
--- a/src/api/app/controllers/concerns/webui/requests_filter.rb
+++ b/src/api/app/controllers/concerns/webui/requests_filter.rb
@@ -21,7 +21,7 @@ module Webui::RequestsFilter
     params[:states] = @filter_state if @filter_state.present?
     params[:priorities] = @filter_priority if @filter_priority.present?
     params[:types] = @filter_action_type if @filter_action_type.present?
-    params[:staging_project] = @filter_staging_project if @filter_staging_project.present?
+    params[:staging_projects] = @filter_staging_projects if @filter_staging_projects.present?
     params[:reviewers] = @filter_reviewers if @filter_reviewers.present?
 
     params[:created_at_from] = @filter_created_at_from if @filter_created_at_from.present?
@@ -51,7 +51,7 @@ module Webui::RequestsFilter
     @filter_creators = params[:creators].present? ? params[:creators].compact_blank! : []
 
     @filter_project_names = params[:project_names].present? ? params[:project_names].compact_blank! : []
-    @filter_staging_project = params[:staging_project].presence || []
+    @filter_staging_projects = params[:staging_projects].presence || []
 
     @filter_created_at_from = params[:created_at_from].presence || ''
     @filter_created_at_to = params[:created_at_to].presence || ''
@@ -64,7 +64,7 @@ module Webui::RequestsFilter
   def set_selected_filter
     @selected_filter = { direction: @filter_direction, action_type: @filter_action_type, search_text: params[:requests_search_text],
                          state: @filter_state, creators: @filter_creators, project_names: @filter_project_names,
-                         staging_project: @filter_staging_project, priority: @filter_priority,
+                         staging_projects: @filter_staging_projects, priority: @filter_priority,
                          created_at_from: @filter_created_at_from, created_at_to: @filter_created_at_to, reviewers: @filter_reviewers }
   end
 
@@ -78,6 +78,6 @@ module Webui::RequestsFilter
   end
 
   def staging_projects
-    Project.where(name: @filter_staging_project)
+    Project.where(name: @filter_staging_projects)
   end
 end

--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -26,7 +26,8 @@ class Webui::ProjectController < Webui::WebuiController
 
   before_action :check_ajax, only: %i[buildresult edit_comment_form]
 
-  after_action :verify_authorized, except: %i[index autocomplete_projects autocomplete_incidents autocomplete_packages
+  after_action :verify_authorized, except: %i[index autocomplete_projects autocomplete_staging_projects
+                                              autocomplete_incidents autocomplete_packages
                                               autocomplete_repositories users subprojects new show
                                               buildresult requests monitor new_release_request
                                               remove_target_request edit_comment edit_comment_form preview_description]
@@ -136,6 +137,10 @@ class Webui::ProjectController < Webui::WebuiController
 
   def autocomplete_projects
     render json: Project.autocomplete(params[:term], params[:local]).not_maintenance_incident.pluck(:name)
+  end
+
+  def autocomplete_staging_projects
+    render json: Project.autocomplete(params[:term]).where.not(staging_workflow_id: nil).pluck(:name)
   end
 
   def autocomplete_incidents

--- a/src/api/app/views/webui/shared/bs_requests/_form.html.haml
+++ b/src/api/app/views/webui/shared/bs_requests/_form.html.haml
@@ -29,21 +29,3 @@
           = render partial: 'webui/shared/bs_requests/request_item', collection: bs_requests, as: :bs_request
           = paginate bs_requests, views_prefix: 'webui'
   = form.submit(nil, class: 'd-none')
-
-:javascript
-  $(document).on("input", "#stag-proj-search", function(event) {
-    var searchInput = event.target;
-    var filterValue = searchInput.value.toLowerCase();
-    var filterContent = document.getElementById("request-filter-stag-proj");
-    var filterItems = filterContent.getElementsByClassName("request-filter-stag-proj-item");
-
-    for (i = 0; i < filterItems.length; i++) {
-      var itemValue = filterItems[i].getElementsByTagName('input')[0].value;
-
-      if (itemValue.toLowerCase().indexOf(filterValue) > -1) {
-        filterItems[i].style.display = "";
-      } else {
-        filterItems[i].style.display = "none";
-      }
-    }
-  });

--- a/src/api/app/views/webui/shared/bs_requests/_requests_filter.html.haml
+++ b/src/api/app/views/webui/shared/bs_requests/_requests_filter.html.haml
@@ -156,21 +156,22 @@
                                                                     checked: selected_filter[:reviewers]&.include?(reviewer) }
 
   .mt-2.mb-2.accordion-item.border-0
-    .px-3.py-2.accordion-button.no-style{ data: { 'bs-toggle': 'collapse', 'bs-target': '#request-filter-stag-proj' },
-                                                       aria: { expanded: 'true', controls: 'request-filter-stag-proj' } }
+    .px-3.py-2.accordion-button.no-style{ data: { 'bs-toggle': 'collapse', 'bs-target': '#request-filter-staging-project' },
+                                                       aria: { expanded: 'true', controls: 'request-filter-staging-project' } }
       %b Staging  Project
       .selected-content.small.ms-1
-    .px-4.pb-2.accordion-collapse.collapse.show#request-filter-stag-proj
-      .mb-3.ui-front
-        %input.form-control#stag-proj-search{ placeholder: 'Filter staging project', type: 'search' }
-      .scroll-list-wrapper
-        - Project.where.not(staging_workflow_id: nil).each do |sp|
-          .dropdown-item-text.request-filter-stag-proj-item
-            - checked = selected_filter[:staging_project]&.include?(sp.name) || defined?(project) && project == sp
-            = render partial: 'webui/shared/check_box', locals: { label: sp.name,
-                                                                  key: "staging_project[#{sp.id}]", name: 'staging_project[]',
-                                                                  value: sp.name,
-                                                                  checked: checked }
+    .px-4.pb-2.accordion-collapse.collapse.show#request-filter-staging-project
+      #request-staging-project-dropdown
+        = render partial: 'webui/shared/autocomplete', locals: { html_id: 'staging_project_search', label: 'Staging Project:',
+                                                                 html_name: 'staging_projects[]', required: false, with_label: false,
+                                                                 data: { source: autocomplete_staging_projects_path } }
+        .scroll-list-wrapper.auto-submit-on-change
+          - selected_filter[:staging_projects].each do |staging_project|
+            .dropdown-item-text
+              = render partial: 'webui/shared/check_box', locals: { label: staging_project,
+                                                                    key: "staging_projects[#{staging_project}]", name: 'staging_project[]',
+                                                                    value: staging_project,
+                                                                    checked: selected_filter[:staging_projects]&.include?(staging_project) }
 
   .mt-2.mb-2.accordion-item.border-0
     .px-3.py-2.accordion-button.no-style{ data: { 'bs-toggle': 'collapse', 'bs-target': '#request-filter-created-at' },

--- a/src/api/config/routes/webui.rb
+++ b/src/api/config/routes/webui.rb
@@ -201,6 +201,7 @@ constraints(RoutesHelper::WebuiMatcher) do
     get 'project/list_all' => :index, show_all: true, as: 'project_list_all'
     get 'project/list' => :index, as: 'project_list'
     get 'project/autocomplete_projects' => :autocomplete_projects, as: 'autocomplete_projects'
+    get 'project/autocomplete_staging_projects' => :autocomplete_staging_projects, as: 'autocomplete_staging_projects'
     get 'project/autocomplete_incidents' => :autocomplete_incidents, as: 'autocomplete_incidents'
     get 'project/autocomplete_packages' => :autocomplete_packages, as: 'autocomplete_packages'
     get 'project/autocomplete_repositories' => :autocomplete_repositories, as: 'autocomplete_repositories'


### PR DESCRIPTION
Make the staging project filter an autocomplete async input field under the hood.
https://trello.com/c/D2jLGmTZ

Before, it was a sync loaded list of staging projects at page loading time, then filtered on the frontend side.
After, it is an async list that loads the partial matching names via ajax dynamically

## Before
![image](https://github.com/user-attachments/assets/afde0fee-8c59-4eda-9291-e3e0f566c00d)


## After
![staging-autocomplete](https://github.com/user-attachments/assets/950a4b50-97e2-49b6-9f34-978f5b229cee)
