### PR TITLE
Fix filter title style for consistency

### DIFF
--- a/src/api/app/views/webui/shared/bs_requests/_requests_filter.html.haml
+++ b/src/api/app/views/webui/shared/bs_requests/_requests_filter.html.haml
@@ -152,7 +152,7 @@
                                                                     checked: selected_filter[:creators]&.include?(creator) }
 
   .mt-2.mb-2.accordion-item.border-0
-    %h6.px-3.py-2.accordion-button.no-style{ data: { 'bs-toggle': 'collapse', 'bs-target': '#request-filter-reviewer' },
+    .px-3.py-2.accordion-button.no-style{ data: { 'bs-toggle': 'collapse', 'bs-target': '#request-filter-reviewer' },
                                                        aria: { expanded: 'true', controls: 'request-filter-reviewer' } }
       %b Reviewers
       .px-1 (Users and Groups)


### PR DESCRIPTION
In `project/requests` and `package/requests` the page is wrapped by a `div.card` HTML tag, which makes the `h6` title behave a little different in terms of style. Only `Reviewers` filter title is an `h6` others don't. This PR aligns the style of it to the rest of the page.

## Before
![image](https://github.com/user-attachments/assets/6299b9f4-a5ea-4c63-bc5f-a8c85273ed9b)

## After
![image](https://github.com/user-attachments/assets/ea473aba-6a0e-4b06-b396-1ef7034e083c)
