### PR TITLE
Remove override of `$link-hover-color` Bootstrap variable

### DIFF
--- a/src/api/app/assets/stylesheets/webui/bootstrap_variables/colors.scss
+++ b/src/api/app/assets/stylesheets/webui/bootstrap_variables/colors.scss
@@ -20,5 +20,4 @@ $warning: $yellow;
 $info: $cyan;
 $success: $green;
 
-$link-hover-color: $green;
 $link-color: $blue;

--- a/src/api/app/assets/stylesheets/webui/tabs.scss
+++ b/src/api/app/assets/stylesheets/webui/tabs.scss
@@ -46,26 +46,3 @@ ul.scrollable-tabs {
     }
   }
 }
-
-// Non-scrollable tabs
-
-ul.nav.nav-tabs li.nav-item {
-  & a {
-    color: $link-color;
-    text-decoration: none;
-
-    &:hover {
-      color: $link-hover-color;
-    }
-
-    &.dropdown-item.active,
-    &.dropdown-item:active {
-      color: $white;
-
-      span.badge {
-        color: $link-hover-color;
-        background-color: $card-bg;
-      }
-    }
-  }
-}


### PR DESCRIPTION
Follow up to #17840.

Previously, the color of the links changed from `$blue` to `$green` when hovering on them. Reproducing this behaviour in different color modes is not an easy task.

Removing the value assigned to the `$link-hover-color` variable, allows Bootstrap link utilities to define a color for hovering on links automatically.

See as reference: https://getbootstrap.com/docs/5.3/helpers/colored-links/#link-utilities

Related to #6539.

### Before

| Light mode | Dark mode |
| --- | --- |
| ![Screenshot From 2025-05-07 14-15-48](https://github.com/user-attachments/assets/7d9260c5-645b-4c9a-a0a1-3ba3e2cb4382) | ![Screenshot From 2025-05-07 14-19-03](https://github.com/user-attachments/assets/c246492c-dc21-421d-b721-bdff579abe03) |

### After

| Light mode | Dark mode |
| --- | --- |
| ![Screenshot From 2025-05-07 14-15-07](https://github.com/user-attachments/assets/c9c8c7c2-aedc-491b-b1d4-eb2f3a527a3f) | ![Screenshot From 2025-05-07 14-19-34](https://github.com/user-attachments/assets/6e40d2a6-6729-4837-888a-eef4b3b8ca31) |
