### PR TITLE
Fix reopening a previously staged request

### DIFF
--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -655,7 +655,9 @@ class BsRequest < ApplicationRecord
     with_lock do
       new_review_state = new_review_state.to_sym
 
-      raise InvalidStateError, 'request is not in a changeable state (new, review or declined)' unless state == :review || (state.in?(%i[new declined]) && new_review_state == :new)
+      unless state == :review || (state.in?(%i[new declined]) && new_review_state == :new) || opts[:relaxed_state_check]
+        raise InvalidStateError, 'request is not in a changeable state (new, review or declined)'
+      end
 
       check_if_valid_review!(opts)
       raise InvalidStateError, "review state must be new, accepted, declined or superseded, was #{new_review_state}" unless new_review_state.in?(%i[new accepted declined superseded])

--- a/src/api/app/models/staging/staged_requests.rb
+++ b/src/api/app/models/staging/staged_requests.rb
@@ -123,7 +123,7 @@ class Staging::StagedRequests
 
   def add_review_for_unstaged_declined_request(request, staging_project)
     request.addreview(by_group: staging_workflow.managers_group.title, comment: "Being evaluated by group \"#{staging_workflow.managers_group}\"", relaxed_state_check: 1)
-    request.change_review_state('declined', by_project: staging_project.name, comment: "Unstaged from project \"#{staging_project}\"")
+    request.change_review_state('accepted', by_project: staging_project.name, comment: "Unstaged from project \"#{staging_project}\"", relaxed_state_check: 1)
   end
 
   def remove_packages(staging_project_packages)


### PR DESCRIPTION
Release managers:

1. Stage the BsRequest into a StagingProject
  - which creates a Review.by_project for StagingProject
  - and adds the BsRequest to StagingProject.staged_requests
2. Find out that the BsRequest is not up to standard
3. Decline the BsRequest
4. Unstage the BsRequest from the StagingProject
  - which removes the BsRequest from StagingProject.staged_requests
  - and declines the Review.by_project for StagingProject

The submitter:

1. disagrees and reopens the BsRequest
   - which sets the Review.by_project for StagingProject to new

Now we have a Review.by_project for StagingProject without the BsRequest being in StagingProject.staged_requests. That breaks the staging workflow because you always have the dangling review on the BsRequest for a StagingProject the request is no in anymore...

If we set the Review.by_project for StagingProject to accepted when we unstage the BsRequest from the StagingProject then reopening the BsRequest will not touch the Review.by_project for StagingProject.