### PR TITLE
Add reporter to report db table

### DIFF
--- a/src/api/app/models/report.rb
+++ b/src/api/app/models/report.rb
@@ -94,16 +94,19 @@ end
 #  updated_at      :datetime         not null
 #  decision_id     :bigint           indexed
 #  reportable_id   :integer          indexed => [reportable_type]
+#  reporter_id     :integer          indexed
 #  user_id         :integer          not null, indexed
 #
 # Indexes
 #
 #  index_reports_on_decision_id  (decision_id)
 #  index_reports_on_reportable   (reportable_type,reportable_id)
+#  index_reports_on_reporter_id  (reporter_id)
 #  index_reports_on_user_id      (user_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (decision_id => decisions.id) ON DELETE => nullify
+#  fk_rails_...  (reporter_id => users.id)
 #  fk_rails_...  (user_id => users.id)
 #

--- a/src/api/db/migrate/20250410141906_add_reporter_to_reports.rb
+++ b/src/api/db/migrate/20250410141906_add_reporter_to_reports.rb
@@ -1,0 +1,5 @@
+class AddReporterToReports < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :reports, :reporter, foreign_key: { to_table: :users }, type: :int
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_03_13_151625) do
+ActiveRecord::Schema[7.1].define(version: 2025_04_10_141906) do
   create_table "active_storage_attachments", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -990,8 +990,10 @@ ActiveRecord::Schema[7.0].define(version: 2025_03_13_151625) do
     t.datetime "updated_at", null: false
     t.bigint "decision_id"
     t.integer "category", default: 99
+    t.integer "reporter_id"
     t.index ["decision_id"], name: "index_reports_on_decision_id"
     t.index ["reportable_type", "reportable_id"], name: "index_reports_on_reportable"
+    t.index ["reporter_id"], name: "index_reports_on_reporter_id"
     t.index ["user_id"], name: "index_reports_on_user_id"
   end
 
@@ -1382,6 +1384,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_03_13_151625) do
   add_foreign_key "release_targets", "repositories", name: "release_targets_ibfk_1"
   add_foreign_key "reports", "decisions", on_delete: :nullify
   add_foreign_key "reports", "users"
+  add_foreign_key "reports", "users", column: "reporter_id"
   add_foreign_key "repositories", "projects", column: "db_project_id", name: "repositories_ibfk_1"
   add_foreign_key "repositories", "repositories", column: "hostsystem_id", name: "repositories_ibfk_2"
   add_foreign_key "repository_architectures", "architectures", name: "repository_architectures_ibfk_2"


### PR DESCRIPTION
The first step to rename the user association on reports to reporter.
In order to not cause any downtime on our production systems, this will be performed in steps:

-> 1. Add the new column to the reports table (can be null for now).
2. Adapt code to write to both columns (user and reporter).
3. Back fill the reporter column.
4. Set not null constraint on reporter column and association.
5. Delete the user column from the reports table.

~**NOTE**: CI currently failing due to the issue fixed by https://github.com/openSUSE/open-build-service/pull/17697~