### PR TITLE
Update list of crawler user agents

### DIFF
--- a/src/api/config/crawler-user-agents.json
+++ b/src/api/config/crawler-user-agents.json
@@ -5108,5 +5108,29 @@
       "Mozilla/5.0 (compatible; OnCrawl/1.0; +http://www.oncrawl.com)",
       "Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12F70 Safari/600.1.4 (compatible; OnCrawl/1.0; +http://www.oncrawl.com)"
     ]
+  },
+  {
+    "pattern": "sindresorhus\\/got",
+    "addition_date": "2025/04/22",
+    "url": "https://github.com/sindresorhus/got",
+    "instances": [
+      "got (https://github.com/sindresorhus/got)"
+    ]
+  },
+  {
+    "pattern": "CensysInspect\\/",
+    "addition_date": "2025/04/22",
+    "url": "https://about.censys.io",
+    "instances": [
+      "Mozilla/5.0 (compatible; CensysInspect/1.1; +https://about.censys.io/)"
+    ]
+  },
+  {
+    "pattern": "SBIntuitionsBot\\/",
+    "addition_date": "2025/04/23",
+    "url": "https://www.sbintuitions.co.jp/bot/",
+    "instances": [
+      "Mozilla/5.0 (compatible; SBIntuitionsBot/0.1; +https://www.sbintuitions.co.jp/bot/)"
+    ]
   }
 ]


### PR DESCRIPTION
The list was updated using `rake voight_kampff:import_user_agents`.

This is a recurring task. Last time we did it in #17709.