### PR TITLE
[backend] findfile: use %files instead of %$files for mkosi matching

### DIFF
--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -995,7 +995,7 @@ sub findfile {
   return $files{'simpleimage'} if $files{'simpleimage'};
   return $files{'snapcraft.yaml'} if $ext eq 'snapcraft';
   return (grep {/flatpak\.(?:ya?ml|json)$/} sort keys %$files)[0] if $ext eq 'flatpak';
-  return (grep {/^mkosi(?:\..*)?\.conf$/} sort keys %$files)[0] if $ext eq 'mkosi';
+  return (map {$files{$_}} grep {/^mkosi(?:\..*)?\.conf$/} sort keys %files)[0] if $ext eq 'mkosi';
 
   my $packid = $rev->{'package'};
   $packid = $1 if $rev->{'originpackage'} && $rev->{'originpackage'} =~ /:([^:]+)$/;


### PR DESCRIPTION
%files contains the files with the _service prefix stripped.