### PR TITLE
Refactoring pulse routing behavior

### DIFF
--- a/src/api/app/controllers/webui/projects/pulse_controller.rb
+++ b/src/api/app/controllers/webui/projects/pulse_controller.rb
@@ -10,16 +10,16 @@ module Webui
 
       def set_range
         @range = params[:range] == 'month' ? 'month' : 'week'
-      end
 
-      def set_pulse
         @date_range = case @range
                       when 'month'
                         1.month.ago..Date.tomorrow
                       else
                         1.week.ago..Date.tomorrow
                       end
+      end
 
+      def set_pulse
         pulse = @project.project_log_entries.where(datetime: @date_range).order(datetime: :asc)
         @builds = pulse.where(event_type: %i[build_fail build_success]).where(datetime: 24.hours.ago..Time.zone.now)
         @new_packages = pulse.where(event_type: :create_package)

--- a/src/api/app/controllers/webui/projects/pulse_controller.rb
+++ b/src/api/app/controllers/webui/projects/pulse_controller.rb
@@ -4,7 +4,15 @@ module Webui
       before_action :lockout_spiders, only: [:show]
       before_action :set_project
       before_action :set_range
-      before_action :set_pulse
+
+      def show
+        respond_to do |format|
+          format.js do
+            set_pulse
+          end
+          format.html
+        end
+      end
 
       private
 

--- a/src/api/app/controllers/webui/projects/pulse_controller.rb
+++ b/src/api/app/controllers/webui/projects/pulse_controller.rb
@@ -6,10 +6,6 @@ module Webui
       before_action :set_range
       before_action :set_pulse
 
-      def show
-        @pulse = @project.project_log_entries.page(params[:page])
-      end
-
       private
 
       def set_range

--- a/src/api/app/views/webui/projects/pulse/show.js.erb
+++ b/src/api/app/views/webui/projects/pulse/show.js.erb
@@ -1,5 +1,3 @@
-$('#range-header').html("<%= escape_javascript(pulse_period(@date_range)) %>");
-$('#range-text').html("<%= @range.titleize %>");
 $('#pulse, .col.spinner').toggleClass('d-none');
 $('#pulse').html("<%= escape_javascript render partial: 'pulse_list', locals: { requests_by_percentage: @requests_by_percentage,
                                                                                 requests_by_state: @requests_by_state,

--- a/src/api/spec/controllers/webui/projects/pulse_controller_spec.rb
+++ b/src/api/spec/controllers/webui/projects/pulse_controller_spec.rb
@@ -1,0 +1,24 @@
+RSpec.describe Webui::Projects::PulseController do
+  let(:project) { create(:project, name: 'pulse_project') }
+  let(:package) { create(:package_with_file, name: 'pulse_package', project: project) }
+  let(:first_user) { create(:confirmed_user) }
+  let(:second_user) { create(:confirmed_user) }
+
+  describe '#show' do
+    render_views
+
+    before do
+      get :show, format: :html, params: { project_name: project.name }
+    end
+
+    it 'load the whole page' do
+      expect(response.body).to have_css('#range-header')
+      expect(response.body).to have_css('#pulse')
+    end
+
+    it 'assigns the correct instance variables' do
+      expect(controller.instance_variable_get(:@range)).to eq('week')
+      expect(controller.instance_variable_get(:@builds)).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## tl;dr
### Before
- `.*` + `before_action :set_pulse` + `show` to simply render the `show.html.haml`
- `.*` + `before_action :set_pulse` + `show` via ajax to render now the `show.js.erb`

### After
- `.*` + `show` to simply render the `show.html.haml`
- `.*` + `show` + `set_pulse` via ajax to render now the `show.js.erb`

`.*` = this placeholder means _whatever is required and did not change at all by this refactoring_


## Longer explanation
`show` route was initially rendering the view only (which behaves as a placeholder, it does not render anything), and after that it sends a request (ajax this time) still pointing to `show` route, which reloads the entire data and then it renders them. This makes the `set_pulse` data to be **computed twice**, the first time for the show template, and the second time to really get and present the pulse data.

The current change splits the show action into two way to respond:
- `show` to `html` just to render the view (show.html.haml), no unused data computed
- `show` to `js` to async load the pulse data