### PR TITLE
Add data migration to set to `light` the default color theme

### DIFF
--- a/src/api/db/data/20250521152851_set_default_for_color_theme.rb
+++ b/src/api/db/data/20250521152851_set_default_for_color_theme.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class SetDefaultForColorTheme < ActiveRecord::Migration[7.2]
+  def up
+    User.where(in_beta: false, color_theme: :system).in_batches do |batch|
+      batch.find_each do |user|
+        user.update_columns(color_theme: :light) # rubocop:disable Rails/SkipsModelValidations
+      end
+    end
+    DisabledBetaFeature.where(name: 'color_themes').find_each do |disabled_beta_feature|
+      disabled_beta_feature.user.update_columns(color_theme: :light) # rubocop:disable Rails/SkipsModelValidations
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/src/api/db/data_schema.rb
+++ b/src/api/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20250411000109)
+DataMigrate::Data.define(version: 20250521152851)

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_04_30_113947) do
+ActiveRecord::Schema[7.2].define(version: 2025_04_30_113947) do
   create_table "active_storage_attachments", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false


### PR DESCRIPTION
Those users who haven't tried the beta program will like to still use the 'light' color theme of OBS. This data migration makes sure the color theme doesn't change for them.

For new users from now own, the default of 'system' makes sense.