### PR TITLE
Refactor download repository factory

### DIFF
--- a/src/api/spec/factories/download_repository_factory.rb
+++ b/src/api/spec/factories/download_repository_factory.rb
@@ -6,16 +6,10 @@ FactoryBot.define do
     repository { association :repository, architectures: [arch] }
 
     before(:create) do |download_repository|
-      repo_arch = RepositoryArchitecture.find_by(
+      RepositoryArchitecture.find_or_create_by!(
         repository: download_repository.repository,
         architecture: Architecture.find_by_name(download_repository.arch)
       )
-      # We need to find and create in two separate steps because for finding the position irrelevant but not for creating
-      # We set the position explicit in the repository_architecture factory
-      unless repo_arch
-        create(:repository_architecture, repository: download_repository.repository,
-                                         architecture: Architecture.find_or_create_by!(name: download_repository.arch))
-      end
     end
   end
 end


### PR DESCRIPTION
Get rid of unnecessary code. A RepositoryArchitecture will allways be created on an existing Architecture.