### PR TITLE
Revert "Make Codecov report a successful status if there is no report"

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,7 +2,6 @@ coverage:
   status:
     project:
       default:
-        if_not_found: success
         target: auto
         threshold: 1
 ignore:


### PR DESCRIPTION
This reverts commit 61e6533fedf04c5d38f8329d2fb42a0d2c7fed33.

It didn't make a difference, after trying this change on master with this pull request https://github.com/openSUSE/open-build-service/pull/17655.