### PR TITLE
Fix: do not crash if counter is nil

### DIFF
--- a/src/api/app/views/layouts/webui/_unread_notifications_counter.html.haml
+++ b/src/api/app/views/layouts/webui/_unread_notifications_counter.html.haml
@@ -1,5 +1,5 @@
 .notifications-counter
   %i.fas.fa-bell
-  - unless unread_notifications_count.zero?
+  - if defined?(unread_notifications_count) && unread_notifications_count.positive?
     %span.badge.text-bg-primary.align-text-top= unread_notifications_count
   %span.d-block Notifications


### PR DESCRIPTION
Fix https://github.com/openSUSE/open-build-service/issues/17171

I did not had the chance to reproduce it and see it failing in a complete use case.
But after some investigation my conclusion is that it could it be something like:

- being on Beta Request Index
- load a request page (package, project, my requests.....any of these)
- in another tab, toggle off the Beta Request Index
- back on the request page, reload it or simply change a filter value (it submits the form and reload the page)
- Beta and NON Beta request pages have different URL, so there is an internal redirect to load the correct page
- the NON Beta request page has an ajax call (xhr) for the `datatables`
- the `webui_controller` is set to `before_action :set_unread_notifications_count, unless: -> { request.xhr? }`
- because of the last two steps above, the `set_unread_notification_count` is not executed in this corner case
- so the `@unread_notifications_count` is never instantiated
- the error occurs because `unread_notifications_count` is `nil` and `unread_notifications_count.zero?` crashes

On one hand that's for sure that the URL mentioned in the error is an `xhr` (AKA ajax) request, and for those we do not activate the `before_action: set_unread_notification_count`.
But on the other hand it is odd that **that** specific URL ajax request hits the `webui.html.haml`-->`_top_navigation.html.haml`-->`_unread_notifications_counter.html.haml`

This PR is more a workaround to not crash if the notification number for any reason is nil.