### PR TITLE
Remove default scope from Group model

### DIFF
--- a/src/api/app/controllers/group_controller.rb
+++ b/src/api/app/controllers/group_controller.rb
@@ -31,6 +31,7 @@ class GroupController < ApplicationController
     else
       @list = Group.all
     end
+    @list = @list.order(:title)
     @list = @list.where('title LIKE ?', "#{params[:prefix]}%") if params[:prefix].present?
   end
 

--- a/src/api/app/controllers/webui/groups_controller.rb
+++ b/src/api/app/controllers/webui/groups_controller.rb
@@ -6,7 +6,7 @@ class Webui::GroupsController < Webui::WebuiController
 
   def index
     authorize Group.new, :index?
-    @groups = Group.includes(:users)
+    @groups = Group.includes(:users).order(:title)
   end
 
   def show
@@ -69,7 +69,7 @@ class Webui::GroupsController < Webui::WebuiController
   end
 
   def autocomplete
-    groups = Group.where('title LIKE ?', "#{params[:term]}%").pluck(:title) if params[:term]
+    groups = Group.where('title LIKE ?', "#{params[:term]}%").order(:title).pluck(:title) if params[:term]
     render json: groups || []
   end
 

--- a/src/api/app/controllers/webui/users_controller.rb
+++ b/src/api/app/controllers/webui/users_controller.rb
@@ -17,7 +17,7 @@ class Webui::UsersController < Webui::WebuiController
   end
 
   def show
-    @groups = @displayed_user.groups
+    @groups = @displayed_user.groups.order(:title)
     @involved_items_service = UserService::Involved.new(user: @displayed_user, filters: extract_filter_params, page: params[:page])
     @comments = paged_comments
 

--- a/src/api/app/models/group.rb
+++ b/src/api/app/models/group.rb
@@ -36,8 +36,6 @@ class Group < ApplicationRecord
                       message: 'must be a valid email address',
                       allow_blank: true }
 
-  default_scope { order(:title) }
-
   alias_attribute :name, :title
 
   def update_from_xml(xmlhash, user_session_login:)


### PR DESCRIPTION
Apply sorting by title only when neccessary.

The default scope had a negative impact on some database queries using the `join` clause.