### PR TITLE
Use reporter association for report creation

### DIFF
--- a/src/api/.database_consistency.todo.yml
+++ b/src/api/.database_consistency.todo.yml
@@ -1708,6 +1708,10 @@ ReleaseTarget:
   id:
     PrimaryKeyTypeChecker:
       enabled: false
+Report:
+  reporter:
+    ColumnPresenceChecker:
+      enabled: false
 Repository:
   channel_targets:
     ForeignKeyCascadeChecker:

--- a/src/api/app/components/reports_modal_component.html.haml
+++ b/src/api/app/components/reports_modal_component.html.haml
@@ -7,7 +7,8 @@
       .modal-body
         - reports.each do |report|
           .info
-            = render UserAvatarComponent.new(report.user)
+            // TODO: Remove user association as soon as `reporter` is fully established
+            = render UserAvatarComponent.new(report.reporter.present? ? report.reporter : report.user)
             reported
             = render TimeComponent.new(time: report.created_at)
             as

--- a/src/api/app/controllers/webui/reports_controller.rb
+++ b/src/api/app/controllers/webui/reports_controller.rb
@@ -14,7 +14,7 @@ class Webui::ReportsController < Webui::WebuiController
 
   def create
     @user = User.session
-    @report = @user.submitted_reports.new(report_params)
+    @report = @user.submitted_reports.new(report_params.merge(reporter: @user))
     authorize @report
 
     @link_id = params[:link_id]
@@ -23,7 +23,8 @@ class Webui::ReportsController < Webui::WebuiController
       if @report.reportable_type == 'Comment' && params[:report_comment_author].present?
         @user.submitted_reports.create!(report_params.merge(reportable_id: @report.reportable.user_id,
                                                             reportable_type: 'User',
-                                                            reason: "This user has been reported together with a comment they wrote. Report reason for the comment: #{@report.reason}"))
+                                                            reason: "This user has been reported together with a comment they wrote. Report reason for the comment: #{@report.reason}",
+                                                            reporter: @user))
         flash[:success] = 'Comment and its author both reported successfully'
       else
         flash[:success] = "#{@report.reportable_type} reported successfully"

--- a/src/api/app/models/report.rb
+++ b/src/api/app/models/report.rb
@@ -13,7 +13,9 @@ class Report < ApplicationRecord
   validates :reportable_type, length: { maximum: 255 }
   validates :reportable, presence: true, on: :create
 
+  # TODO: Remove user association as soon as `reporter` is fully established
   belongs_to :user, optional: false
+  belongs_to :reporter, class_name: 'User', optional: false
   belongs_to :reportable, polymorphic: true, optional: true
   has_many :comments, as: :commentable, dependent: :destroy
 
@@ -53,7 +55,8 @@ class Report < ApplicationRecord
   end
 
   def event_parameters
-    { id: id, reporter: user.login, reportable_id: reportable_id, reportable_type: reportable_type, reason: reason, category: category }
+    # TODO: Remove user association as soon as `reporter` is fully established
+    { id: id, reporter: reporter.present? ? reporter.login : user.login, reportable_id: reportable_id, reportable_type: reportable_type, reason: reason, category: category }
   end
 
   def event_parameters_for_comment(commentable:)

--- a/src/api/app/policies/report_policy.rb
+++ b/src/api/app/policies/report_policy.rb
@@ -1,7 +1,8 @@
 class ReportPolicy < ApplicationPolicy
   def show?
     return true if user.admin? || user.moderator? || user.staff?
-    return true if record.user == user
+    # TODO: Remove user association as soon as `reporter` is fully established
+    return true if record.reporter.present? ? record.reporter == user : record.user == user
 
     CommentPolicy.new(user, record.reportable).maintainer? if record.reportable_type == 'Comment'
   end

--- a/src/api/spec/factories/reports.rb
+++ b/src/api/spec/factories/reports.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :report do
     user
+    reporter { user }
     reportable { association :comment_package }
     reason { Faker::Markdown.emphasis }
   end

--- a/src/api/spec/features/beta/webui/decisions_spec.rb
+++ b/src/api/spec/features/beta/webui/decisions_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Decisions', :js, :vcr do
 
   describe 'project' do
     let(:project) { create(:project, name: 'against_the_rules') }
-    let!(:report_for_project) { create(:report, reportable: project, reason: 'This project does not follow the rules!', user: reporter) }
+    let!(:report_for_project) { create(:report, reportable: project, reason: 'This project does not follow the rules!', user: reporter, reporter: reporter) }
 
     before do
       login(moderator)
@@ -38,7 +38,7 @@ RSpec.describe 'Decisions', :js, :vcr do
   describe 'package' do
     let(:project) { create(:project, name: 'factory') }
     let(:package) { create(:package_with_maintainer, project: project, name: 'against_the_rules') }
-    let!(:report_for_package) { create(:report, reportable: package, reason: 'This package does not follow the rules!', user: reporter) }
+    let!(:report_for_package) { create(:report, reportable: package, reason: 'This package does not follow the rules!', user: reporter, reporter: reporter) }
 
     before do
       login(moderator)
@@ -57,7 +57,7 @@ RSpec.describe 'Decisions', :js, :vcr do
 
   describe 'user' do
     let(:spammer) { create(:confirmed_user, login: 'spammer') }
-    let!(:report_for_user) { create(:report, reportable: spammer, reason: 'User produces spam comments!', user: reporter) }
+    let!(:report_for_user) { create(:report, reportable: spammer, reason: 'User produces spam comments!', user: reporter, reporter: reporter) }
 
     before do
       login(moderator)
@@ -80,7 +80,7 @@ RSpec.describe 'Decisions', :js, :vcr do
     let(:project) { create(:project, name: 'some_random_project') }
     let(:bs_request) { create(:delete_bs_request, target_project: project, description: 'Delete this project!', creator: user) }
     let(:comment_on_request) { create(:comment, commentable: bs_request, user: spammer) }
-    let!(:report_for_comment) { create(:report, reportable: comment_on_request, reason: 'This is spam!', user: reporter) }
+    let!(:report_for_comment) { create(:report, reportable: comment_on_request, reason: 'This is spam!', user: reporter, reporter: reporter) }
 
     before do
       login moderator
@@ -101,7 +101,7 @@ RSpec.describe 'Decisions', :js, :vcr do
     let(:spammer) { create(:confirmed_user, login: 'trouble_maker') }
     let(:project) { create(:project, name: 'factory') }
     let(:comment_on_project) { create(:comment_project, commentable: project, user: spammer) }
-    let!(:report_for_comment) { create(:report, reportable: comment_on_project, reason: 'This is spam!', user: reporter) }
+    let!(:report_for_comment) { create(:report, reportable: comment_on_project, reason: 'This is spam!', user: reporter, reporter: reporter) }
 
     before do
       login(moderator)
@@ -123,7 +123,7 @@ RSpec.describe 'Decisions', :js, :vcr do
     let(:project) { create(:project, name: 'factory') }
     let(:package) { create(:package, name: 'hello', project: project) }
     let(:comment_on_package) { create(:comment_package, commentable: package, user: spammer) }
-    let!(:report_for_comment) { create(:report, reportable: comment_on_package, reason: 'This is spam!', user: reporter) }
+    let!(:report_for_comment) { create(:report, reportable: comment_on_package, reason: 'This is spam!', user: reporter, reporter: reporter) }
 
     before do
       login(moderator)


### PR DESCRIPTION
The second step to rename the user association on reports to reporter. In order to not cause any downtime on our production systems, this will be performed in steps:

1. Add the new column to the reports table (can be null for now). 
2. Adapt code to write to both columns (user and reporter). <-
3. Back fill the reporter column.
4. Set not null constraint on reporter column and association.
5. Delete the user column from the reports table.

~~Depends on: https://github.com/openSUSE/open-build-service/pull/17696~~