### PR TITLE
Drop usage of user on reports

### DIFF
--- a/src/api/app/components/reports_modal_component.html.haml
+++ b/src/api/app/components/reports_modal_component.html.haml
@@ -7,8 +7,7 @@
       .modal-body
         - reports.each do |report|
           .info
-            // TODO: Remove user association as soon as `reporter` is fully established
-            = render UserAvatarComponent.new(report.reporter.present? ? report.reporter : report.user)
+            = render UserAvatarComponent.new(report.reporter)
             reported
             = render TimeComponent.new(time: report.created_at)
             as

--- a/src/api/app/components/reports_notice_component.rb
+++ b/src/api/app/components/reports_notice_component.rb
@@ -15,7 +15,7 @@ class ReportsNoticeComponent < ApplicationComponent
   end
 
   def by_user?
-    Report.exists?(user:, reportable:)
+    Report.exists?(reporter: user, reportable:)
   end
 
   def report_amount

--- a/src/api/app/controllers/webui/reports_controller.rb
+++ b/src/api/app/controllers/webui/reports_controller.rb
@@ -13,18 +13,17 @@ class Webui::ReportsController < Webui::WebuiController
   end
 
   def create
-    @user = User.session
-    @report = @user.submitted_reports.new(report_params.merge(reporter: @user))
+    @reporter = User.session
+    @report = @reporter.submitted_reports.new(report_params)
     authorize @report
 
     @link_id = params[:link_id]
 
     if @report.save
       if @report.reportable_type == 'Comment' && params[:report_comment_author].present?
-        @user.submitted_reports.create!(report_params.merge(reportable_id: @report.reportable.user_id,
-                                                            reportable_type: 'User',
-                                                            reason: "This user has been reported together with a comment they wrote. Report reason for the comment: #{@report.reason}",
-                                                            reporter: @user))
+        @reporter.submitted_reports.create!(report_params.merge(reportable_id: @report.reportable.user_id,
+                                                                reportable_type: 'User',
+                                                                reason: "This user has been reported together with a comment they wrote. Report reason for the comment: #{@report.reason}"))
         flash[:success] = 'Comment and its author both reported successfully'
       else
         flash[:success] = "#{@report.reportable_type} reported successfully"

--- a/src/api/app/helpers/webui/notification_helper.rb
+++ b/src/api/app/helpers/webui/notification_helper.rb
@@ -92,7 +92,7 @@ module Webui::NotificationHelper
   end
 
   def description_for_user_report(notification)
-    reporter = notification.notifiable.user
+    reporter = notification.notifiable.reporter
     accused = notification.notifiable.reportable
     reports_on_comments = count_reports_on_comments(accused) if accused
     reports_on_user = count_reports_on_user(accused) if accused
@@ -101,7 +101,7 @@ module Webui::NotificationHelper
   end
 
   def description_for_comment_report(notification)
-    reporter = notification.notifiable.user
+    reporter = notification.notifiable.reporter
     accused = notification.notifiable.reportable&.user
     reports_on_user = count_reports_on_user(accused) if accused
     reports_on_comments = count_reports_on_comments(accused) if accused

--- a/src/api/app/models/event/base.rb
+++ b/src/api/app/models/event/base.rb
@@ -258,7 +258,7 @@ module Event
 
     def reporters
       decision = ::Decision.find(payload['id'])
-      decision.reports.map(&:user)
+      decision.reports.map(&:reporter)
     end
 
     def offenders

--- a/src/api/app/models/report.rb
+++ b/src/api/app/models/report.rb
@@ -54,8 +54,7 @@ class Report < ApplicationRecord
   end
 
   def event_parameters
-    # TODO: Remove user association as soon as `reporter` is fully established
-    { id: id, reporter: reporter.present? ? reporter.login : user.login, reportable_id: reportable_id, reportable_type: reportable_type, reason: reason, category: category }
+    { id: id, reporter: reporter.login, reportable_id: reportable_id, reportable_type: reportable_type, reason: reason, category: category }
   end
 
   def event_parameters_for_comment(commentable:)

--- a/src/api/app/models/report.rb
+++ b/src/api/app/models/report.rb
@@ -13,8 +13,7 @@ class Report < ApplicationRecord
   validates :reportable_type, length: { maximum: 255 }
   validates :reportable, presence: true, on: :create
 
-  # TODO: Remove user association as soon as `reporter` is fully established
-  belongs_to :user, optional: true
+  self.ignored_columns += [:user_id] # TODO: Remove once user_id column is dropped
   belongs_to :reporter, class_name: 'User', optional: false
   belongs_to :reportable, polymorphic: true, optional: true
   has_many :comments, as: :commentable, dependent: :destroy

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -63,7 +63,7 @@ class User < ApplicationRecord
 
   has_many :disabled_beta_features, dependent: :destroy
   has_many :reports, as: :reportable, dependent: :nullify
-  has_many :submitted_reports, class_name: 'Report'
+  has_many :submitted_reports, class_name: 'Report', foreign_key: 'reporter_id'
 
   has_many :moderated_comments, class_name: 'Comment', foreign_key: 'moderator_id'
   has_many :decisions, foreign_key: 'moderator_id'

--- a/src/api/app/policies/appeal_policy.rb
+++ b/src/api/app/policies/appeal_policy.rb
@@ -31,7 +31,7 @@ class AppealPolicy < ApplicationPolicy
   def decision_cleared_report_from_user?
     return false unless record.appellant == user
 
-    record.decision.type == 'DecisionCleared' && record.decision.reports.pluck(:user_id).include?(user.id)
+    record.decision.type == 'DecisionCleared' && record.decision.reports.pluck(:reporter_id).include?(user.id)
   end
 
   def decision_favored_report_of_action_from_user?

--- a/src/api/app/policies/report_policy.rb
+++ b/src/api/app/policies/report_policy.rb
@@ -1,8 +1,7 @@
 class ReportPolicy < ApplicationPolicy
   def show?
     return true if user.admin? || user.moderator? || user.staff?
-    # TODO: Remove user association as soon as `reporter` is fully established
-    return true if record.reporter.present? ? record.reporter == user : record.user == user
+    return true if record.reporter == user
 
     CommentPolicy.new(user, record.reportable).maintainer? if record.reportable_type == 'Comment'
   end

--- a/src/api/app/views/webui/reports/create.js.erb
+++ b/src/api/app/views/webui/reports/create.js.erb
@@ -4,5 +4,5 @@ $('#flash').html("<%= escape_javascript(render(partial: 'layouts/webui/flash'))%
 hideReportButton("#<%= @link_id %>");
 showYouReportedMessage("#<%= @link_id %>", "<%= @report.reportable_type %>",
                        "<%= @report.reportable_id %>",
-                       "<%= escape_javascript(render ReportsNoticeComponent.new(reportable: @report.reportable, user: @user)) %>");
+                       "<%= escape_javascript(render ReportsNoticeComponent.new(reportable: @report.reportable, user: @reporter)) %>");
 collectReportModalsAndSetValues();

--- a/src/api/app/views/webui/reports/show.html.haml
+++ b/src/api/app/views/webui/reports/show.html.haml
@@ -7,7 +7,7 @@
       .badge.text-bg-primary= @report.category.humanize
     %p
       Created by
-      = render UserAvatarComponent.new(@report.user)
+      = render UserAvatarComponent.new(@report.reporter)
       - if @report.reportable.present?
         on
         = link_to_reportables(report_id: @report.id, reportable_type: @report.reportable_type)

--- a/src/api/spec/factories/reports.rb
+++ b/src/api/spec/factories/reports.rb
@@ -1,7 +1,6 @@
 FactoryBot.define do
   factory :report do
-    user
-    reporter { user }
+    reporter factory: [:user]
     reportable { association :comment_package }
     reason { Faker::Markdown.emphasis }
   end

--- a/src/api/spec/features/beta/webui/decisions_spec.rb
+++ b/src/api/spec/features/beta/webui/decisions_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Decisions', :js, :vcr do
 
   describe 'project' do
     let(:project) { create(:project, name: 'against_the_rules') }
-    let!(:report_for_project) { create(:report, reportable: project, reason: 'This project does not follow the rules!', user: reporter, reporter: reporter) }
+    let!(:report_for_project) { create(:report, reportable: project, reason: 'This project does not follow the rules!', reporter: reporter) }
 
     before do
       login(moderator)
@@ -38,7 +38,7 @@ RSpec.describe 'Decisions', :js, :vcr do
   describe 'package' do
     let(:project) { create(:project, name: 'factory') }
     let(:package) { create(:package_with_maintainer, project: project, name: 'against_the_rules') }
-    let!(:report_for_package) { create(:report, reportable: package, reason: 'This package does not follow the rules!', user: reporter, reporter: reporter) }
+    let!(:report_for_package) { create(:report, reportable: package, reason: 'This package does not follow the rules!', reporter: reporter) }
 
     before do
       login(moderator)
@@ -57,7 +57,7 @@ RSpec.describe 'Decisions', :js, :vcr do
 
   describe 'user' do
     let(:spammer) { create(:confirmed_user, login: 'spammer') }
-    let!(:report_for_user) { create(:report, reportable: spammer, reason: 'User produces spam comments!', user: reporter, reporter: reporter) }
+    let!(:report_for_user) { create(:report, reportable: spammer, reason: 'User produces spam comments!', reporter: reporter) }
 
     before do
       login(moderator)
@@ -80,7 +80,7 @@ RSpec.describe 'Decisions', :js, :vcr do
     let(:project) { create(:project, name: 'some_random_project') }
     let(:bs_request) { create(:delete_bs_request, target_project: project, description: 'Delete this project!', creator: user) }
     let(:comment_on_request) { create(:comment, commentable: bs_request, user: spammer) }
-    let!(:report_for_comment) { create(:report, reportable: comment_on_request, reason: 'This is spam!', user: reporter, reporter: reporter) }
+    let!(:report_for_comment) { create(:report, reportable: comment_on_request, reason: 'This is spam!', reporter: reporter) }
 
     before do
       login moderator
@@ -101,7 +101,7 @@ RSpec.describe 'Decisions', :js, :vcr do
     let(:spammer) { create(:confirmed_user, login: 'trouble_maker') }
     let(:project) { create(:project, name: 'factory') }
     let(:comment_on_project) { create(:comment_project, commentable: project, user: spammer) }
-    let!(:report_for_comment) { create(:report, reportable: comment_on_project, reason: 'This is spam!', user: reporter, reporter: reporter) }
+    let!(:report_for_comment) { create(:report, reportable: comment_on_project, reason: 'This is spam!', reporter: reporter) }
 
     before do
       login(moderator)
@@ -123,7 +123,7 @@ RSpec.describe 'Decisions', :js, :vcr do
     let(:project) { create(:project, name: 'factory') }
     let(:package) { create(:package, name: 'hello', project: project) }
     let(:comment_on_package) { create(:comment_package, commentable: package, user: spammer) }
-    let!(:report_for_comment) { create(:report, reportable: comment_on_package, reason: 'This is spam!', user: reporter, reporter: reporter) }
+    let!(:report_for_comment) { create(:report, reportable: comment_on_package, reason: 'This is spam!', reporter: reporter) }
 
     before do
       login(moderator)

--- a/src/api/spec/mailers/event_mailer_spec.rb
+++ b/src/api/spec/mailers/event_mailer_spec.rb
@@ -419,7 +419,7 @@ RSpec.describe EventMailer, :vcr do
     context 'for an event of type Event::ClearedDecision' do
       let(:admin) { create(:admin_user) }
       let(:reporter) { create(:confirmed_user) }
-      let(:report) { create(:report, user: reporter) }
+      let(:report) { create(:report, reporter: reporter) }
       let(:package) { report.reportable.commentable }
       let!(:subscription) { create(:event_subscription_decision, user: reporter) }
       let(:decision) { create(:decision_cleared, moderator: admin, reason: 'This is NOT spam.', reports: [report]) }
@@ -460,7 +460,7 @@ RSpec.describe EventMailer, :vcr do
 
       let(:comment) { create(:comment_project, user: offender) }
       let(:project) { comment.commentable }
-      let(:report) { create(:report, user: reporter, reportable: comment) }
+      let(:report) { create(:report, reporter: reporter, reportable: comment) }
 
       let!(:reporter_subscription) { create(:event_subscription_decision, user: reporter) }
       let!(:offender_subscription) { create(:event_subscription_decision, user: offender, receiver_role: 'offender') }
@@ -504,7 +504,7 @@ RSpec.describe EventMailer, :vcr do
 
       let(:comment) { create(:comment_project, user: offender) }
       let(:project) { comment.commentable }
-      let(:report) { create(:report, user: reporter, reportable: comment) }
+      let(:report) { create(:report, reporter: reporter, reportable: comment) }
 
       let!(:moderator_subscription) { create(:event_subscription_appeal_created, user: moderator) }
 
@@ -548,7 +548,7 @@ RSpec.describe EventMailer, :vcr do
 
       let(:comment) { create(:comment_project, user: offender) }
       let(:project) { comment.commentable }
-      let(:report) { create(:report, user: reporter, reportable: comment) }
+      let(:report) { create(:report, reporter: reporter, reportable: comment) }
 
       let!(:moderator_subscription) { create(:event_subscription_appeal_created, user: moderator) }
 

--- a/src/api/spec/policies/appeal_policy_spec.rb
+++ b/src/api/spec/policies/appeal_policy_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe AppealPolicy do
 
     context 'when the decision cleared a report created by the reporter' do
       let(:report) { create(:report) }
-      let(:reporter) { report.user }
+      let(:reporter) { report.reporter }
       let(:decision) { create(:decision_cleared, reports: [report]) }
       let(:appeal) { create(:appeal, decision: decision, appellant: reporter) }
 
@@ -55,7 +55,7 @@ RSpec.describe AppealPolicy do
 
     context 'when the decision is on reports for a now-deleted reportable' do
       let(:report) { create(:report) }
-      let(:reporter) { report.user }
+      let(:reporter) { report.reporter }
       let(:decision) { create(:decision_favored, reports: [report]) }
       let(:appeal) { create(:appeal, decision: decision, appellant: reporter) }
 
@@ -75,7 +75,7 @@ RSpec.describe AppealPolicy do
 
     context 'when the decision favored a report created by the reporter' do
       let(:report) { create(:report) }
-      let(:reporter) { report.user }
+      let(:reporter) { report.reporter }
       let(:decision) { create(:decision_favored, reports: [report]) }
       let(:appeal) { create(:appeal, decision: decision, appellant: reporter) }
 

--- a/src/api/spec/policies/report_policy_spec.rb
+++ b/src/api/spec/policies/report_policy_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe ReportPolicy, type: :policy do
 
   permissions :show? do
     context 'when the current user is the owner of the report' do
-      let(:report) { create(:report, user: user) }
+      let(:report) { create(:report, reporter: user) }
 
       it { is_expected.to permit(user, report) }
     end
@@ -31,10 +31,10 @@ RSpec.describe ReportPolicy, type: :policy do
   permissions :create? do
     context 'when the current user has already reported it' do
       let(:reported_comment) { create(:comment_package) }
-      let(:report) { build(:report, user: user, reportable: reported_comment) }
+      let(:report) { build(:report, reporter: user, reportable: reported_comment) }
 
       before do
-        create(:report, user: user, reportable: reported_comment)
+        create(:report, reporter: user, reportable: reported_comment)
       end
 
       it { is_expected.not_to(permit(user, report)) }
@@ -43,36 +43,36 @@ RSpec.describe ReportPolicy, type: :policy do
     context 'when the current user can change the reportable' do
       context 'when reporting a comment' do
         let(:reported_comment) { create(:comment_package, user: user) }
-        let(:report) { build(:report, user: user, reportable: reported_comment) }
+        let(:report) { build(:report, reporter: user, reportable: reported_comment) }
 
         it { is_expected.not_to(permit(user, report)) }
       end
 
       context 'when reporting a package' do
         let(:reported_package) { create(:package_with_maintainer, maintainer: user) }
-        let(:report) { build(:report, user: user, reportable: reported_package) }
+        let(:report) { build(:report, reporter: user, reportable: reported_package) }
 
         it { is_expected.not_to(permit(user, report)) }
       end
 
       context 'when reporting a project' do
         let(:reported_project) { create(:project, maintainer: user) }
-        let(:report) { build(:report, user: user, reportable: reported_project) }
+        let(:report) { build(:report, reporter: user, reportable: reported_project) }
 
         it { is_expected.not_to(permit(user, report)) }
       end
 
       context 'when reporting a user' do
-        let(:report) { build(:report, user: user, reportable: user) }
+        let(:report) { build(:report, reporter: user, reportable: user) }
 
         it { is_expected.not_to(permit(user, report)) }
       end
 
       context "when trying to report a report's comment" do
-        let(:report_on_package_comment) { create(:report, user: user) }
+        let(:report_on_package_comment) { create(:report, reporter: user) }
         let(:report_comment) { create(:comment_report, commentable: report_on_package_comment) }
         let(:moderator) { create(:moderator) }
-        let(:report) { build(:report, user: moderator, reportable: report_comment) }
+        let(:report) { build(:report, reporter: moderator, reportable: report_comment) }
 
         it { is_expected.not_to(permit(moderator, report)) }
       end
@@ -81,28 +81,28 @@ RSpec.describe ReportPolicy, type: :policy do
     context 'when the current user can not change the reportable' do
       context 'when reporting a comment' do
         let(:comment) { create(:comment_package) }
-        let(:report) { build(:report, user: user, reportable: comment) }
+        let(:report) { build(:report, reporter: user, reportable: comment) }
 
         it { is_expected.to permit(user, report) }
       end
 
       context 'when reporting a package' do
         let(:reported_package) { create(:package) }
-        let(:report) { build(:report, user: user, reportable: reported_package) }
+        let(:report) { build(:report, reporter: user, reportable: reported_package) }
 
         it { is_expected.to permit(user, report) }
       end
 
       context 'when reporting a project' do
         let(:reported_project) { create(:project) }
-        let(:report) { build(:report, user: user, reportable: reported_project) }
+        let(:report) { build(:report, reporter: user, reportable: reported_project) }
 
         it { is_expected.to permit(user, report) }
       end
 
       context 'when reporting a user' do
         let(:reported_user) { create(:confirmed_user) }
-        let(:report) { build(:report, user: user, reportable: reported_user) }
+        let(:report) { build(:report, reporter: user, reportable: reported_user) }
 
         it { is_expected.to permit(user, report) }
       end


### PR DESCRIPTION
Now that we safely migrated to report reporter, we can
remove the usage of report user from the codebase.

1. Add the new column to the reports table (can be null for now). [DONE]
2. Adapt code to write to both columns (user and reporter). [DONE]
3. Back fill the reporter column. [DONE]
4. Switch no null constraint from user to reporter column [DONE]
5. Remove all references to reports user in the codebase and ignore user_id
   column. <--
6. Delete the user column from the reports table

~~Depends on: https://github.com/openSUSE/open-build-service/pull/17700~~