### PR TITLE
Fix `dev:assignments` rake task

### DIFF
--- a/src/api/lib/tasks/dev/assignments.rake
+++ b/src/api/lib/tasks/dev/assignments.rake
@@ -10,6 +10,7 @@ namespace :dev do
     project = RakeSupport.find_or_create_project('home:Admin', admin)
     package = Package.where(name: 'hello_world', project: project).first ||
               create(:package_with_files, name: 'hello_world', project: project)
+    Relationship.find_or_create_by(user: iggy, package: package, role: Role.hashed['maintainer'])
     Assignment.create!(assigner: admin, assignee: iggy, package: package)
   end
 end

--- a/src/api/lib/tasks/dev/assignments.rake
+++ b/src/api/lib/tasks/dev/assignments.rake
@@ -11,6 +11,6 @@ namespace :dev do
     package = Package.where(name: 'hello_world', project: project).first ||
               create(:package_with_files, name: 'hello_world', project: project)
     Relationship.find_or_create_by(user: iggy, package: package, role: Role.hashed['maintainer'])
-    Assignment.create!(assigner: admin, assignee: iggy, package: package)
+    Assignment.find_or_create_by(assigner: admin, assignee: iggy, package: package)
   end
 end


### PR DESCRIPTION
Only for the development enviroment.

Otherwise, we receive the following exception:

```bash
:/obs/src/api> rake dev:assignments
rake aborted!
ActiveRecord::RecordInvalid: Validation failed: Package has already been taken (ActiveRecord::RecordInvalid)
/obs/src/api/lib/tasks/dev/assignments.rake:15:in 'block (2 levels) in <top (required)>'
:/obs/src/api>
```