### PR TITLE
Refactoring package_command before actions

### DIFF
--- a/src/api/app/controllers/source_package_command_controller.rb
+++ b/src/api/app/controllers/source_package_command_controller.rb
@@ -16,23 +16,11 @@ class SourcePackageCommandController < SourceController
 
   before_action :require_valid_project_name
   before_action :require_package
+  before_action :set_command
 
   # POST /source/:project/:package
   def package_command
     params[:user] = User.session.login
-
-    raise MissingParameterError, 'POST request without given cmd parameter' unless params[:cmd]
-
-    # valid post commands
-    valid_commands = %w[diff branch servicediff linkdiff showlinked copy
-                        remove_flag set_flag undelete runservice waitservice
-                        mergeservice commit commitfilelist createSpecFileTemplate
-                        deleteuploadrev linktobranch updatepatchinfo getprojectservices
-                        unlock release importchannel rebuild collectbuildenv
-                        instantiate addcontainers addchannels enablechannel fork]
-
-    @command = params[:cmd]
-    raise IllegalRequest, 'invalid_command' unless valid_commands.include?(@command)
 
     if params[:oproject]
       origin_project_name = params[:oproject]
@@ -470,6 +458,21 @@ class SourcePackageCommandController < SourceController
   ##
   ## HELPER METHODS ##
   ##
+
+  def set_command
+    raise MissingParameterError, 'POST request without given cmd parameter' unless params[:cmd]
+
+    # valid post commands
+    valid_commands = %w[diff branch servicediff linkdiff showlinked copy
+                        remove_flag set_flag undelete runservice waitservice
+                        mergeservice commit commitfilelist createSpecFileTemplate
+                        deleteuploadrev linktobranch updatepatchinfo getprojectservices
+                        unlock release importchannel rebuild collectbuildenv
+                        instantiate addcontainers addchannels enablechannel fork]
+
+    @command = params[:cmd]
+    raise IllegalRequest, 'invalid_command' unless valid_commands.include?(@command)
+  end
 
   def verify_can_modify_target!
     # we require a target, but are we allowed to modify the existing target ?

--- a/src/api/app/controllers/source_package_command_controller.rb
+++ b/src/api/app/controllers/source_package_command_controller.rb
@@ -18,14 +18,12 @@ class SourcePackageCommandController < SourceController
   before_action :require_package # FIXME: This is actually setting @deleted_package, @target_project_name and @target_package_name
   before_action :set_command
   before_action :set_origin_package
+  before_action :validate_target_project_name
+  before_action :validate_target_package_name
 
   # POST /source/:project/:package
   def package_command
     params[:user] = User.session.login
-
-    raise InvalidProjectNameError, "invalid project name '#{params[:target_project]}'" if params[:target_project] && !Project.valid_name?(params[:target_project])
-
-    valid_package_name!(params[:target_package]) if params[:target_package]
 
     unless PACKAGE_CREATING_COMMANDS.include?(@command) && !Project.exists_by_name(@target_project_name)
       raise InvalidProjectNameError, "invalid project name '#{params[:project]}'" unless Project.valid_name?(params[:project])
@@ -444,6 +442,16 @@ class SourcePackageCommandController < SourceController
   ##
   ## HELPER METHODS ##
   ##
+
+  def validate_target_project_name
+    return unless params[:target_project]
+    raise InvalidProjectNameError, "invalid project name '#{params[:target_project]}'" unless Project.valid_name?(params[:target_project])
+  end
+
+  def validate_target_package_name
+    return unless params[:target_package]
+    raise InvalidPackageNameError, "invalid package name '#{params[:target_package]}'" unless Package.valid_name?(params[:target_package])
+  end
 
   def set_command
     raise MissingParameterError, 'POST request without given cmd parameter' unless params[:cmd]

--- a/src/api/app/controllers/source_package_command_controller.rb
+++ b/src/api/app/controllers/source_package_command_controller.rb
@@ -564,16 +564,15 @@ class SourcePackageCommandController < SourceController
     @project = nil
     @package = nil
 
-    follow_project_links = SOURCE_UNTOUCHED_COMMANDS.include?(@command)
-
     unless @target_package_name.in?(%w[_project _pattern])
-      use_source = true
-      use_source = false if @command == 'showlinked'
+      follow_project_links = SOURCE_UNTOUCHED_COMMANDS.include?(@command)
+      use_source = @command != 'showlinked'
+      ignore_lock = @command == 'unlock'
+
       @package = Package.get_by_project_and_name(@target_project_name, @target_package_name,
                                                  use_source: use_source, follow_project_links: follow_project_links)
       if @package # for remote package case it's nil
         @project = @package.project
-        ignore_lock = @command == 'unlock'
         raise CmdExecutionNoPermission, "no permission to modify package #{@package.name} in project #{@project.name}" unless READ_COMMANDS.include?(@command) || User.session.can_modify?(@package, ignore_lock)
       end
     end

--- a/src/api/app/controllers/source_package_command_controller.rb
+++ b/src/api/app/controllers/source_package_command_controller.rb
@@ -17,14 +17,13 @@ class SourcePackageCommandController < SourceController
   before_action :require_valid_project_name
   before_action :require_package # FIXME: This is actually setting @deleted_package, @target_project_name and @target_package_name
   before_action :set_command
+  before_action :set_user_param
   before_action :set_origin_package
   before_action :validate_target_project_name
   before_action :validate_target_package_name
 
   # POST /source/:project/:package
   def package_command
-    params[:user] = User.session.login
-
     unless PACKAGE_CREATING_COMMANDS.include?(@command) && !Project.exists_by_name(@target_project_name)
       raise InvalidProjectNameError, "invalid project name '#{params[:project]}'" unless Project.valid_name?(params[:project])
 
@@ -451,6 +450,10 @@ class SourcePackageCommandController < SourceController
   def validate_target_package_name
     return unless params[:target_package]
     raise InvalidPackageNameError, "invalid package name '#{params[:target_package]}'" unless Package.valid_name?(params[:target_package])
+  end
+
+  def set_user_param
+    params[:user] = User.session.login
   end
 
   def set_command


### PR DESCRIPTION
Make the `package_command` action smaller and readable