### PR TITLE
Stop reporting retried failed database queries to Errbit

### DIFF
--- a/src/api/app/models/package_issue.rb
+++ b/src/api/app/models/package_issue.rb
@@ -27,12 +27,9 @@ class PackageIssue < ApplicationRecord
           # rubocop:enable Rails/SkipsModelValidations
         end
       end
-    rescue ActiveRecord::StatementInvalid, Mysql2::Error => e
+    rescue ActiveRecord::StatementInvalid, Mysql2::Error
       retries -= 1
-      if retries.positive?
-        Airbrake.notify("Failed to update PackageIssue : retries left: #{retries}, #{e}, package: #{package.inspect}")
-        retry
-      end
+      retry if retries.positive?
     end
   end
 


### PR DESCRIPTION
We know these database queries happen to fail. We tried to get rid of the loop in #17515, but we will need a different and more complex approach.

See also:
- #16959
- #16956