### PR TITLE
[api] fix commands on package flavors

### DIFF
--- a/src/api/app/controllers/build_controller.rb
+++ b/src/api/app/controllers/build_controller.rb
@@ -56,7 +56,7 @@ class BuildController < ApplicationController
 
       if !allowed && !params[:package].nil?
         [params[:package]].flatten.each do |pack_name|
-          pkg = Package.find_by_project_and_name(prj.name, pack_name)
+          pkg = Package.find_by_project_and_name(prj.name, Package.multibuild_flavor(pack_name))
           if pkg.nil?
             allowed = permissions.project_change?(prj)
             unless allowed


### PR DESCRIPTION
The user got an error, if he has maintainer rights only the package sources, but he wanted to operate on a flavor.

Therefore strip flavor part to check for local package object here

Issue: #17548