### PR TITLE
Bugfix: missing class to autosubmit filters

### DIFF
--- a/src/api/app/components/workflow_run_filter_component.html.haml
+++ b/src/api/app/components/workflow_run_filter_component.html.haml
@@ -19,7 +19,7 @@
 
 = form_for(:token, url: token_workflow_runs_path(@token), method: :get, id: 'content-selector-filters-form') do |form|
   .accordion.accordion-flush
-    .mt-2.mb-2.accordion-item.border-0
+    .mt-2.mb-2.accordion-item.border-0.auto-submit-on-change
       .px-3.py-2.accordion-button.no-style{ data: { 'bs-toggle': 'collapse', 'bs-target': '#workflow-filter-status' },
                                               aria: { expanded: 'true', controls: 'workflow-filter-status' } }
         %b Status
@@ -36,7 +36,7 @@
         = render partial: 'webui/shared/check_box', locals: { label: 'Failed', amount: @count['fail'] || 0,
                                                               key: 'fail', label_icon: 'fas fa-exclamation-triangle text-danger',
                                                               checked: @selected_filter[:status]&.include?('fail')}
-    .mt-4.mb-2.accordion-item.border-0
+    .mt-4.mb-2.accordion-item.border-0.auto-submit-on-change
       .px-3.py-2.accordion-button.no-style{ data: { 'bs-toggle': 'collapse', 'bs-target': '#workflow-filter-event-type' },
                                               aria: { expanded: 'true', controls: 'workflow-filter-event-type' } }
         %b Event Type
@@ -51,7 +51,7 @@
         = render partial: 'webui/shared/check_box', locals: { label: 'Tag Push', amount: @count['tag_push'] || 0,
                                                               key: 'tag_push', checked: @selected_filter[:event_type]&.include?('tag_push')}
 
-    .mt-4.mb-2.accordion-item.border-0
+    .mt-4.mb-2.accordion-item.border-0.auto-submit-on-change
       .px-3.py-2.accordion-button.no-style{ data: { 'bs-toggle': 'collapse', 'bs-target': '#workflow-filter-event-action' },
                                               aria: { expanded: 'true', controls: 'workflow-filter-event-action' } }
         %b Event Action
@@ -63,7 +63,7 @@
                                                           selected_value: @selected_filter[:request_action],
                                                           filter_options: WorkflowRun::ALL_POSSIBLE_REQUEST_ACTIONS,
                                                           label: 'Action', visible_inner_label: true }
-    .mt-4.mb-2.accordion-item.border-0
+    .mt-4.mb-2.accordion-item.border-0.auto-submit-on-change
       .px-3.py-2.accordion-button.no-style{ data: { 'bs-toggle': 'collapse', 'bs-target': '#workflow-filter-event-source' },
                                               aria: { expanded: 'true', controls: 'workflow-filter-event-source' } }
         %b Event Source

--- a/src/api/app/views/webui/users/notifications/_notification_filter.html.haml
+++ b/src/api/app/views/webui/users/notifications/_notification_filter.html.haml
@@ -1,7 +1,7 @@
 -# haml-lint:disable ViewLength
 = form_for(:notification, url: my_notifications_path, method: :get, id: 'content-selector-filters-form') do |form|
   .accordion.accordion-flush
-    .mt-2.mb-2.accordion-item.border-0
+    .mt-2.mb-2.accordion-item.border-0.auto-submit-on-change
       .px-3.py-2.accordion-button.no-style{ data: { 'bs-toggle': 'collapse', 'bs-target': '#notification-filter-state' },
                                               aria: { expanded: 'true', controls: 'notification-filter-state' } }
         %b State
@@ -15,7 +15,7 @@
         = render partial: 'webui/shared/radio_button', locals: { label: 'Read',
                                                                 key: 'state[read]', name: 'state', value: 'read',
                                                                 checked: selected_filter[:state] == 'read' }
-    .mt-2.mb-2.accordion-item.border-0
+    .mt-2.mb-2.accordion-item.border-0.auto-submit-on-change
       .px-3.py-2.accordion-button.no-style{ data: { 'bs-toggle': 'collapse', 'bs-target': '#notification-filter-type' },
                                               aria: { expanded: 'true', controls: 'notification-filter-type' } }
         %b Type
@@ -61,7 +61,7 @@
                                                               checked: selected_filter[:kind]&.include?('member_on_groups') }
 
     - if policy(Report.new).notify?
-      .mt-2.mb-2.accordion-item.border-0
+      .mt-2.mb-2.accordion-item.border-0.auto-submit-on-change
         .px-3.py-2.accordion-button.no-style{ data: { 'bs-toggle': 'collapse', 'bs-target': '#notification-filter-reports' },
                                                 aria: { expanded: 'true', controls: 'notification-filter-reports' } }
           %b Reports
@@ -84,7 +84,7 @@
                                                                     value: reportable_type,
                                                                     checked: selected_filter[:reportable_type]&.include?(reportable_type.to_s) }
 
-    .mt-2.mb-2.accordion-item.border-0
+    .mt-2.mb-2.accordion-item.border-0.auto-submit-on-change
       .px-3.py-2.accordion-button.no-style{ data: { 'bs-toggle': 'collapse', 'bs-target': '#notification-filter-requests' },
                                               aria: { expanded: 'true', controls: 'notification-filter-requests' } }
         %b Requests
@@ -107,7 +107,7 @@
                                                                   checked: selected_filter[:request_state]&.include?(request_state.to_s) }
 
     - unless projects_for_filter.empty?
-      .mt-2.mb-2.accordion-item.border-0
+      .mt-2.mb-2.accordion-item.border-0.auto-submit-on-change
         .px-3.py-2.accordion-button.no-style{ data: { 'bs-toggle': 'collapse', 'bs-target': '#notification-filter-projects' },
                                                 aria: { expanded: 'true', controls: 'notification-filter-projects' } }
           %b Projects
@@ -120,7 +120,7 @@
                                                                       key: "project[#{project_name}]", name: 'project[]', value: project_name,
                                                                       checked: selected_filter[:project]&.include?(project_name) }
     - unless groups_for_filter.empty?
-      .mt-2.mb-2.accordion-item.border-0
+      .mt-2.mb-2.accordion-item.border-0.auto-submit-on-change
         .px-3.py-2.accordion-button.no-style{ data: { 'bs-toggle': 'collapse', 'bs-target': '#notification-filter-groups' },
                                                 aria: { expanded: 'true', controls: 'notification-filter-groups' } }
           %b Groups


### PR DESCRIPTION
Fixes https://github.com/openSUSE/open-build-service/issues/17452

We changed the implementation in request index since https://github.com/openSUSE/open-build-service/pull/17414, but the event subscription and behavior for filters is shared across requests/notifications/workflowruns