### PR TITLE
Remove project maintainer hint for non-maintainers

### DIFF
--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -361,7 +361,7 @@ class Webui::RequestController < Webui::WebuiController
     projects = Project.where(name: @actions.select(:target_project)).distinct
     user = User.possibly_nobody
 
-    Relationship.maintainers.where(project: projects, user: user).or(Relationship.where(group: [user.groups.unscope(:order)])).any?
+    Relationship.maintainers.where(project: projects, user: user).or(Relationship.maintainers.where(group: [user.groups.unscope(:order)])).any?
   end
 
   def new_state


### PR DESCRIPTION
Fixes #17287

The note mentioned in #17287 is being displayed to users who are part of a group, even if they do not have the maintainer role. This note should only be visible to users who are maintainers, either directly or through a group.