### PR TITLE
Do not fetch package's meta data when it's an scmsync project

### DIFF
--- a/src/api/app/controllers/webui/packages/meta_controller.rb
+++ b/src/api/app/controllers/webui/packages/meta_controller.rb
@@ -12,7 +12,13 @@ module Webui
       after_action :verify_authorized, only: :update
 
       def show
-        @meta = @package.render_xml
+        if @project.scmsync.present?
+          flash.now[:error] = "Package sources for project #{@project.name} are received through scmsync." \
+                              'This is not supported by the OBS frontend'
+          render :show, status: :not_found
+        else
+          @meta = @package.render_xml
+        end
       end
 
       def update


### PR DESCRIPTION
The package does not exist locally, so we cannot get the meta data like we usually do

Fixes #17690