### PR TITLE
Don't send notifications from blocked users

### DIFF
--- a/src/api/app/controllers/webui/users/block_controller.rb
+++ b/src/api/app/controllers/webui/users/block_controller.rb
@@ -5,7 +5,7 @@ class Webui::Users::BlockController < Webui::WebuiController
   after_action :verify_authorized
 
   def create
-    @user_block = User.session.blocked_users.new(blocked: @displayed_user)
+    @user_block = User.session.user_blocks.new(blocked: @displayed_user)
 
     authorize @user_block
 

--- a/src/api/app/models/comment.rb
+++ b/src/api/app/models/comment.rb
@@ -138,7 +138,7 @@ class Comment < ApplicationRecord
 
   def blocked?
     return false unless (session = User.session)
-    return true if session.blocked_users.exists?(blocked: user)
+    return true if session.blocked_users.exists?(user_id)
 
     false
   end

--- a/src/api/app/models/event_subscription/find_for_event.rb
+++ b/src/api/app/models/event_subscription/find_for_event.rb
@@ -42,7 +42,7 @@ class EventSubscription
             next
           end
 
-          if receiver.blocked_users.exists?(blocked: event.originator)
+          if receiver.is_a?(User) && receiver.blocked_users.include?(event.originator)
             puts "Skipped the notification for receiver #{receiver}, since the originator is blocked by them..." if @debug
             next
           end

--- a/src/api/app/models/event_subscription/find_for_event.rb
+++ b/src/api/app/models/event_subscription/find_for_event.rb
@@ -42,6 +42,11 @@ class EventSubscription
             next
           end
 
+          if receiver.blocked_users.exists?(blocked: event.originator)
+            puts "Skipped the notification for receiver #{receiver}, since the originator is blocked by them..." if @debug
+            next
+          end
+
           # Try to find the subscription for this receiver
           receiver_subscription = EventSubscription.for_subscriber(receiver).find_by(options)
           if receiver_subscription.present?

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -67,7 +67,8 @@ class User < ApplicationRecord
   has_many :moderated_comments, class_name: 'Comment', foreign_key: 'moderator_id'
   has_many :decisions, foreign_key: 'moderator_id'
   has_many :canned_responses, dependent: :destroy
-  has_many :blocked_users, foreign_key: 'blocker_id', dependent: :destroy
+  has_many :user_blocks, class_name: 'BlockedUser', foreign_key: 'blocker_id', dependent: :destroy
+  has_many :blocked_users, through: :user_blocks, source: :blocked
 
   scope :confirmed, -> { where(state: 'confirmed') }
   scope :all_without_nobody, -> { where.not(login: NOBODY_LOGIN) }

--- a/src/api/app/services/notification_service/web_channel.rb
+++ b/src/api/app/services/notification_service/web_channel.rb
@@ -31,7 +31,7 @@ module NotificationService
         default_subscription = EventSubscription.defaults.find_by(options)
 
         @subscription.subscriber.web_users.map do |user|
-          next if user.blocked_users.exists?(blocked: @event.originator)
+          next if user.blocked_users.include?(@event.originator)
 
           finder = finder_class.new(notification_scope(user: user), @parameters_for_notification.merge!(subscriber: user))
 

--- a/src/api/app/services/notification_service/web_channel.rb
+++ b/src/api/app/services/notification_service/web_channel.rb
@@ -31,6 +31,8 @@ module NotificationService
         default_subscription = EventSubscription.defaults.find_by(options)
 
         @subscription.subscriber.web_users.map do |user|
+          next if user.blocked_users.exists?(blocked: @event.originator)
+
           finder = finder_class.new(notification_scope(user: user), @parameters_for_notification.merge!(subscriber: user))
 
           renew_notification(finder: finder) if subscribed?(user, options, default_subscription)

--- a/src/api/spec/services/notification_service/notifier_spec.rb
+++ b/src/api/spec/services/notification_service/notifier_spec.rb
@@ -296,6 +296,16 @@ RSpec.describe NotificationService::Notifier do
             it 'creates a new notification for the target user' do
               expect { NotificationService::Notifier.new(event).call }.to change(Notification, :count).to(1)
             end
+
+            context 'originator of the event is blocked' do
+              before do
+                BlockedUser.create(blocker: user, blocked: owner)
+              end
+
+              it 'does not create a new notification for the target user' do
+                expect { NotificationService::Notifier.new(event).call }.not_to change(Notification, :count)
+              end
+            end
           end
 
           context 'and no user is subscribed to the event' do
@@ -325,6 +335,16 @@ RSpec.describe NotificationService::Notifier do
 
             it 'creates a new notification for the target user' do
               expect { NotificationService::Notifier.new(event).call }.to change(Notification, :count).to(1)
+            end
+
+            context 'originator of the event is blocked' do
+              before do
+                BlockedUser.create(blocker: user, blocked: owner)
+              end
+
+              it 'does not create a new notification for the target user' do
+                expect { NotificationService::Notifier.new(event).call }.not_to change(Notification, :count)
+              end
             end
           end
 


### PR DESCRIPTION
Ensures that blocked users can't send notifications to people who blocked them