### PR TITLE
Drop unused "supported?" methods

### DIFF
--- a/src/api/app/models/concerns/workflow_run_gitea_payload.rb
+++ b/src/api/app/models/concerns/workflow_run_gitea_payload.rb
@@ -61,18 +61,6 @@ module WorkflowRunGiteaPayload
     scm_vendor == 'gitea' && hook_event == 'ping'
   end
 
-  def gitea_supported_event?
-    scm_vendor == 'gitea' && ALLOWED_GITEA_EVENTS.include?(hook_event)
-  end
-
-  def gitea_supported_pull_request_action?
-    gitea_pull_request? && ALLOWED_GITEA_PULL_REQUEST_ACTIONS.include?(hook_action)
-  end
-
-  def gitea_supported_push_action?
-    gitea_push_event? && !payload[:deleted]
-  end
-
   def gitea_new_pull_request?
     gitea_pull_request? && gitea_hook_action == 'opened'
   end

--- a/src/api/app/models/concerns/workflow_run_github_payload.rb
+++ b/src/api/app/models/concerns/workflow_run_github_payload.rb
@@ -81,18 +81,6 @@ module WorkflowRunGithubPayload
     scm_vendor == 'github' && hook_event == 'ping'
   end
 
-  def github_supported_event?
-    scm_vendor == 'github' && ALLOWED_GITHUB_EVENTS.include?(hook_event)
-  end
-
-  def github_supported_pull_request_action?
-    github_pull_request? && ALLOWED_GITHUB_PULL_REQUEST_ACTIONS.include?(hook_action)
-  end
-
-  def github_supported_push_action?
-    github_push_event? && !payload[:deleted]
-  end
-
   def github_new_pull_request?
     github_pull_request? && github_hook_action == 'opened'
   end

--- a/src/api/app/models/concerns/workflow_run_gitlab_payload.rb
+++ b/src/api/app/models/concerns/workflow_run_gitlab_payload.rb
@@ -78,19 +78,6 @@ module WorkflowRunGitlabPayload
     scm_vendor == 'gitlab' && hook_event == 'Merge Request Hook'
   end
 
-  def gitlab_supported_event?
-    scm_vendor == 'gitlab' && ALLOWED_GITLAB_EVENTS.include?(hook_event)
-  end
-
-  def gitlab_supported_merge_request_action?
-    gitlab_merge_request? && ALLOWED_MERGE_REQUEST_ACTIONS.include?(hook_action)
-  end
-
-  def gitlab_supported_push_action?
-    # In Push Hook events to delete a branch, the after field is '0000000000000000000000000000000000000000'
-    gitlab_push_event? && !payload[:commit_sha].match?(/\A0+\z/)
-  end
-
   def gitlab_new_pull_request?
     gitlab_merge_request? && gitlab_hook_action == 'open'
   end

--- a/src/api/app/models/concerns/workflow_run_payload.rb
+++ b/src/api/app/models/concerns/workflow_run_payload.rb
@@ -41,24 +41,8 @@ module WorkflowRunPayload
     github_pull_request? || gitlab_merge_request? || gitea_pull_request?
   end
 
-  def supported_pull_request_action?
-    github_supported_pull_request_action? || gitea_supported_pull_request_action? || gitlab_supported_merge_request_action?
-  end
-
   def ping_event?
     github_ping? || gitea_ping?
-  end
-
-  def supported_push_action?
-    github_supported_push_action? || gitea_supported_push_action? || gitlab_supported_push_action?
-  end
-
-  def supported_action?
-    supported_push_action? || supported_pull_request_action?
-  end
-
-  def supported_event?
-    github_supported_event? || gitea_supported_event? || gitlab_supported_event?
   end
 
   def commit_sha


### PR DESCRIPTION
WorkflowRun has validations about actions/events which decide what is supported and what is not.