### PR TITLE
[backend] check existens for scmsync objects on triggerscmsync

### DIFF
--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -412,7 +412,7 @@ sub triggerscmsyncrun {
   my ($cgi, $scmrepo, $scmbranch) = @_;
   for my $ref (BSSrcServer::ScmsyncDB::getscmsyncpackages($scmrepo, $scmbranch)) {
     my ($projid, $packid) = @$ref;
-    my $proj = BSRevision::readproj_local($projid);
+    my $proj = BSRevision::readproj_local($projid, 1);
     next unless $proj;
     if ($packid eq '_project') {
       die("$projid is a remote project\n") if $proj->{'remoteurl'};


### PR DESCRIPTION
Otherwise we fail with 404 and further references don't get triggered.

This may be caused by out-of-sync database, but it is also in any case racy, since a parallel job may remove the object in parallel.