### PR TITLE
[backend] support new productcompose-onlydirectrepos option

### DIFF
--- a/src/backend/BSSched/BuildJob/ProductCompose.pm
+++ b/src/backend/BSSched/BuildJob/ProductCompose.pm
@@ -149,6 +149,11 @@ sub check {
     return ('broken', 'require path entries');
   }
 
+  if ($bconf->{'buildflags:productcompose-onlydirectrepos'}) {
+    @bprps = map {"$_->{'project'}/$_->{'repository'}"} @{$repo->{'path'} || []};
+    @bprps = BSUtil::unify($prp, @bprps);
+  }
+
   my @blocked;
   my @rpms;
   my %rpms_meta;


### PR DESCRIPTION
This limits the repositories used for product building to the ones coming from the configured path. This is needed to make the product builds in the staging of the SLES-16 update projects small.