### PR TITLE
Remove `ignored_columns` line for `user_id` on report model

### DIFF
--- a/src/api/app/models/report.rb
+++ b/src/api/app/models/report.rb
@@ -13,7 +13,6 @@ class Report < ApplicationRecord
   validates :reportable_type, length: { maximum: 255 }
   validates :reportable, presence: true, on: :create
 
-  self.ignored_columns += [:user_id] # TODO: Remove once user_id column is dropped
   belongs_to :reporter, class_name: 'User', optional: false
   belongs_to :reportable, polymorphic: true, optional: true
   has_many :comments, as: :commentable, dependent: :destroy


### PR DESCRIPTION
This is just needed until the `user_id` column is dropped from the reports table to not cause possible interruptions on production. This can be dropped after the migration has run.

Depends on https://github.com/openSUSE/open-build-service/pull/17715 being merged and deployed.