### PR TITLE
Drop private_branch_command

### DIFF
--- a/src/api/app/controllers/source_command_controller.rb
+++ b/src/api/app/controllers/source_command_controller.rb
@@ -12,7 +12,15 @@ class SourceCommandController < SourceController
 
   # POST /source?cmd=branch (aka osc mbranch)
   def global_command_branch
-    private_branch_command
+    ret = BranchPackage.new(params).branch
+    if ret[:text]
+      render plain: ret[:text]
+    else
+      Event::BranchCommand.create(project: params[:project], package: params[:package],
+                                  targetproject: params[:target_project], targetpackage: params[:target_package],
+                                  user: User.session.login)
+      render_ok ret
+    end
   end
 
   # POST /source?cmd=orderkiwirepos

--- a/src/api/app/controllers/source_controller.rb
+++ b/src/api/app/controllers/source_controller.rb
@@ -113,18 +113,6 @@ class SourceController < ApplicationController
     raise NoMatchingReleaseTarget, 'No defined or matching release target' unless repo_matches
   end
 
-  def private_branch_command
-    ret = BranchPackage.new(params).branch
-    if ret[:text]
-      render plain: ret[:text]
-    else
-      Event::BranchCommand.create(project: params[:project], package: params[:package],
-                                  targetproject: params[:target_project], targetpackage: params[:target_package],
-                                  user: User.session.login)
-      render_ok ret
-    end
-  end
-
   def obj_set_flag(obj)
     obj.transaction do
       begin

--- a/src/api/app/controllers/source_package_command_controller.rb
+++ b/src/api/app/controllers/source_package_command_controller.rb
@@ -382,7 +382,15 @@ class SourcePackageCommandController < SourceController
     # The branch command may be used just for simulation
     verify_can_modify_target! if !params[:dryrun] && @target_project_name
 
-    private_branch_command
+    ret = BranchPackage.new(params).branch
+    if ret[:text]
+      render plain: ret[:text]
+    else
+      Event::BranchCommand.create(project: params[:project], package: params[:package],
+                                  targetproject: params[:target_project], targetpackage: params[:target_package],
+                                  user: User.session.login)
+      render_ok ret
+    end
   end
 
   # POST /source/<project>/<package>?cmd=fork&scmsync="url"&target_project="optional_project"


### PR DESCRIPTION
It's easy enough to understand how BranchPackage.new works, no need to hide it away in some shared method.