### PR TITLE
Add missing gcc lib to compile racc gem on install

### DIFF
--- a/dist/t/Makefile
+++ b/dist/t/Makefile
@@ -4,7 +4,7 @@ all:
 	@echo "Targets: install test dbclean installclean"
 
 install:
-	zypper -vv -n --gpg-auto-import-keys in --force-resolution --no-recommends chromedriver xorg-x11-fonts libxml2-devel libxslt-devel ruby2.7-devel
+	zypper -vv -n --gpg-auto-import-keys in --force-resolution --no-recommends chromedriver xorg-x11-fonts libxml2-devel libxslt-devel ruby2.7-devel gcc
 	git clone --single-branch --branch 2.10 --depth 1 https://github.com/openSUSE/open-build-service.git /tmp/open-build-service
 	cd /tmp/open-build-service/dist/t
 	bundle install


### PR DESCRIPTION
Run OpenQA smoketest, on `build install` it fails with
```
An error occurred while installing racc (1.7.1), and Bundler cannot continue.
Make sure that `gem install racc -v '1.7.1' --source 'https://rubygems.org/'` succeeds before bundling.

In Gemfile:
  apparition was resolved to 0.6.0, which depends on
    capybara was resolved to 3.39.2, which depends on
      xpath was resolved to 3.2.0, which depends on
        nokogiri was resolved to 1.15.3, which depends on
          racc
```

because it misses the `gcc` lib to compile `racc 1.7.1`

E.g.: https://openqa.opensuse.org/tests/4883480#step/rspec_webui_tests/6

Same as in master https://github.com/openSUSE/open-build-service/pull/15744