### PR TITLE
Support triggering Package in a Project with scmsync

### DIFF
--- a/src/api/app/controllers/concerns/triggerable.rb
+++ b/src/api/app/controllers/concerns/triggerable.rb
@@ -19,7 +19,7 @@ module Triggerable
                                                    @package_name,
                                                    package_find_options)
     end
-    return unless @project.links_to_remote?
+    return unless project_links_to_remote?
 
     # The token has no package, we did not find a package in the database but the project has a link to remote.
     # See https://github.com/openSUSE/open-build-service/wiki/Links#project-links
@@ -39,8 +39,14 @@ module Triggerable
     @multibuild_container = @package_name.gsub(/.*:/, '') if @package_name.present? && @package_name.include?(':')
   end
 
+  private
+
   def package_from_project_link?
     # a remote package is always included via project link
     !(@package.is_a?(Package) && @package.project == @project)
+  end
+
+  def project_links_to_remote?
+    @project.scmsync.present? || @project.links_to_remote?
   end
 end

--- a/src/api/spec/controllers/concerns/triggerable_spec.rb
+++ b/src/api/spec/controllers/concerns/triggerable_spec.rb
@@ -83,6 +83,21 @@ RSpec.describe Triggerable do
         expect(fake_controller_instance.instance_variable_get(:@package)).to eq('remote_package_trigger')
       end
     end
+
+    context 'project with scmsync link' do
+      let(:token) { Token::Rebuild.create(executor: user) }
+      let(:project_name) { 'project_with_scmsync' }
+      let(:package_name) { 'some-scm-package' }
+
+      let(:project_with_scmsync) { create(:project, name: project_name, maintainer: user, scmsync: 'https://github.com/hennevogel/scmsync-project.git') }
+
+      it 'assigns remote package string' do
+        stub_params(project_name: project_with_scmsync.name, package_name: package_name)
+        fake_controller_instance.set_project
+        fake_controller_instance.set_package
+        expect(fake_controller_instance.instance_variable_get(:@package)).to eq('some-scm-package')
+      end
+    end
   end
 
   describe '#set_object_to_authorize' do


### PR DESCRIPTION
Do the same thing as for packages on remote links.

So far we did not set `@package` in that case, which lead to triggering `@project` for some tokens.