### PR TITLE
Fix personal contribution graph

### DIFF
--- a/src/api/app/assets/javascripts/webui/nav_tabs.js
+++ b/src/api/app/assets/javascripts/webui/nav_tabs.js
@@ -7,7 +7,7 @@ $(document).ready(function () {
 
   $('.nav-tabs:not(.disable-link-generation) .nav-link[href="' + tabPaneId + '"]').tab('show');
 
-  changeActionHashOfButtonTo();
+  replaceURLActionHash();
 
   // Change url hash for page-reload
   $('.nav-tabs:not(.disable-link-generation) .nav-item .nav-link').on('shown.bs.tab', function (event) {
@@ -17,7 +17,7 @@ $(document).ready(function () {
     else {
       document.location.hash = event.target.hash.replace('#', '#' + HASH_PREFIX);
     }
-    changeActionHashOfButtonTo();
+    replaceURLActionHash();
 
     /*
      * jshint false positive fires an error saying the `setCollapsible` function is not defined
@@ -26,10 +26,13 @@ $(document).ready(function () {
     setCollapsible(); // jshint ignore:line
   });
 
-  function changeActionHashOfButtonTo() {
+  function replaceURLActionHash() {
     var buttonToAction = $('.button_to').attr('action');
     if (typeof buttonToAction !== 'undefined') {
       $('.button_to').attr('action', buttonToAction.replace(/#.+/, '') + document.location.hash);
     }
+    $('.activity-link').each(function() {
+      this.href += document.location.hash;
+    });
   }
 });

--- a/src/api/app/assets/stylesheets/webui/user.scss
+++ b/src/api/app/assets/stylesheets/webui/user.scss
@@ -1,23 +1,3 @@
-.activity-percentil0 {
-  background-color: #dcd5da;
-}
-
-.activity-percentil1 {
-  background-color: #f9b4dd;
-}
-
-.activity-percentil2 {
-  background-color: #ff5cb3;
-}
-
-.activity-percentil3 {
-  background-color: #ec1596;
-}
-
-.activity-percentil4 {
-  background-color: #c60b7b;
-}
-
 #contributors-table {
   td {
     padding: 0;
@@ -26,6 +6,7 @@
   td.week-day {
     width: 1px;
     padding: 0 .5rem 0 .5rem;
+    @extend .table-activity;
   }
   a.activity-link {
     display: block;
@@ -34,4 +15,16 @@
 
 #bio-chars-counter {
   min-height: 1.2rem;
+}
+
+$table-activity-variants: (
+  "activity":            shift-color($gray-400, -50%),
+  "activity-percentil1": shift-color($pink-300, -50%),
+  "activity-percentil2": shift-color($pink-500, -50%),
+  "activity-percentil3": shift-color($pink-700, -50%),
+  "activity-percentil4": shift-color($pink-900, -50%),
+);
+
+@each $color, $value in $table-activity-variants {
+  @include table-variant($color, $value);
 }

--- a/src/api/app/assets/stylesheets/webui/user.scss
+++ b/src/api/app/assets/stylesheets/webui/user.scss
@@ -25,7 +25,7 @@
   }
   td.week-day {
     width: 1px;
-    padding-right: 1rem
+    padding: 0 .5rem 0 .5rem;
   }
   a.activity-link {
     display: block;

--- a/src/api/app/assets/stylesheets/webui/user.scss
+++ b/src/api/app/assets/stylesheets/webui/user.scss
@@ -29,7 +29,6 @@
   }
   a.activity-link {
     display: block;
-    text-decoration: none;
   }
 }
 

--- a/src/api/app/assets/stylesheets/webui/user.scss
+++ b/src/api/app/assets/stylesheets/webui/user.scss
@@ -21,7 +21,7 @@
 #contributors-table {
   td {
     padding: 0;
-    border: 1px solid white;
+    border: 1px solid $gray-400;
   }
   td.week-day {
     width: 1px;

--- a/src/api/app/helpers/webui/user_activity_helper.rb
+++ b/src/api/app/helpers/webui/user_activity_helper.rb
@@ -18,15 +18,15 @@ module Webui::UserActivityHelper
 
   def activity_classname(activity, percentiles)
     if activity.zero?
-      'activity-percentil0'
+      ''
     elsif activity <= percentiles[0]
-      'activity-percentil1'
+      'table-activity-percentil1'
     elsif activity <= percentiles[1]
-      'activity-percentil2'
+      'table-activity-percentil2'
     elsif activity <= percentiles[2]
-      'activity-percentil3'
+      'table-activity-percentil3'
     else
-      'activity-percentil4'
+      'table-activity-percentil4'
     end
   end
 

--- a/src/api/app/views/webui/user/_activity.html.haml
+++ b/src/api/app/views/webui/user/_activity.html.haml
@@ -1,32 +1,31 @@
 - percentiles = contributions_percentiles(activities_per_year.values)
 
-.card.mb-3
-  .card-body
-    .h5
-      - number_of_contributions = activities_per_year.values.sum
-      = pluralize(number_of_contributions, 'contribution')
-      in the last year
-    %table.table#contributors-table
-      - 7.times do |week_day|
-        %tr
-          %td.week-day= Date::ABBR_DAYNAMES[(week_day + 1) % 7]
-          - 53.times do |week_number|
-            - current_day = first_day + (week_number * 7) + week_day
+.card-body
+  .h5
+    - number_of_contributions = activities_per_year.values.sum
+    = pluralize(number_of_contributions, 'contribution')
+    in the last year
+  %table.table#contributors-table
+    - 7.times do |week_day|
+      %tr
+        %td.week-day= Date::ABBR_DAYNAMES[(week_day + 1) % 7]
+        - 53.times do |week_number|
+          - current_day = first_day + (week_number * 7) + week_day
 
-            - if current_day > last_day
-              %td
-            - else
-              :ruby
-                activity = activities_per_year.fetch(current_day, 0)
-                classname = activity_classname(activity, percentiles)
+          - if current_day > last_day
+            %td
+          - else
+            :ruby
+              activity = activities_per_year.fetch(current_day, 0)
+              classname = activity_classname(activity, percentiles)
 
-              %td{ title: "#{current_day} - #{activity} contributions", class: classname }
-                - if activity.positive?
-                  = link_to(user_path(login: user, params: { date: current_day }), class: 'activity-link') do
-                    &nbsp;
-                - else
+            %td{ title: "#{current_day} - #{activity} contributions", class: classname }
+              - if activity.positive?
+                = link_to(user_path(login: user, params: { date: current_day }), class: 'activity-link') do
                   &nbsp;
+              - else
+                &nbsp;
 
-    - if date
-      = render partial: 'activity_date', locals: { date: date,
-                                                   activities_per_day: activities_per_day }
+  - if date
+    = render partial: 'activity_date', locals: { date: date,
+                                                 activities_per_day: activities_per_day }


### PR DESCRIPTION
Define contribution graph cell colors with Bootstrap table variants. Follow Bootstrap recomendation for customizing tables instead of using fixed colors.

See:
- https://github.com/twbs/bootstrap/blob/v5.3.5/scss/_tables.scss#L148-L155
- https://getbootstrap.com/docs/5.3/content/tables/#css

Also fix switching to the "Contributions" pane after clicking on a date on the Contributions graph.

For details on the changes, please read the sequence of commits and their descriptions.


### After

![Screenshot From 2025-05-05 14-20-15](https://github.com/user-attachments/assets/d8e7e68b-19ab-4604-8fbf-827885458b77)

![Screenshot From 2025-05-05 14-20-01](https://github.com/user-attachments/assets/b798a4b8-75a6-4b8c-a539-1c9ba664e0ec)
