### PR TITLE
Rename ALLOWED_MERGE_REQUEST_ACTIONS variable

### DIFF
--- a/src/api/app/models/concerns/workflow_run_gitlab_payload.rb
+++ b/src/api/app/models/concerns/workflow_run_gitlab_payload.rb
@@ -3,7 +3,7 @@ module WorkflowRunGitlabPayload
   extend ActiveSupport::Concern
 
   ALLOWED_GITLAB_EVENTS = ['Merge Request Hook', 'Push Hook', 'Tag Push Hook'].freeze
-  ALLOWED_MERGE_REQUEST_ACTIONS = %w[close merge open reopen update].freeze
+  ALLOWED_GITLAB_PULL_REQUEST_ACTIONS = %w[close merge open reopen update].freeze
 
   def gitlab_project_id
     return payload.dig(:object_attributes, :source_project_id) if gitlab_merge_request?

--- a/src/api/app/models/workflow_run.rb
+++ b/src/api/app/models/workflow_run.rb
@@ -22,7 +22,7 @@ class WorkflowRun < ApplicationRecord
     :state, :status_options
   ].freeze
 
-  ALL_POSSIBLE_REQUEST_ACTIONS = (['all'] + ALLOWED_GITHUB_PULL_REQUEST_ACTIONS + ALLOWED_MERGE_REQUEST_ACTIONS + ALLOWED_GITEA_PULL_REQUEST_ACTIONS).uniq
+  ALL_POSSIBLE_REQUEST_ACTIONS = (['all'] + ALLOWED_GITHUB_PULL_REQUEST_ACTIONS + ALLOWED_GITLAB_PULL_REQUEST_ACTIONS + ALLOWED_GITEA_PULL_REQUEST_ACTIONS).uniq
 
   validates :scm_vendor, :response_url,
             :workflow_configuration_path, :workflow_configuration_url,
@@ -36,7 +36,7 @@ class WorkflowRun < ApplicationRecord
   validates :hook_event, inclusion: { in: ALLOWED_GITEA_EVENTS, allow_nil: true, message: "unsupported '%{value}'" }, if: -> { scm_vendor == 'gitea' }
   validates :hook_action, inclusion: { in: ALLOWED_GITHUB_PULL_REQUEST_ACTIONS, allow_nil: true, message: "unsupported '%{value}'" }, if: -> { scm_vendor == 'github' && hook_event == 'pull_request' }
   validates :hook_action, inclusion: { in: ALLOWED_GITEA_PULL_REQUEST_ACTIONS, allow_nil: true, message: "unsupported '%{value}'" }, if: -> { scm_vendor == 'gitea' && hook_event == 'pull_request' }
-  validates :hook_action, inclusion: { in: ALLOWED_MERGE_REQUEST_ACTIONS, allow_nil: true, message: "unsupported event action '%{value}'" }, if: -> { scm_vendor == 'gitlab' && hook_event == 'Merge Request Hook' }
+  validates :hook_action, inclusion: { in: ALLOWED_GITLAB_PULL_REQUEST_ACTIONS, allow_nil: true, message: "unsupported '%{value}'" }, if: -> { scm_vendor == 'gitlab' && hook_event == 'Merge Request Hook' }
   validate :validate_payload_is_json
 
   belongs_to :token, class_name: 'Token::Workflow', optional: true


### PR DESCRIPTION
For consistency with how the other two SCM vendor variables are named. That pull requests are named merge requests on gitlab does not matter for WorkflowRun...