### PR TITLE
Move canned responses into its own beta feature

### DIFF
--- a/src/api/app/components/reports_modal_component.html.haml
+++ b/src/api/app/components/reports_modal_component.html.haml
@@ -23,7 +23,8 @@
             .d-flex.align-items-center.justify-content-between.mb-1
               = form.label(:reason)
               -# Decision-related canned responses exclusively:
-              = render CannedResponsesDropdownComponent.new(canned_responses)
+              - if Flipper.enabled?(:canned_responses, User.session)
+                = render CannedResponsesDropdownComponent.new(canned_responses)
             = form.text_area(:reason, class: 'form-control mb-3', required: true, placeholder: 'Reason for the decision')
             = form.select(:type, Decision.types(reportable), {}, class: 'form-select')
           .modal-footer

--- a/src/api/app/components/request_decision_component.html.haml
+++ b/src/api/app/components/request_decision_component.html.haml
@@ -19,7 +19,7 @@
         .tab-content.px-3
           .tab-pane.fade.show.active.my-3{ id: 'write_new_comment', role: 'tabpanel',
                                           'aria-labelledby': 'write-comment-tab', 'data-canned-controller': '' }
-            - if Flipper.enabled?(:content_moderation, User.session)
+            - if Flipper.enabled?(:canned_responses, User.session)
               .d-flex.justify-content-end
                 = render CannedResponsesDropdownComponent.new(User.session.canned_responses.where(decision_type: nil).order(:title))
             = text_area_tag(:reason, nil,

--- a/src/api/app/policies/canned_response_policy.rb
+++ b/src/api/app/policies/canned_response_policy.rb
@@ -4,7 +4,7 @@ class CannedResponsePolicy < ApplicationPolicy
   end
 
   def update?
-    return false unless Flipper.enabled?(:content_moderation, user)
+    return false unless Flipper.enabled?(:canned_responses, user)
 
     record.user == user
   end

--- a/src/api/app/views/webui/comment/_comment_field.html.haml
+++ b/src/api/app/views/webui/comment/_comment_field.html.haml
@@ -21,7 +21,7 @@ data: { preview_message_url: preview_comments_path, message_body_param: 'comment
     .tab-content.px-3
       .tab-pane.fade.show.active.my-3{ id: "write_#{element_suffix}", role: 'tabpanel', 'aria-labelledby': 'write-comment-tab',
                                        'data-canned-controller': '' }
-        - if Flipper.enabled?(:content_moderation, User.session)
+        - if Flipper.enabled?(:canned_responses, User.session)
           .d-flex.justify-content-end
             = render CannedResponsesDropdownComponent.new(User.session.canned_responses.where(decision_type: nil).order(:title))
         ~ f.text_area :body, id: "#{element_suffix}_body", rows: '4',

--- a/src/api/config/initializers/flipper.rb
+++ b/src/api/config/initializers/flipper.rb
@@ -7,7 +7,8 @@ ENABLED_FEATURE_TOGGLES = [
   { name: :color_themes, description: 'Color themes' },
   { name: :foster_collaboration, description: 'Features improving the collaboration opportunities between users of the build service.' },
   { name: :labels, description: 'Allow to apply labels to packages, submit requests and projects to improve collaboration between build service users.' },
-  { name: :request_index, description: 'Redesign of listing requests' }
+  { name: :request_index, description: 'Redesign of listing requests' },
+  { name: :canned_responses, description: 'Create messages using templates' }
 ].freeze
 
 Flipper.configure do

--- a/src/api/spec/controllers/webui/users/canned_responses_controller_spec.rb
+++ b/src/api/spec/controllers/webui/users/canned_responses_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Webui::Users::CannedResponsesController do
 
   before do
     login(user)
-    Flipper.enable(:content_moderation)
+    Flipper.enable(:canned_responses)
 
     post :create, params: { canned_response: { title: title, content: content, decision_type: decision_type } }
   end

--- a/src/api/spec/features/webui/canned_responses_spec.rb
+++ b/src/api/spec/features/webui/canned_responses_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Canned responses', :js do
   let(:user) { create(:confirmed_user, login: 'burdenski') }
 
   before do
-    Flipper.enable(:content_moderation)
+    Flipper.enable(:canned_responses)
   end
 
   context 'can be created' do
@@ -54,6 +54,7 @@ RSpec.describe 'Canned responses', :js do
     let(:moderator) { create(:moderator) }
 
     before do
+      Flipper.enable(:content_moderation)
       login moderator
       visit canned_responses_path
       fill_in(name: 'canned_response[title]', with: 'wow')

--- a/src/api/spec/features/webui/comments_spec.rb
+++ b/src/api/spec/features/webui/comments_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Comments', :js, :vcr do
   end
 
   it 'can be created using canned responses' do
-    Flipper.enable(:content_moderation)
+    Flipper.enable(:canned_responses)
     login user
     create(:canned_response, user: user, title: 'test reply', content: 'This is a canned response')
     visit project_show_path(user.home_project)


### PR DESCRIPTION
Allows for reuse with other opportunities without requiring content moderation