### PR TITLE
Turn `show_add_submitter_as_maintainer_option?` into a pundit policy

### DIFF
--- a/src/api/app/components/request_decision_component.html.haml
+++ b/src/api/app/components/request_decision_component.html.haml
@@ -45,7 +45,7 @@
                         title: 'Decline the request, as the author of the request you can reopen it again.')
         - if policy(@bs_request).accept_request?
           -# Hidden checkbox input to flag make_maintainer option
-          - if accept_with_options_allowed? && show_add_submitter_as_maintainer_option?
+          - if accept_with_options_allowed? && policy(@bs_request).add_creator_as_maintainer?
             .form-check.mb-2.mt-2.d-none
               = check_box_tag('add_submitter_as_maintainer_0', "#{@action.target_project}_#_#{@action.target_package}",
                               false, class: 'form-check-input')
@@ -58,7 +58,7 @@
               = submit_tag('Accept request', name: 'accepted', class: 'btn-link dropdown-item', data: confirmation,
                             title: 'Accept the request, this will apply the changes on the target.')
               -# Accept and make maintainer submit
-              - if accept_with_options_allowed? && show_add_submitter_as_maintainer_option?
+              - if accept_with_options_allowed? && policy(@bs_request).add_creator_as_maintainer?
                 = submit_tag("Accept and make #{@creator} maintainer of #{make_maintainer_of}",
                             name: 'accepted',
                             class: 'btn-link dropdown-item', data: confirmation,

--- a/src/api/app/components/request_decision_component.rb
+++ b/src/api/app/components/request_decision_component.rb
@@ -36,10 +36,6 @@ class RequestDecisionComponent < ApplicationComponent
     { confirm: "Do you really want to #{decision_text} this request?\n\n#{@package_maintainers_hint}" }
   end
 
-  def show_add_submitter_as_maintainer_option?
-    @action.type == 'submit' && !@action.creator_is_target_maintainer
-  end
-
   def accept_with_options_allowed?
     single_action_request && @is_target_maintainer && @bs_request.state.in?(%i[new review])
   end

--- a/src/api/app/policies/bs_request_policy.rb
+++ b/src/api/app/policies/bs_request_policy.rb
@@ -55,6 +55,14 @@ class BsRequestPolicy < ApplicationPolicy
     record.bs_request_actions.where(type: :submit).any? { |submit_action| submit_action.forward.any? }
   end
 
+  def add_creator_as_maintainer?
+    # A user who has permission to accept a bs_request has a maintainer role on all targets
+    # of the associated bs_request_actions
+    return false unless accept_request?
+
+    record.bs_request_actions.where(type: :submit).any? { |submit_action| !submit_action.creator_is_target_maintainer }
+  end
+
   private
 
   def author?


### PR DESCRIPTION
This method is basically authorization logic, and therefore should be a Pundit policy. Currently this method also (besides some other authorization logic in the same view component) heavily depends on being correctly nested (e.g must be nested under the policy of  `accept_request?`...).
This easily leads to mistakes in further code movements and makes the review process hard since you have to look up many places in order to get the full picture.
For the sake of readability and therefore preventing possible mistakes, it makes sense to have some redundancy over complicated nesting. Some redundancy will disappear with further commits. But to make it easier to review I will do this in steps...

Logic is extracted from https://github.com/openSUSE/open-build-service/pull/17595 and turned into a pundit policy.