### PR TITLE
Fix error for enum not backed by database column

### DIFF
--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -10,6 +10,7 @@ class User < ApplicationRecord
   NOBODY_LOGIN = '_nobody_'.freeze
   MAX_BIOGRAPHY_LENGTH_ALLOWED = 250
 
+  attribute :color_theme, :integer
   enum :color_theme, { 'system' => 0, 'light' => 1, 'dark' => 2 }
 
   # disable validations because there can be users which don't have a bcrypt


### PR DESCRIPTION
Since Rails Version 7.1 an exception is raised when defining an enum that is not backed by the database column.

For reference see:
https://github.com/rails/rails/issues/45668
and
https://github.com/rails/rails/pull/45734

In order to still do this, we can explicitly define the type via `attribute` on the models.

For reference see:
https://github.com/rails/rails/pull/49769

This is currently blocking the `migration_tests` in our CI.
See CI Pipeline of https://github.com/openSUSE/open-build-service/pull/17696