### PR TITLE
Turn `forward_allowed` method into a pundit policy

### DIFF
--- a/src/api/app/components/request_decision_component.html.haml
+++ b/src/api/app/components/request_decision_component.html.haml
@@ -28,7 +28,7 @@
           .tab-pane.fade{ id: 'preview_new_comment', role: 'tabpanel', 'aria-labelledby': 'preview-message-tab' }
             .comment-preview.message-preview.my-3
       .mt-2
-        - if @forward_allowed
+        - if policy(@bs_request).forward_request?
           - @action.forward.each_with_index do |forward, index|
             .form-check.m-2
               = check_box_tag("forward-#{index}", "#{forward[:project]}_#_#{forward[:package]}", true,

--- a/src/api/app/components/request_decision_component.rb
+++ b/src/api/app/components/request_decision_component.rb
@@ -7,7 +7,6 @@ class RequestDecisionComponent < ApplicationComponent
     @action = action
     @package_maintainers = package_maintainers
     @creator = bs_request.creator
-    @forward_allowed = forward_allowed?
 
     return unless render? && show_project_maintainer_hint
 
@@ -43,10 +42,6 @@ class RequestDecisionComponent < ApplicationComponent
 
   def accept_with_options_allowed?
     single_action_request && @is_target_maintainer && @bs_request.state.in?(%i[new review])
-  end
-
-  def forward_allowed?
-    @action.type == 'submit' && policy(@bs_request).accept_request? && @action.forward.any?
   end
 
   def make_maintainer_of

--- a/src/api/app/policies/bs_request_policy.rb
+++ b/src/api/app/policies/bs_request_policy.rb
@@ -46,6 +46,15 @@ class BsRequestPolicy < ApplicationPolicy
     record.state == :declined
   end
 
+  def forward_request?
+    # A user who has permission to accept a bs_request has a maintainer role on all targets
+    # of the associated bs_request_actions
+    return false unless accept_request?
+
+    # Only bs_request_actions of type submit can be forwarded
+    record.bs_request_actions.where(type: :submit).any? { |submit_action| submit_action.forward.any? }
+  end
+
   private
 
   def author?


### PR DESCRIPTION
In the end this is authorization logic and therefore a Pundit policy is the better suited.

Logic is extracted from https://github.com/openSUSE/open-build-service/pull/17595 and turned into a pundit policy.