### PR TITLE
Fix passing `none` as parameter

### DIFF
--- a/src/api/app/assets/stylesheets/webui/collapsible-text.scss
+++ b/src/api/app/assets/stylesheets/webui/collapsible-text.scss
@@ -50,12 +50,12 @@
 }
 
 #involvement-description {
-  @include collapsible($maxHeight: 2.75em, $maxWidth: 'none');
+  @include collapsible($maxHeight: 2.75em, $maxWidth: none);
   .obs-collapsible-textbox {  @extend .pe-0; }
 }
 
 .list-group-item {
-  @include collapsible($maxHeight: 2.75em, $maxWidth: 'none', $moreButtonLabel: 'Expand name ', $lessButtonLabel: 'Shrink name ');
+  @include collapsible($maxHeight: 2.75em, $maxWidth: none, $moreButtonLabel: 'Expand name ', $lessButtonLabel: 'Shrink name ');
 }
 
 #mentioned-issues .list-group-item {


### PR DESCRIPTION
Fix the following error thrown in the browser console:

"Error in parsing value for ‘max-width’.  Declaration dropped."