### PR TITLE
Unify input|search|autocomplete

### DIFF
--- a/src/api/app/assets/javascripts/webui/after_loading_fixes.js
+++ b/src/api/app/assets/javascripts/webui/after_loading_fixes.js
@@ -1,0 +1,13 @@
+// Purpose: fix the search bar look&feel in the data tables to look like the rest of the search bars in the app.
+$(document).ready(function() {
+  window.setTimeout(function() {
+    $('.dataTables_filter').each(function() {
+      const filterWrapper = $(this);
+      filterWrapper.addClass('form-group d-flex justify-content-end mb-1');
+
+      const inputWrapper = $(this).children('label');
+      inputWrapper.addClass('input-group flex-nowrap');
+      inputWrapper.css('max-width', '500px');
+      inputWrapper.append("<span class='input-group-text'><i class='fa fa-search'></i></span>");
+    }); }, 50);
+});

--- a/src/api/app/assets/javascripts/webui/application.js
+++ b/src/api/app/assets/javascripts/webui/application.js
@@ -72,3 +72,4 @@
 //= require webui/canned_responses.js
 //= require webui/multi_select.js
 //= require webui/dropdown.js
+//= require webui/after_loading_fixes.js

--- a/src/api/app/assets/javascripts/webui/autocomplete.js
+++ b/src/api/app/assets/javascripts/webui/autocomplete.js
@@ -6,10 +6,10 @@ function setupAutocomplete() {
       source:    $(this).data('source'),
       minLength: 2,
       search: function() {
-        $(this).prev().find('i').toggleClass('fa-search fa-spinner fa-spin');
+        $(this).next().find('i').toggleClass('fa-search fa-spinner fa-spin');
       },
       response: function() {
-        $(this).prev().find('i').toggleClass('fa-search fa-spinner fa-spin');
+        $(this).next().find('i').toggleClass('fa-search fa-spinner fa-spin');
       }
     });
   });

--- a/src/api/app/assets/javascripts/webui/content-selector-filters.js
+++ b/src/api/app/assets/javascripts/webui/content-selector-filters.js
@@ -46,19 +46,6 @@ $(document).on('change keyup', '.auto-submit-on-change input, .auto-submit-on-ch
   submitFiltersTimeout = window.setTimeout(submitFilters, 2000);
 });
 
-// NOTE: no need to implement a keypress ENTER event, pressing enter on a form input will submit the form by default
-// Implement a click event on the search icon below
-const autoSubmitOnClickSelector = '#content-selector-filters-form .input-group-text';
-$(document).on('click', autoSubmitOnClickSelector, function() {
-  // Do nothing if there is no search icon inside
-  if ($(this).children('.fa-search').length === 0) {
-    return;
-  }
-  // Clear the timeout to prevent the pending submission, if any
-  window.clearTimeout(submitFiltersTimeout);
-
-  submitFilters();
-});
 // Cannot apply the .auto-submit-on-change class to the autocomplete input, so we need to handle it separately
 $(document).on('change', '.obs-autocomplete', function() {
   // Clear the timeout to prevent the pending submission, if any
@@ -70,5 +57,4 @@ $(document).on('change', '.obs-autocomplete', function() {
 
 $(document).ready(function(){
   highlightSelectedFilters();
-  $(autoSubmitOnClickSelector).each(function() {$(this).css('cursor', 'pointer');});
 });

--- a/src/api/app/components/input_component.html.haml
+++ b/src/api/app/components/input_component.html.haml
@@ -1,0 +1,11 @@
+.form-group.d-flex.justify-content-between.align-items-center
+  - if label?
+    .col-3.fs-6
+      = label
+  .input-group
+    = content
+    - if icon?
+      %span.input-group-text
+        = icon
+    - if button?
+      = button

--- a/src/api/app/components/input_component.rb
+++ b/src/api/app/components/input_component.rb
@@ -1,0 +1,9 @@
+# This component shapes the input field, and it can be used in different places and different ways:
+# - input box
+# - input box with icon
+# - input box with button
+class InputComponent < ApplicationComponent
+  renders_one :label
+  renders_one :icon
+  renders_one :button
+end

--- a/src/api/app/components/workflow_run_filter_component.html.haml
+++ b/src/api/app/components/workflow_run_filter_component.html.haml
@@ -71,11 +71,17 @@
           = render partial: 'webui/shared/info_popover', locals: { position: 'bottom', text: event_source_info_text }
         .selected-content.small.ms-1
       .px-4.pb-2.accordion-collapse.collapse.show#workflow-filter-event-source
-        = render partial: 'webui/shared/input', locals: { label: 'PR/MR', filter_item: 'pr_mr',
-                                                          placeholder: 'eg. 12345', selected_input_value: @selected_filter[:pr_mr] }
-        = render partial: 'webui/shared/input', locals: { label: 'Commit', filter_item: 'commit_sha',
-                                                          placeholder: 'eg. 97561db8664eaf86a1e4c7b77d5fb5d5bff6681e',
-                                                          selected_input_value: @selected_filter[:commit_sha] }
+        = render partial: 'webui/shared/input', locals: { html_id: 'pr_mr',
+                                                          class: 'auto-submit-on-change',
+                                                          placeholder: 'eg. 12345',
+                                                          label: 'PR/MR',
+                                                          value: @selected_filter[:pr_mr] }
+        .mt-1
+          = render partial: 'webui/shared/input', locals: { html_id: 'commit_sha',
+                                                            class: 'auto-submit-on-change',
+                                                            placeholder: 'eg. 97561db8664eaf86a1e4c7b77d5fb5d5bff6681e',
+                                                            label: 'Commit',
+                                                            value: @selected_filter[:commit_sha] }
   .text-center.mt-4.mb-4
     = link_to('Clear', token_workflow_runs_path(@token, []), class: 'btn btn-light border')
 

--- a/src/api/app/views/layouts/webui/_top_navigation_search.html.haml
+++ b/src/api/app/views/layouts/webui/_top_navigation_search.html.haml
@@ -1,2 +1,3 @@
 = form_tag(search_path(project: 1, package: 1, name: 1), method: :get, class: 'my-auto') do
-  %input.form-control.w-100{ 'aria-label': 'Search', name: 'search_text', placeholder: 'Search', type: 'search' }/
+  = render partial: 'webui/shared/search_box', locals: { html_id: 'search_text', placeholder: 'Search',
+                                                         with_label: false, required: false, button: { type: 'submit' } }

--- a/src/api/app/views/layouts/webui/_top_navigation_search.html.haml
+++ b/src/api/app/views/layouts/webui/_top_navigation_search.html.haml
@@ -1,3 +1,2 @@
 = form_tag(search_path(project: 1, package: 1, name: 1), method: :get, class: 'my-auto') do
-  = render partial: 'webui/shared/search_box', locals: { html_id: 'search_text', placeholder: 'Search',
-                                                         with_label: false, required: false, button: { type: 'submit' } }
+  = render partial: 'webui/shared/search_box', locals: { html_id: 'search_text', required: false, button: { type: 'submit' } }

--- a/src/api/app/views/webui/groups/_add_group_user_modal.html.haml
+++ b/src/api/app/views/webui/groups/_add_group_user_modal.html.haml
@@ -6,7 +6,7 @@
         .modal-header
           %h5.modal-title#add-group-user-modal-label Add Member
         .modal-body
-          = render partial: 'webui/shared/autocomplete', locals: { html_id: 'user_login', label: 'User:',
+          = render partial: 'webui/shared/search_box', locals: { html_id: 'user_login', label: 'User:',
                                                             data: { source: autocomplete_users_path } }
         .modal-footer
           = render partial: 'webui/shared/dialog_action_buttons'

--- a/src/api/app/views/webui/packages/branches/into.html.haml
+++ b/src/api/app/views/webui/packages/branches/into.html.haml
@@ -23,9 +23,9 @@
                     = link_to("#{name}: #{title}", project_show_path(project: name))
           .col-12.col-md-9.col-lg-6
             = form_tag(packages_branches_path) do
-              = render partial: 'webui/shared/autocomplete', locals: { html_id: 'linked_project', label: 'Original project name',
+              = render partial: 'webui/shared/search_box', locals: { html_id: 'linked_project', label: 'Original project name',
                                                                        data: { source: autocomplete_projects_path } }
-              = render partial: 'webui/shared/autocomplete', locals: { html_id: 'linked_package', label: 'Original package name', disabled: true,
+              = render partial: 'webui/shared/search_box', locals: { html_id: 'linked_package', label: 'Original package name', disabled: true,
                                                                        data: { source: autocomplete_packages_path } }
               = hidden_field_tag 'target_project', @project
               = render partial: 'webui/shared/package_branch_form', locals: { show_project_field: false, target_project: @project,

--- a/src/api/app/views/webui/patchinfo/edit.html.haml
+++ b/src/api/app/views/webui/patchinfo/edit.html.haml
@@ -8,7 +8,7 @@
     = form_for(@patchinfo, url: patchinfo_path(project: @project, package: @package), method: :put, html: { id: 'patchinfo' }) do |form|
       = form.hidden_field(:name)
       .mb-3.col-md-8.col-lg-4
-        = render partial: 'webui/shared/autocomplete', locals: { html_id: 'patchinfo[packager]', label: 'Packager', value: @patchinfo.packager,
+        = render partial: 'webui/shared/search_box', locals: { html_id: 'patchinfo[packager]', label: 'Packager', value: @patchinfo.packager,
                                                                  data: { source: autocomplete_users_path } }
       .mb-3.col-md-6
         = form.label(:summary) do

--- a/src/api/app/views/webui/projects/label_templates/copy.html.haml
+++ b/src/api/app/views/webui/projects/label_templates/copy.html.haml
@@ -8,7 +8,7 @@
       .col-12.col-md-10.col-lg-8
         = form_with(url: clone_project_label_templates_path(@project), method: :post) do |f|
           .mb-3#label-templates-source-project
-            = render partial: 'webui/shared/autocomplete',
+            = render partial: 'webui/shared/search_box',
                      locals: { html_id: "source_project",
                                html_name: "source_project",
                                label: 'Source Project:', required: true,

--- a/src/api/app/views/webui/projects/maintained_projects/_create_dialog.html.haml
+++ b/src/api/app/views/webui/projects/maintained_projects/_create_dialog.html.haml
@@ -6,7 +6,7 @@
           %h5.modal-title#new-maintenance-project-modal-label
             Add maintained project to #{project_name}
         .modal-body
-          = render partial: 'webui/shared/autocomplete', locals: { html_id: 'maintained_project', label: 'Project to be maintained:',
+          = render partial: 'webui/shared/search_box', locals: { html_id: 'maintained_project', label: 'Project to be maintained:',
                                                                    data: { source: autocomplete_projects_path } }
         .modal-footer
           = render partial: 'webui/shared/dialog_action_buttons', locals: { submit_tag_text: 'Add' }

--- a/src/api/app/views/webui/repositories/_add_repository_from_project_modal.html.haml
+++ b/src/api/app/views/webui/repositories/_add_repository_from_project_modal.html.haml
@@ -5,7 +5,7 @@
         .modal-header
           %h5.modal-title Add Repository to #{project}
         .modal-body.repository-autocomplete
-          = render partial: 'webui/shared/autocomplete', locals: { html_id: 'target_project', label: '<strong>Project:</strong>'.html_safe,
+          = render partial: 'webui/shared/search_box', locals: { html_id: 'target_project', label: '<strong>Project:</strong>'.html_safe,
                                                                    data: { source: autocomplete_projects_path } }
 
           .mb-3

--- a/src/api/app/views/webui/repositories/_add_repository_path_modal.html.haml
+++ b/src/api/app/views/webui/repositories/_add_repository_path_modal.html.haml
@@ -5,7 +5,7 @@
         .modal-header
           %h5.modal-title Add additional path to #{repository}
         .modal-body.repository-autocomplete
-          = render partial: 'webui/shared/autocomplete', locals: { html_id: 'target_project', label: '<strong>Project:</strong>'.html_safe,
+          = render partial: 'webui/shared/search_box', locals: { html_id: 'target_project', label: '<strong>Project:</strong>'.html_safe,
                                                                    data: { source: autocomplete_projects_path } }
           .mb-3
             = label_tag :repositories do

--- a/src/api/app/views/webui/request/_add_reviewer_dialog.html.haml
+++ b/src/api/app/views/webui/request/_add_reviewer_dialog.html.haml
@@ -14,18 +14,18 @@
             %p.text-wrap.mt-1#reviewer-meaning
               The review will be requested from the selected user
           .hideable.review-user
-            = render partial: 'webui/shared/autocomplete', locals: { html_id: 'review_user', label: 'User:', required: true,
+            = render partial: 'webui/shared/search_box', locals: { html_id: 'review_user', label: 'User:', required: true,
                                                                      data: { source: autocomplete_users_path } }
 
           .hideable.review-group.d-none
-            = render partial: 'webui/shared/autocomplete', locals: { html_id: 'review_group', label: 'Group:', required: true,
+            = render partial: 'webui/shared/search_box', locals: { html_id: 'review_group', label: 'Group:', required: true,
                                                                      data: { source: autocomplete_groups_path } }
           .hideable.review-project.review-package.d-none
-            = render partial: 'webui/shared/autocomplete', locals: { html_id: 'review_project', label: 'Project:', required: true,
+            = render partial: 'webui/shared/search_box', locals: { html_id: 'review_project', label: 'Project:', required: true,
                                                                      data: { source: autocomplete_projects_path } }
 
           .hideable.review-package.d-none
-            = render partial: 'webui/shared/autocomplete', locals: { html_id: 'review_package', label: 'Package:', required: true,
+            = render partial: 'webui/shared/search_box', locals: { html_id: 'review_package', label: 'Package:', required: true,
                                                                      data: { source: autocomplete_packages_path } }
 
           .mb-3

--- a/src/api/app/views/webui/requests/devel_project_changes/new.html.haml
+++ b/src/api/app/views/webui/requests/devel_project_changes/new.html.haml
@@ -17,7 +17,7 @@
                 = bs_request_actions.hidden_field(:type)
                 = bs_request_actions.hidden_field(:target_project)
                 = bs_request_actions.hidden_field(:target_package)
-                = render partial: 'webui/shared/autocomplete',
+                = render partial: 'webui/shared/search_box',
                            locals: { html_id: "#{bs_request_actions.object_name.gsub(/\]\[|\]|\[/, '_')}source_project",
                                      html_name: "#{bs_request_actions.object_name}[source_project]",
                                      label: 'New Devel Project:', required: true,

--- a/src/api/app/views/webui/requests/role_additions/new.html.haml
+++ b/src/api/app/views/webui/requests/role_additions/new.html.haml
@@ -41,14 +41,14 @@
                     = label_tag(:role_type, 'Group', for: 'role_type_group', class: 'form-check-label')
                 .hideable.user
                   -# Reproduce the naming convention for nested fields since we cannot use the FormBuilder (we replace ][, ] and [ by _)
-                  = render partial: 'webui/shared/autocomplete',
+                  = render partial: 'webui/shared/search_box',
                            locals: { html_id: "#{bs_request_actions.object_name.gsub(/\]\[|\]|\[/, '_')}person_name",
                                      html_name: "#{bs_request_actions.object_name}[person_name]",
                                      label: 'User:', required: true,
                                      data: { source: autocomplete_users_path } }
                 .hideable.group.d-none
                   -# Reproduce the naming convention for nested fields since we cannot use the FormBuilder (we replace ][, ] and [ by _)
-                  = render partial: 'webui/shared/autocomplete',
+                  = render partial: 'webui/shared/search_box',
                            locals: { html_id: "#{bs_request_actions.object_name.gsub(/\]\[|\]|\[/, '_')}group_name",
                                      html_name: "#{bs_request_actions.object_name}[group_name]",
                                      label: 'Group:', required: true,

--- a/src/api/app/views/webui/requests/submissions/new.html.haml
+++ b/src/api/app/views/webui/requests/submissions/new.html.haml
@@ -23,7 +23,7 @@
                 = bs_request_action.hidden_field(:source_project)
               .mb-3
                 -# Reproduce the naming convention for nested fields since we cannot use the FormBuilder (we replace ][, ] and [ by _)
-                = render partial: 'webui/shared/autocomplete',
+                = render partial: 'webui/shared/search_box',
                          locals: { html_id: "#{bs_request_action.object_name.gsub(/\]\[|\]|\[/, '_')}target_project",
                                    html_name: "#{bs_request_action.object_name}[target_project]",
                                    label: 'To target project:',

--- a/src/api/app/views/webui/search/_request_bugowner_change_dialog.html.haml
+++ b/src/api/app/views/webui/search/_request_bugowner_change_dialog.html.haml
@@ -10,10 +10,10 @@
             = select_tag(:review_type, options_for_select([%w[User review-user], %w[Group review-group]], 'review-user'), class: 'form-select')
 
           .hideable.review-user
-            = render partial: 'webui/shared/autocomplete', locals: { html_id: 'user', label: 'User:', required: true,
+            = render partial: 'webui/shared/search_box', locals: { html_id: 'user', label: 'User:', required: true,
                                                                      data: { source: autocomplete_users_path } }
           .hideable.review-group.d-none
-            = render partial: 'webui/shared/autocomplete', locals: { html_id: 'group', label: 'Group:', required: true,
+            = render partial: 'webui/shared/search_box', locals: { html_id: 'group', label: 'Group:', required: true,
                                                                      data: { source: autocomplete_groups_path } }
           .mb-3
             For:

--- a/src/api/app/views/webui/search/index.html.haml
+++ b/src/api/app/views/webui/search/index.html.haml
@@ -7,7 +7,7 @@
     .d-flex.justify-content-center
       = form_tag(search_path, method: :get, class: 'my-3 w-75') do
         .mb-3
-          = render partial: 'webui/shared/search_box', locals: { html_id: 'search_input', with_label: false,
+          = render partial: 'webui/shared/search_box', locals: { html_id: 'search_input',
                                                                 value: params[:search_text],
                                                                 html_name: 'search_text', required: true,
                                                                 minlength: 2, autofocus: true,

--- a/src/api/app/views/webui/search/index.html.haml
+++ b/src/api/app/views/webui/search/index.html.haml
@@ -6,12 +6,12 @@
     %h3 Search for packages or projects:
     .d-flex.justify-content-center
       = form_tag(search_path, method: :get, class: 'my-3 w-75') do
-        .mb-3.input-group
-          = search_field_tag('search_text', params[:search_text], placeholder: 'Search', autofocus: true,
-                             required: true, minlength: 2, class: 'form-control rounded', id: 'search_input')
-          %button.btn.btn-primary.ms-1{ type: 'submit', title: 'Search' }
-            %i.fa.fa-search
-
+        .mb-3
+          = render partial: 'webui/shared/search_box', locals: { html_id: 'search_input', with_label: false,
+                                                                value: params[:search_text],
+                                                                html_name: 'search_text', required: true,
+                                                                minlength: 2, autofocus: true,
+                                                                button: { type: 'submit', class: 'btn-primary' } }
         = render(partial: 'search_for')
         = render(partial: 'advanced_search', locals: { attrib_type_list: @attrib_type_list,
                                                          issue_tracker_list: @issue_tracker_list,

--- a/src/api/app/views/webui/search/issue.html.haml
+++ b/src/api/app/views/webui/search/issue.html.haml
@@ -6,14 +6,19 @@
     %h3 Search issues:
     .d-flex.justify-content-center
       = form_tag(search_issue_path, method: :get, class: 'my-3 w-75') do
-        .mb-3.input-group
-          = search_field_tag('issue', params[:issue], placeholder: 'Issue ID', autofocus: true, required: true, class: 'form-control')
+        .mb-3.d-flex
+          .w-50
+            = select_tag(:issue_tracker, options_for_select(@issue_tracker_list, params[:issue_tracker] || @default_tracker),
+                          class: 'form-select rounded-end-0')
+          .w-50
+            = render partial: 'webui/shared/search_box', locals: { html_id: 'issue', with_label: false,
+                                                                  value: params[:issue],
+                                                                  placeholder: 'Issue ID',
+                                                                  required: true,
+                                                                  autofocus: true,
+                                                                  input_class: 'rounded-start-0',
+                                                                  button: { type: 'submit', class: 'btn-primary' } }
 
-          = select_tag(:issue_tracker, options_for_select(@issue_tracker_list, params[:issue_tracker] || @default_tracker),
-                      class: 'form-select rounded-end')
-
-          %button.btn.btn-primary.ms-1{ type: 'submit', title: 'Search' }
-            %i.fa.fa-search
         = render(partial: 'search_for')
 
     - if @results.present?

--- a/src/api/app/views/webui/search/issue.html.haml
+++ b/src/api/app/views/webui/search/issue.html.haml
@@ -11,7 +11,7 @@
             = select_tag(:issue_tracker, options_for_select(@issue_tracker_list, params[:issue_tracker] || @default_tracker),
                           class: 'form-select rounded-end-0')
           .w-50
-            = render partial: 'webui/shared/search_box', locals: { html_id: 'issue', with_label: false,
+            = render partial: 'webui/shared/search_box', locals: { html_id: 'issue',
                                                                   value: params[:issue],
                                                                   placeholder: 'Issue ID',
                                                                   required: true,

--- a/src/api/app/views/webui/search/owner.html.haml
+++ b/src/api/app/views/webui/search/owner.html.haml
@@ -7,11 +7,14 @@
     .d-flex.justify-content-center
       = form_tag(search_owner_path, method: :get, class: 'my-3 w-75') do
         %input{ name: 'owner', type: 'hidden', value: '1' }
-        .mb-3.d-flex
-          = search_field_tag('search_text', params[:search_text], placeholder: 'Search', autofocus: true, required: true, class: 'form-control',
-                             id: 'search_input')
-          %button.btn.btn-primary.ms-1{ type: 'submit', title: 'Search' }
-            %i.fa.fa-search
+        .mb-3
+          = render partial: 'webui/shared/search_box', locals: { html_id: 'search_input', with_label: false,
+                                                                value: params[:search_text],
+                                                                html_name: 'search_text',
+                                                                placeholder: 'Search',
+                                                                required: true,
+                                                                autofocus: true,
+                                                                button: { type: 'submit', class: 'btn-primary' } }
         .row
           .d-flex.flex-wrap.flex-column.flex-sm-row
             .mb-3.row.row-cols-auto

--- a/src/api/app/views/webui/search/owner.html.haml
+++ b/src/api/app/views/webui/search/owner.html.haml
@@ -8,10 +8,9 @@
       = form_tag(search_owner_path, method: :get, class: 'my-3 w-75') do
         %input{ name: 'owner', type: 'hidden', value: '1' }
         .mb-3
-          = render partial: 'webui/shared/search_box', locals: { html_id: 'search_input', with_label: false,
+          = render partial: 'webui/shared/search_box', locals: { html_id: 'search_input',
                                                                 value: params[:search_text],
                                                                 html_name: 'search_text',
-                                                                placeholder: 'Search',
                                                                 required: true,
                                                                 autofocus: true,
                                                                 button: { type: 'submit', class: 'btn-primary' } }

--- a/src/api/app/views/webui/shared/_autocomplete.html.haml
+++ b/src/api/app/views/webui/shared/_autocomplete.html.haml
@@ -5,6 +5,8 @@
   data = local_assigns.fetch(:data, {})
   html_name = local_assigns.fetch(:html_name, html_id)
   with_label = local_assigns.fetch(:with_label, true)
+  icon = local_assigns.fetch(:icon, 'fa-search')
+  button = local_assigns.fetch(:button, false)
 
 .mb-3.ui-front
   - if with_label
@@ -14,5 +16,10 @@
   = render(InputComponent.new) do |component|
     = search_field_tag(html_id, value, required: required, disabled: disabled, placeholder: 'Type to autocomplete...',
                        class: 'obs-autocomplete form-control', data: data, name: html_name)
-    - component.with_icon do
-      %i.fa.fa-search
+    - if button
+      - component.with_button do
+        %button.btn.border{ type: button[:type], class: button[:class] ? button[:class] : 'btn-light' }
+          %i.fa{ class: button[:icon] ? button[:icon] : 'fa-search' }
+    - else
+      - component.with_icon do
+        %i.fa{ class: icon }

--- a/src/api/app/views/webui/shared/_autocomplete.html.haml
+++ b/src/api/app/views/webui/shared/_autocomplete.html.haml
@@ -11,8 +11,8 @@
     = label_tag(html_id, label)
   - if required
     = render partial: 'webui/shared/required_label_mark'
-  .input-group
-    %span.input-group-text
-      %i.fas.fa-search
+  = render(InputComponent.new) do |component|
     = search_field_tag(html_id, value, required: required, disabled: disabled, placeholder: 'Type to autocomplete...',
                        class: 'obs-autocomplete form-control', data: data, name: html_name)
+    - component.with_icon do
+      %i.fa.fa-search

--- a/src/api/app/views/webui/shared/_input.haml
+++ b/src/api/app/views/webui/shared/_input.haml
@@ -1,8 +1,17 @@
-.form-group.d-flex.justify-content-between
-  .col-3
-    = label_tag filter_item, "#{label}:", class: 'fs-6'
-  .col-9.d-flex
-    = text_field_tag(filter_item, '',
-                     class: 'form-control form-control-sm',
-                     placeholder: defined?(placeholder) ? placeholder : '', value: selected_input_value,
-                     type: defined?(type) ? type : 'text')
+:ruby
+  html_name = local_assigns.fetch(:html_name, html_id)
+  input_class = local_assigns.fetch(:class, '')
+  value = local_assigns.fetch(:value, '')
+  placeholder = local_assigns.fetch(:placeholder, '')
+  label = local_assigns.fetch(:label, nil)
+  type = local_assigns.fetch(:type, 'text')
+
+= render(InputComponent.new) do |component|
+  = text_field_tag(html_id, '', type: type,
+                   name: html_name,
+                   class: "form-control #{input_class}",
+                   value: value,
+                   placeholder: placeholder)
+  - if !label.nil?
+    - component.with_label do
+      = label_tag(html_id, label)

--- a/src/api/app/views/webui/shared/_input.haml
+++ b/src/api/app/views/webui/shared/_input.haml
@@ -12,6 +12,6 @@
                    class: "form-control #{input_class}",
                    value: value,
                    placeholder: placeholder)
-  - if !label.nil?
+  - unless label.nil?
     - component.with_label do
       = label_tag(html_id, label)

--- a/src/api/app/views/webui/shared/_search_box.html.haml
+++ b/src/api/app/views/webui/shared/_search_box.html.haml
@@ -23,7 +23,9 @@
                        minlength: minlength, autofocus: autofocus)
     - if button
       - component.with_button do
-        %button.btn.border{ type: button[:type], class: button[:class] ? button[:class] : 'btn-light' }
+        %button.btn.border{ type: button[:type], class: button[:class] ? button[:class] : 'btn-light', title: button[:title] }
+          - if button[:text]
+            %span.me-1= button[:text]
           %i.fa{ class: button[:icon] ? button[:icon] : 'fa-search' }
     - else
       - component.with_icon do

--- a/src/api/app/views/webui/shared/_search_box.html.haml
+++ b/src/api/app/views/webui/shared/_search_box.html.haml
@@ -4,7 +4,7 @@
   disabled = local_assigns.fetch(:disabled, false)
   data = local_assigns.fetch(:data, {})
   html_name = local_assigns.fetch(:html_name, html_id)
-  with_label = local_assigns.fetch(:with_label, true)
+  label = local_assigns.fetch(:label, nil)
   placeholder = local_assigns.fetch(:placeholder, !data.empty? ? 'Type to autocomplete...' : 'Search')
   icon = local_assigns.fetch(:icon, 'fa-search')
   button = local_assigns.fetch(:button, false)
@@ -13,7 +13,7 @@
   input_class = local_assigns.fetch(:input_class, '')
 
 .ui-front
-  - if with_label
+  - if !label.nil?
     = label_tag(html_id, label)
     - if required
       = render partial: 'webui/shared/required_label_mark'

--- a/src/api/app/views/webui/shared/_search_box.html.haml
+++ b/src/api/app/views/webui/shared/_search_box.html.haml
@@ -8,6 +8,9 @@
   placeholder = local_assigns.fetch(:placeholder, !data.empty? ? 'Type to autocomplete...' : 'Search')
   icon = local_assigns.fetch(:icon, 'fa-search')
   button = local_assigns.fetch(:button, false)
+  minlength = local_assigns.fetch(:minlength, 0)
+  autofocus = local_assigns.fetch(:autofocus, false)
+  input_class = local_assigns.fetch(:input_class, '')
 
 .ui-front
   - if with_label
@@ -16,7 +19,8 @@
       = render partial: 'webui/shared/required_label_mark'
   = render(InputComponent.new) do |component|
     = search_field_tag(html_id, value, required: required, disabled: disabled, placeholder: placeholder,
-                       class: "form-control #{!data.empty? ? 'obs-autocomplete' : ''}", data: data, name: html_name)
+                       class: "form-control #{!data.empty? ? 'obs-autocomplete' : ''} #{input_class}", data: data, name: html_name,
+                       minlength: minlength, autofocus: autofocus)
     - if button
       - component.with_button do
         %button.btn.border{ type: button[:type], class: button[:class] ? button[:class] : 'btn-light' }

--- a/src/api/app/views/webui/shared/_search_box.html.haml
+++ b/src/api/app/views/webui/shared/_search_box.html.haml
@@ -5,17 +5,18 @@
   data = local_assigns.fetch(:data, {})
   html_name = local_assigns.fetch(:html_name, html_id)
   with_label = local_assigns.fetch(:with_label, true)
+  placeholder = local_assigns.fetch(:placeholder, !data.empty? ? 'Type to autocomplete...' : 'Search')
   icon = local_assigns.fetch(:icon, 'fa-search')
   button = local_assigns.fetch(:button, false)
 
-.mb-3.ui-front
+.ui-front
   - if with_label
     = label_tag(html_id, label)
-  - if required
-    = render partial: 'webui/shared/required_label_mark'
+    - if required
+      = render partial: 'webui/shared/required_label_mark'
   = render(InputComponent.new) do |component|
-    = search_field_tag(html_id, value, required: required, disabled: disabled, placeholder: 'Type to autocomplete...',
-                       class: 'obs-autocomplete form-control', data: data, name: html_name)
+    = search_field_tag(html_id, value, required: required, disabled: disabled, placeholder: placeholder,
+                       class: "form-control #{!data.empty? ? 'obs-autocomplete' : ''}", data: data, name: html_name)
     - if button
       - component.with_button do
         %button.btn.border{ type: button[:type], class: button[:class] ? button[:class] : 'btn-light' }

--- a/src/api/app/views/webui/shared/_search_box.html.haml
+++ b/src/api/app/views/webui/shared/_search_box.html.haml
@@ -13,7 +13,7 @@
   input_class = local_assigns.fetch(:input_class, '')
 
 .ui-front
-  - if !label.nil?
+  - unless label.nil?
     = label_tag(html_id, label)
     - if required
       = render partial: 'webui/shared/required_label_mark'

--- a/src/api/app/views/webui/shared/bs_requests/_form.html.haml
+++ b/src/api/app/views/webui/shared/bs_requests/_form.html.haml
@@ -19,8 +19,10 @@
             .card-body.row
               .col
               .col-lg
-                %input.ms-auto.form-control{ 'aria-label': 'Search', name: 'search',
-                  placeholder: 'Search', type: 'search', value: selected_filter[:search] }
+                = render partial: 'webui/shared/search_box', locals: { html_id: 'search', placeholder: 'Search',
+                                                                       value: selected_filter[:search],
+                                                                       required: false, with_label: false,
+                                                                       button: { type: 'submit' } }
           .text-center.mb-3
             - if bs_requests.total_count == 0
               %p There are no requests available

--- a/src/api/app/views/webui/shared/bs_requests/_form.html.haml
+++ b/src/api/app/views/webui/shared/bs_requests/_form.html.haml
@@ -19,9 +19,9 @@
             .card-body.row
               .col
               .col-lg
-                = render partial: 'webui/shared/search_box', locals: { html_id: 'search', placeholder: 'Search',
+                = render partial: 'webui/shared/search_box', locals: { html_id: 'search',
                                                                        value: selected_filter[:search],
-                                                                       required: false, with_label: false,
+                                                                       required: false,
                                                                        button: { type: 'submit' } }
           .text-center.mb-3
             - if bs_requests.total_count == 0

--- a/src/api/app/views/webui/shared/bs_requests/_requests_filter.html.haml
+++ b/src/api/app/views/webui/shared/bs_requests/_requests_filter.html.haml
@@ -101,7 +101,8 @@
       #request-project-name-dropdown
         = render partial: 'webui/shared/autocomplete', locals: { html_id: 'project_names_search', label: 'Project names:',
                                                                  html_name: 'project_names[]', required: false, with_label: false,
-                                                                 data: { source: autocomplete_projects_path } }
+                                                                 data: { source: autocomplete_projects_path },
+                                                                 button: { type: 'submit' } }
         .scroll-list-wrapper.auto-submit-on-change
           - selected_filter[:project_names].each do |project_name|
             .dropdown-item-text
@@ -123,7 +124,8 @@
       #request-package-name-dropdown
         = render partial: 'webui/shared/autocomplete', locals: { html_id: 'package_names_search', label: 'Package names:',
                                                                  html_name: 'package_names[]', required: false, with_label: false,
-                                                                 data: { source: package_autocomplete_path } }
+                                                                 data: { source: package_autocomplete_path },
+                                                                 button: { type: 'submit' } }
         .scroll-list-wrapper.auto-submit-on-change
           - selected_filter[:package_names].each do |package_name|
             .dropdown-item-text
@@ -141,7 +143,8 @@
       #request-creator-dropdown
         = render partial: 'webui/shared/autocomplete', locals: { html_id: 'creators_search', label: 'Creators:',
                                                                  html_name: 'creators[]', required: false, with_label: false,
-                                                                 data: { source: autocomplete_users_path } }
+                                                                 data: { source: autocomplete_users_path },
+                                                                 button: { type: 'submit' } }
         .scroll-list-wrapper.auto-submit-on-change
           - if selected_filter[:creators].include?(User.session.login)
             .dropdown-item-text
@@ -167,7 +170,8 @@
       #request-reviewer-dropdown
         = render partial: 'webui/shared/autocomplete', locals: { html_id: 'reviewer_search', label: 'Reviewers:',
                                                                  html_name: 'reviewers[]', required: false, with_label: false,
-                                                                 data: { source: autocomplete_reviewers_path } }
+                                                                 data: { source: autocomplete_reviewers_path },
+                                                                 button: { type: 'submit' } }
 
         .scroll-list-wrapper.auto-submit-on-change
           - if selected_filter[:reviewers].include?(User.session.login)
@@ -195,7 +199,8 @@
       #request-staging-project-dropdown
         = render partial: 'webui/shared/autocomplete', locals: { html_id: 'staging_project_search', label: 'Staging Project:',
                                                                  html_name: 'staging_projects[]', required: false, with_label: false,
-                                                                 data: { source: autocomplete_staging_projects_path } }
+                                                                 data: { source: autocomplete_staging_projects_path },
+                                                                 button: { type: 'submit' } }
         .scroll-list-wrapper.auto-submit-on-change
           - selected_filter[:staging_projects].each do |staging_project|
             .dropdown-item-text

--- a/src/api/app/views/webui/shared/bs_requests/_requests_filter.html.haml
+++ b/src/api/app/views/webui/shared/bs_requests/_requests_filter.html.haml
@@ -99,7 +99,7 @@
       .selected-content.small.ms-1
     .px-4.pb-2.accordion-collapse.collapse.show#request-filter-project-name
       #request-project-name-dropdown
-        = render partial: 'webui/shared/autocomplete', locals: { html_id: 'project_names_search', label: 'Project names:',
+        = render partial: 'webui/shared/search_box', locals: { html_id: 'project_names_search', label: 'Project names:',
                                                                  html_name: 'project_names[]', required: false, with_label: false,
                                                                  data: { source: autocomplete_projects_path },
                                                                  button: { type: 'submit' } }
@@ -122,7 +122,7 @@
       .selected-content.small.ms-1
     .px-4.pb-2.accordion-collapse.collapse.show#request-filter-package-name
       #request-package-name-dropdown
-        = render partial: 'webui/shared/autocomplete', locals: { html_id: 'package_names_search', label: 'Package names:',
+        = render partial: 'webui/shared/search_box', locals: { html_id: 'package_names_search', label: 'Package names:',
                                                                  html_name: 'package_names[]', required: false, with_label: false,
                                                                  data: { source: package_autocomplete_path },
                                                                  button: { type: 'submit' } }
@@ -141,7 +141,7 @@
       .selected-content.small.ms-1
     .px-4.pb-2.accordion-collapse.collapse.show#request-filter-creator
       #request-creator-dropdown
-        = render partial: 'webui/shared/autocomplete', locals: { html_id: 'creators_search', label: 'Creators:',
+        = render partial: 'webui/shared/search_box', locals: { html_id: 'creators_search', label: 'Creators:',
                                                                  html_name: 'creators[]', required: false, with_label: false,
                                                                  data: { source: autocomplete_users_path },
                                                                  button: { type: 'submit' } }
@@ -168,7 +168,7 @@
       .selected-content.small.ms-1
     .px-4.pb-2.accordion-collapse.collapse.show#request-filter-reviewer
       #request-reviewer-dropdown
-        = render partial: 'webui/shared/autocomplete', locals: { html_id: 'reviewer_search', label: 'Reviewers:',
+        = render partial: 'webui/shared/search_box', locals: { html_id: 'reviewer_search', label: 'Reviewers:',
                                                                  html_name: 'reviewers[]', required: false, with_label: false,
                                                                  data: { source: autocomplete_reviewers_path },
                                                                  button: { type: 'submit' } }
@@ -197,7 +197,7 @@
       .selected-content.small.ms-1
     .px-4.pb-2.accordion-collapse.collapse.show#request-filter-staging-project
       #request-staging-project-dropdown
-        = render partial: 'webui/shared/autocomplete', locals: { html_id: 'staging_project_search', label: 'Staging Project:',
+        = render partial: 'webui/shared/search_box', locals: { html_id: 'staging_project_search', label: 'Staging Project:',
                                                                  html_name: 'staging_projects[]', required: false, with_label: false,
                                                                  data: { source: autocomplete_staging_projects_path },
                                                                  button: { type: 'submit' } }

--- a/src/api/app/views/webui/shared/bs_requests/_requests_filter.html.haml
+++ b/src/api/app/views/webui/shared/bs_requests/_requests_filter.html.haml
@@ -212,10 +212,13 @@
         = render partial: 'webui/shared/bs_requests/filter_help_created_at'
       .selected-content.small.ms-1
     .px-4.pb-2.accordion-collapse.collapse.show#request-filter-created-at
-      = render partial: 'webui/shared/input', locals: { label: 'From', filter_item: 'created_at_from', type: 'datetime-local',
-                                                        selected_input_value: selected_filter[:created_at_from] }
-      = render partial: 'webui/shared/input', locals: { label: 'To', filter_item: 'created_at_to', type: 'datetime-local',
-                                                        selected_input_value: selected_filter[:created_at_to] }
+      = render partial: 'webui/shared/input', locals: { html_id: 'created_at_from', type: 'datetime-local',
+                                                        class: 'auto-submit-on-change',
+                                                        label: 'From', value: selected_filter[:created_at_from] }
+      .mt-1
+        = render partial: 'webui/shared/input', locals: { html_id: 'created_at_to', type: 'datetime-local',
+                                                          class: 'auto-submit-on-change',
+                                                          label: 'To', value: selected_filter[:created_at_to] }
 
 .text-center.mt-4.mb-4
   = link_to('Clear', url, class: 'btn btn-light border')

--- a/src/api/app/views/webui/shared/bs_requests/_requests_filter.html.haml
+++ b/src/api/app/views/webui/shared/bs_requests/_requests_filter.html.haml
@@ -99,8 +99,8 @@
       .selected-content.small.ms-1
     .px-4.pb-2.accordion-collapse.collapse.show#request-filter-project-name
       #request-project-name-dropdown
-        = render partial: 'webui/shared/search_box', locals: { html_id: 'project_names_search', label: 'Project names:',
-                                                                 html_name: 'project_names[]', required: false, with_label: false,
+        = render partial: 'webui/shared/search_box', locals: { html_id: 'project_names_search',
+                                                                 html_name: 'project_names[]', required: false,
                                                                  data: { source: autocomplete_projects_path },
                                                                  button: { type: 'submit' } }
         .scroll-list-wrapper.auto-submit-on-change
@@ -122,8 +122,8 @@
       .selected-content.small.ms-1
     .px-4.pb-2.accordion-collapse.collapse.show#request-filter-package-name
       #request-package-name-dropdown
-        = render partial: 'webui/shared/search_box', locals: { html_id: 'package_names_search', label: 'Package names:',
-                                                                 html_name: 'package_names[]', required: false, with_label: false,
+        = render partial: 'webui/shared/search_box', locals: { html_id: 'package_names_search',
+                                                                 html_name: 'package_names[]', required: false,
                                                                  data: { source: package_autocomplete_path },
                                                                  button: { type: 'submit' } }
         .scroll-list-wrapper.auto-submit-on-change
@@ -141,8 +141,8 @@
       .selected-content.small.ms-1
     .px-4.pb-2.accordion-collapse.collapse.show#request-filter-creator
       #request-creator-dropdown
-        = render partial: 'webui/shared/search_box', locals: { html_id: 'creators_search', label: 'Creators:',
-                                                                 html_name: 'creators[]', required: false, with_label: false,
+        = render partial: 'webui/shared/search_box', locals: { html_id: 'creators_search',
+                                                                 html_name: 'creators[]', required: false,
                                                                  data: { source: autocomplete_users_path },
                                                                  button: { type: 'submit' } }
         .scroll-list-wrapper.auto-submit-on-change
@@ -168,8 +168,8 @@
       .selected-content.small.ms-1
     .px-4.pb-2.accordion-collapse.collapse.show#request-filter-reviewer
       #request-reviewer-dropdown
-        = render partial: 'webui/shared/search_box', locals: { html_id: 'reviewer_search', label: 'Reviewers:',
-                                                                 html_name: 'reviewers[]', required: false, with_label: false,
+        = render partial: 'webui/shared/search_box', locals: { html_id: 'reviewer_search',
+                                                                 html_name: 'reviewers[]', required: false,
                                                                  data: { source: autocomplete_reviewers_path },
                                                                  button: { type: 'submit' } }
 
@@ -197,8 +197,8 @@
       .selected-content.small.ms-1
     .px-4.pb-2.accordion-collapse.collapse.show#request-filter-staging-project
       #request-staging-project-dropdown
-        = render partial: 'webui/shared/search_box', locals: { html_id: 'staging_project_search', label: 'Staging Project:',
-                                                                 html_name: 'staging_projects[]', required: false, with_label: false,
+        = render partial: 'webui/shared/search_box', locals: { html_id: 'staging_project_search',
+                                                                 html_name: 'staging_projects[]', required: false,
                                                                  data: { source: autocomplete_staging_projects_path },
                                                                  button: { type: 'submit' } }
         .scroll-list-wrapper.auto-submit-on-change

--- a/src/api/app/views/webui/shared/user_or_groups_roles/_add_group_dialog.html.haml
+++ b/src/api/app/views/webui/shared/user_or_groups_roles/_add_group_dialog.html.haml
@@ -5,7 +5,7 @@
         .modal-header
           %h5.modal-title#edit-modal-label Add Group
         .modal-body
-          = render partial: 'webui/shared/autocomplete', locals: { html_id: 'groupid', label: 'Group:',
+          = render partial: 'webui/shared/search_box', locals: { html_id: 'groupid', label: 'Group:',
                                                                    data: { source: autocomplete_groups_path } }
           .mb-3
             = label_tag(:role, 'Role:')

--- a/src/api/app/views/webui/shared/user_or_groups_roles/_add_user_dialog.html.haml
+++ b/src/api/app/views/webui/shared/user_or_groups_roles/_add_user_dialog.html.haml
@@ -5,7 +5,7 @@
         .modal-header
           %h5.modal-title#edit-modal-label Add User
         .modal-body
-          = render partial: 'webui/shared/autocomplete', locals: { html_id: 'userid', label: 'User:',
+          = render partial: 'webui/shared/search_box', locals: { html_id: 'userid', label: 'User:',
                                                                    data: { source: autocomplete_users_path } }
           .mb-3
             = label_tag(:role, 'Role:')

--- a/src/api/app/views/webui/staging/excluded_requests/_create_dialog.html.haml
+++ b/src/api/app/views/webui/staging/excluded_requests/_create_dialog.html.haml
@@ -5,7 +5,7 @@
         %h5.modal-title#exclude-request-modal-label Exclude Request
       = form_for Staging::RequestExclusion.new, url: excluded_requests_path do |f|
         .modal-body
-          = render partial: 'webui/shared/autocomplete', locals: { html_id: 'staging_request_exclusion[number]',
+          = render partial: 'webui/shared/search_box', locals: { html_id: 'staging_request_exclusion[number]',
                                                                   label: 'Request', value: f.object.number,
                                                                   data: { source: autocomplete_excluded_requests_path(staging_workflow_project) } }
           .mb-3

--- a/src/api/app/views/webui/staging/workflows/_create_staging_project.html.haml
+++ b/src/api/app/views/webui/staging/workflows/_create_staging_project.html.haml
@@ -5,7 +5,7 @@
         .modal-header
           %h5.modal-title#create-staging-projects-modal-label Create Staging Project
         .modal-body
-          = render partial: 'webui/shared/autocomplete', locals: { html_id: 'staging_project_name',
+          = render partial: 'webui/shared/search_box', locals: { html_id: 'staging_project_name',
                                                                    label: 'Please enter a project you have permissions to',
                                                                    data: { source: autocomplete_projects_path } }
           %small.text-muted

--- a/src/api/app/views/webui/staging/workflows/_staging_managers_group.html.haml
+++ b/src/api/app/views/webui/staging/workflows/_staging_managers_group.html.haml
@@ -10,7 +10,7 @@
             Assigned group is:
             %strong= actual_group
 
-          = render partial: 'webui/shared/autocomplete', locals: { html_id: 'managers_title', label: 'Replace the group with:',
+          = render partial: 'webui/shared/search_box', locals: { html_id: 'managers_title', label: 'Replace the group with:',
                                                                    data: { source: autocomplete_groups_path } }
         .modal-footer
           = render partial: 'webui/shared/dialog_action_buttons'

--- a/src/api/app/views/webui/staging/workflows/new.html.haml
+++ b/src/api/app/views/webui/staging/workflows/new.html.haml
@@ -14,7 +14,7 @@
     .mb-3.w-50.m-auto
       = form_for @staging_workflow, method: :post do |f|
         = hidden_field_tag :project_name, @project
-        = render partial: 'webui/shared/autocomplete', locals: { html_id: 'managers_title', label: 'Managers Group:',
+        = render partial: 'webui/shared/search_box', locals: { html_id: 'managers_title', label: 'Managers Group:',
                                                                  data: { source: autocomplete_groups_path } }
         .text-center
           = f.submit 'Create Staging Projects', class: 'btn btn-primary'

--- a/src/api/app/views/webui/user/_involvement.html.haml
+++ b/src/api/app/views/webui/user/_involvement.html.haml
@@ -17,9 +17,9 @@
     .card-body
       = form_with(model: displayed_user, method: :get, local: true, class: 'row row-cols-auto justify-content-end') do
         .mb-3
-          = render partial: 'webui/shared/search_box', locals: { html_id: 'search_text', placeholder: 'Search',
+          = render partial: 'webui/shared/search_box', locals: { html_id: 'search_text',
                                                                  value: filters[:search_text],
-                                                                 required: false, with_label: false }
+                                                                 required: false }
         %span.dropdown.mb-3#involved-project-package
           %button.btn.btn-outline-secondary.dropdown-toggle.form-control{ data: { 'bs-toggle': :dropdown }, type: :button }
             %span.caret

--- a/src/api/app/views/webui/user/_involvement.html.haml
+++ b/src/api/app/views/webui/user/_involvement.html.haml
@@ -17,7 +17,9 @@
     .card-body
       = form_with(model: displayed_user, method: :get, local: true, class: 'row row-cols-auto justify-content-end') do
         .mb-3
-          %input.form-control{ 'aria-label': 'Search', name: 'search_text', placeholder: 'Search', type: 'search', value: filters[:search_text] }
+          = render partial: 'webui/shared/search_box', locals: { html_id: 'search_text', placeholder: 'Search',
+                                                                 value: filters[:search_text],
+                                                                 required: false, with_label: false }
         %span.dropdown.mb-3#involved-project-package
           %button.btn.btn-outline-secondary.dropdown-toggle.form-control{ data: { 'bs-toggle': :dropdown }, type: :button }
             %span.caret

--- a/src/api/app/views/webui/users/tokens/new.html.haml
+++ b/src/api/app/views/webui/users/tokens/new.html.haml
@@ -31,10 +31,10 @@
 
           .row#package-project-form
             .col-sm
-              = render partial: 'webui/shared/autocomplete', locals: { html_id: 'project_name', label: 'Project name', required: false,
+              = render partial: 'webui/shared/search_box', locals: { html_id: 'project_name', label: 'Project name', required: false,
                                                                        data: { source: autocomplete_projects_path(local: true) } }
             .col-sm
-              = render partial: 'webui/shared/autocomplete', locals: { html_id: 'package_name', label: 'Package name', required: false,
+              = render partial: 'webui/shared/search_box', locals: { html_id: 'package_name', label: 'Package name', required: false,
                                                                        data: { source: autocomplete_packages_path }, disabled: true }
             .col-12
               .mb-3.form-text.text-muted

--- a/src/api/app/views/webui/users/tokens/users/_add_group_to_token_dialog.html.haml
+++ b/src/api/app/views/webui/users/tokens/users/_add_group_to_token_dialog.html.haml
@@ -5,7 +5,7 @@
         .modal-header
           %h5.modal-title#edit-modal-label Add Group
         .modal-body
-          = render partial: 'webui/shared/autocomplete', locals: { html_id: 'groupid', label: 'Group:',
+          = render partial: 'webui/shared/search_box', locals: { html_id: 'groupid', label: 'Group:',
                                                                    data: { source: autocomplete_groups_path } }
         .modal-footer
           = render partial: 'webui/shared/dialog_action_buttons'

--- a/src/api/app/views/webui/users/tokens/users/_add_user_to_token_dialog.html.haml
+++ b/src/api/app/views/webui/users/tokens/users/_add_user_to_token_dialog.html.haml
@@ -5,7 +5,7 @@
         .modal-header
           %h5.modal-title#edit-modal-label Add User
         .modal-body
-          = render partial: 'webui/shared/autocomplete', locals: { html_id: 'userid', label: 'User:',
+          = render partial: 'webui/shared/search_box', locals: { html_id: 'userid', label: 'User:',
                                                                    data: { source: autocomplete_users_path } }
         .modal-footer
           = render partial: 'webui/shared/dialog_action_buttons'

--- a/src/api/spec/components/previews/input_component_preview.rb
+++ b/src/api/spec/components/previews/input_component_preview.rb
@@ -1,0 +1,64 @@
+class InputComponentPreview < ViewComponent::Preview
+  def with_label
+    render(InputComponent.new) do |component|
+      component.with_label do
+        content_tag(
+          :label,
+          'Search:',
+          for: 'search_text'
+        )
+      end
+      tag.input(type: 'text',
+                name: 'search_text',
+                id: 'search_text',
+                class: 'form-control',
+                placeholder: 'Search',
+                value: '',
+                'aria-label': 'Search text')
+    end
+  end
+
+  def with_label_and_icon
+    render(InputComponent.new) do |component|
+      component.with_label do
+        content_tag(
+          :label,
+          'Search:',
+          for: 'search_text'
+        )
+      end
+      component.with_icon do
+        tag.i(class: 'fas fa-search')
+      end
+      tag.input(type: 'text',
+                name: 'search_text',
+                id: 'search_text',
+                class: 'form-control',
+                placeholder: 'Search',
+                value: '',
+                'aria-label': 'Search text')
+    end
+  end
+
+  def with_label_and_button
+    render(InputComponent.new) do |component|
+      component.with_label do
+        content_tag(
+          :label,
+          'Search:',
+          for: 'search_text'
+        )
+      end
+      component.with_button do
+        tag.button('Submit', class: 'btn btn-outline-secondary')
+      end
+      tag.input(type: 'text',
+                name: 'search_text',
+                id: 'search_text',
+                class: 'form-control',
+                placeholder: 'Search',
+                value: '',
+                'aria-label': 'Search')
+    end
+  end
+end

--- a/src/api/spec/features/webui/change_bugowner_spec.rb
+++ b/src/api/spec/features/webui/change_bugowner_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'ChangeBugowner', :js do
 
     visit search_owner_path
     fill_in :search_input, with: package.name
-    click_button 'Search'
+    find('input', id: 'search_input').sibling('button[type=submit]').click
     click_link 'Request bugowner change'
   end
 

--- a/src/api/spec/features/webui/search_spec.rb
+++ b/src/api/spec/features/webui/search_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Search', :js do
       page.evaluate_script('$.fx.off = true;') # Needed to disable javascript animations that can end in not checking the checkboxes properly
 
       fill_in 'search_input', with: package.name
-      click_button 'Search'
+      find('input', id: 'search_input').sibling('button[type=submit]').click
 
       within '#search-results' do
         expect(page).to have_link(user.home_project_name)
@@ -46,7 +46,7 @@ RSpec.describe 'Search', :js do
       click_button 'Advanced'
       select('Projects', from: 'search_for')
 
-      click_button 'Search'
+      find('input', id: 'search_input').sibling('button[type=submit]').click
 
       within '#search-results' do
         expect(page).to have_link(apache2.name)
@@ -67,7 +67,7 @@ RSpec.describe 'Search', :js do
       select('Packages', from: 'search_for')
 
       check 'title'
-      click_button 'Search'
+      find('input', id: 'search_input').sibling('button[type=submit]').click
 
       within '#search-results' do
         expect(page).to have_link(user.home_project_name)
@@ -88,7 +88,7 @@ RSpec.describe 'Search', :js do
       check 'title'
       uncheck 'name'
       uncheck 'description'
-      click_button 'Search'
+      find('input', id: 'search_input').sibling('button[type=submit]').click
 
       within '#search-results' do
         expect(page).to have_link(apache.name)
@@ -108,7 +108,7 @@ RSpec.describe 'Search', :js do
       uncheck 'title'
       uncheck 'name'
       check 'description'
-      click_button 'Search'
+      find('input', id: 'search_input').sibling('button[type=submit]').click
 
       within '#search-results' do
         expect(page).to have_link(apache.name)
@@ -124,7 +124,7 @@ RSpec.describe 'Search', :js do
       page.evaluate_script('$.fx.off = true;') # Needed to disable javascript animations that can end in not checking the checkboxes properly
 
       fill_in 'search_input', with: 'fooo'
-      click_button 'Search'
+      find('input', id: 'search_input').sibling('button[type=submit]').click
 
       within('#flash') do
         expect(page).to have_text('Your search did not return any results.')
@@ -143,7 +143,7 @@ RSpec.describe 'Search', :js do
       click_button 'Advanced'
       uncheck 'name'
       check 'title'
-      click_button 'Search'
+      find('input', id: 'search_input').sibling('button[type=submit]').click
 
       within '#search-results' do
         expect(page).to have_link(russian_project.name)
@@ -162,7 +162,7 @@ RSpec.describe 'Search', :js do
         fill_in 'search_input', with: 'hidden'
         click_button 'Advanced'
         check 'title'
-        click_button 'Search'
+        find('input', id: 'search_input').sibling('button[type=submit]').click
 
         within('#flash') do
           expect(page).to have_text('Your search did not return any results.')
@@ -183,7 +183,7 @@ RSpec.describe 'Search', :js do
         fill_in 'search_input', with: 'hidden'
         click_button 'Advanced'
         check 'title'
-        click_button 'Search'
+        find('input', id: 'search_input').sibling('button[type=submit]').click
 
         within '#search-results' do
           expect(page).to have_link(hidden_package.name)
@@ -226,7 +226,7 @@ RSpec.describe 'Search', :js do
       page.evaluate_script('$.fx.off = true;') # Needed to disable javascript animations that can end in not checking the checkboxes properly
 
       fill_in 'search_input', with: apache_package.name
-      click_button 'Search'
+      find('input', id: 'search_input').sibling('button[type=submit]').click
 
       within '#search-results' do
         expect(page).to have_text(relationship_package_user.user.name)
@@ -247,7 +247,7 @@ RSpec.describe 'Search', :js do
 
       fill_in 'search_input', with: apache_package.name
 
-      click_button 'Search'
+      find('input', id: 'search_input').sibling('button[type=submit]').click
 
       within '#search-results' do
         expect(page).to have_text(relationship_package_user.user.name)
@@ -265,7 +265,7 @@ RSpec.describe 'Search', :js do
       page.evaluate_script('$.fx.off = true;') # Needed to disable javascript animations that can end in not checking the checkboxes properly
 
       fill_in 'search_input', with: apache_package.name
-      click_button 'Search'
+      find('input', id: 'search_input').sibling('button[type=submit]').click
 
       within '#search-results' do
         expect(page).to have_text(relationship_package_group.group.title)
@@ -280,7 +280,7 @@ RSpec.describe 'Search', :js do
       page.evaluate_script('$.fx.off = true;') # Needed to disable javascript animations that can end in not checking the checkboxes properly
 
       fill_in 'search_input', with: apache_package.name
-      click_button 'Search'
+      find('input', id: 'search_input').sibling('button[type=submit]').click
 
       expect(page).to have_no_css('#serach-results')
     end


### PR DESCRIPTION
## What's new? What's changed?
- The new `InputComponent` defines the template for the `form-control` field with [`slots`](https://viewcomponent.org/guide/slots.html). It can then be used to define a simple `input` or with a more sophisticated field with an icon or a button [see here](https://getbootstrap.com/docs/5.3/forms/input-group/#button-addons)
- `_input` partial is built on top of the `InputComponent`
- `_autocomplete` partial is **renamed** to `_search_box`
- `_search_box` partial is built on top of the `InputComponent`
- _auto-completion_ is just an option of the `_search_box`: the call just needs to define a `data: some_autocomplete_path` parameter (which is supposed to be an existing path for the remote auto-completion)
- all `_autocomplete` and `search_field_tag` and `input type=search` instances have been replaced by the `_search_box` partial, as described above
- datatable search box adapted: `datatable.js` is an external plugin that generates table and the related search box on its internal own. The style is tailored with a post-loading script to add bootstrap classes and HTML elements to mimic the `_search_box` look&feel.

## Reviewer
It is pointless to go through all the code changes, the most of it is just adapting the existing code with the new parameter name or the new partial name.
#### What to review then?
- `src/api/app/components/input_component.html.haml`
- `src/api/app/components/input_component.rb`
- `src/api/app/views/webui/shared/_input.haml`
- `src/api/app/views/webui/shared/_search_box.haml`
- `src/api/app/assets/javascripts/webui/application.js`
- `src/api/app/assets/javascript/webui/after_loading_fixes.js`


## Few examples:

#### InputComponent used directly
```
= render(InputComponent.new) do |component|
        = text_field_tag('text_input', '', type: 'text', class: 'form-control', value: '')
        - component.with_label do
          = label_tag('text_input', 'Inline input label')
```

#### Simple input
```
= render partial: 'webui/shared/input', locals: { html_id: 'input_id', value: 'sample text' }
```


#### Search box with default icon
```
= render partial: 'webui/shared/search_box', locals: { html_id: 'search_text', placeholder: 'Search', required: false)
```

#### Autocomplete with submit button
```haml
= render partial: 'webui/shared/search_box', locals: { html_id: 'project_names_search',
                                                       html_name: 'project_names[]', required: false,
                                                       data: { source: autocomplete_projects_path },
                                                       button: { type: 'submit' } }
```


- simple input
![image](https://github.com/user-attachments/assets/1e1d7a9b-1056-489a-985c-48d2c3ac0816)
- search box with icon
![image](https://github.com/user-attachments/assets/b372c929-e6ee-4c3c-9f7f-a65afc469b53)
- autocomplete with button
![image](https://github.com/user-attachments/assets/03ec9b84-4c0e-4339-9976-43cbcbc67ba3)
- datatable search box
![image](https://github.com/user-attachments/assets/bf8eac02-a662-489a-b6a8-497e38bed52d)