### PR TITLE
Load canned js on purpose

### DIFF
--- a/src/api/app/assets/config/manifest.js
+++ b/src/api/app/assets/config/manifest.js
@@ -2,6 +2,7 @@
 //
 //= link webui/application.css
 //= link webui/application.js
+//= link webui/canned_responses.js
 //= link webui/cm2/codemirror-file.js
 //= link webui/cm2/codemirror-prjconf.js
 //= link webui/cm2/codemirror-xml.js

--- a/src/api/app/assets/javascripts/webui/application.js
+++ b/src/api/app/assets/javascripts/webui/application.js
@@ -67,7 +67,6 @@
 //= require webui/add_file.js
 //= require chartkick
 //= require Chart.bundle
-//= require webui/canned_responses.js
 //= require webui/multi_select.js
 //= require webui/dropdown.js
 //= require webui/after_loading_fixes.js

--- a/src/api/app/components/canned_responses_dropdown_component.html.haml
+++ b/src/api/app/components/canned_responses_dropdown_component.html.haml
@@ -11,6 +11,9 @@
           = canned_response.title
     %hr.dropdown-divider/
     = link_to('Create and modify' , canned_responses_path, class: 'dropdown-item')
+
+- content_for(:content_for_head, javascript_include_tag('webui/canned_responses'))
+
 :javascript
   $(document).ready(function(){
     setupCannedResponses();


### PR DESCRIPTION
TODO:

This PR revealed that
```js
$(document).ready(function(){
    setupCannedResponses();
  });
```
is initializing the script every time the `canned_responses_dropdown_component` is used. This should be better refactored to make that happen only once. The same fix should go as well for the introduced
`- content_for(:content_for_head, javascript_include_tag('webui/canned_responses'))` which is now importing the script on every instance of the component (the script is cached by the browser btw, but it's not a best practice and should be fixed too)