### PR TITLE
Reject branching support

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -359,6 +359,7 @@ class Webui::PackageController < Webui::WebuiController
 
   def set_file_details
     @forced_unexpand ||= ''
+    @is_branchable = @package.find_attribute('OBS', 'RejectBranch').nil?
 
     # check source access
     @files = []

--- a/src/api/app/models/branch_package.rb
+++ b/src/api/app/models/branch_package.rb
@@ -35,6 +35,7 @@ class BranchPackage
     @copy_from_devel = true
     @add_repositories = true
     @update_path_elements = true
+
   end
 
   delegate :logger, to: :Rails
@@ -174,6 +175,10 @@ class BranchPackage
       raise CanNotBranchPackage, "package is developed at #{p[:package].scmsync}. Fork it instead" if p[:package].try(:scmsync).present?
 
       pac = p[:package]
+      if pac.instance_of? Package
+        a = pac.find_attribute('OBS', 'RejectBranch')
+        raise BranchRejected, "Branching is not allowed because: #{a.values.first.value}" if a && a.values.first
+      end
 
       # find origin package to be branched
       pack_name = branch_target_package(p)

--- a/src/api/app/models/branch_package.rb
+++ b/src/api/app/models/branch_package.rb
@@ -35,7 +35,6 @@ class BranchPackage
     @copy_from_devel = true
     @add_repositories = true
     @update_path_elements = true
-
   end
 
   delegate :logger, to: :Rails
@@ -175,7 +174,7 @@ class BranchPackage
       raise CanNotBranchPackage, "package is developed at #{p[:package].scmsync}. Fork it instead" if p[:package].try(:scmsync).present?
 
       pac = p[:package]
-      if pac.instance_of? Package
+      if pac.instance_of?(Package)
         a = pac.find_attribute('OBS', 'RejectBranch')
         raise BranchRejected, "Branching is not allowed because: #{a.values.first.value}" if a && a.values.first
       end

--- a/src/api/app/models/branch_package/errors.rb
+++ b/src/api/app/models/branch_package/errors.rb
@@ -11,6 +11,10 @@ module BranchPackage::Errors
     setup 403
   end
 
+  class BranchRejected < APIError
+    setup 403
+  end
+
   class CanNotBranchPackageNotFound < APIError
     setup 404
   end

--- a/src/api/app/views/webui/package/_show_actions.html.haml
+++ b/src/api/app/views/webui/package/_show_actions.html.haml
@@ -5,6 +5,7 @@
     - if current_rev && is_working && is_branchable
       = render partial: 'webui/package/show_actions/branch_package', locals: { package: package, project: project,
                                                                                              revision: revision }
+    - if current_rev && is_working
       = render partial: 'webui/package/show_actions/submit_package', locals: { package: package, project: project,
                                                                                              revision: revision }
     - if User.possibly_nobody.can_modify?(package)

--- a/src/api/app/views/webui/package/_show_actions.html.haml
+++ b/src/api/app/views/webui/package/_show_actions.html.haml
@@ -2,7 +2,7 @@
   %li.nav-item.action-report-bug
     = render partial: 'webui/package/show_actions/bugzilla_owner', locals: { url: package.report_bug_or_bugzilla_url }
   - if User.session
-    - if current_rev && is_working
+    - if current_rev && is_working && is_branchable
       = render partial: 'webui/package/show_actions/branch_package', locals: { package: package, project: project,
                                                                                              revision: revision }
       = render partial: 'webui/package/show_actions/submit_package', locals: { package: package, project: project,

--- a/src/api/app/views/webui/package/show.html.haml
+++ b/src/api/app/views/webui/package/show.html.haml
@@ -11,7 +11,8 @@
                                             services: @services,
                                             project: @project,
                                             package: @package,
-                                            is_working: @forced_unexpand.blank? }
+                                            is_working: @forced_unexpand.blank?,
+                                            is_branchable: @is_branchable }
 
 .card.mb-3
   = render partial: 'tabs', locals: { project: @project, package: @package }

--- a/src/api/db/attribute_descriptions.rb
+++ b/src/api/db/attribute_descriptions.rb
@@ -31,7 +31,8 @@ def update_all_attrib_type_descriptions
     'AllowSubmitToMaintenanceRelease' => 'Allow submit requests to maintenance release projects',
     'EnforceRevisionsInRequests' => 'Enforce revisions in request actions',
     'CreatorCannotAcceptOwnRequests' => 'The creator and the accepter of a request cannot be the same person',
-    'SkipChannelBranch' => 'Opt-Out creating channels in maintenance incidents'
+    'SkipChannelBranch' => 'Opt-Out creating channels in maintenance incidents',
+    'RejectBranch' => 'Reject branching of sources'
   }
   d.keys.each do |k|
     at = ans.attrib_types.where(name: k).first

--- a/src/api/db/data/20250326100650_add_reject_branch_to_attrib_types.rb
+++ b/src/api/db/data/20250326100650_add_reject_branch_to_attrib_types.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class AddRejectBranchToAttribTypes < ActiveRecord::Migration[7.0]
+  def up
+    ans = AttribNamespace.find_by(name: 'OBS')
+    at = ans.attrib_types.create_with(
+      description: 'Reject Branch Operation',
+      value_count: 1
+    ).find_or_create_by(name: 'RejectBranch')
+
+    maintainer_role = Role.find_by(title: 'maintainer')
+    at.attrib_type_modifiable_bies.find_or_create_by(role_id: maintainer_role.id)
+  end
+
+  def down
+    ans = AttribNamespace.find_by(name: 'OBS')
+    ans.attrib_types.find_by(name: 'RejectBranch').destroy
+  end
+end

--- a/src/api/db/data_schema.rb
+++ b/src/api/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20250312082028)
+DataMigrate::Data.define(version: 20250326100650)

--- a/src/api/db/seeds.rb
+++ b/src/api/db/seeds.rb
@@ -171,6 +171,8 @@ at = ans.attrib_types.where(name: 'EnforceRevisionsInRequests').first_or_create
 at.attrib_type_modifiable_bies.where(role_id: maintainer_role.id).first_or_create
 at = ans.attrib_types.where(name: 'PlannedReleaseDate').first_or_create(value_count: 1)
 at.attrib_type_modifiable_bies.where(role_id: maintainer_role.id).first_or_create
+at = ans.attrib_types.where(name: 'RejectBranch').first_or_create(value_count: 1)
+at.attrib_type_modifiable_bies.where(role_id: maintainer_role.id).first_or_create
 
 update_all_attrib_type_descriptions
 

--- a/src/api/test/fixtures/attrib_types.yml
+++ b/src/api/test/fixtures/attrib_types.yml
@@ -143,4 +143,9 @@ OBS_EnforceRevisionsInRequests:
   value_count: 0
   attrib_namespace_id: 9
   issue_list: 0
-
+OBS_RejectBranch:
+  id: 85
+  name: RejectBranch
+  attrib_namespace_id: 9
+  value_count: 1
+  issue_list: 0

--- a/src/api/test/functional/attributes_test.rb
+++ b/src/api/test/functional/attributes_test.rb
@@ -32,7 +32,7 @@ class AttributeControllerTest < ActionDispatch::IntegrationTest
 
     get '/attribute/OBS'
     assert_response :success
-    count = 24
+    count = 25
     assert_xml_tag tag: 'directory', attributes: { count: count }
     assert_xml_tag children: { count: count }
     assert_xml_tag child: { tag: 'entry', attributes: { name: 'Maintained' } }
@@ -276,7 +276,7 @@ ription</description>
 
     get '/attribute/OBS'
     assert_response :success
-    count = 24
+    count = 25
     assert_xml_tag tag: 'directory', attributes: { count: count }
     assert_xml_tag children: { count: count }
     assert_xml_tag child: { tag: 'entry', attributes: { name: 'Maintained' } }

--- a/src/api/test/functional/source_controller_test.rb
+++ b/src/api/test/functional/source_controller_test.rb
@@ -3361,6 +3361,25 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  def test_block_branching
+    login_king
+    post '/source/kde4/kdelibs/_attribute', params: "
+        <attributes><attribute namespace='OBS' name='RejectBranch'>
+          <value>Please work instead elsewhere</value>
+        </attribute></attributes>"
+    assert_response :success
+
+    login_Iggy
+    post '/source/kde4/kdelibs?cmd=branch&ignoredevel=1'
+    assert_response :forbidden
+    assert_match 'Please work instead elsewhere', @response.body
+
+    # cleanup
+    login_king
+    delete '/source/kde4/kdelibs/_attribute/OBS:RejectBranch'
+    assert_response :success
+  end
+
   def test_list_of_linking_instances
     login_tom
 


### PR DESCRIPTION
allows to send old time users a helpful message how to proceed.

The webui part is not tested at all by me, it should just hide the branch button in this case.