### PR TITLE
Revert "Use dropdown instead of popover for double links"

### DIFF
--- a/src/api/app/views/webui/shared/_build_status_badge.html.haml
+++ b/src/api/app/views/webui/shared/_build_status_badge.html.haml
@@ -1,15 +1,23 @@
 - if url
-  .dropdown
-    %button{ class: "btn btn-link badge #{build_status_category_color(status)} build_status dropdown-toggle",
-          data: { 'bs-toggle': 'dropdown' } }
-      %i.fa.me-2{ class: build_status_icon(status), title: status.humanize }
-      %span.architecture #{architecture} :
-      = text
-    .dropdown-menu
-      = link_to 'Live build log', url, class: 'dropdown-item', target: '_blank'
-      = link_to 'RPM lint', rpm_lint_url, class: 'dropdown-item', target: '_blank'
+  - popover_content = render partial: 'webui/shared/build_status_badge_links', locals: { url: url, rpm_lint_url: rpm_lint_url }
+
+  %button{ class: "btn btn-link badge #{build_status_category_color(status)} build_status",
+         data: { 'bs-toggle': 'popover', 'bs-html': true, 'bs-content': popover_content } }
+    %i.fa.me-2{ class: build_status_icon(status), title: status.humanize }
+    %span.architecture #{architecture} :
+    = text
 - else
   %span.badge{ class: build_status_category_color(status), title: details }
     %i.fa.me-2{ class: build_status_icon(status) }
     %span.architecture #{architecture} :
     = text
+
+:javascript
+  $(function () {
+    $('button.badge.build_status[data-bs-toggle="popover"]').popover({
+      html: true,
+      trigger: 'focus',
+      container: 'body',
+      placement: 'top'
+    });
+  });

--- a/src/api/app/views/webui/shared/_build_status_badge_links.html.haml
+++ b/src/api/app/views/webui/shared/_build_status_badge_links.html.haml
@@ -1,0 +1,3 @@
+= link_to 'Live build log', url, target: '_blank'
+%hr
+= link_to 'RPM lint', rpm_lint_url, target: '_blank'


### PR DESCRIPTION
This reverts commit e2388cfb23be39102166b66eb62d1f65298ddff0.

Dropdown is used in this case inside of an accordion, and when the accordion content has only one/few rows, there is no space to show the dropdown content, and this makes the accordion content box to overflow and scroll to see the dropdown content. Using the popover makes this glitch go away.


## Dropdown glitch
![dropdown-glitch](https://github.com/user-attachments/assets/a5df1152-2822-426d-a97c-4c9866620317)
