### PR TITLE
Fix state filtering

### DIFF
--- a/src/api/app/controllers/webui/users/bs_requests_controller.rb
+++ b/src/api/app/controllers/webui/users/bs_requests_controller.rb
@@ -44,9 +44,9 @@ module Webui
         when 'all'
           User.session.requests
         when 'incoming'
-          User.session.incoming_requests
+          User.session.incoming_requests.unscope(where: :state)
         when 'outgoing'
-          User.session.outgoing_requests
+          User.session.outgoing_requests.unscope(where: :state)
         end
       end
 


### PR DESCRIPTION
We filter first by direction and afterward by state. The methods in User already filter by state by default...

You can see the effect in #17419 