### PR TITLE
Make filter involvement configurable

### DIFF
--- a/src/api/app/views/webui/shared/bs_requests/_form.html.haml
+++ b/src/api/app/views/webui/shared/bs_requests/_form.html.haml
@@ -9,6 +9,7 @@
         .collapse#content-selector-filters
           = render partial: 'webui/shared/bs_requests/requests_filter',
                    locals: { selected_filter: selected_filter, creators: bs_requests_creators, url: url,
+                             allowed_involvements: defined?(allowed_involvements) ? allowed_involvements : %w[incoming outgoing],
                              project: defined?(project) ? project : nil  }
     .col-md-8.col-lg-9.px-0.px-md-3.d-none.content-list-loading
       = render partial: 'webui/shared/loading', locals: { text: 'Loading...', wrapper_css: ['loading'] }


### PR DESCRIPTION
Depends on #17431
Makes the displayed filters in the left panel configurable. That way we can hide/replace those filters that make no sense in certain scenarios, for example: #17429

![image](https://github.com/user-attachments/assets/982af4a9-be0b-4cda-9dd7-143b6fe2bbcf)
