### PR TITLE
Do not trigger callbacks when expiring assignments

### DIFF
--- a/src/api/app/jobs/expire_assignments_job.rb
+++ b/src/api/app/jobs/expire_assignments_job.rb
@@ -2,6 +2,6 @@ class ExpireAssignmentsJob < ApplicationJob
   queue_as :default
 
   def perform
-    Assignment.where(created_at: ...1.day.ago).destroy_all
+    Assignment.where(created_at: ...1.day.ago).delete_all
   end
 end


### PR DESCRIPTION
Because we do not want to send notifications when that happens