### PR TITLE
[backend] bs_srcserver: fix mkosi recipe detection in findfiles()

### DIFF
--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -995,7 +995,7 @@ sub findfile {
   return $files{'simpleimage'} if $files{'simpleimage'};
   return $files{'snapcraft.yaml'} if $ext eq 'snapcraft';
   return (grep {/flatpak\.(?:ya?ml|json)$/} sort keys %$files)[0] if $ext eq 'flatpak';
-  return (grep {/mkosi\.*/} sort keys %$files)[0] if $ext eq 'mkosi';
+  return (grep {/^mkosi(?:\..*)?\.conf$/} sort keys %$files)[0] if $ext eq 'mkosi';
 
   my $packid = $rev->{'package'};
   $packid = $1 if $rev->{'originpackage'} && $rev->{'originpackage'} =~ /:([^:]+)$/;


### PR DESCRIPTION
The old regex matched everything that contained the substring 'mkosi'.