### PR TITLE
Load Rails 7.0 defaults

### DIFF
--- a/src/api/config/application.rb
+++ b/src/api/config/application.rb
@@ -38,8 +38,8 @@ module OBSApi
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
 
-    # Enable rails version 6.1 defaults
-    config.load_defaults(6.1)
+    # Enable rails version 7.0 defaults
+    config.load_defaults 7.0
     # FIXME: This is a known isue in RAILS 6.1 https://github.com/rails/rails/issues/40867
     config.active_record.has_many_inversing = false
 


### PR DESCRIPTION
Get rid of the following deprecation warning:

```
DEPRECATION WARNING: Support for `config.active_support.cache_format_version = 6.1` has been deprecated and will be removed in Rails 7.2.

Check the Rails upgrade guide at https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#new-activesupport-cache-serialization-format for more information on how to upgrade.
```

This is a step needed to be done previous to the upgrade of Rails to version 7.2.