### PR TITLE
Make Codecov report a successful status if there is no report

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,6 +2,7 @@ coverage:
   status:
     project:
       default:
+        if_not_found: success
         target: auto
         base: auto
         threshold: 1

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,9 +4,7 @@ coverage:
       default:
         if_not_found: success
         target: auto
-        base: auto
         threshold: 1
 ignore:
   - "src/api/lib/tasks/dev/"
 comment: false
-


### PR DESCRIPTION
Found while working on #17655. In that PR, there is no diff where a code coverage analysis is performed. Therefore, a status is not reported.

This PR makes sure Codecov reports a successful status, even when there is no report.

See: https://docs.codecov.com/docs/commit-status#if_not_found