### PR TITLE
Drop `has_patchinfo` view variable

### DIFF
--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -45,7 +45,6 @@ class Webui::ProjectController < Webui::WebuiController
   def show
     @release_targets = @project.release_targets
 
-    @has_patchinfo = @project.patchinfos.exists?
     @comments = @project.comments
     @comment = Comment.new
     @current_notification = handle_notification

--- a/src/api/app/helpers/webui/project_helper.rb
+++ b/src/api/app/helpers/webui/project_helper.rb
@@ -36,10 +36,6 @@ module Webui::ProjectHelper
     true
   end
 
-  def can_be_released?(project, packages, open_release_requests, has_patchinfo)
-    !project.defines_remote_instance? && project.maintenance_incident? && packages.present? && has_patchinfo && open_release_requests.blank?
-  end
-
   def project_labels(project, &block)
     project.label_templates.includes([:labels]).find_each do |label_template|
       label_template.labels.each(&block)

--- a/src/api/app/helpers/webui/project_helper.rb
+++ b/src/api/app/helpers/webui/project_helper.rb
@@ -31,7 +31,7 @@ module Webui::ProjectHelper
     return false if @project.scmsync.present?
     return false if @project.defines_remote_instance?
     return false if @is_incident_project && @packages.present? &&
-                    @has_patchinfo && @open_release_requests.empty?
+                    @project.patchinfos.exists? && @open_release_requests.empty?
 
     true
   end

--- a/src/api/app/views/webui/project/_show_actions.html.haml
+++ b/src/api/app/views/webui/project/_show_actions.html.haml
@@ -8,7 +8,6 @@
   - if User.possibly_nobody.can_modify?(project)
     = render partial: 'webui/project/show_actions/modify_project', locals: { project: project,
                                                                              packages: packages,
-                                                                             has_patchinfo: has_patchinfo,
                                                                              open_release_requests: open_release_requests,
                                                                              release_targets: release_targets }
     = render partial: 'webui/project/show_actions/delete_project', locals: { project: project }

--- a/src/api/app/views/webui/project/_side_links.html.haml
+++ b/src/api/app/views/webui/project/_side_links.html.haml
@@ -8,12 +8,11 @@
       = render partial: 'webui/project/side_links/project_monitor', locals: { project: project,
                                                                               nr_of_problem_packages: nr_of_problem_packages }
 
-    - if has_patchinfo
+    - if project.patchinfos.exists?
       = render partial: 'webui/project/side_links/patchinfo_present', locals: { project: project }
 
     - if project.maintenance_incident?
-      = render partial: 'webui/project/side_links/incident_project', locals: { has_patchinfo: has_patchinfo,
-                                                                               project: project,
+      = render partial: 'webui/project/side_links/incident_project', locals: { project: project,
                                                                                open_release_requests: open_release_requests }
 
     - if release_targets.present?

--- a/src/api/app/views/webui/project/show.html.haml
+++ b/src/api/app/views/webui/project/show.html.haml
@@ -4,7 +4,6 @@
   @pagetitle = "Show #{@project}"
   render partial: 'webui/project/show_actions', locals: { project: @project,
                                                           packages: @packages,
-                                                          has_patchinfo: @has_patchinfo,
                                                           open_release_requests: @open_release_requests,
                                                           release_targets: @release_targets }
 
@@ -27,7 +26,6 @@
                                                   project: @project,
                                                   maintained_projects: @maintained_projects,
                                                   nr_of_problem_packages: @nr_of_problem_packages,
-                                                  has_patchinfo: @has_patchinfo,
                                                   open_release_requests: @open_release_requests,
                                                   release_targets: @release_targets,
                                                   requests: @requests,

--- a/src/api/app/views/webui/project/show_actions/_modify_project.html.haml
+++ b/src/api/app/views/webui/project/show_actions/_modify_project.html.haml
@@ -1,6 +1,6 @@
 - unless project.defines_remote_instance?
-  - if project.maintenance_incident? && packages.present? && has_patchinfo && open_release_requests.blank?
+  - if project.maintenance_incident? && packages.present? && project.patchinfos.exists? && open_release_requests.blank?
     = render partial: 'webui/project/show_actions/request_to_release', locals: { project: project }
   - else
-    = render partial: 'webui/project/show_actions/patchinfo', locals: { project: project, has_patchinfo: has_patchinfo }
+    = render partial: 'webui/project/show_actions/patchinfo', locals: { project: project }
     = render partial: 'webui/project/show_actions/submit_as_update', locals: { release_targets: release_targets, project: project }

--- a/src/api/app/views/webui/project/show_actions/_patchinfo.html.haml
+++ b/src/api/app/views/webui/project/show_actions/_patchinfo.html.haml
@@ -1,4 +1,4 @@
-- unless has_patchinfo
+- unless project.patchinfos.exists?
   %li.nav-item
     = link_to(patchinfo_path(project: project), method: :post, class: 'nav-link', title: 'Create Patchinfo') do
       %i.fas.fa-band-aid.fa-fw.me-2

--- a/src/api/app/views/webui/project/side_links/_incident_project.html.haml
+++ b/src/api/app/views/webui/project/side_links/_incident_project.html.haml
@@ -1,4 +1,4 @@
-- unless has_patchinfo
+- unless project.patchinfos.exists?
   %li
     %i.fa.fa-exclamation-circle.text-danger
     = link_to_if(User.possibly_nobody.can_modify?(project), 'Patchinfo missing',

--- a/src/api/spec/controllers/webui/project_controller_spec.rb
+++ b/src/api/spec/controllers/webui/project_controller_spec.rb
@@ -246,24 +246,6 @@ RSpec.describe Webui::ProjectController, :vcr do
       allow_any_instance_of(Project).to receive(:number_of_build_problems).and_return(0)
     end
 
-    context 'without patchinfo' do
-      before do
-        get :show, params: { project: apache_project }
-      end
-
-      it { expect(assigns(:has_patchinfo)).to be_falsey }
-    end
-
-    context 'with patchinfo' do
-      before do
-        login admin_user
-        create(:patchinfo, project_name: apache_project.name, comment: 'Fake comment', force: false)
-        get :show, params: { project: apache_project }
-      end
-
-      it { expect(assigns(:has_patchinfo)).to be_truthy }
-    end
-
     context 'with comments' do
       before do
         apache_project.comments << build(:comment_project, user: user)


### PR DESCRIPTION
Make use of the project instance variable to retrieve if a project has patchinfos, instead.