### PR TITLE
Make html input id unique

### DIFF
--- a/src/api/app/views/webui/repositories/_add_repository_path_modal.html.haml
+++ b/src/api/app/views/webui/repositories/_add_repository_path_modal.html.haml
@@ -5,7 +5,8 @@
         .modal-header
           %h5.modal-title Add additional path to #{repository}
         .modal-body.repository-autocomplete
-          = render partial: 'webui/shared/search_box', locals: { html_id: 'add_repo_path_target_project',
+          = render partial: 'webui/shared/search_box', locals: { html_id: "repository_#{repository.id}_add_repo_path_target_project",
+                                                                 html_name: 'add_repo_path_target_project',
                                                                  label: '<strong>Project:</strong>'.html_safe,
                                                                  data: { source: autocomplete_projects_path } }
           .mb-3


### PR DESCRIPTION
Fixes https://github.com/openSUSE/open-build-service/issues/17775#issuecomment-2839411026

Former fix https://github.com/openSUSE/open-build-service/pull/17795 **was required** but **not enough**. Initially there were two partials they had conflicting ids. Now that they are solved, another conflict surfaced: `_add_repository_path_modal` is rendered multiple times in the same page, and html ids must be unique across the whole page, otherwise they conflict on each other