### PR TITLE
Fix checking read access of deleted project/packages

### DIFF
--- a/src/api/app/helpers/validation_helper.rb
+++ b/src/api/app/helpers/validation_helper.rb
@@ -10,45 +10,34 @@ module ValidationHelper
 
   # load last package meta file and just check if sourceaccess flag was used at all, no per user checking atm
   def validate_read_access_of_deleted_package(project, name)
-    prj = Project.get_by_name(project)
-    if prj.is_a?(Project)
-      raise Project::ReadAccessError, project.to_s if prj.disabled_for?('access', nil, nil)
-      raise Package::ReadSourceAccessError, "#{target_project_name}/#{target_package_name}" if prj.disabled_for?('sourceaccess', nil, nil)
+    project_object = Project.find_by(name: project)
+    if project_object
+      raise Package::ReadSourceAccessError, "#{project}/#{name}" if project_object.disabled_for?('sourceaccess', nil, nil)
+    else
+      validate_visibility_of_deleted_project(project)
     end
 
     begin
-      revisions_list = Backend::Api::Sources::Package.revisions(project, name)
-    rescue StandardError
+      meta = Xmlhash.parse(Backend::Api::Sources::Package.meta(project, name, { deleted: 1 }))
+    rescue Backend::NotFoundError
       raise Package::UnknownObjectError, "Package not found: #{project}/#{name}"
     end
-    data = Xmlhash.parse(revisions_list)
-    lastrev = data.elements('revision').last
-
-    query = { deleted: 1 }
-    query[:rev] = lastrev.value('srcmd5') if lastrev
-    meta = PackageMetaFile.new(project_name: project, package_name: name).content(query)
-    raise Package::UnknownObjectError, "Package not found: #{project}/#{name}" unless meta
 
     return true if User.admin_session?
-    raise Package::ReadSourceAccessError, "#{project}/#{name}" if FlagHelper.xml_disabled_for?(Xmlhash.parse(meta), 'sourceaccess')
+    raise Package::ReadSourceAccessError, "#{project}/#{name}" if FlagHelper.xml_disabled_for?(meta, 'sourceaccess')
 
     true
   end
 
   def validate_visibility_of_deleted_project(project)
     begin
-      revisions_list = Backend::Api::Sources::Project.revisions(project)
-    rescue StandardError
+      meta = Xmlhash.parse(Backend::Api::Sources::Project.meta(project, deleted: 1))
+    rescue Backend::NotFoundError
       raise Project::UnknownObjectError, "Project not found: #{project}"
     end
-    data = Xmlhash.parse(revisions_list)
-    lastrev = data.elements('revision').last
-    raise Project::UnknownObjectError, "Project not found: #{project}" unless lastrev
 
-    meta = Backend::Api::Sources::Project.meta(project, revision: lastrev.value('srcmd5'), deleted: 1)
-    raise Project::UnknownObjectError, "Project not found: #{project}" unless meta
     return true if User.admin_session?
     # FIXME: actually a per user checking would be more accurate here
-    raise Project::UnknownObjectError, "Project not found: #{project}" if FlagHelper.xml_disabled_for?(Xmlhash.parse(meta), 'access')
+    raise Project::UnknownObjectError, "Project not found: #{project}" if FlagHelper.xml_disabled_for?(meta, 'access')
   end
 end

--- a/src/api/app/lib/backend/api/sources/package.rb
+++ b/src/api/app/lib/backend/api/sources/package.rb
@@ -41,8 +41,8 @@ module Backend
 
         # Returns the meta file from a package
         # @return [String]
-        def self.meta(project_name, package_name)
-          http_get(['/source/:project/:package/_meta', project_name, package_name])
+        def self.meta(project_name, package_name, options = {})
+          http_get(['/source/:project/:package/_meta', project_name, package_name], params: options.compact, accepted: :deleted)
         end
 
         # Returns the content of the _service file (if present)

--- a/src/api/spec/cassettes/SourcePackageController/GET_show/1_1_1.yml
+++ b/src/api/spec/cassettes/SourcePackageController/GET_show/1_1_1.yml
@@ -1,0 +1,191 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/hans/_meta?user=user_1
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="hans">
+          <title>That Hideous Strength</title>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '145'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="hans">
+          <title>That Hideous Strength</title>
+          <description></description>
+          <person userid="tom" role="maintainer"/>
+        </project>
+  recorded_at: Wed, 28 May 2025 13:23:57 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/hans/franz/_meta?user=user_2
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="franz" project="hans">
+          <title>From Here to Eternity</title>
+          <description>Laudantium magnam fuga cumque.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '148'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="franz" project="hans">
+          <title>From Here to Eternity</title>
+          <description>Laudantium magnam fuga cumque.</description>
+        </package>
+  recorded_at: Wed, 28 May 2025 13:23:57 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/hans/franz/_config
+    body:
+      encoding: UTF-8
+      string: Et voluptatem numquam. Sit assumenda voluptatem. Aut accusantium est.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="1" vrev="1">
+          <srcmd5>dcfd3c2655ee8ac5dd94afeaf73af808</srcmd5>
+          <version>unknown</version>
+          <time>1748438637</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 28 May 2025 13:23:57 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/hans/franz/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Eos neque ut. Ut reprehenderit eos. Consequatur nostrum accusamus.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="2" vrev="2">
+          <srcmd5>20df910d3ab2a5846f4b18307c1d2b88</srcmd5>
+          <version>unknown</version>
+          <time>1748438637</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 28 May 2025 13:23:57 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/hans/franz
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '290'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="franz" rev="2" vrev="2" srcmd5="20df910d3ab2a5846f4b18307c1d2b88">
+          <entry name="_config" md5="198dd222b16d706fe78138261474191a" size="69" mtime="1748438637"/>
+          <entry name="somefile.txt" md5="317b3726135f778a112cef77c987971b" size="66" mtime="1748438637"/>
+        </directory>
+  recorded_at: Wed, 28 May 2025 13:23:57 GMT
+recorded_with: VCR 6.3.1

--- a/src/api/spec/cassettes/SourcePackageController/GET_show/when_the_package_does_not_exist/1_1_3_1.yml
+++ b/src/api/spec/cassettes/SourcePackageController/GET_show/when_the_package_does_not_exist/1_1_3_1.yml
@@ -1,0 +1,189 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/hans/_meta?user=user_1
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="hans">
+          <title>This Side of Paradise</title>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '145'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="hans">
+          <title>This Side of Paradise</title>
+          <description></description>
+          <person userid="tom" role="maintainer"/>
+        </project>
+  recorded_at: Wed, 28 May 2025 13:23:18 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/hans/franz/_meta?user=user_2
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="franz" project="hans">
+          <title>The Green Bay Tree</title>
+          <description>Autem veniam molestiae esse.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '143'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="franz" project="hans">
+          <title>The Green Bay Tree</title>
+          <description>Autem veniam molestiae esse.</description>
+        </package>
+  recorded_at: Wed, 28 May 2025 13:23:18 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/hans/franz/_config
+    body:
+      encoding: UTF-8
+      string: Dolorem natus fugit. Voluptatem est corporis. Autem explicabo molestiae.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="1" vrev="1">
+          <srcmd5>b11c6ac6e703786368b766581f9ad5bd</srcmd5>
+          <version>unknown</version>
+          <time>1748438598</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 28 May 2025 13:23:18 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/hans/franz/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Omnis odit dicta. Repellat autem earum. Quia modi dolor.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="2" vrev="2">
+          <srcmd5>623757ecaef799deb64af9464dbd6309</srcmd5>
+          <version>unknown</version>
+          <time>1748438598</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 28 May 2025 13:23:18 GMT
+- request:
+    method: delete
+    uri: http://backend:5352/source/hans/franz?user=user_2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+  recorded_at: Wed, 28 May 2025 13:23:18 GMT
+recorded_with: VCR 6.3.1

--- a/src/api/spec/cassettes/SourcePackageController/GET_show/when_the_project_does_not_exist/1_1_2_1.yml
+++ b/src/api/spec/cassettes/SourcePackageController/GET_show/when_the_project_does_not_exist/1_1_2_1.yml
@@ -1,0 +1,188 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/hans/_meta?user=user_1
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="hans">
+          <title>East of Eden</title>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '136'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="hans">
+          <title>East of Eden</title>
+          <description></description>
+          <person userid="tom" role="maintainer"/>
+        </project>
+  recorded_at: Wed, 28 May 2025 13:23:40 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/hans/franz/_meta?user=user_2
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="franz" project="hans">
+          <title>The Moon by Night</title>
+          <description>Quibusdam minima porro eos.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '141'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="franz" project="hans">
+          <title>The Moon by Night</title>
+          <description>Quibusdam minima porro eos.</description>
+        </package>
+  recorded_at: Wed, 28 May 2025 13:23:40 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/hans/franz/_config
+    body:
+      encoding: UTF-8
+      string: Ipsum rerum officiis. Doloribus repellat corporis. Adipisci praesentium
+        possimus.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="1" vrev="1">
+          <srcmd5>e3787db0dfb3c5809d532024accc9b44</srcmd5>
+          <version>unknown</version>
+          <time>1748438620</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 28 May 2025 13:23:40 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/hans/franz/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Dolor aut et. Ut earum deserunt. Reprehenderit sunt totam.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="2" vrev="2">
+          <srcmd5>ca2cb6409c58df85716b6672386d3604</srcmd5>
+          <version>unknown</version>
+          <time>1748438620</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 28 May 2025 13:23:40 GMT
+- request:
+    method: delete
+    uri: http://backend:5352/source/hans?comment=&user=tom
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+  recorded_at: Wed, 28 May 2025 13:23:41 GMT
+recorded_with: VCR 6.3.1

--- a/src/api/spec/cassettes/SourcePackageController/GET_show/with_deleted_parameter_set/when_the_package_is_deleted/1_1_4_2_1.yml
+++ b/src/api/spec/cassettes/SourcePackageController/GET_show/with_deleted_parameter_set/when_the_package_is_deleted/1_1_4_2_1.yml
@@ -1,0 +1,257 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/hans/_meta?user=user_1
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="hans">
+          <title>Mother Night</title>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '136'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="hans">
+          <title>Mother Night</title>
+          <description></description>
+          <person userid="tom" role="maintainer"/>
+        </project>
+  recorded_at: Wed, 28 May 2025 13:22:08 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/hans/franz/_meta?user=user_2
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="franz" project="hans">
+          <title>Such, Such Were the Joys</title>
+          <description>Dignissimos quo ipsum aut.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '147'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="franz" project="hans">
+          <title>Such, Such Were the Joys</title>
+          <description>Dignissimos quo ipsum aut.</description>
+        </package>
+  recorded_at: Wed, 28 May 2025 13:22:08 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/hans/franz/_config
+    body:
+      encoding: UTF-8
+      string: Magnam inventore aliquid. Impedit nemo et. Facilis et facere.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="1" vrev="1">
+          <srcmd5>ed5ece9a28e2dc8d4927e981db5115e0</srcmd5>
+          <version>unknown</version>
+          <time>1748438528</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 28 May 2025 13:22:08 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/hans/franz/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Dolores inventore delectus. Aut quisquam impedit. Ullam quis veniam.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="2" vrev="2">
+          <srcmd5>92368f1aeaf2ea9df7a8d956bb6d14a8</srcmd5>
+          <version>unknown</version>
+          <time>1748438528</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 28 May 2025 13:22:08 GMT
+- request:
+    method: delete
+    uri: http://backend:5352/source/hans/franz?user=user_2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+  recorded_at: Wed, 28 May 2025 13:22:08 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/hans/franz/_meta?deleted=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '147'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="franz" project="hans">
+          <title>Such, Such Were the Joys</title>
+          <description>Dignissimos quo ipsum aut.</description>
+        </package>
+  recorded_at: Wed, 28 May 2025 13:22:09 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/hans/franz?deleted=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '290'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="franz" rev="3" vrev="2" srcmd5="92368f1aeaf2ea9df7a8d956bb6d14a8">
+          <entry name="_config" md5="ff0a860e199e20e69871c729e107ade2" size="61" mtime="1748438528"/>
+          <entry name="somefile.txt" md5="70190996c7e712a513738567b44201aa" size="68" mtime="1748438528"/>
+        </directory>
+  recorded_at: Wed, 28 May 2025 13:22:09 GMT
+recorded_with: VCR 6.3.1

--- a/src/api/spec/cassettes/SourcePackageController/GET_show/with_deleted_parameter_set/when_the_package_was_sourceaccess_protected/1_1_4_5_1.yml
+++ b/src/api/spec/cassettes/SourcePackageController/GET_show/with_deleted_parameter_set/when_the_package_was_sourceaccess_protected/1_1_4_5_1.yml
@@ -1,0 +1,194 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/hans/_meta?user=user_1
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="hans">
+          <title>Blue Remembered Earth</title>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '145'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="hans">
+          <title>Blue Remembered Earth</title>
+          <description></description>
+          <person userid="tom" role="maintainer"/>
+        </project>
+  recorded_at: Wed, 28 May 2025 13:14:20 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/hans/franz/_meta?user=user_2
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="franz" project="hans">
+          <title>Endless Night</title>
+          <description>Nisi sed quis amet.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '129'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="franz" project="hans">
+          <title>Endless Night</title>
+          <description>Nisi sed quis amet.</description>
+        </package>
+  recorded_at: Wed, 28 May 2025 13:14:20 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/hans/franz/_meta?user=user_2
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="franz" project="hans">
+          <title>Endless Night</title>
+          <description>Nisi sed quis amet.</description>
+          <sourceaccess>
+            <disable/>
+          </sourceaccess>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '179'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="franz" project="hans">
+          <title>Endless Night</title>
+          <description>Nisi sed quis amet.</description>
+          <sourceaccess>
+            <disable/>
+          </sourceaccess>
+        </package>
+  recorded_at: Wed, 28 May 2025 13:14:20 GMT
+- request:
+    method: delete
+    uri: http://backend:5352/source/hans/franz?user=user_2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+  recorded_at: Wed, 28 May 2025 13:14:20 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/hans/franz/_meta?deleted=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '179'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="franz" project="hans">
+          <title>Endless Night</title>
+          <description>Nisi sed quis amet.</description>
+          <sourceaccess>
+            <disable/>
+          </sourceaccess>
+        </package>
+  recorded_at: Wed, 28 May 2025 13:14:21 GMT
+recorded_with: VCR 6.3.1

--- a/src/api/spec/cassettes/SourcePackageController/GET_show/with_deleted_parameter_set/when_the_project_is_deleted/1_1_4_1_1.yml
+++ b/src/api/spec/cassettes/SourcePackageController/GET_show/with_deleted_parameter_set/when_the_project_is_deleted/1_1_4_1_1.yml
@@ -1,0 +1,290 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/hans/_meta?user=user_1
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="hans">
+          <title>Let Us Now Praise Famous Men</title>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '152'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="hans">
+          <title>Let Us Now Praise Famous Men</title>
+          <description></description>
+          <person userid="tom" role="maintainer"/>
+        </project>
+  recorded_at: Wed, 28 May 2025 13:22:32 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/hans/franz/_meta?user=user_2
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="franz" project="hans">
+          <title>Let Us Now Praise Famous Men</title>
+          <description>Placeat voluptatem et aliquid.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '155'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="franz" project="hans">
+          <title>Let Us Now Praise Famous Men</title>
+          <description>Placeat voluptatem et aliquid.</description>
+        </package>
+  recorded_at: Wed, 28 May 2025 13:22:32 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/hans/franz/_config
+    body:
+      encoding: UTF-8
+      string: Qui vero reprehenderit. Quos facilis ut. Quo accusamus dolor.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="1" vrev="1">
+          <srcmd5>835b83a8e14dded90f7fe10619e5d15c</srcmd5>
+          <version>unknown</version>
+          <time>1748438552</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 28 May 2025 13:22:32 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/hans/franz/somefile.txt
+    body:
+      encoding: UTF-8
+      string: Consequatur voluptatibus expedita. Velit qui et. Accusamus nulla impedit.
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '207'
+    body:
+      encoding: UTF-8
+      string: |
+        <revision rev="2" vrev="2">
+          <srcmd5>594b07932c9a91fa6ae6aaf1eb6e1bcc</srcmd5>
+          <version>unknown</version>
+          <time>1748438552</time>
+          <user>unknown</user>
+          <comment></comment>
+          <requestid/>
+        </revision>
+  recorded_at: Wed, 28 May 2025 13:22:32 GMT
+- request:
+    method: delete
+    uri: http://backend:5352/source/hans?comment=&user=tom
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '21'
+    body:
+      encoding: UTF-8
+      string: '<status code="ok" />
+
+'
+  recorded_at: Wed, 28 May 2025 13:22:32 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/hans/_project/_meta?deleted=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '152'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="hans">
+          <title>Let Us Now Praise Famous Men</title>
+          <description></description>
+          <person userid="tom" role="maintainer"/>
+        </project>
+  recorded_at: Wed, 28 May 2025 13:22:32 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/hans/franz/_meta?deleted=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '155'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="franz" project="hans">
+          <title>Let Us Now Praise Famous Men</title>
+          <description>Placeat voluptatem et aliquid.</description>
+        </package>
+  recorded_at: Wed, 28 May 2025 13:22:32 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/hans/franz?deleted=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '290'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="franz" rev="2" vrev="2" srcmd5="594b07932c9a91fa6ae6aaf1eb6e1bcc">
+          <entry name="_config" md5="4377268dec3642f75f9b62528939b209" size="61" mtime="1748438552"/>
+          <entry name="somefile.txt" md5="da0a7ccb3e2ab2cb4a7fa345ae5ea5d1" size="73" mtime="1748438552"/>
+        </directory>
+  recorded_at: Wed, 28 May 2025 13:22:33 GMT
+recorded_with: VCR 6.3.1

--- a/src/api/spec/cassettes/SourcePackageController/GET_show/with_deleted_parameter_set/when_the_project_was_access_protected/1_1_4_4_1.yml
+++ b/src/api/spec/cassettes/SourcePackageController/GET_show/with_deleted_parameter_set/when_the_project_was_access_protected/1_1_4_4_1.yml
@@ -1,0 +1,37 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://backend:5352/source/hans/_project/_meta?deleted=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: _meta  no such file
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '116'
+    body:
+      encoding: UTF-8
+      string: |
+        <status code="404">
+          <summary>_meta: no such file</summary>
+          <details>404 _meta: no such file</details>
+        </status>
+  recorded_at: Wed, 28 May 2025 13:19:55 GMT
+recorded_with: VCR 6.3.1

--- a/src/api/spec/controllers/source_package_controller_spec.rb
+++ b/src/api/spec/controllers/source_package_controller_spec.rb
@@ -1,0 +1,84 @@
+RSpec.describe SourcePackageController, :vcr do
+  let(:user) { create(:confirmed_user, login: 'tom') }
+  let(:project) { create(:project, name: 'hans', maintainer: user) }
+  let!(:package) { create(:package_with_file, project: project, name: 'franz') }
+
+  describe 'GET #show' do
+    subject { get :show, params: { project: 'hans', package: 'franz' } }
+
+    before do
+      login user
+    end
+
+    it { expect(subject).to have_http_status(:success) }
+
+    context 'when the project does not exist' do
+      before do
+        project.destroy
+      end
+
+      it { expect(subject.headers['X-Opensuse-Errorcode']).to eql('unknown_project') }
+    end
+
+    context 'when the package does not exist' do
+      before do
+        package.destroy
+      end
+
+      it { expect(subject.headers['X-Opensuse-Errorcode']).to eql('unknown_package') }
+    end
+
+    # If you change things in this context and want to re-record cassettes you will have to reset your
+    # backend every time you run an example.
+    context 'with deleted parameter set' do
+      subject { get :show, params: { project: 'hans', package: 'franz', deleted: 1 } }
+
+      let(:revisions) { file_fixture('project-or-package-revisons.xml').read }
+
+      context 'when the project is deleted' do
+        before do
+          project.destroy
+        end
+
+        it { expect(subject).to have_http_status(:success) }
+      end
+
+      context 'when the package is deleted' do
+        before do
+          package.destroy
+        end
+
+        it { expect(subject).to have_http_status(:success) }
+      end
+
+      context 'when the project and the package are deleted', skip: 'FIXME: https://github.com/openSUSE/open-build-service/issues/17958' do
+        before do
+          package.destroy
+          project.destroy
+        end
+
+        it { expect(subject).to have_http_status(:success) }
+      end
+
+      context 'when the project was access protected' do
+        let(:project) { create(:forbidden_project, name: 'hans', maintainer: user) }
+
+        before do
+          project.destroy
+        end
+
+        it { expect(subject.headers['X-Opensuse-Errorcode']).to eql('unknown_project') }
+      end
+
+      context 'when the package was sourceaccess protected' do
+        let!(:package) { create(:forbidden_package, project: project, name: 'franz') }
+
+        before do
+          package.destroy
+        end
+
+        it { expect(subject.headers['X-Opensuse-Errorcode']).to eql('source_access_no_permission') }
+      end
+    end
+  end
+end

--- a/src/api/spec/factories/packages.rb
+++ b/src/api/spec/factories/packages.rb
@@ -225,5 +225,12 @@ FactoryBot.define do
         create(:project_status_package_fail_comment_attrib, package: package)
       end
     end
+
+    factory :forbidden_package do
+      after(:create) do |package|
+        create(:sourceaccess_flag, status: 'disable', package: package)
+        package.save
+      end
+    end
   end
 end

--- a/src/api/spec/factories/project.rb
+++ b/src/api/spec/factories/project.rb
@@ -93,6 +93,7 @@ FactoryBot.define do
     factory :forbidden_project do
       after(:create) do |project|
         create(:access_flag, status: 'disable', project: project)
+        project.store if CONFIG['global_write_through']
       end
     end
 


### PR DESCRIPTION
Project.get_by_name(project) raises if the project is deleted which
made it impossible to check for a package in a deleted project.

Also there is *no* significance to the revisions. Either you can fetch meta
(the last revision) or the project/package never existed. I guess I know where
this came from, fetching revisions of a project that never existed returns an
empty revisions list.

```
[1] pry(main)> Backend::Api::Sources::Project.revisions('rutzelfulz13892')
=> "<revisionlist>\n</revisionlist>\n"
[2] pry(main)> Backend::Api::Sources::Package.revisions('rutzelfulz13892', '38sjwj2')
=> "<revisionlist>\n</revisionlist>\n"
```

Probably confused whoever wrote this first...