### PR TITLE
Fix error message for a not found label when deleting a label

### DIFF
--- a/src/api/app/controllers/labels_controller.rb
+++ b/src/api/app/controllers/labels_controller.rb
@@ -25,7 +25,12 @@ class LabelsController < ApplicationController
   # DELETE /labels/requests/:request_number/:id
   def destroy
     authorize @labelable, :update_labels?
-    label = @labelable.labels.find(params[:id])
+    label = @labelable.labels.find_by(id: params[:id])
+
+    unless label
+      render_error(status: 404, message: "Unable to find label `#{params[:id]}`")
+      return
+    end
 
     if label.destroy
       render_ok

--- a/src/api/public/apidocs/paths/labels_requests_request_number_label_id.yaml
+++ b/src/api/public/apidocs/paths/labels_requests_request_number_label_id.yaml
@@ -22,6 +22,10 @@ delete:
           schema:
             $ref: '../components/schemas/api_response.yaml'
           examples:
+            Label Not Found:
+              value:
+                code: not_found
+                summary: Unable to find label '42'
             Request Not Found:
               value:
                 code: not_found


### PR DESCRIPTION
On the development environment, for an existing request with number 18 and a non-existing label with id 42, this API call:

```
curl -i -u Admin:opensuse -H 'Content-Type: application/octet-stream' -H 'accept: application/xml' \
-X DELETE 'http://localhost:3000/labels/requests/18/42'
```

returns:

### Before
```
<status code="not_found">
  <summary>Couldn't find Label with 'id'=42 [WHERE `labels`.`labelable_id` = ? AND `labels`.`labelable_type` = ?]</summary>
</status>
```

### After
```
<status code="not_found">
  <summary>Unable to find label `42`</summary>
</status>
```