### PR TITLE
[backend] bs_srcserver: fix mkosi recipe detection when using obs_scm

### DIFF
--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -995,7 +995,7 @@ sub findfile {
   return $files{'simpleimage'} if $files{'simpleimage'};
   return $files{'snapcraft.yaml'} if $ext eq 'snapcraft';
   return (grep {/flatpak\.(?:ya?ml|json)$/} sort keys %$files)[0] if $ext eq 'flatpak';
-  return (grep {/^mkosi(?:\..*)?\.conf$/} sort keys %$files)[0] if $ext eq 'mkosi';
+  return (grep {/mkosi(?:\..*)?\.conf$/} sort keys %$files)[0] if $ext eq 'mkosi';
 
   my $packid = $rev->{'package'};
   $packid = $1 if $rev->{'originpackage'} && $rev->{'originpackage'} =~ /:([^:]+)$/;


### PR DESCRIPTION
When using obs_scm to fetch recipes, the files are prefixed with _service:obs_scm, e.g.: _service:obs_scm:mkosi.conf so the regex as amended by https://github.com/openSUSE/open-build-service/pull/17863 won't match anymore due to the leading '^'. Drop it so that images can be scheduled for building again.

Follow-up for 27f9b065d7a9edb9bd41ebabe5801a1312f69d5a

Tested on a local OBS VM, fixes the issue.