### PR TITLE
Guard against @token.package / param mis-matches

### DIFF
--- a/src/api/app/controllers/concerns/triggerable.rb
+++ b/src/api/app/controllers/concerns/triggerable.rb
@@ -2,6 +2,8 @@ module Triggerable
   def set_project
     # By default we operate on the package association
     @project = @token.package.try(:project)
+    validate_token_project
+
     # If the token has no package, let's find one from the parameters or the step intructions
     @project ||= Project.get_by_name(@project_name)
     # Remote projects are read-only, can't trigger something for them.
@@ -13,6 +15,8 @@ module Triggerable
     package_find_options = @token.package_find_options if package_find_options.blank?
     # By default we operate on the package association
     @package = @token.package
+    validate_token_package
+
     # If the token has no package, let's find one from the parameters
     if @package_name.present?
       @package ||= Package.get_by_project_and_name(@project.name,
@@ -48,5 +52,13 @@ module Triggerable
 
   def project_links_to_remote?
     @project.scmsync.present? || @project.links_to_remote?
+  end
+
+  def validate_token_project
+    raise Trigger::Errors::InvalidProject if @project && @project_name && (@project_name != @project.name)
+  end
+
+  def validate_token_package
+    raise Trigger::Errors::InvalidPackage if @package && @package_name && (@package_name != @package.name)
   end
 end

--- a/src/api/app/controllers/trigger/errors.rb
+++ b/src/api/app/controllers/trigger/errors.rb
@@ -12,4 +12,12 @@ module Trigger::Errors
   class MissingExtractor < APIError
     setup 'bad_request', 400, 'Extractor could not be created.'
   end
+
+  class InvalidProject < APIError
+    setup 'bad_request', 400, 'Token is setup with another project.'
+  end
+
+  class InvalidPackage < APIError
+    setup 'bad_request', 400, 'Token is setup with another package.'
+  end
 end


### PR DESCRIPTION
So far we just triggered `@token.package` if it was setup, no matter if you passed in params. Now we want to guard people from triggering the wrong token.