### PR TITLE
Autosubmit on change of autocomplete input too

### DIFF
--- a/src/api/app/assets/javascripts/webui/content-selector-filters.js
+++ b/src/api/app/assets/javascripts/webui/content-selector-filters.js
@@ -59,6 +59,14 @@ $(document).on('click', autoSubmitOnClickSelector, function() {
 
   submitFilters();
 });
+// Cannot apply the .auto-submit-on-change class to the autocomplete input, so we need to handle it separately
+$(document).on('change', '.obs-autocomplete', function() {
+  // Clear the timeout to prevent the pending submission, if any
+  window.clearTimeout(submitFiltersTimeout);
+
+  // Set a timeout to submit the filters
+  submitFiltersTimeout = window.setTimeout(submitFilters, 2000);
+});
 
 $(document).ready(function(){
   highlightSelectedFilters();


### PR DESCRIPTION
At the moment we wait for user input to submit filters when using the autocomplete component.
Now that we fixed the former undesired behavior of submiting on `keyup` (it was firing the submit too early on typing on the autocomplete input field, the fix introduced by https://github.com/openSUSE/open-build-service/pull/17414), we can now improve it and make it more comfortable by auto-submiting the filters form on `change` of the autocomplete. This can be done now because the `change` event happens only on pressing enter (already handled by default by the form in the browser), or by clicking on an element of the autocomplete dropdown list or losing the focus from the input. These two last events are the target handler of this PR.

As you can see in the example below, typing in the autocomplete input only triggers the autocomplete dropdown to be visible and populated, but it does not trigger the form submit (which was the problem before https://github.com/openSUSE/open-build-service/pull/17414). With this PR, after selecting an element of the autocomplete dropdown the autosubmit starts its countdown (like the other filters do) and then triggers the submit.

![autosubmit-autocomplete](https://github.com/user-attachments/assets/314afb56-e9ca-4e00-a9ea-744323821469)
