### PR TITLE
Improve performance of User/Project/Package.bs_request

### DIFF
--- a/src/api/app/controllers/webui/packages/bs_requests_controller.rb
+++ b/src/api/app/controllers/webui/packages/bs_requests_controller.rb
@@ -12,7 +12,7 @@ module Webui
         if Flipper.enabled?(:request_index, User.session)
           # FIXME: Once we roll out filter_requests should become a before_action
           filter_requests
-          @bs_requests = @bs_requests.page(params[:page])
+          @bs_requests = @bs_requests.order('number DESC').page(params[:page])
 
           @url = packages_requests_path(@project, @package)
         else

--- a/src/api/app/controllers/webui/projects/bs_requests_controller.rb
+++ b/src/api/app/controllers/webui/projects/bs_requests_controller.rb
@@ -11,7 +11,7 @@ module Webui
         if Flipper.enabled?(:request_index, User.session)
           # FIXME: Once we roll out filter_requests should become a before_action
           filter_requests
-          @bs_requests = @bs_requests.page(params[:page])
+          @bs_requests = @bs_requests.order('number DESC').page(params[:page])
         else
           parsed_params = BsRequest::DataTable::ParamsParserWithStateAndType.new(params).parsed_params
           requests_query = BsRequest::DataTable::FindForProjectQuery.new(@project, parsed_params)

--- a/src/api/app/controllers/webui/users/bs_requests_controller.rb
+++ b/src/api/app/controllers/webui/users/bs_requests_controller.rb
@@ -20,7 +20,7 @@ module Webui
           format.html do
             # FIXME: Once we roll out request_index filter_requests should become a before_action
             filter_requests
-            @bs_requests = @bs_requests.page(params[:page])
+            @bs_requests = @bs_requests.order('number DESC').page(params[:page])
           end
           # TODO: Remove this old index action when request_index feature is rolled-over
           format.json do

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -1320,10 +1320,10 @@ class Package < ApplicationRecord
 
   # Returns an ActiveRecord::Relation with all BsRequest that the package is somehow involved in
   def bs_requests
-    BsRequest.order('number DESC').includes(:bs_request_actions, :comments, :reviews, :labels)
-             .where(bs_request_actions: { source_package_id: id })
-             .or(BsRequest.includes(:bs_request_actions, :comments, :reviews, :labels).where(bs_request_actions: { target_package_id: id }))
-             .or(BsRequest.includes(:bs_request_actions, :comments, :reviews, :labels).where(reviews: { package_id: id }))
+    BsRequest.left_outer_joins(:bs_request_actions, :reviews)
+             .where(reviews: { package_id: id })
+             .or(BsRequest.left_outer_joins(:bs_request_actions, :reviews).where(bs_request_actions: { source_package_id: id }))
+             .or(BsRequest.left_outer_joins(:bs_request_actions, :reviews).where(bs_request_actions: { target_package_id: id }))
              .distinct
   end
 

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -1401,10 +1401,10 @@ class Project < ApplicationRecord
 
   # Returns an ActiveRecord::Relation with all BsRequest that the project is somehow involved in
   def bs_requests
-    BsRequest.order('number DESC').includes(:bs_request_actions, :comments, :reviews, :labels)
-             .where(bs_request_actions: { source_project_id: id })
-             .or(BsRequest.includes(:bs_request_actions, :comments, :reviews, :labels).where(bs_request_actions: { target_project_id: id }))
-             .or(BsRequest.includes(:bs_request_actions, :comments, :reviews, :labels).where(reviews: { project_id: id }))
+    BsRequest.left_outer_joins(:bs_request_actions, :reviews)
+             .where(reviews: { project_id: id })
+             .or(BsRequest.left_outer_joins(:bs_request_actions, :reviews).where(bs_request_actions: { source_project_id: id }))
+             .or(BsRequest.left_outer_joins(:bs_request_actions, :reviews).where(bs_request_actions: { target_project_id: id }))
              .distinct
   end
 

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -698,16 +698,15 @@ class User < ApplicationRecord
 
   # Returns an ActiveRecord::Relation with all BsRequest that the user is somehow involved in
   def bs_requests
-    BsRequest.order('number DESC').includes(:bs_request_actions, :comments, :reviews, :labels)
-             .where(creator: login)
-             .or(BsRequest.includes(:bs_request_actions, :comments, :reviews, :labels).where(reviews: { user_id: id }))
-             .or(BsRequest.includes(:bs_request_actions, :comments, :reviews, :labels).where(reviews: { group: groups }))
-             .or(BsRequest.includes(:bs_request_actions, :comments, :reviews, :labels).where(reviews: { project: involved_projects }))
-             .or(BsRequest.includes(:bs_request_actions, :comments, :reviews, :labels).where(reviews: { package: involved_packages }))
-             .or(BsRequest.includes(:bs_request_actions, :comments, :reviews, :labels).where(bs_request_actions: { target_project_id: involved_projects }))
-             .or(BsRequest.includes(:bs_request_actions, :comments, :reviews, :labels).where(bs_request_actions: { target_package_id: involved_packages }))
-             .or(BsRequest.includes(:bs_request_actions, :comments, :reviews, :labels).where(bs_request_actions: { source_project_id: involved_projects }))
-             .or(BsRequest.includes(:bs_request_actions, :comments, :reviews, :labels).where(bs_request_actions: { source_package_id: involved_packages }))
+    BsRequest.left_outer_joins(:bs_request_actions, :reviews).where(creator: login)
+             .or(BsRequest.left_outer_joins(:bs_request_actions, :reviews).where(reviews: { user_id: id }))
+             .or(BsRequest.left_outer_joins(:bs_request_actions, :reviews).where(reviews: { group_id: groups.pluck(:id) }))
+             .or(BsRequest.left_outer_joins(:bs_request_actions, :reviews).where(reviews: { project_id: involved_projects.pluck(:id) }))
+             .or(BsRequest.left_outer_joins(:bs_request_actions, :reviews).where(reviews: { package_id: involved_packages.pluck(:id) }))
+             .or(BsRequest.left_outer_joins(:bs_request_actions, :reviews).where(bs_request_actions: { target_project_id: involved_projects.pluck(:id) }))
+             .or(BsRequest.left_outer_joins(:bs_request_actions, :reviews).where(bs_request_actions: { target_package_id: involved_packages.pluck(:id) }))
+             .or(BsRequest.left_outer_joins(:bs_request_actions, :reviews).where(bs_request_actions: { source_project_id: involved_projects.pluck(:id) }))
+             .or(BsRequest.left_outer_joins(:bs_request_actions, :reviews).where(bs_request_actions: { source_package_id: involved_packages.pluck(:id) }))
              .distinct
   end
 

--- a/src/api/spec/models/user_spec.rb
+++ b/src/api/spec/models/user_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe User do
   let(:admin_user) { create(:admin_user, login: 'king') }
   let(:user) { create(:user, :with_home, login: 'eisendieter') }
-  let(:confirmed_user) { create(:confirmed_user, login: 'confirmed_user') }
+  let(:confirmed_user) { create(:confirmed_user, :with_home, login: 'confirmed_user') }
   let(:user_belongs_to_confirmed_owner) { create(:user, owner: confirmed_user) }
   let(:user_belongs_to_unconfirmed_owner) { create(:confirmed_user, owner: user) }
   let(:input) { { 'Event::RequestCreate' => { source_maintainer: '1' } } }
@@ -646,13 +646,13 @@ RSpec.describe User do
   end
 
   describe '#bs_requests' do
-    let!(:incoming_request) { create(:bs_request_with_submit_action, source_project: user.home_project) }
-    let!(:outgoing_request) { create(:bs_request_with_submit_action, target_project: user.home_project) }
-    let!(:request_with_user_review) { create(:delete_bs_request, target_project: create(:project), review_by_user: user) }
-    let!(:request_with_project_review) { create(:delete_bs_request, target_project: create(:project), review_by_project: user.home_project) }
-    let!(:request_with_package_review) { create(:delete_bs_request, target_project: create(:project), review_by_package: create(:package, project: user.home_project)) }
-    let!(:unrelated_request) { create(:bs_request_with_submit_action, source_project: create(:project)) }
+    let!(:incoming_request) { create(:bs_request_with_submit_action, target_project: confirmed_user.home_project, description: 'incoming') }
+    let!(:outgoing_request) { create(:bs_request_with_submit_action, creator: confirmed_user, description: 'outgoing') }
+    let!(:request_with_user_review) { create(:delete_bs_request, target_project: create(:project), review_by_user: confirmed_user, description: 'user_review') }
+    let!(:request_with_project_review) { create(:delete_bs_request, target_project: create(:project), review_by_project: confirmed_user.home_project, description: 'project_review') }
+    let!(:request_with_package_review) { create(:delete_bs_request, target_project: create(:project), review_by_package: create(:package_with_maintainer, maintainer: confirmed_user), description: 'package_review') }
+    let!(:unrelated_request) { create(:bs_request_with_submit_action, source_project: create(:project), description: 'unrelated') }
 
-    it { expect(user.bs_requests).to contain_exactly(incoming_request, outgoing_request, request_with_user_review, request_with_project_review, request_with_package_review) }
+    it { expect(confirmed_user.bs_requests.pluck(:description)).to contain_exactly('incoming', 'outgoing', 'user_review', 'project_review', 'package_review') }
   end
 end


### PR DESCRIPTION
If we OR data from BsRequest with data from BsRequestAction/Review everything
is stuffed into a temporary table first, then queried. Depending on the amount
of records this can be *very* slow.

If we join the tables, we can OR without temporary tables.