### PR TITLE
Destroy dependent label templates when removing the owning project

### DIFF
--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -89,7 +89,7 @@ class Project < ApplicationRecord
   has_many :notified_projects, dependent: :destroy
   has_many :notifications, through: :notified_projects
   has_many :reports, as: :reportable, dependent: :nullify
-  has_many :label_templates
+  has_many :label_templates, dependent: :destroy
   has_many :label_globals
   accepts_nested_attributes_for :label_globals, allow_destroy: true
 


### PR DESCRIPTION
Fixes #17745