### PR TITLE
[backend] Add annotations to the concatenated project configs

### DIFF
--- a/src/backend/BSRepServer/ProjPacks.pm
+++ b/src/backend/BSRepServer/ProjPacks.pm
@@ -148,11 +148,12 @@ sub getconfig {
     $config .= "%define _is_this_project $new_is_this_project\n" if $new_is_this_project ne $old_is_this_project;
     $config .= "%define _is_in_project $new_is_in_project\n" if $new_is_in_project ne $old_is_in_project;
     ($old_is_this_project, $old_is_in_project) = ($new_is_this_project, $new_is_in_project);
+    $config .= "#!!line $p:0\n";
 
     # get rid of the Macros sections
-    my $s1 = '^\s*macros:\s*$.*?^\s*:macros\s*$';
+    my $s1 = '^[ \t]*macros:[ \t]*$(.*?)^[ \t]*:macros[ \t]*$';
     my $s2 = '^\s*macros:\s*$.*\Z';
-    $c =~ s/$s1//gmsi;
+    $c =~ s/$s1/$1 =~ tr!\n!!cdr/gmsie;		# keep newlines
     $c =~ s/$s2//gmsi;
     $config .= $c;
   }

--- a/src/backend/BSSched/ProjPacks.pm
+++ b/src/backend/BSSched/ProjPacks.pm
@@ -1636,11 +1636,12 @@ sub getconfig {
     $config .= "%define _is_this_project $new_is_this_project\n" if $new_is_this_project ne $old_is_this_project;
     $config .= "%define _is_in_project $new_is_in_project\n" if $new_is_in_project ne $old_is_in_project;
     ($old_is_this_project, $old_is_in_project) = ($new_is_this_project, $new_is_in_project);
+    $config .= "#!!line $p:0\n";
 
     # get rid of the Macros sections
-    my $s1 = '^\s*macros:\s*$.*?^\s*:macros\s*$';
+    my $s1 = '^[ \t]*macros:[ \t]*$(.*?)^[ \t]*:macros[ \t]*$';
     my $s2 = '^\s*macros:\s*$.*\Z';
-    $c =~ s/$s1//gmsi;
+    $c =~ s/$s1/$1 =~ tr!\n!!cdr/gmsie;		# keep newlines
     $c =~ s/$s2//gmsi;
     $config .= $c;
   }

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -2675,6 +2675,7 @@ sub concatconfigs {
     $config .= "%define _is_this_project $new_is_this_project\n" if $new_is_this_project ne $old_is_this_project;
     $config .= "%define _is_in_project $new_is_in_project\n" if $new_is_in_project ne $old_is_in_project;
     ($old_is_this_project, $old_is_in_project) = ($new_is_this_project, $new_is_in_project);
+    $config .= "#!!line $p:0\n";
 
     if ($c =~ /^\s*:macros\s*$/im) {
       # probably some multiple macro sections with %if statements


### PR DESCRIPTION
This gives us nice error messages with contain the project and the correct line numbers when a config cannot be parsed.