### PR TITLE
Simplify TriggerWorkflowController error handling

### DIFF
--- a/src/api/app/controllers/trigger_workflow_controller.rb
+++ b/src/api/app/controllers/trigger_workflow_controller.rb
@@ -16,41 +16,23 @@ class TriggerWorkflowController < ApplicationController
   before_action :validate_token_type
   before_action :check_token_enabled
 
-  # overwrite the exception handling inherited from the rescue handler
-  rescue_from ActiveRecord::RecordInvalid do |exception|
-    if exception.record.errors[:hook_action].any? || exception.record.errors[:hook_event].any?
-      render_ok(data: { info: exception.record.errors.full_messages.to_sentence })
-    else
-      render_error(status: 400, message: exception.record.errors.full_messages.to_sentence)
-    end
-  end
-
   def create
     authorize @token, :trigger?
 
-    @workflow_run = @token.workflow_runs.create!(request_headers: request_headers,
-                                                 request_payload: request.body.read,
-                                                 workflow_configuration_path: @token.workflow_configuration_path,
-                                                 workflow_configuration_url: @token.workflow_configuration_url,
-                                                 scm_vendor: scm_vendor,
-                                                 hook_event: hook_event)
+    @workflow_run = @token.workflow_runs.new(request_headers: request_headers,
+                                             request_payload: request.body.read,
+                                             workflow_configuration_path: @token.workflow_configuration_path,
+                                             workflow_configuration_url: @token.workflow_configuration_url,
+                                             scm_vendor: scm_vendor,
+                                             hook_event: hook_event)
 
-    @token.executor.run_as do
-      validation_errors = @token.call(workflow_run: @workflow_run)
-
-      unless @workflow_run.status == 'fail' # The SCMStatusReporter might already set the status to 'fail', lets not overwrite it
-        if validation_errors.none?
-          @workflow_run.update(status: 'success', response_body: render_ok)
-        else
-          @workflow_run.update_as_failed(render_error(status: 400, message: validation_errors.to_sentence))
-        end
-      end
-    # We always want to return 200 in the request. Because a lot of things in `Workflow`` can go wrong outside this request cycle.
-    # People need to have a look at their `WorkflowRun` to see how `Workflow` went.
-    rescue APIError => e
-      @workflow_run.update_as_failed(render_error(status: e.status, errorcode: e.errorcode, message: e.message))
-    rescue Pundit::NotAuthorizedError => e
-      @workflow_run.update_as_failed(e.message)
+    if @workflow_run.save
+      call_token
+    # Ignore actions and events we do not support
+    elsif @workflow_run.errors[:hook_action].any? || @workflow_run.errors[:hook_event].any?
+      render_ok(data: { info: @workflow_run.errors.full_messages.to_sentence })
+    else
+      render_error(status: 400, message: @workflow_run.errors.full_messages.to_sentence)
     end
   end
 
@@ -77,5 +59,25 @@ class TriggerWorkflowController < ApplicationController
     request.headers.to_h.keys.filter_map do |k|
       "#{k}: #{request.headers[k]}" if k.match?(/^HTTP_/)
     end.join("\n")
+  end
+
+  def call_token
+    @token.executor.run_as do
+      validation_errors = @token.call(workflow_run: @workflow_run)
+
+      unless @workflow_run.status == 'fail' # The SCMStatusReporter might already set the status to 'fail', lets not overwrite it
+        if validation_errors.none?
+          @workflow_run.update(status: 'success', response_body: render_ok)
+        else
+          @workflow_run.update_as_failed(render_error(status: 400, message: validation_errors.to_sentence))
+        end
+      end
+    # We always want to return 200 in the request. Because a lot of things in `Workflow`` can go wrong outside this request cycle.
+    # People need to have a look at their `WorkflowRun` to see how `Workflow` went.
+    rescue APIError => e
+      @workflow_run.update_as_failed(render_error(status: e.status, errorcode: e.errorcode, message: e.message))
+    rescue Pundit::NotAuthorizedError => e
+      @workflow_run.update_as_failed(e.message)
+    end
   end
 end


### PR DESCRIPTION
Instead of force saving an WorkflowRun and catching it's exception, try to save it and render errors if it would not save..