### PR TITLE
Skip creating subscriptions for remote packages

### DIFF
--- a/src/api/app/services/workflows/scm_event_subscription_creator.rb
+++ b/src/api/app/services/workflows/scm_event_subscription_creator.rb
@@ -10,11 +10,8 @@ module Workflows
       # SCMs don't support commit status for tags, so we don't need to report back in this case
       return if @workflow_run.tag_push_event?
 
-      if @package_or_request.is_a?(Package)
-        create_or_update_subscriptions_for_package(package: @package_or_request)
-      else
-        create_or_update_subscriptions_for_request(bs_request: @package_or_request)
-      end
+      create_or_update_subscriptions_for_package(package: @package_or_request) if @package_or_request.is_a?(Package)
+      create_or_update_subscriptions_for_request(bs_request: @package_or_request) if @package_or_request.is_a?(BsRequest)
     end
 
     private


### PR DESCRIPTION
We support triggering remote packages. In that case @package is a string and not a Package.

Fixes #17788 

We should probably support package links better in SCM/CI, tracked in https://trello.com/c/eWvTPRYL