### PR TITLE
Preserve staged requests' styles on datatable collapsed columns

### DIFF
--- a/src/api/app/assets/stylesheets/webui/staging-workflow.scss
+++ b/src/api/app/assets/stylesheets/webui/staging-workflow.scss
@@ -75,7 +75,7 @@ ul .table-list-group-item {
       }
     }
   }
-  &.requests {
+  &.requests, &.child {
     .request-elements { min-width: 20rem; }
 
     span.badge {


### PR DESCRIPTION
Follow up to #17910.

### Before

| Light mode | Dark mode |
| --- | --- |
| ![Screenshot From 2025-05-22 13-42-22](https://github.com/user-attachments/assets/70f0616f-2660-4422-a4d4-4d965a2d4b17) | ![Screenshot From 2025-05-22 13-42-29](https://github.com/user-attachments/assets/97648cda-df85-43fd-a95f-ec880a132970) |

### After

| Light mode | Dark mode |
| --- | --- |
| ![Screenshot From 2025-05-22 13-42-55](https://github.com/user-attachments/assets/93fdcfda-3fca-4833-8283-a4bd7846b880) | ![Screenshot From 2025-05-22 13-43-06](https://github.com/user-attachments/assets/d6f5f9b8-f614-4590-9ed3-ab051f248acc) |