### PR TITLE
Italicize parentheses around usernames

### DIFF
--- a/src/api/app/helpers/webui/user_or_groups_roles_helper.rb
+++ b/src/api/app/helpers/webui/user_or_groups_roles_helper.rb
@@ -2,9 +2,8 @@ module Webui::UserOrGroupsRolesHelper
   def display_name(object)
     if object.is_a?(User) && object.realname.present?
       tag.span do
-        concat("#{object.name} (")
-        concat(tag.i(object.login))
-        concat(')')
+        concat("#{object.name} ")
+        concat(tag.i("(#{object.login})"))
       end
     else
       tag.span(object.name)


### PR DESCRIPTION
The current user view renders the username in italics, surrounded by regular parentheses. This creates an undesirable typographic result.

This change ensures that the parentheses are also italicized.