### PR TITLE
Don't redirect back on not required_admin before filter

### DIFF
--- a/src/api/app/controllers/webui/webui_controller.rb
+++ b/src/api/app/controllers/webui/webui_controller.rb
@@ -191,7 +191,7 @@ class Webui::WebuiController < ActionController::Base
     return if User.admin_session?
 
     flash[:error] = 'Requires admin privileges'
-    redirect_back_or_to({ controller: 'main', action: 'index' })
+    redirect_to({ controller: 'main', action: 'index' })
   end
 
   # before filter to only show the frontpage to anonymous users

--- a/src/api/spec/cassettes/User_s_admin_edit_page/remove_admin_rights_from_user.yml
+++ b/src/api/spec/cassettes/User_s_admin_edit_page/remove_admin_rights_from_user.yml
@@ -1,0 +1,102 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/home:user_1/_meta?user=user_1
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_1">
+          <title/>
+          <description/>
+          <person userid="user_1" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '134'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:user_1">
+          <title></title>
+          <description></description>
+          <person userid="user_1" role="maintainer"/>
+        </project>
+  recorded_at: Mon, 24 Mar 2025 04:24:30 GMT
+- request:
+    method: get
+    uri: http://backend:5352/build/_workerstatus
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - a3c0d0a8-dc05-446f-b26f-cd311c0fc017
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '1344'
+    body:
+      encoding: UTF-8
+      string: |
+        <workerstatus clients="2">
+          <idle workerid="6adb887f3065:1" hostarch="x86_64"/>
+          <idle workerid="6adb887f3065:2" hostarch="x86_64"/>
+          <waiting arch="i586" jobs="0"/>
+          <waiting arch="x86_64" jobs="0"/>
+          <blocked arch="i586" jobs="0"/>
+          <blocked arch="x86_64" jobs="0"/>
+          <buildavg arch="i586" buildavg="1200"/>
+          <buildavg arch="x86_64" buildavg="1200"/>
+          <partition>
+            <daemon type="srcserver" state="running" starttime="1742790242"/>
+            <daemon type="servicedispatch" state="running" starttime="1742790248"/>
+            <daemon type="service" state="running" starttime="1742790248"/>
+            <daemon type="clouduploadserver" state="running" starttime="1742790248"/>
+            <daemon type="clouduploadworker" state="running" starttime="1742790248"/>
+            <daemon type="scheduler" arch="i586" state="running" starttime="1742790249">
+              <queue high="0" med="0" low="0" next="0"/>
+            </daemon>
+            <daemon type="scheduler" arch="x86_64" state="running" starttime="1742790248">
+              <queue high="0" med="0" low="0" next="0"/>
+            </daemon>
+            <daemon type="repserver" state="running" starttime="1742790246"/>
+            <daemon type="dispatcher" state="running" starttime="1742790248"/>
+            <daemon type="publisher" state="running" starttime="1742790248"/>
+            <daemon type="signer" state="running" starttime="1742790249"/>
+          </partition>
+        </workerstatus>
+  recorded_at: Mon, 24 Mar 2025 04:24:37 GMT
+recorded_with: VCR 6.3.1

--- a/src/api/spec/features/webui/users/user_admin_edit_spec.rb
+++ b/src/api/spec/features/webui/users/user_admin_edit_spec.rb
@@ -1,12 +1,14 @@
 require 'browser_helper'
 
-RSpec.describe "User's admin edit page", :js do
+RSpec.describe "User's admin edit page", :js, :vcr do
   let(:user) { create(:confirmed_user, realname: 'John Doe', email: 'john@suse.de') }
   let(:admin) { create(:admin_user) }
-  let(:admin_role_html_id) { "user_role_ids_#{Role.find_by(title: 'Admin').id}" }
+
+  before do
+    login(admin)
+  end
 
   it 'view user' do
-    login(admin)
     visit edit_user_path(login: user.login)
 
     expect(page).to have_field('Name:', with: 'John Doe')
@@ -20,19 +22,20 @@ RSpec.describe "User's admin edit page", :js do
   end
 
   it 'make user admin' do
-    login(admin)
     visit edit_user_path(login: user.login)
-
     check('Admin')
     click_button('Update')
-    expect(user.admin?).to be(true)
+
+    expect(page).to have_content('successfully updated')
+    expect(user).to be_admin
   end
 
   it 'remove admin rights from user' do
-    login(admin)
     visit edit_user_path(login: admin.login)
     uncheck('Admin')
     click_button('Update')
-    expect(admin.admin?).to be(false)
+
+    expect(page).to have_content('Requires admin privileges')
+    expect(admin).not_to be_admin
   end
 end


### PR DESCRIPTION
Prevent a user trying to access a page without admin permissions from performing a redirect to the same page.