### PR TITLE
Rename direction parameter (back?) to involvement

### DIFF
--- a/src/api/app/controllers/concerns/webui/requests_filter.rb
+++ b/src/api/app/controllers/concerns/webui/requests_filter.rb
@@ -1,7 +1,7 @@
 module Webui::RequestsFilter
   extend ActiveSupport::Concern
 
-  ALLOWED_DIRECTIONS = %w[all incoming outgoing].freeze
+  ALLOWED_INVOLVEMENTS = %w[all incoming outgoing].freeze
   TEXT_SEARCH_MAX_RESULTS = 10_000
 
   # rubocop:disable Metrics/CyclomaticComplexity
@@ -11,9 +11,9 @@ module Webui::RequestsFilter
 
     if params[:requests_search_text].present?
       initial_bs_requests = filter_by_text(params[:requests_search_text])
-      params[:ids] = filter_by_direction(@filter_direction).ids
+      params[:ids] = filter_by_involvement(@filter_involvement).ids
     else
-      initial_bs_requests = filter_by_direction(@filter_direction)
+      initial_bs_requests = filter_by_involvement(@filter_involvement)
     end
 
     params[:creator] = @filter_creators if @filter_creators.present?
@@ -36,8 +36,8 @@ module Webui::RequestsFilter
   # rubocop:disable Metrics/CyclomaticComplexity
   # rubocop:disable Metrics/PerceivedComplexity
   def set_filters
-    @filter_direction = params[:direction].presence || 'all'
-    @filter_direction = 'all' if ALLOWED_DIRECTIONS.exclude?(@filter_direction)
+    @filter_involvement = params[:involvement].presence || 'all'
+    @filter_involvement = 'all' if ALLOWED_INVOLVEMENTS.exclude?(@filter_involvement)
 
     @filter_state = params[:state].presence || []
     @filter_state = @filter_state.intersection(BsRequest::VALID_REQUEST_STATES.map(&:to_s))
@@ -62,7 +62,7 @@ module Webui::RequestsFilter
   # rubocop:enable Metrics/PerceivedComplexity
 
   def set_selected_filter
-    @selected_filter = { direction: @filter_direction, action_type: @filter_action_type, search_text: params[:requests_search_text],
+    @selected_filter = { involvement: @filter_involvement, action_type: @filter_action_type, search_text: params[:requests_search_text],
                          state: @filter_state, creators: @filter_creators, project_names: @filter_project_names,
                          staging_projects: @filter_staging_projects, priority: @filter_priority,
                          created_at_from: @filter_created_at_from, created_at_to: @filter_created_at_to, reviewers: @filter_reviewers }

--- a/src/api/app/controllers/webui/packages/bs_requests_controller.rb
+++ b/src/api/app/controllers/webui/packages/bs_requests_controller.rb
@@ -27,10 +27,10 @@ module Webui
 
       private
 
-      def filter_by_direction(direction)
-        return filter_by_direction_staging_project(direction) if staging_projects.present?
+      def filter_by_involvement(involvement)
+        return filter_by_involvement_staging_project(involvement) if staging_projects.present?
 
-        case direction
+        case involvement
         when 'all'
           target = BsRequest.with_actions_and_reviews.where(bs_request_actions: { target_project: @project.name, target_package: @package.name })
           source = BsRequest.with_actions_and_reviews.where(bs_request_actions: { source_project: @project.name, source_package: @package.name })
@@ -43,8 +43,8 @@ module Webui
         end
       end
 
-      def filter_by_direction_staging_project(direction)
-        case direction
+      def filter_by_involvement_staging_project(involvement)
+        case involvement
         when 'all'
           target = BsRequest.with_actions_and_reviews.where(staging_project: staging_projects, bs_request_actions: { target_project: @project.name, target_package: @package.name })
           source = BsRequest.with_actions_and_reviews.where(staging_project: staging_projects, bs_request_actions: { source_project: @project.name, source_package: @package.name })

--- a/src/api/app/controllers/webui/projects/bs_requests_controller.rb
+++ b/src/api/app/controllers/webui/projects/bs_requests_controller.rb
@@ -26,10 +26,10 @@ module Webui
 
       private
 
-      def filter_by_direction(direction)
-        return filter_by_direction_staging_project(direction) if staging_projects.present?
+      def filter_by_involvement(involvement)
+        return filter_by_involvement_staging_project(involvement) if staging_projects.present?
 
-        case direction
+        case involvement
         when 'all'
           target = BsRequest.with_actions_and_reviews.where(bs_request_actions: { target_project: @project.name })
           source = BsRequest.with_actions_and_reviews.where(bs_request_actions: { source_project: @project.name })
@@ -42,8 +42,8 @@ module Webui
         end
       end
 
-      def filter_by_direction_staging_project(direction)
-        case direction
+      def filter_by_involvement_staging_project(involvement)
+        case involvement
         when 'all'
           target = BsRequest.with_actions_and_reviews.where(staging_project: staging_projects, bs_request_actions: { target_project: @project.name })
           source = BsRequest.with_actions_and_reviews.where(staging_project: staging_projects, bs_request_actions: { source_project: @project.name })

--- a/src/api/app/controllers/webui/users/bs_requests_controller.rb
+++ b/src/api/app/controllers/webui/users/bs_requests_controller.rb
@@ -37,10 +37,10 @@ module Webui
 
       private
 
-      def filter_by_direction(direction)
-        return filter_by_direction_staging_project(direction) if staging_projects.present?
+      def filter_by_involvement(involvement)
+        return filter_by_involvement_staging_project(involvement) if staging_projects.present?
 
-        case direction
+        case involvement
         when 'all'
           User.session.requests
         when 'incoming'
@@ -50,8 +50,8 @@ module Webui
         end
       end
 
-      def filter_by_direction_staging_project(direction)
-        case direction
+      def filter_by_involvement_staging_project(involvement)
+        case involvement
         when 'all'
           User.session.requests.where(staging_project: staging_projects)
         when 'incoming'

--- a/src/api/app/views/webui/shared/bs_requests/_requests_filter.html.haml
+++ b/src/api/app/views/webui/shared/bs_requests/_requests_filter.html.haml
@@ -1,19 +1,19 @@
 -# haml-lint:disable ViewLength
 .accordion.accordion-flush
-  .mt-2.mb-2.accordion-item.border-0.auto-submit-on-change
-    .px-3.py-2.accordion-button.no-style{ data: { 'bs-toggle': 'collapse', 'bs-target': '#request-filter-direction' },
-                                             aria: { expanded: 'true', controls: 'request-filter-direction' } }
-      %b Direction
-    .px-4.pb-2.accordion-collapse.collapse.show#request-filter-direction
+  .mt-2.mb-2.accordion-item.border-0
+    .px-3.py-2.accordion-button.no-style{ data: { 'bs-toggle': 'collapse', 'bs-target': '#request-filter-involvement' },
+                                             aria: { expanded: 'true', controls: 'request-filter-involvement' } }
+      %b Involvement
+    .px-4.pb-2.accordion-collapse.collapse.show#request-filter-involvement
       = render partial: 'webui/shared/radio_button', locals: { label: 'All',
-                                                              key: 'direction[all]', name: 'direction', value: 'all',
-                                                              checked: selected_filter[:direction] == 'all' }
+                                                              key: 'involvement[all]', name: 'involvement', value: 'all',
+                                                              checked: selected_filter[:involvement] == 'all' }
       = render partial: 'webui/shared/radio_button', locals: { label: 'Incoming',
-                                                              key: 'direction[incoming]', name: 'direction', value: 'incoming',
-                                                              checked: selected_filter[:direction] == 'incoming' }
+                                                              key: 'involvement[incoming]', name: 'involvement', value: 'incoming',
+                                                              checked: selected_filter[:involvement] == 'incoming' }
       = render partial: 'webui/shared/radio_button', locals: { label: 'Outgoing',
-                                                              key: 'direction[outgoing]', name: 'direction', value: 'outgoing',
-                                                              checked: selected_filter[:direction] == 'outgoing' }
+                                                              key: 'involvement[outgoing]', name: 'involvement', value: 'outgoing',
+                                                              checked: selected_filter[:involvement] == 'outgoing' }
 
   .mt-2.mb-2.accordion-item.border-0.auto-submit-on-change
     .px-3.py-2.accordion-button.no-style{ data: { 'bs-toggle': 'collapse', 'bs-target': '#request-filter-state' },

--- a/src/api/spec/controllers/webui/packages/bs_requests_controller_spec.rb
+++ b/src/api/spec/controllers/webui/packages/bs_requests_controller_spec.rb
@@ -53,14 +53,14 @@ RSpec.describe Webui::Packages::BsRequestsController do
 
       it { expect(assigns[:bs_requests]).to contain_exactly(incoming_request, outgoing_request, request_with_review) }
 
-      context 'and the direction parameters is "incoming"' do
-        let(:context_params) { { direction: 'incoming' } }
+      context 'and the involvement parameters is "incoming"' do
+        let(:context_params) { { involvement: 'incoming' } }
 
         it { expect(assigns[:bs_requests]).to contain_exactly(incoming_request) }
       end
 
-      context 'and the direction parameters is "outgoing"' do
-        let(:context_params) { { direction: 'outgoing' } }
+      context 'and the involvement parameters is "outgoing"' do
+        let(:context_params) { { involvement: 'outgoing' } }
 
         it { expect(assigns[:bs_requests]).to contain_exactly(outgoing_request) }
       end

--- a/src/api/spec/controllers/webui/projects/bs_requests_controller_spec.rb
+++ b/src/api/spec/controllers/webui/projects/bs_requests_controller_spec.rb
@@ -56,14 +56,14 @@ RSpec.describe Webui::Projects::BsRequestsController do
 
         it { expect(assigns[:bs_requests]).to contain_exactly(incoming_request, outgoing_request, request_with_review) }
 
-        context 'and the direction parameters is "incoming"' do
-          let(:context_params) { { direction: 'incoming' } }
+        context 'and the involvement parameters is "incoming"' do
+          let(:context_params) { { involvement: 'incoming' } }
 
           it { expect(assigns[:bs_requests]).to contain_exactly(incoming_request) }
         end
 
-        context 'and the direction parameters is "outgoing"' do
-          let(:context_params) { { direction: 'outgoing' } }
+        context 'and the involvement parameters is "outgoing"' do
+          let(:context_params) { { involvement: 'outgoing' } }
 
           it { expect(assigns[:bs_requests]).to contain_exactly(outgoing_request) }
         end
@@ -100,14 +100,14 @@ RSpec.describe Webui::Projects::BsRequestsController do
           get :index, params: params, format: :html
         end
 
-        context 'and the direction parameters is "incoming"' do
-          let(:context_params) { { direction: 'incoming' } }
+        context 'and the involvement parameters is "incoming"' do
+          let(:context_params) { { involvement: 'incoming' } }
 
           it { expect(assigns[:bs_requests]).to contain_exactly(incoming_request) }
         end
 
-        context 'and the direction parameters is "outgoing"' do
-          let(:context_params) { { direction: 'outgoing' } }
+        context 'and the involvement parameters is "outgoing"' do
+          let(:context_params) { { involvement: 'outgoing' } }
 
           it { expect(assigns[:bs_requests]).to contain_exactly(outgoing_request) }
         end

--- a/src/api/spec/controllers/webui/users/bs_requests_controller_spec.rb
+++ b/src/api/spec/controllers/webui/users/bs_requests_controller_spec.rb
@@ -77,14 +77,14 @@ RSpec.describe Webui::Users::BsRequestsController do
 
       it { expect(assigns[:bs_requests]).to contain_exactly(incoming_request, outgoing_request, request_with_review) }
 
-      context 'and the direction parameter is incoming' do
-        let(:context_params) { { direction: 'incoming' } }
+      context 'and the involvement parameter is incoming' do
+        let(:context_params) { { involvement: 'incoming' } }
 
         it { expect(assigns[:bs_requests]).to contain_exactly(incoming_request) }
       end
 
-      context 'and the direction parameter is outgoing' do
-        let(:context_params) { { direction: 'outgoing' } }
+      context 'and the involvement parameter is outgoing' do
+        let(:context_params) { { involvement: 'outgoing' } }
 
         it { expect(assigns[:bs_requests]).to contain_exactly(outgoing_request) }
       end


### PR DESCRIPTION
We want to clarify what this filter means. Incoming / Outgoing implies duality.
But there are requests (by review) that have no "direction" in regards to the
User/Project/Package we are looking at.