### PR TITLE
[api] allow to process certain operations on scmsync operations

### DIFF
--- a/src/api/app/models/bs_request_action.rb
+++ b/src/api/app/models/bs_request_action.rb
@@ -959,7 +959,8 @@ class BsRequestAction < ApplicationRecord
                                      'a submit self is not possible, please use the maintenance workflow instead.'
       end
 
-      if tprj.scmsync.present?
+      if tprj.scmsync.present? &&
+         (target_package.present? || !action_type.in?(%i[delete change_devel add_role set_bugowner]))
         raise RequestRejected,
               "The target project #{target_project} is managed in an external SCM: #{tprj.scmsync}"
       end


### PR DESCRIPTION
Allowing esp. to remove projects or alter meta data via request when they are scmsync managed. This is fixing esp. the crashes in delayed jobs for the cleanup jobs.

Should be done via different policy rules instead makeing a difference between meta and source modification of a project, but the merge request 15476 providing this is not merged yet.