### PR TITLE
obsstoragesetup: call prepare_os_settings

### DIFF
--- a/dist/obsstoragesetup
+++ b/dist/obsstoragesetup
@@ -8,6 +8,8 @@
 source /etc/sysconfig/obs-server
 source /usr/lib/obs/server/functions.setup-appliance.sh
 
+prepare_os_settings
+
 # instance defaults
 if [ -e /etc/buildhost.config ]; then
   source /etc/buildhost.config


### PR DESCRIPTION
After sourcing functions.setup-appliance.sh, the function prepare_os_settings must be called to properly set some variables; in this specific case, the later call to prepare_obssigner must have OBS_SIGND set, which requires the call to prepare_os_settings