### PR TITLE
Fix undefined exception when retrieving buttonToAction

### DIFF
--- a/src/api/app/assets/javascripts/webui/nav_tabs.js
+++ b/src/api/app/assets/javascripts/webui/nav_tabs.js
@@ -28,6 +28,8 @@ $(document).ready(function () {
 
   function changeActionHashOfButtonTo() {
     var buttonToAction = $('.button_to').attr('action');
-    $('.button_to').attr('action', buttonToAction.replace(/#.+/, '') + document.location.hash);
+    if (typeof buttonToAction !== 'undefined') {
+      $('.button_to').attr('action', buttonToAction.replace(/#.+/, '') + document.location.hash);
+    }
   }
 });


### PR DESCRIPTION
Prevent from throwing this exception where there aren't any elements with the `button_to` class found in the current page:

`Uncaught TypeError: t is undefined`

This should have been included in #17680.