### PR TITLE
[backend] Add support for %_is_this_project and %_is_in_project

### DIFF
--- a/src/backend/BSRepServer/ProjPacks.pm
+++ b/src/backend/BSRepServer/ProjPacks.pm
@@ -135,6 +135,7 @@ sub getconfig {
   }
   my $projpacks = $gctx->{'projpacks'};
   my $remoteprojs = $gctx->{'remoteprojs'};
+  my ($old_is_this_project, $old_is_in_project) = (-1, -1);
   for my $prp (reverse @$path) {
     my ($p, $r) = split('/', $prp, 2);
     my $proj = $remoteprojs->{$p} || $projpacks->{$p} || {};
@@ -142,6 +143,12 @@ sub getconfig {
     next unless defined $c;
     $config .= "\n### from $p\n";
     $config .= "%define _repository $r\n";
+    my $new_is_this_project = $p eq $projid ? 1 : 0; 
+    my $new_is_in_project = $new_is_this_project || substr($p, 0, length($projid) + 1) eq "$projid:" ? 1 : 0; 
+    $config .= "%define _is_this_project $new_is_this_project\n" if $new_is_this_project ne $old_is_this_project;
+    $config .= "%define _is_in_project $new_is_in_project\n" if $new_is_in_project ne $old_is_in_project;
+    ($old_is_this_project, $old_is_in_project) = ($new_is_this_project, $new_is_in_project);
+
     # get rid of the Macros sections
     my $s1 = '^\s*macros:\s*$.*?^\s*:macros\s*$';
     my $s2 = '^\s*macros:\s*$.*\Z';

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -2612,11 +2612,9 @@ sub concatconfigs {
   $macros .= "%_project $projid\n";
   my $lastr = '';
 
-  my $distinfo = "$projid / $repoid";
-  if ($repoid eq 'standard') {
-    $distinfo = $projid;
-  } 
+  my $distinfo = $repoid eq 'standard' ? $projid : "$projid / $repoid";
 
+  my ($old_is_this_project, $old_is_in_project) = (-1, -1);
   for my $prp (reverse @path) {
     if ($prp eq "$projid/$repoid") {
       $macros .= "\n%distribution $distinfo\n";
@@ -2640,6 +2638,11 @@ sub concatconfigs {
     next unless defined $c;
     $config .= "\n### from $p\n";
     $config .= "%define _repository $r\n";
+    my $new_is_this_project = $p eq $projid ? 1 : 0;
+    my $new_is_in_project = $new_is_this_project || substr($p, 0, length($projid) + 1) eq "$projid:" ? 1 : 0;
+    $config .= "%define _is_this_project $new_is_this_project\n" if $new_is_this_project ne $old_is_this_project;
+    $config .= "%define _is_in_project $new_is_in_project\n" if $new_is_in_project ne $old_is_in_project;
+    ($old_is_this_project, $old_is_in_project) = ($new_is_this_project, $new_is_in_project);
 
     if ($c =~ /^\s*:macros\s*$/im) {
       # probably some multiple macro sections with %if statements


### PR DESCRIPTION
This macros are meant to be used in the project config. %_is_this_project is true if the project is the same as the config's project. %_is_in_project is true if the project is the same or a sub-project.