### PR TITLE
Color theme toggler

### DIFF
--- a/src/api/app/controllers/webui/users_controller.rb
+++ b/src/api/app/controllers/webui/users_controller.rb
@@ -3,7 +3,7 @@ class Webui::UsersController < Webui::WebuiController
 
   before_action :require_login, except: %i[show new create tokens autocomplete]
   before_action :require_admin, only: %i[index edit destroy]
-  before_action :check_displayed_user, only: %i[show edit censor update destroy edit_account]
+  before_action :check_displayed_user, only: %i[show edit censor update destroy edit_account update_color_theme]
   before_action :role_titles, only: %i[show edit_account update]
   before_action :account_edit_link, only: %i[show edit_account update]
 
@@ -102,6 +102,16 @@ class Webui::UsersController < Webui::WebuiController
     end
   end
 
+  def update_color_theme
+    authorize @displayed_user, :update?
+    @displayed_user.color_theme = params[:color_theme]
+
+    unless @displayed_user.save
+      flash[:error] = "Couldn't update user: #{@displayed_user.errors.full_messages.to_sentence}."
+    end
+    redirect_back_or_to root_path
+  end
+
   def destroy
     authorize @displayed_user, :destroy?
 
@@ -191,7 +201,7 @@ class Webui::UsersController < Webui::WebuiController
   end
 
   def assign_common_user_attributes
-    @displayed_user.assign_attributes(params[:user].slice(:biography, :color_theme, :in_beta).permit!)
+    @displayed_user.assign_attributes(params[:user].slice(:biography, :in_beta).permit!)
     @displayed_user.assign_attributes(params[:user].slice(:realname, :email).permit!) unless @account_edit_link
   end
 

--- a/src/api/app/views/webui/user/_basic_info.html.haml
+++ b/src/api/app/views/webui/user/_basic_info.html.haml
@@ -4,43 +4,55 @@
              locals: { displayed_user: user, role_titles: role_titles, account_edit_link: account_edit_link }
 
 .basic-info
-  .d-flex.flex-row-reverse.align-items-center.mb-3
-    = render ReportsNoticeComponent.new(reportable: user, user: User.session)
-    - if policy(Report.new(reportable: user)).create?
-      = link_to('#', id: "js-user-#{user.id}", class: 'ps-2',
-            data: { 'bs-toggle': 'modal',
-                    'bs-target': '#report-modal',
-                    'modal-title': "Report #{user.login}",
-                    'reportable-type': user.class.name,
-                    'reportable-id': user.id }) do
-        %i.fas.fa-regular.fa-flag
-        %span.nav-item-name Report
-    - if User.session
-      - if (blocked_user = BlockedUser.find_by(blocker: User.session, blocked: user))
-        - if policy(blocked_user).destroy?
-          = button_to(user_block_path(user), method: :delete, class: 'btn btn-link p-0 text-decoration-none ms-2') do
-            %i.fas.fa-user-lock
-            Unblock
-      - else
-        - if policy(BlockedUser.new(blocker: User.session, blocked: user)).create?
-          = button_to(user_block_path(user), method: :post, class: 'btn btn-link p-0 text-decoration-none ms-2') do
-            %i.fas.fa-user-lock
-            Block
-    - if User.possibly_nobody.admin? && user.state != 'deleted'
-      = link_to('#', title: 'Delete user', class: 'ms-2', data: { 'bs-toggle': 'modal', 'bs-target': '#delete-user-modal' }) do
-        %i.fas.fa-times-circle.text-danger
-        %span.nav-item-name.text-danger Delete
-      = render DeleteConfirmationDialogComponent.new(modal_id: 'delete-user-modal', method: :delete,
-                                                     options: { modal_title: 'Delete user?', remote: false,
-                                                                confirmation_text: "Please confirm deletion of '#{user.login}'",
-                                                                action: user_path(user) }) do |component|
-        - component.with_text_area do
-          = label_tag('Adminnote', 'Admin note:', for: 'adminnote')
-          = text_area_tag(:adminnote, '', placeholder: 'Please explain the reason for the deletion...', class: 'form-control')
-    - if Configuration.accounts_editable? && policy(user).update?
-      = link_to('#', id: 'toggle-in-place-editing', title: 'Edit Your Account') do
-        %i.fas.fa-user-edit
-        %span.nav-item-name Edit
+  .d-flex.justify-content-between.flex-row-reverse
+    .d-flex.flex-row-reverse.align-items-center.mb-3
+      = render ReportsNoticeComponent.new(reportable: user, user: User.session)
+      - if policy(Report.new(reportable: user)).create?
+        = link_to('#', id: "js-user-#{user.id}", class: 'ps-2',
+              data: { 'bs-toggle': 'modal',
+                      'bs-target': '#report-modal',
+                      'modal-title': "Report #{user.login}",
+                      'reportable-type': user.class.name,
+                      'reportable-id': user.id }) do
+          %i.fas.fa-regular.fa-flag
+          %span.nav-item-name Report
+      - if User.session
+        - if (blocked_user = BlockedUser.find_by(blocker: User.session, blocked: user))
+          - if policy(blocked_user).destroy?
+            = button_to(user_block_path(user), method: :delete, class: 'btn btn-link p-0 text-decoration-none ms-2') do
+              %i.fas.fa-user-lock
+              Unblock
+        - else
+          - if policy(BlockedUser.new(blocker: User.session, blocked: user)).create?
+            = button_to(user_block_path(user), method: :post, class: 'btn btn-link p-0 text-decoration-none ms-2') do
+              %i.fas.fa-user-lock
+              Block
+      - if User.possibly_nobody.admin? && user.state != 'deleted'
+        = link_to('#', title: 'Delete user', class: 'ms-2', data: { 'bs-toggle': 'modal', 'bs-target': '#delete-user-modal' }) do
+          %i.fas.fa-times-circle.text-danger
+          %span.nav-item-name.text-danger Delete
+        = render DeleteConfirmationDialogComponent.new(modal_id: 'delete-user-modal', method: :delete,
+                                                      options: { modal_title: 'Delete user?', remote: false,
+                                                                  confirmation_text: "Please confirm deletion of '#{user.login}'",
+                                                                  action: user_path(user) }) do |component|
+          - component.with_text_area do
+            = label_tag('Adminnote', 'Admin note:', for: 'adminnote')
+            = text_area_tag(:adminnote, '', placeholder: 'Please explain the reason for the deletion...', class: 'form-control')
+      - if Configuration.accounts_editable? && policy(user).update?
+        = link_to('#', id: 'toggle-in-place-editing', title: 'Edit Your Account') do
+          %i.fas.fa-user-edit
+          %span.nav-item-name Edit
+    - if user == User.possibly_nobody
+      .dropdown
+        = link_to('#', class: 'dropdown-toggle', id: 'top-navigation-color-theme-dropdown', role: 'button',
+                  'data-bs-toggle': 'dropdown', aria: { haspopup: true, expanded: false }) do
+          %i.fas.fa-palette{ title: 'Color Theme' }
+        = form_for(User.session, url: update_color_theme_user_path(User.session), method: :post, id: 'color-theme-form') do |f|
+          = f.hidden_field(:login, id: 'user')
+          %ul.dropdown-menu.dropdown-menu-start{ 'aria-labelledby': 'top-navigation-color-theme-dropdown' }
+            - User.color_themes.keys.each do |color_theme|
+              %li.dropdown-item{ class: "#{'active' if User.session.color_theme == color_theme}" }
+                %input.nav-link.p-0.text-start{ name: 'color_theme', value: color_theme, type: 'submit', text: color_theme.titleize }
   .row.mb-3
     .col-4.col-sm-2.col-md-12.text-center
       = render(AvatarComponent.new(name: user.name, email: user.email, size: 200))

--- a/src/api/app/views/webui/user/_basic_info.html.haml
+++ b/src/api/app/views/webui/user/_basic_info.html.haml
@@ -92,11 +92,7 @@
           = label_tag("user[censored]", 'Comment Block', class: 'form-check-label')
 
 :javascript
-  $('#toggle-in-place-editing').on('click', function () {
-    $('.in-place-editing .basic-info').toggleClass('d-none');
-    $('.in-place-editing .editing-form').toggleClass('d-none');
-  });
-  $('#cancel-in-place-editing').on('click', function () {
+  $('#toggle-in-place-editing, #cancel-in-place-editing').on('click', function () {
     $('.in-place-editing .basic-info').toggleClass('d-none');
     $('.in-place-editing .editing-form').toggleClass('d-none');
     return false;

--- a/src/api/app/views/webui/user/_basic_info.html.haml
+++ b/src/api/app/views/webui/user/_basic_info.html.haml
@@ -47,6 +47,7 @@
         = link_to('#', class: 'dropdown-toggle', id: 'top-navigation-color-theme-dropdown', role: 'button',
                   'data-bs-toggle': 'dropdown', aria: { haspopup: true, expanded: false }) do
           %i.fas.fa-palette{ title: 'Color Theme' }
+          %span.nav-item-name Theme
         = form_for(User.session, url: update_color_theme_user_path(User.session), method: :post, id: 'color-theme-form') do |f|
           = f.hidden_field(:login, id: 'user')
           %ul.dropdown-menu.dropdown-menu-start{ 'aria-labelledby': 'top-navigation-color-theme-dropdown' }

--- a/src/api/app/views/webui/user/_edit_account_form.html.haml
+++ b/src/api/app/views/webui/user/_edit_account_form.html.haml
@@ -19,9 +19,6 @@
   .mb-3
     = f.text_field(:email, required: true, email: true, placeholder: 'Email', readonly: behind_proxy, class: 'form-control')
   .mb-3
-    = f.label :color_theme, "Theme"
-    = f.select(:color_theme, options_for_select(User.color_themes.keys), {}, class: 'form-select')
-  .mb-3
   - if behind_proxy
     %p
       You are behind a proxy. You can modify other data related to your profile by

--- a/src/api/config/routes/webui.rb
+++ b/src/api/config/routes/webui.rb
@@ -387,6 +387,7 @@ constraints(RoutesHelper::WebuiMatcher) do
       post 'change_password'
       post 'rss_secret'
       get 'edit_account'
+      post 'update_color_theme'
     end
     resource :block, only: %i[create destroy], controller: 'webui/users/block', constraints: cons
   end


### PR DESCRIPTION
Make it easier to change the user color theme directly by a toggler instead of editing the entire user profile. Plus, the toggler reloads the page automatically with the new color theme applied ahead.

![color-theme-toggler](https://github.com/user-attachments/assets/26a8cae8-299e-4a25-8fed-86c2b2340447)

