### PR TITLE
Fix: autocomplete in the same page with distinct ids

### DIFF
--- a/src/api/app/controllers/webui/repositories_controller.rb
+++ b/src/api/app/controllers/webui/repositories_controller.rb
@@ -31,7 +31,8 @@ class Webui::RepositoriesController < Webui::WebuiController
     authorize @project, :update?
     repository = @project.repositories.find_or_initialize_by(name: params[:repository])
     if params[:target_repo]
-      target_repository = Repository.find_by_project_and_name(params[:target_project], params[:target_repo])
+      target_project = params[:add_repo_path_target_project] || params[:add_repo_from_project_target_project] || params[:add_repo_kiwi_target_project]
+      target_repository = Repository.find_by_project_and_name(target_project, params[:target_repo])
       repository.path_elements.find_or_initialize_by(link: target_repository)
     end
 

--- a/src/api/app/views/webui/repositories/_add_repository_from_project_modal.html.haml
+++ b/src/api/app/views/webui/repositories/_add_repository_from_project_modal.html.haml
@@ -5,8 +5,9 @@
         .modal-header
           %h5.modal-title Add Repository to #{project}
         .modal-body.repository-autocomplete
-          = render partial: 'webui/shared/search_box', locals: { html_id: 'target_project', label: '<strong>Project:</strong>'.html_safe,
-                                                                   data: { source: autocomplete_projects_path } }
+          = render partial: 'webui/shared/search_box', locals: { html_id: 'add_repo_from_project_target_project',
+                                                                 label: '<strong>Project:</strong>'.html_safe,
+                                                                 data: { source: autocomplete_projects_path } }
 
           .mb-3
             = label_tag :repositories do

--- a/src/api/app/views/webui/repositories/_add_repository_path_modal.html.haml
+++ b/src/api/app/views/webui/repositories/_add_repository_path_modal.html.haml
@@ -5,8 +5,9 @@
         .modal-header
           %h5.modal-title Add additional path to #{repository}
         .modal-body.repository-autocomplete
-          = render partial: 'webui/shared/search_box', locals: { html_id: 'target_project', label: '<strong>Project:</strong>'.html_safe,
-                                                                   data: { source: autocomplete_projects_path } }
+          = render partial: 'webui/shared/search_box', locals: { html_id: 'add_repo_path_target_project',
+                                                                 label: '<strong>Project:</strong>'.html_safe,
+                                                                 data: { source: autocomplete_projects_path } }
           .mb-3
             = label_tag :repositories do
               %strong Repositories:

--- a/src/api/spec/controllers/webui/repositories_controller_spec.rb
+++ b/src/api/spec/controllers/webui/repositories_controller_spec.rb
@@ -76,7 +76,8 @@ RSpec.describe Webui::RepositoriesController, :vcr do
 
     context 'with a non valid target repository' do
       before do
-        post :create, params: { project: user.home_project, repository: 'valid_name', target_project: another_project, target_repo: 'non_valid_repo' }
+        post :create, params: { project: user.home_project, repository: 'valid_name',
+                                add_repo_from_project_target_project: another_project, target_repo: 'non_valid_repo' }
       end
 
       it { expect(flash[:error]).to eq('Can not add repository: Path elements is invalid and Path Element: Link must exist') }
@@ -98,7 +99,7 @@ RSpec.describe Webui::RepositoriesController, :vcr do
         target_repo = create(:repository, project: another_project)
         post :create, params: {
           project: user.home_project, repository: 'valid_name',
-          target_project: another_project, target_repo: target_repo.name, architectures: ['i586']
+          add_repo_from_project_target_project: another_project, target_repo: target_repo.name, architectures: ['i586']
         }
       end
 

--- a/src/api/spec/features/webui/kiwi/images_spec.rb
+++ b/src/api/spec/features/webui/kiwi/images_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe 'Kiwi_Images', :js, :vcr do
       click_link('Add repository')
 
       within('#add-repository-') do
-        fill_in('target_project', with: project)
+        fill_in('add_repo_kiwi_target_project', with: project)
         first('.ui-menu-item-wrapper').click
         click_link('Continue')
       end
@@ -93,7 +93,7 @@ RSpec.describe 'Kiwi_Images', :js, :vcr do
       click_link('Add repository')
 
       within('#add-repository-') do
-        fill_in('target_project', with: project)
+        fill_in('add_repo_kiwi_target_project', with: project)
         first('.ui-menu-item-wrapper').click
         click_link('Continue')
       end
@@ -125,7 +125,7 @@ RSpec.describe 'Kiwi_Images', :js, :vcr do
       click_link('Add repository')
 
       within('#add-repository-') do
-        fill_in('target_project', with: project)
+        fill_in('add_repo_kiwi_target_project', with: project)
         first('.ui-menu-item-wrapper').click
         click_link('Continue')
       end

--- a/src/api/spec/features/webui/repositories_spec.rb
+++ b/src/api/spec/features/webui/repositories_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe 'Repositories', :js do
       visit(project_repositories_path(project: admin_user.home_project))
 
       click_link('Add from a Project')
-      fill_in('target_project', with: repository.project)
+      fill_in('add_repo_from_project_target_project', with: repository.project)
       # Select the first autocomplete result
       first('.ui-menu-item-wrapper').click
       # Remove focus from autocomplete. Needed to trigger update of the other input fields.


### PR DESCRIPTION
Fixes https://github.com/openSUSE/open-build-service/issues/17775

Make more unique the `id` attribute.

Both `add_repository_path...` and `add_repository_from_project...` reuse the same partial that implements the `autocomplete` functionality targetting the html element by the `id` attribute. If both input fields has the same `id` the autocomplete crashes on the first one and works only on the last one that was implemented in the page.