### PR TITLE
Staging project filter without blank elements

### DIFF
--- a/src/api/app/controllers/concerns/webui/requests_filter.rb
+++ b/src/api/app/controllers/concerns/webui/requests_filter.rb
@@ -51,7 +51,7 @@ module Webui::RequestsFilter
     @filter_creators = params[:creators].present? ? params[:creators].compact_blank! : []
 
     @filter_project_names = params[:project_names].present? ? params[:project_names].compact_blank! : []
-    @filter_staging_projects = params[:staging_projects].presence || []
+    @filter_staging_projects = params[:staging_projects].present? ? params[:staging_projects].compact_blank! : []
 
     @filter_created_at_from = params[:created_at_from].presence || ''
     @filter_created_at_to = params[:created_at_to].presence || ''

--- a/src/api/app/views/webui/shared/bs_requests/_requests_filter.html.haml
+++ b/src/api/app/views/webui/shared/bs_requests/_requests_filter.html.haml
@@ -169,7 +169,7 @@
           - selected_filter[:staging_projects].each do |staging_project|
             .dropdown-item-text
               = render partial: 'webui/shared/check_box', locals: { label: staging_project,
-                                                                    key: "staging_projects[#{staging_project}]", name: 'staging_project[]',
+                                                                    key: "staging_projects[#{staging_project}]", name: 'staging_projects[]',
                                                                     value: staging_project,
                                                                     checked: selected_filter[:staging_projects]&.include?(staging_project) }
 


### PR DESCRIPTION
Missing a `compact_blank!` cleanup on the returned values.
Fixing a type in the input name