### PR TITLE
[backend] logging: always log the process pid

### DIFF
--- a/src/backend/BSServer.pm
+++ b/src/backend/BSServer.pm
@@ -671,7 +671,8 @@ sub parse_error_string {
 
 sub request_infostr {
   my ($req) = @_;
-  my $id = $req->{'reqid'} || $$;
+  my $id = $req->{'reqid'} || $req->{'keepalive_count'};
+  $id = $id ? "$$.$id" : $$;
   return sprintf("%s: %3ds %-7s %-22s %s%s\n", BSUtil::isotime($req->{'starttime'}), time() - $req->{'starttime'}, "[$id]",
       "$req->{'action'} ($req->{'peer'})", $req->{'path'}, ($req->{'query'}) ? "?$req->{'query'}" : '');
 }

--- a/src/backend/BSStdServer.pm
+++ b/src/backend/BSStdServer.pm
@@ -145,7 +145,8 @@ sub dispatch {
     $req = $BSServerEvents::gev->{'request'};
   }
   $msg .= " [$requestid]" if $requestid;
-  BSUtil::printlog($msg, undef, $req->{'reqid'});
+  my $id = $req->{'reqid'} || $req->{'keepalive_count'};
+  BSUtil::printlog($msg, undef, $id ? "$$.$id" : $$);
   return BSDispatch::dispatch($conf, $req);
 }
 


### PR DESCRIPTION
We now use a sub-pid when there is a reqid (AJAX) or we have a keepalive request.