### PR TITLE
[backend] bs_mkarchrepo: merge depends fields into desc

### DIFF
--- a/src/backend/bs_mkarchrepo
+++ b/src/backend/bs_mkarchrepo
@@ -35,8 +35,6 @@ my %todo = (
     'BUILDDATE' => 'builddate',
     'PACKAGER' => 'packager',
     'REPLACES' => 'replaces',
-  ],
-  'depends' => [
     'DEPENDS' => 'depend',
     'CONFLICTS' => 'conflict',
     'PROVIDES' => 'provides',


### PR DESCRIPTION
The `depends` file no longer exists in the ArchLinux repository db file.

```
$ find ./*/ -type f -printf "%f\n" | sort | uniq
desc
```

The corresponding field in the depends file is now provided by desc.

```
$ cat ./*/desc  | grep "^%" | sort | uniq
%ARCH%
%BASE%
%BUILDDATE%
%CHECKDEPENDS%
%CONFLICTS%
%CSIZE%
%DEPENDS%
%DESC%
%FILENAME%
%ISIZE%
%LICENSE%
%MAKEDEPENDS%
%MD5SUM%
%NAME%
%OPTDEPENDS%
%PACKAGER%
%PGPSIG%
%PROVIDES%
%REPLACES%
%SHA256SUM%
%URL%
%VERSION%
```