### PR TITLE
Fix parameter names for comment-pull-request action

### DIFF
--- a/.github/workflows/comment_diffend_io_links_to_pr.yml
+++ b/.github/workflows/comment_diffend_io_links_to_pr.yml
@@ -23,6 +23,6 @@ jobs:
       - name: Add Comment to PR
         uses: thollander/actions-comment-pull-request@v3
         with:
-          filePath: comment_text_and_pr_number/comment_text.txt
-          pr_number: ${{ env.pr_number }}
-          comment_tag: comment_with_diffend_io_links
+          file-path: comment_text_and_pr_number/comment_text.txt
+          pr-number: ${{ env.pr_number }}
+          comment-tag: comment_with_diffend_io_links


### PR DESCRIPTION
This change should have been introduced in #16942.