### PR TITLE
Use Leap 15.6 in SCM/CI tests

### DIFF
--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -9,10 +9,10 @@ testbuild:
     - configure_repositories:
         project: home:bs-team
         repositories:
-          - name: 15.5
+          - name: 15.6
             paths:
               - target_project: OBS:Server:2.10:Staging
-                target_repository: 15.5
+                target_repository: 15.6
             architectures:
               - x86_64
   filters:


### PR DESCRIPTION
We use Leap 15.6 since 2.10.23.