### PR TITLE
Don't send notifications for events outside of notification_events

### DIFF
--- a/src/api/app/models/event/base.rb
+++ b/src/api/app/models/event/base.rb
@@ -176,6 +176,9 @@ module Event
     end
 
     def subscriptions(channel = :instant_email)
+      # Don't claim to have subscriptions unless this is a notification_event
+      return [] if self.class.notification_events.none? { |e| is_a?(e) }
+
       EventSubscription::FindForEvent.new(self).subscriptions(channel)
     end
 


### PR DESCRIPTION
Fixes #17672 