### PR TITLE
No underlined text on build badge

### DIFF
--- a/src/api/app/views/webui/shared/_build_status_badge.html.haml
+++ b/src/api/app/views/webui/shared/_build_status_badge.html.haml
@@ -1,6 +1,6 @@
 - if url
   .dropdown
-    %button{ class: "btn btn-link badge #{build_status_category_color(status)} build_status dropdown-toggle",
+    %button{ class: "btn badge #{build_status_category_color(status)} build_status dropdown-toggle",
           data: { 'bs-toggle': 'dropdown' } }
       %i.fa.me-2{ class: build_status_icon(status), title: status.humanize }
       %span.architecture #{architecture} :


### PR DESCRIPTION
## Before

![image](https://github.com/user-attachments/assets/d21be847-1040-4ff3-aab0-c99aced09753)


## After

![image](https://github.com/user-attachments/assets/68786123-6d34-4669-ad94-03d23c3d29a8)
