### PR TITLE
Fix definitions of theme colors for Bootstrap

### DIFF
--- a/src/api/app/assets/config/manifest.js
+++ b/src/api/app/assets/config/manifest.js
@@ -11,6 +11,7 @@
 //= link webui/report.js
 //= link_tree ../images
 
+//= link favicon.ico
 
 //= link_tree ../../javascript .js
 //= link_tree ../../../vendor/javascript .js

--- a/src/api/app/assets/stylesheets/webui/bootstrap_variables/colors.scss
+++ b/src/api/app/assets/stylesheets/webui/bootstrap_variables/colors.scss
@@ -4,15 +4,15 @@ $gray-300: #e9ecef;
 $gray-400: #aeaeae;
 $gray-500: #878c92;
 
-$blue: #069;
-$green: #008000;
-$yellow: #f0ad4e;
-$cyan: #007a7c;
+$custom-blue:   #069;
+$custom-green:  #008000;
+$custom-yellow: #f0ad4e;
+$custom-cyan:   #007a7c;
 
-$primary: $green;
-$secondary: $blue;
-$warning: $yellow;
-$info: $cyan;
-$success: $green;
+$primary:   $custom-green;
+$secondary: $custom-blue;
+$success:   $custom-green;
+$info:      $custom-cyan;
+$warning:   $custom-yellow;
 
-$link-color: $blue;
+$link-color: $custom-blue;

--- a/src/api/app/assets/stylesheets/webui/coderay.scss
+++ b/src/api/app/assets/stylesheets/webui/coderay.scss
@@ -21,7 +21,7 @@ span.CodeRay { white-space: pre }
   padding: 0 0.25rem;
 }
 .CodeRay .line-numbers a:target {
-  background-color: rgba($warning, 0.3);
+  background-color: rgba($editor-warning, 0.3);
   color: $body-color;
 }
 

--- a/src/api/app/assets/stylesheets/webui/diff.scss
+++ b/src/api/app/assets/stylesheets/webui/diff.scss
@@ -75,10 +75,10 @@
       .line-comment .comment-diff { display: none; }
       &:target {
         .number {
-          background-color: rgba($warning, 0.5)!important
+          background-color: rgba($editor-warning, 0.5)!important
         }
         .value {
-          background-color: rgba($warning, 0.1);
+          background-color: rgba($editor-warning, 0.1);
           width: 100%
         }
       }


### PR DESCRIPTION
Prevent from overriding basic Bootstrap color definitions.

Define theme colors as Bootstrap recomends. See:

https://getbootstrap.com/docs/5.3/customize/color/#theme-colors

Follow-up to #17862.