### PR TITLE
Drop user_id column from reports table

### DIFF
--- a/src/api/app/models/report.rb
+++ b/src/api/app/models/report.rb
@@ -96,18 +96,15 @@ end
 #  decision_id     :bigint           indexed
 #  reportable_id   :integer          indexed => [reportable_type]
 #  reporter_id     :integer          not null, indexed
-#  user_id         :integer          indexed
 #
 # Indexes
 #
 #  index_reports_on_decision_id  (decision_id)
 #  index_reports_on_reportable   (reportable_type,reportable_id)
 #  index_reports_on_reporter_id  (reporter_id)
-#  index_reports_on_user_id      (user_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (decision_id => decisions.id) ON DELETE => nullify
 #  fk_rails_...  (reporter_id => users.id)
-#  fk_rails_...  (user_id => users.id)
 #

--- a/src/api/db/migrate/20250414154434_drop_user_id_from_reports.rb
+++ b/src/api/db/migrate/20250414154434_drop_user_id_from_reports.rb
@@ -1,0 +1,5 @@
+class DropUserIdFromReports < ActiveRecord::Migration[7.1]
+  def change
+    safety_assured { remove_column :reports, :user_id, :integer }
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_04_14_133357) do
+ActiveRecord::Schema[7.1].define(version: 2025_04_14_154434) do
   create_table "active_storage_attachments", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -982,7 +982,6 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_14_133357) do
   end
 
   create_table "reports", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.integer "user_id"
     t.string "reportable_type"
     t.integer "reportable_id"
     t.text "reason"
@@ -994,7 +993,6 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_14_133357) do
     t.index ["decision_id"], name: "index_reports_on_decision_id"
     t.index ["reportable_type", "reportable_id"], name: "index_reports_on_reportable"
     t.index ["reporter_id"], name: "index_reports_on_reporter_id"
-    t.index ["user_id"], name: "index_reports_on_user_id"
   end
 
   create_table "repositories", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
@@ -1383,7 +1381,6 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_14_133357) do
   add_foreign_key "release_targets", "repositories", column: "target_repository_id", name: "release_targets_ibfk_2"
   add_foreign_key "release_targets", "repositories", name: "release_targets_ibfk_1"
   add_foreign_key "reports", "decisions", on_delete: :nullify
-  add_foreign_key "reports", "users"
   add_foreign_key "reports", "users", column: "reporter_id"
   add_foreign_key "repositories", "projects", column: "db_project_id", name: "repositories_ibfk_1"
   add_foreign_key "repositories", "repositories", column: "hostsystem_id", name: "repositories_ibfk_2"


### PR DESCRIPTION
Last step of migrating from user to reporter on reports. Now we can safely drop the `user_id` column.

1. Add the new column to the reports table (can be null for now). [DONE]
2. Adapt code to write to both columns (user and reporter). [DONE]
3. Back fill the reporter column. [DONE]
4. Switch no null constraint from user to reporter column. [DONE]
5. Remove all references to reports user in the codebase and ignore user_id column. [DONE]
6. Delete the user column from the reports table. <---
7. Drop `ignored_columns` line 

~~Depends on: https://github.com/openSUSE/open-build-service/pull/17713~~

