### PR TITLE
[dist] drop build dependency to python2

### DIFF
--- a/dist/obs-bundled-gems.spec
+++ b/dist/obs-bundled-gems.spec
@@ -46,7 +46,6 @@ BuildRequires:  libxslt-devel
 BuildRequires:  make
 BuildRequires:  mysql-devel
 BuildRequires:  nodejs
-BuildRequires:  python-devel
 %if 0%{?suse_version}
 BuildRequires:  ruby3.1-devel
 BuildRequires:  openldap2-devel

--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -141,7 +141,6 @@ Version:        2.10~pre
 Release:        0
 Url:            http://www.openbuildservice.org
 Source0:        open-build-service-%version.tar.xz
-BuildRequires:  python-devel
 
 # None of our perl modules are for consumption
 %define __provides_exclude ^perl\\(


### PR DESCRIPTION
SLFO does not provide it anymore and it seems not be needed anymore on first glance.