### PR TITLE
Load js report on purpose

### DIFF
--- a/src/api/app/assets/config/manifest.js
+++ b/src/api/app/assets/config/manifest.js
@@ -6,6 +6,7 @@
 //= link webui/cm2/codemirror-prjconf.js
 //= link webui/cm2/codemirror-xml.js
 //= link webui/content-selector-filters.js
+//= link webui/report.js
 //= link_tree ../images
 
 

--- a/src/api/app/assets/javascripts/webui/application.js
+++ b/src/api/app/assets/javascripts/webui/application.js
@@ -68,7 +68,6 @@
 //= require webui/add_file.js
 //= require chartkick
 //= require Chart.bundle
-//= require webui/report.js
 //= require webui/canned_responses.js
 //= require webui/multi_select.js
 //= require webui/dropdown.js

--- a/src/api/app/assets/javascripts/webui/report.js
+++ b/src/api/app/assets/javascripts/webui/report.js
@@ -66,9 +66,3 @@ function showYouReportedMessage(reportLinkId, reportableType, reportableId, mess
       break;
   }
 }
-
-$(document).ready(function(){
-  $('#report-category').on('change', '.form-check-input', function(e) {
-    $('#report-reason textarea').attr('required', (e.target.value !== 'other' ? null : true));
-  });
-});

--- a/src/api/app/views/webui/shared/_report_modal.html.haml
+++ b/src/api/app/views/webui/shared/_report_modal.html.haml
@@ -38,5 +38,11 @@
 
 :javascript
   $(document).ready(function() {
+    $('#report-category').on('change', '.form-check-input', function(e) {
+      $('#report-reason textarea').attr('required', (e.target.value !== 'other' ? null : true));
+    });
+
     collectReportModalsAndSetValues();
   });
+
+- content_for(:content_for_head, javascript_include_tag('webui/report'))


### PR DESCRIPTION
`report.js` is the _source library_ of function definitions for reports, so let's load it only when the context requires it.
Also, use the `$(document).ready` locally where the context requires.