### PR TITLE
Destroy dependent global labels when removing the owning project

### DIFF
--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -90,7 +90,7 @@ class Project < ApplicationRecord
   has_many :notifications, through: :notified_projects
   has_many :reports, as: :reportable, dependent: :nullify
   has_many :label_templates, dependent: :destroy
-  has_many :label_globals
+  has_many :label_globals, dependent: :destroy
   accepts_nested_attributes_for :label_globals, allow_destroy: true
 
   default_scope { where.not('projects.id' => Relationship.forbidden_project_ids) }


### PR DESCRIPTION
We need to remove the dependent Global labels as well when removing a project.

Follows up #17749
Fixes #17745