### PR TITLE
Extract colors needed by editors to `editor-colors.scss`

### DIFF
--- a/src/api/app/assets/stylesheets/webui/application.scss
+++ b/src/api/app/assets/stylesheets/webui/application.scss
@@ -11,6 +11,7 @@
 */
 
 @import 'codemirror';
+@import 'editor-colors';
 @import 'bootstrap_variables/breakpoints';
 @import 'bootstrap_variables/colors';
 @import 'bootstrap_variables/spacers';

--- a/src/api/app/assets/stylesheets/webui/bootstrap_variables/colors.scss
+++ b/src/api/app/assets/stylesheets/webui/bootstrap_variables/colors.scss
@@ -6,11 +6,6 @@ $gray-500: #878c92;
 
 $blue: #069;
 $green: #008000;
-$pink: #708;
-$indigo: #219;
-$purple: #30a;
-$teal: #164;
-$orange: #a50;
 $yellow: #f0ad4e;
 $cyan: #007a7c;
 

--- a/src/api/app/assets/stylesheets/webui/cm2/bootstrap.scss
+++ b/src/api/app/assets/stylesheets/webui/cm2/bootstrap.scss
@@ -1,17 +1,17 @@
 // Bootstrap theme for CodeMirror
 .cm-s-bootstrap {
   --cm-body: var(--bs-body-color);
-  --cm-blue: #{$blue};
-  --cm-pink: #{$pink};
-  --cm-indigo: #{$indigo};
-  --cm-teal: #{$teal};
-  --cm-orange: #{$orange};
+  --cm-blue: #{$editor-blue};
+  --cm-pink: #{$editor-pink};
+  --cm-indigo: #{$editor-indigo};
+  --cm-teal: #{$editor-teal};
+  --cm-orange: #{$editor-orange};
   --cm-red: #{$red};
   --cm-gray: #{$text-muted};
-  --cm-purple: #{$purple};
-  --cm-yellow: #{$yellow};
-  --cm-green: #{$green};
-  --cm-link: #{$link-color};
+  --cm-purple: #{$editor-purple};
+  --cm-yellow: #{$editor-yellow};
+  --cm-green: #{$editor-green};
+  --cm-link: #{$editor-link-color};
 
   &.CodeMirror {
     font-family: $font-family-monospace, monospace;
@@ -60,11 +60,11 @@
     background: rgba($danger, 0.1);
   }
   .cm-positive {
-    color: $success;
+    color: $editor-success;
   }
 
   .CodeMirror-positive-line {
-    background: rgba($success, 0.1);
+    background: rgba($editor-success, 0.1);
   }
 
   .CodeMirror-gutters {
@@ -75,7 +75,7 @@
   .CodeMirror-guttermarker-subtle { color: var(--cm-gray); }
   .CodeMirror-linenumber { color: var(--cm-gray); }
   div.CodeMirror-selected {
-    background: $primary;
+    background: $editor-primary;
     opacity: 0.2;
   }
 
@@ -85,16 +85,16 @@
 
 @include color-mode(dark) {
   .cm-s-bootstrap {
-    --cm-blue: #{lighten($blue, 20%)};
-    --cm-pink: #{lighten($pink, 20%)};
-    --cm-indigo: #{lighten($indigo, 40%)};
-    --cm-teal: #{lighten($teal, 20%)};
-    --cm-orange: #{lighten($orange, 20%)};
+    --cm-blue: #{lighten($editor-blue, 20%)};
+    --cm-pink: #{lighten($editor-pink, 20%)};
+    --cm-indigo: #{lighten($editor-indigo, 40%)};
+    --cm-teal: #{lighten($editor-teal, 20%)};
+    --cm-orange: #{lighten($editor-orange, 20%)};
     --cm-red: #{lighten($danger, 20%)};
-    --cm-purple: #{lighten($purple, 20%)};
-    --cm-yellow: #{lighten($warning, 20%)};
-    --cm-green: #{lighten($success, 20%)};
-    --cm-link: #{lighten($link-color, 20%)};
+    --cm-purple: #{lighten($editor-purple, 20%)};
+    --cm-yellow: #{lighten($editor-warning, 20%)};
+    --cm-green: #{lighten($editor-success, 20%)};
+    --cm-link: #{lighten($editor-link-color, 20%)};
   }
 }
 

--- a/src/api/app/assets/stylesheets/webui/coderay.scss
+++ b/src/api/app/assets/stylesheets/webui/coderay.scss
@@ -27,7 +27,7 @@ span.CodeRay { white-space: pre }
 
 .CodeRay .line, .CodeRay .code { width: 100% }
 
-.CodeRay .debug { color: $card-bg; background: $blue }
+.CodeRay .debug { color: $card-bg; background: $editor-blue }
 
 .CodeRay .done, .CodeRay .comment, .CodeRay .escape,
 .CodeRay .inline-delimiter { color: $text-muted }
@@ -36,7 +36,7 @@ span.CodeRay { white-space: pre }
 
 .CodeRay .binary .char, .CodeRay .binary .delimiter,
 .CodeRay .map .content, .CodeRay .map .delimiter, .CodeRay .octal,
-.CodeRay .regexp .content, .CodeRay .head .head { color: $purple }
+.CodeRay .regexp .content, .CodeRay .head .head { color: $editor-purple }
 
 .CodeRay .comment .char, .CodeRay .comment .delimiter,
 .CodeRay .done, .CodeRay .preprocessor { color: $dark }
@@ -53,40 +53,40 @@ span.CodeRay { white-space: pre }
 .CodeRay .string .modifier { color: $danger }
 
 .CodeRay .annotation, .CodeRay .function, .CodeRay .predefined,
-.CodeRay .predefined-constant, .CodeRay .variable { color: $blue }
+.CodeRay .predefined-constant, .CodeRay .variable { color: $editor-blue }
 
 .CodeRay .attribute-name, .CodeRay .keyword,
-.CodeRay .regexp .delimiter { color: $pink }
+.CodeRay .regexp .delimiter { color: $editor-pink }
 
 .CodeRay .binary, .CodeRay .binary .char,
 .CodeRay .binary .delimiter, .CodeRay .constant,
-.CodeRay .regexp .modifier, .CodeRay .type { color: $indigo }
+.CodeRay .regexp .modifier, .CodeRay .type { color: $editor-indigo }
 
 .CodeRay .class, .CodeRay .class-variable, .CodeRay .color,
 .CodeRay .definition, .CodeRay .directive, .CodeRay .doctype,
 .CodeRay .float, .CodeRay .function .delimiter, .CodeRay .reserved,
-.CodeRay .shell .delimiter, .CodeRay .tag { color: $green }
+.CodeRay .shell .delimiter, .CodeRay .tag { color: $editor-green }
 
 .CodeRay .function .content, .CodeRay .hex, .CodeRay .id,
 .CodeRay .instance-variable, .CodeRay .integer, .CodeRay .key .char,
-.CodeRay .pseudo-class, .CodeRay .shell .content { color: $success }
+.CodeRay .pseudo-class, .CodeRay .shell .content { color: $editor-success }
 
 .CodeRay .decorator, .CodeRay .key, .CodeRay .key .delimiter,
-.CodeRay .namespace, .CodeRay .symbol, .CodeRay .symbol .content { color: $yellow }
+.CodeRay .namespace, .CodeRay .symbol, .CodeRay .symbol .content { color: $editor-yellow }
 
-.CodeRay .string .char, .CodeRay .include, .CodeRay .symbol .delimiter { color: $orange }
+.CodeRay .string .char, .CodeRay .include, .CodeRay .symbol .delimiter { color: $editor-orange }
 
-.CodeRay .predefined-type, .CodeRay .shell, .CodeRay .value { color: $teal }
+.CodeRay .predefined-type, .CodeRay .shell, .CodeRay .value { color: $editor-teal }
 
 .CodeRay .done { text-decoration: line-through }
 
-.CodeRay .insert { background: rgba($success, 0.1); display: inline-block }
+.CodeRay .insert { background: rgba($editor-success, 0.1); display: inline-block }
 .CodeRay .delete { background: rgba($danger, 0.1); display: inline-block }
 .CodeRay .head { color: $light; background: $dark }
 
 .CodeRay .delete .eyecatcher { background-color: rgba($danger, 0.3) }
-.CodeRay .insert .eyecatcher { background-color: rgba($success, 0.3) }
+.CodeRay .insert .eyecatcher { background-color: rgba($editor-success, 0.3) }
 
-.CodeRay .insert .insert { color: $success; background: transparent }
+.CodeRay .insert .insert { color: $editor-success; background: transparent }
 .CodeRay .delete .delete { color: $danger; background: transparent }
 .CodeRay .change .change { color: $body-color }

--- a/src/api/app/assets/stylesheets/webui/editor-colors.scss
+++ b/src/api/app/assets/stylesheets/webui/editor-colors.scss
@@ -1,0 +1,15 @@
+// Define colors used in editors
+$editor-blue: #069;
+$editor-green: #008000;
+$editor-pink: #708;
+$editor-indigo: #219;
+$editor-purple: #30a;
+$editor-teal: #164;
+$editor-orange: #a50;
+$editor-yellow: #f0ad4e;
+
+$editor-primary: $editor-green;
+$editor-warning: $editor-yellow;
+$editor-success: $editor-green;
+
+$editor-link-color: $editor-blue;


### PR DESCRIPTION
Remove some Bootstrap basic colors definitions overrides. The colors needed by editors are now defined in a separate file, prepending their color variable name with `$editor-`.

Also, prepare the next removal of Bootstrap basic colors overrides making sure that editor colors will not be affected.