### PR TITLE
Don't return a boolean value in before filters

### DIFF
--- a/src/api/app/controllers/application_controller.rb
+++ b/src/api/app/controllers/application_controller.rb
@@ -95,14 +95,11 @@ class ApplicationController < ActionController::Base
       next if key == 'xmlhash' # perfectly fine
       raise InvalidParameterError, "Parameter #{key} has non String class #{value.class}" unless value.is_a?(String)
     end
-    true
   end
 
   def require_valid_project_name
     required_parameters :project
     valid_project_name!(params[:project])
-    # important because otherwise the filter chain is stopped
-    true
   end
 
   def require_scmsync_host_check

--- a/src/api/app/lib/authenticator.rb
+++ b/src/api/app/lib/authenticator.rb
@@ -211,7 +211,7 @@ class Authenticator
     if @http_user.state == 'confirmed'
       Rails.logger.debug { "USER found: #{@http_user.login}" }
       @user_permissions = Suse::Permission.new(@http_user)
-      return true
+      return
     end
 
     raise InactiveUserError, 'User is registered but not in confirmed state. Your account ' \


### PR DESCRIPTION
Returning a value is simply ignored. From the [documentation](https://api.rubyonrails.org/v7.0.8.1/classes/AbstractController/Callbacks/ClassMethods.html#method-i-before_action):

"If the callback renders or redirects, the action will not run. If there are additional callbacks scheduled to run after that callback, they are also cancelled."