### PR TITLE
Do proper authorization when assigning someone to a package

### DIFF
--- a/src/api/app/controllers/webui/packages/assignments_controller.rb
+++ b/src/api/app/controllers/webui/packages/assignments_controller.rb
@@ -6,7 +6,8 @@ module Webui
       before_action :set_assignee
 
       def create
-        assignment = Assignment.new(assigner: User.session, assignee: @assignee, package: @package)
+        assignment = authorize Assignment.new(assigner: User.session, assignee: @assignee, package: @package)
+
         unless assignment.save
           flash[:error] = "Could not assign the user: #{assignment.errors.full_messages.to_sentence}"
         end

--- a/src/api/app/controllers/webui/packages/assignments_controller.rb
+++ b/src/api/app/controllers/webui/packages/assignments_controller.rb
@@ -1,13 +1,13 @@
 module Webui
   module Packages
     class AssignmentsController < Webui::WebuiController
+      before_action :require_login
       before_action :set_package
       before_action :set_assignee
 
       def create
-        # TODO: Security
         assignment = Assignment.new(assigner: User.session, assignee: @assignee, package: @package)
-        unless assignment.save # FIXME: if there is a validation errors this can go by the else
+        unless assignment.save
           flash[:error] = "Could not assign the user: #{assignment.errors.full_messages.to_sentence}"
         end
         redirect_to package_show_path(@package.project, @package)

--- a/src/api/app/models/assignment.rb
+++ b/src/api/app/models/assignment.rb
@@ -21,6 +21,7 @@ class Assignment < ApplicationRecord
   #### Validations macros
   validate :assignee do
     errors.add(:assignee, 'must be in confirmed state') unless assignee && assignee.state == 'confirmed'
+    errors.add(:assignee, 'must be a project or package collaborator') unless assignee && assignee_is_a_collaborator
   end
   validates :package, uniqueness: true
 
@@ -40,6 +41,13 @@ class Assignment < ApplicationRecord
 
   def event_parameters
     { id: id, assignee: assignee.login, assigner: assigner.login, project: package.project.name, package: package.name }
+  end
+
+  def assignee_is_a_collaborator
+    collaborators = (package.relationships + package.project.relationships).map(&:user)
+    return false if collaborators.empty?
+
+    collaborators.include?(assignee)
   end
 end
 

--- a/src/api/app/models/assignment.rb
+++ b/src/api/app/models/assignment.rb
@@ -21,18 +21,20 @@ class Assignment < ApplicationRecord
   #### Validations macros
   validate :assignee do
     errors.add(:assignee, 'must be in confirmed state') unless assignee && assignee.state == 'confirmed'
-    errors.add(:assignee, 'must be a project or package collaborator') unless assignee && assignee_is_a_collaborator
+    errors.add(:assignee, 'must be a project or package collaborator') unless assignee_is_a_collaborator
   end
   validates :package, uniqueness: true
 
-  #### Class methods using self. (public and then private)
-
-  #### To define class methods as private use private_class_method
-  #### private
-
   #### Instance methods (public and then protected/private)
+  def assignee_is_a_collaborator
+    return false if assignee.nil?
 
-  #### Alias of methods
+    collaborators = (package.relationships + package.project.relationships).map(&:user)
+    return false if collaborators.empty?
+
+    collaborators.include?(assignee)
+  end
+
   private
 
   def create_event
@@ -41,13 +43,6 @@ class Assignment < ApplicationRecord
 
   def event_parameters
     { id: id, assignee: assignee.login, assigner: assigner.login, project: package.project.name, package: package.name }
-  end
-
-  def assignee_is_a_collaborator
-    collaborators = (package.relationships + package.project.relationships).map(&:user)
-    return false if collaborators.empty?
-
-    collaborators.include?(assignee)
   end
 end
 

--- a/src/api/app/policies/assignment_policy.rb
+++ b/src/api/app/policies/assignment_policy.rb
@@ -1,0 +1,12 @@
+# Only package or project collaborators (and Admin) can assign people.
+# We are only checking the assigner here. Who can you assign as assignee is
+# checked as Assignment model validation.
+class AssignmentPolicy < ApplicationPolicy
+  def create?
+    return false unless Flipper.enabled?(:foster_collaboration, user)
+
+    return true if user.admin?
+
+    record.assignee_is_a_collaborator
+  end
+end

--- a/src/api/spec/features/beta/webui/assignments_spec.rb
+++ b/src/api/spec/features/beta/webui/assignments_spec.rb
@@ -2,8 +2,8 @@ require 'browser_helper'
 
 RSpec.describe 'Assignments', :vcr do
   let!(:user) { create(:confirmed_user, :with_home, login: 'tom') }
-  let!(:package) { create(:package_with_file, name: 'test_package', project: user.home_project) }
   let(:assignee) { create(:confirmed_user, login: 'mal') }
+  let!(:package) { create(:package_with_maintainer, name: 'test_package', project: user.home_project, maintainer: assignee) }
 
   before do
     Flipper.enable(:foster_collaboration)

--- a/src/api/spec/models/assignment_spec.rb
+++ b/src/api/spec/models/assignment_spec.rb
@@ -1,0 +1,30 @@
+RSpec.describe Assignment do
+  describe '#assignee_is_a_collaborator' do
+    subject do
+      assignment.assignee_is_a_collaborator
+    end
+
+    context 'when the assignee is a package collaborator' do
+      let(:package) { create(:package_with_maintainer) }
+      let(:assignment) { create(:assignment, package: package, assignee: package.maintainers.first) }
+
+      it { expect(subject).to be true }
+    end
+
+    context 'when the assignee is a project collaborator' do
+      let(:maintainer) { create(:confirmed_user) }
+      let(:project) { create(:project_with_package, maintainer: maintainer) }
+      let(:package) { project.packages.first }
+      let(:assignment) { create(:assignment, package: package, assignee: maintainer) }
+
+      it { expect(subject).to be true }
+    end
+
+    context 'when the assignee is not a collaborator' do
+      let(:iggy) { create(:confirmed_user) }
+      let(:assignment) { build(:assignment, assignee: iggy) }
+
+      it { expect(subject).to be false }
+    end
+  end
+end

--- a/src/api/spec/policies/assignment_policy_spec.rb
+++ b/src/api/spec/policies/assignment_policy_spec.rb
@@ -1,0 +1,40 @@
+RSpec.describe AssignmentPolicy do
+  subject { described_class }
+
+  permissions :create? do
+    before do
+      Flipper.enable(:foster_collaboration)
+    end
+
+    context 'a package collaborator' do
+      let(:package_collaborator) { package.maintainers.first }
+      let(:package) { create(:package_with_maintainer) }
+      let(:assignment) { create(:assignment, assigner: package_collaborator, assignee: package_collaborator, package: package) }
+
+      it { is_expected.to permit(package_collaborator, assignment) }
+    end
+
+    context 'a project collaborator' do
+      let(:project_collaborator) { create(:confirmed_user) }
+      let(:project) { create(:project_with_package, maintainer: project_collaborator) }
+      let(:package) { project.packages.first }
+      let(:assignment) { build(:assignment, assigner: project_collaborator, assignee: project_collaborator, package: package) }
+
+      it { is_expected.to permit(project_collaborator, assignment) }
+    end
+
+    context 'an admin' do
+      let(:admin_user) { create(:admin_user) }
+      let(:assignment) { build(:assignment) }
+
+      it { is_expected.to permit(admin_user, assignment) }
+    end
+
+    context 'any other user' do
+      let(:user) { create(:confirmed_user) }
+      let(:assignment) { build(:assignment) }
+
+      it { is_expected.not_to permit(user, assignment) }
+    end
+  end
+end


### PR DESCRIPTION
Previously you couldn't create an assignment without being logged in because the Assignment model would complain about an assigner missing, but it's not the proper way to do authorization.