### PR TITLE
Refactor comment js

### DIFF
--- a/src/api/app/assets/javascripts/webui/comment.js
+++ b/src/api/app/assets/javascripts/webui/comment.js
@@ -87,16 +87,15 @@ function handlingCommentEvents() {
     });
   });
 
+  // Toggle visibility of reply form of the same comment
   $(document).on('click', '[id*="edit_button_of_"]', function (e) {
-    var closest = $(e.target).parent().parent().find('[id*="reply_button_of_"]');
-    if (!closest.hasClass('collapsed'))
-      closest.trigger('click');
+    const idNumber = $(e.target).attr('id').split('edit_button_of_')[1];
+    $('#reply_form_of_' + idNumber + ' .cancel-comment').click();
   });
-
+  // Toggle visibility of edit form of the same comment]
   $(document).on('click', '[id*="reply_button_of_"]', function (e) {
-    var closest = $(e.target).parent().parent().find('[id*="edit_button_of_"]');
-    if (!closest.hasClass('collapsed'))
-      closest.trigger('click');
+    const idNumber = $(e.target).attr('id').split('reply_button_of_')[1];
+    $('#edit_form_of_' + idNumber + ' .cancel-comment').click();
   });
 
   $(document).on('click', '.cancel-comment', function (e) {

--- a/src/api/app/assets/javascripts/webui/comment.js
+++ b/src/api/app/assets/javascripts/webui/comment.js
@@ -7,9 +7,11 @@ function resizeTextarea(textarea) { // jshint ignore:line
 }
 
 function updateCommentCounter(selector, count) {
-  var oldValue = $(selector).text();
+  if (selector !== undefined && selector !== null && selector !== '') {
+    var oldValue = $(selector).text();
 
-  $(selector).text(parseInt(oldValue) + count);
+    $(selector).text(parseInt(oldValue) + count);
+  }
 }
 
 function validateForm(e) {
@@ -26,7 +28,7 @@ function handlingCommentEvents() {
 
   // This is being used by the legacy request view comment form to capture the rendered template
   // from the controller and replace the whole .comments-list with it
-  $('.comments-list').on('ajax:complete', '.post-comment-form', function(_, data) {
+  $('.comments-list').on('ajax:complete', '.post-comment-form, .put-comment-form, .moderate-form', function(_, data) {
     var $commentsList = $(this).closest('.comments-list');
 
     $commentsList.html(data.responseText);
@@ -34,7 +36,7 @@ function handlingCommentEvents() {
   });
 
   // This is being used to render only the comment thread for a reply by the beta request show view
-  $('.timeline,.diff-accordion').on('ajax:complete', '.post-comment-form', function(_, data) {
+  $('.timeline, .diff-accordion, .diff').on('ajax:complete', '.post-comment-form, .put-comment-form, .moderate-form', function(_, data) {
     $(this).closest('.comments-thread').html(data.responseText);
   });
 
@@ -48,30 +50,6 @@ function handlingCommentEvents() {
       '</div>'
     );
     $(this).trigger("reset");
-  });
-
-  // This is being used to update the comment with the updated content after an edit from the legacy request view
-  $('.comments-list').on('ajax:complete', '.put-comment-form', function(_, data) {
-    var $commentsList = $(this).closest('.comments-list');
-
-    $commentsList.html(data.responseText);
-  });
-
-  // This is being used to update the comment with the updated content after an edit from the beta request show view
-  $('.timeline,.diff-accordion').on('ajax:complete', '.put-comment-form', function(_, data) {
-    $(this).closest('.comments-thread').html(data.responseText);
-  });
-
-  // This is being used to update the comment with the updated content after a moderation from the legacy request view
-  $('.comments-list').on('ajax:complete', '.moderate-form', function(_, data) {
-    var $commentsList = $(this).closest('.comments-list');
-
-    $commentsList.html(data.responseText);
-  });
-
-  // This is being used to update the comment with the updated content after a moderation from the beta request show view
-  $('.timeline,.diff-accordion').on('ajax:complete', '.moderate-form', function(_, data) {
-    $(this).closest('.comments-thread').html(data.responseText);
   });
 
   // This is used to delete a comment from the legacy request view

--- a/src/api/app/assets/javascripts/webui/comment.js
+++ b/src/api/app/assets/javascripts/webui/comment.js
@@ -21,14 +21,18 @@ function validateForm(e) {
 
 function handlingCommentEvents() {
   // Disable submit button if textarea is empty and enable otherwise
-  $('.comments-list,.comment_new,.timeline,.diff-accordion').on('input', '.comment-field', function(e) {
+  const commentFieldSelector = `.comments-list .comment-field, .comment_new .comment-field,
+                                .timeline .comment-field, .diff .comment-field,
+                                .diff-accordion .comment-field`;
+  $(document).on('input', commentFieldSelector, function(e) {
     validateForm(e);
     resizeTextarea(this);
   });
 
   // This is being used by the legacy request view comment form to capture the rendered template
   // from the controller and replace the whole .comments-list with it
-  $('.comments-list').on('ajax:complete', '.post-comment-form, .put-comment-form, .moderate-form', function(_, data) {
+  const commentListSelector = '.comments-list .post-comment-form, .comments-list .put-comment-form, .comments-list .moderate-form';
+  $(document).on('ajax:complete', commentListSelector, function(_, data) {
     var $commentsList = $(this).closest('.comments-list');
 
     $commentsList.html(data.responseText);
@@ -36,12 +40,16 @@ function handlingCommentEvents() {
   });
 
   // This is being used to render only the comment thread for a reply by the beta request show view
-  $('.timeline, .diff-accordion, .diff').on('ajax:complete', '.post-comment-form, .put-comment-form, .moderate-form', function(_, data) {
+  const timelineDiffSelector = `.timeline .post-comment-form, .timeline .put-comment-form, .timeline .moderate-form,
+                                .diff .post-comment-form, .diff .put-comment-form, .diff .moderate-form,
+                                .diff-accordion .post-comment-form, .diff-accordion .put-comment-form,
+                                .diff-accordion .moderate-form`;
+  $(document).on('ajax:complete', timelineDiffSelector, function(_, data) {
     $(this).closest('.comments-thread').html(data.responseText);
   });
 
   // This is being used to render a new root comment by the beta request show view
-  $('.comment_new').on('ajax:complete', '.post-comment-form', function(_, data) {
+  $(document).on('ajax:complete', '.comment_new .post-comment-form', function(_, data) {
     $(this).closest('.comment_new').prev().append(
       '<div class="timeline-item">' +
         '<div class="comments-thread">' +
@@ -53,7 +61,7 @@ function handlingCommentEvents() {
   });
 
   // This is used to delete a comment from the legacy request view
-  $('.comments-list').on('ajax:complete', '.delete-comment-form', function(_, data) {
+  $(document).on('ajax:complete', '.comments-list .delete-comment-form', function(_, data) {
     var $this = $(this),
         $commentsList = $this.closest('.comments-list'),
         $form = $('#delete-comment-modal-' + $this.data('commentId'));
@@ -67,7 +75,7 @@ function handlingCommentEvents() {
   });
 
   // This is used to delete comments from the beta request show view, we are not gonna get an updated comment thread like
-  $('body').on('ajax:complete', '#delete-comment-modal form', function(_, data) {
+  $(document).on('ajax:complete', '#delete-comment-modal form', function(_, data) {
     var $commentId = $(this).attr('action').split('/').slice(-1),
         $commentsList = $('[name=comment-' + $commentId + ']').closest('.comments-thread'),
         $form = $('#delete-comment-modal');
@@ -79,19 +87,19 @@ function handlingCommentEvents() {
     });
   });
 
-  $('body').on('click', '[id*="edit_button_of_"]', function (e) {
+  $(document).on('click', '[id*="edit_button_of_"]', function (e) {
     var closest = $(e.target).parent().parent().find('[id*="reply_button_of_"]');
     if (!closest.hasClass('collapsed'))
       closest.trigger('click');
   });
 
-  $('body').on('click', '[id*="reply_button_of_"]', function (e) {
+  $(document).on('click', '[id*="reply_button_of_"]', function (e) {
     var closest = $(e.target).parent().parent().find('[id*="edit_button_of_"]');
     if (!closest.hasClass('collapsed'))
       closest.trigger('click');
   });
 
-  $('body').on('click', '.cancel-comment', function (e) {
+  $(document).on('click', '.cancel-comment', function (e) {
     $(e.target).closest('.collapse').collapse('hide');
   });
 }

--- a/src/api/app/views/webui/request/request_action_changes.js.erb
+++ b/src/api/app/views/webui/request/request_action_changes.js.erb
@@ -1,3 +1,1 @@
 $('.tab-content.sourcediff').html("<%= escape_javascript(render(partial: 'webui/request/changes_content', locals: { bs_request: @bs_request, action: @action, diff_to_superseded: @diff_to_superseded })) %>");
-
-handlingCommentEvents();


### PR DESCRIPTION
- deduplicate handler code for the same event on different elements
- hook the listener to the document instead of retriggering the handler implementation on new elements