### PR TITLE
Use the reporter association in seed data.

### DIFF
--- a/src/api/lib/tasks/dev/reports.rake
+++ b/src/api/lib/tasks/dev/reports.rake
@@ -34,7 +34,7 @@ namespace :dev do
                source_package: source_package,
                description: 'Hey! Visit my new site $$$!')
       ].each do |reportable|
-        Report.create!(reportable: reportable, user: user1, reason: 'This is a scam')
+        Report.create!(reportable: reportable, reporter: user1, reason: 'This is a scam')
       end
     end
 
@@ -58,7 +58,7 @@ namespace :dev do
       # The same decision applies to more than one report about the same object/reportable.
       reportable = Decision.first.reports.first.reportable
       another_user = User.find_by(login: 'Requestor') || create(:confirmed_user, login: 'Requestor')
-      another_report = Report.create!(reportable: reportable, user: another_user, reason: 'Behave properly, please!')
+      another_report = Report.create!(reportable: reportable, reporter: another_user, reason: 'Behave properly, please!')
       Decision.first.reports << another_report
 
       # Create an appeal against a favored decision and subscribe moderators to it


### PR DESCRIPTION
The user relation was changed to reporter in
[e1446f2b08d2c69a1350c5161609a63d530c68c9](https://github.com/openSUSE/open-build-service/commit/e1446f2b08d2c69a1350c5161609a63d530c68c9)

This fixes the seed data generation to use the new association.