### PR TITLE
Differentiate the succeeded and failed build results in pulse

### DIFF
--- a/src/api/app/views/webui/projects/pulse/_pulse_list_entry.html.haml
+++ b/src/api/app/views/webui/projects/pulse/_pulse_list_entry.html.haml
@@ -1,4 +1,14 @@
-= log_entry.event_type.camelcase.prepend('Event::').constantize.description
+- if log_entry.event_type.camelcase === 'BuildSuccess'
+  %span.text-success
+    %i.fas.fa-check-circle
+    %span= log_entry.event_type.camelcase.prepend('Event::').constantize.description
+- elsif log_entry.event_type.camelcase === 'BuildFail'
+  %span.text-danger
+    %i.fas.fa-exclamation-circle
+    %span= log_entry.event_type.camelcase.prepend('Event::').constantize.description
+- else
+  = log_entry.event_type.camelcase.prepend('Event::').constantize.description
+
 - if log_entry.package_name
   (#{link_to(log_entry.package_name, package_show_path(project.name, log_entry.package_name))})
 - if log_entry.user_name


### PR DESCRIPTION
## Before
![pulse-before](https://github.com/user-attachments/assets/deffe85f-5188-40c1-9072-6c70a3da8a8c)


## After
![pulse-after](https://github.com/user-attachments/assets/5319ecab-1ebd-4ea2-8b11-5f0dcae8eb40)
