### PR TITLE
[backend] add interconnect_serialize_slots config option

### DIFF
--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -2652,7 +2652,7 @@ sub getbuildconfig_ajax {
     return ($jev->{'getbuildconfig_shared_result'}, 'Content-Type: text/plain');
   }
   $jev->{'getbuildconfig_key'} = "$projid/$repoid";
-  my $serialkey = "getbuildconfig/$projid";
+  my $serialkey = BSSrcServer::Remote::getserialkey('getbuildconfig', $projid);
   my $serial = BSWatcher::serialize($serialkey);
   return undef unless $serial;
   my @path;


### PR DESCRIPTION
This limits the parallelism of the src server interconnect requests to a number of slots.