### PR TITLE
Drop `@deleted_package`

### DIFF
--- a/src/api/app/controllers/source_controller.rb
+++ b/src/api/app/controllers/source_controller.rb
@@ -37,12 +37,7 @@ class SourceController < ApplicationController
     @login = params[:login]
   end
 
-  # before_action for show_package, delete_package and package_command
   def require_package
-    # init and validation
-    #--------------------
-    @deleted_package = params.key?(:deleted)
-
     @target_package_name = params[:package]
 
     # FIXME: for OBS 3, api of branch and copy calls have target and source in the opposite place

--- a/src/api/app/controllers/source_package_command_controller.rb
+++ b/src/api/app/controllers/source_package_command_controller.rb
@@ -14,7 +14,7 @@ class SourcePackageCommandController < SourceController
   # we use an array for the "file" parameter
   skip_before_action :validate_params, only: %i[diff linkdiff servicediff]
 
-  before_action :require_package # FIXME: This is actually setting @deleted_package, @target_project_name and @target_package_name
+  before_action :require_package # FIXME: This is actually setting @target_project_name and @target_package_name
   before_action :set_user_param
   before_action :set_origin_package
   before_action :validate_target_project_name
@@ -555,6 +555,6 @@ class SourcePackageCommandController < SourceController
     end
 
     # check read access rights when the package does not exist anymore
-    validate_read_access_of_deleted_package(@target_project_name, @target_package_name) if @package.nil? && @deleted_package
+    validate_read_access_of_deleted_package(@target_project_name, @target_package_name) if @package.nil? && params.key?(:deleted)
   end
 end

--- a/src/api/app/controllers/source_package_controller.rb
+++ b/src/api/app/controllers/source_package_controller.rb
@@ -4,7 +4,7 @@ class SourcePackageController < SourceController
 
   # GET /source/:project/:package
   def show
-    if @deleted_package
+    if params.key?(:deleted)
       tpkg = Package.find_by_project_and_name(@target_project_name, @target_package_name)
       raise PackageExists, 'the package is not deleted' if tpkg
 


### PR DESCRIPTION
We use this only in controllers, they have access to params.