### PR TITLE
Handle the comment js errors

### DIFF
--- a/src/api/app/assets/javascripts/webui/comment.js
+++ b/src/api/app/assets/javascripts/webui/comment.js
@@ -14,6 +14,15 @@ function updateCommentCounter(selector, count) {
   }
 }
 
+function commentErrorFlash(text) {
+  const flash = document.getElementById('flash');
+  const container = flash.querySelector('.col-12');
+  const alert = document.createElement('div');
+  alert.classList.add('alert', 'alert-danger');
+  alert.innerText = text;
+  container.appendChild(alert);
+}
+
 function validateForm(e) {
   var submitButton = $(e.target).closest('[class*="-comment-form"]').find('input[type="submit"]');
   submitButton.prop('disabled', !$(e.target).val());
@@ -33,6 +42,10 @@ function handlingCommentEvents() {
   // from the controller and replace the whole .comments-list with it
   const commentListSelector = '.comments-list .post-comment-form, .comments-list .put-comment-form, .comments-list .moderate-form';
   $(document).on('ajax:complete', commentListSelector, function(_, data) {
+    if (data.status !== 200) {
+      commentErrorFlash('Failed to submit the comment.');
+      return;
+    }
     var $commentsList = $(this).closest('.comments-list');
 
     $commentsList.html(data.responseText);
@@ -45,11 +58,19 @@ function handlingCommentEvents() {
                                 .diff-accordion .post-comment-form, .diff-accordion .put-comment-form,
                                 .diff-accordion .moderate-form`;
   $(document).on('ajax:complete', timelineDiffSelector, function(_, data) {
+    if (data.status !== 200) {
+      commentErrorFlash('Failed to submit the comment.');
+      return;
+    }
     $(this).closest('.comments-thread').html(data.responseText);
   });
 
   // This is being used to render a new root comment by the beta request show view
   $(document).on('ajax:complete', '.comment_new .post-comment-form', function(_, data) {
+    if (data.status !== 200) {
+      commentErrorFlash('Failed to create a comment.');
+      return;
+    }
     $(this).closest('.comment_new').prev().append(
       '<div class="timeline-item">' +
         '<div class="comments-thread">' +
@@ -62,6 +83,10 @@ function handlingCommentEvents() {
 
   // This is used to delete a comment from the legacy request view
   $(document).on('ajax:complete', '.comments-list .delete-comment-form', function(_, data) {
+    if (data.status !== 200) {
+      commentErrorFlash('Failed to delete the comment.');
+      return;
+    }
     var $this = $(this),
         $commentsList = $this.closest('.comments-list'),
         $form = $('#delete-comment-modal-' + $this.data('commentId'));
@@ -76,6 +101,10 @@ function handlingCommentEvents() {
 
   // This is used to delete comments from the beta request show view, we are not gonna get an updated comment thread like
   $(document).on('ajax:complete', '#delete-comment-modal form', function(_, data) {
+    if (data.status !== 200) {
+      commentErrorFlash('Failed to delete the comment.');
+      return;
+    }
     var $commentId = $(this).attr('action').split('/').slice(-1),
         $commentsList = $('[name=comment-' + $commentId + ']').closest('.comments-thread'),
         $form = $('#delete-comment-modal');

--- a/src/api/app/controllers/webui/comments_controller.rb
+++ b/src/api/app/controllers/webui/comments_controller.rb
@@ -11,22 +11,18 @@ class Webui::CommentsController < Webui::WebuiController
     build_new_comment(@commented, permitted_params)
     @commentable = @comment.commentable
 
-    status = if @comment.save
-               flash.now[:success] = 'Comment created successfully.'
-               :ok
-             else
-               flash.now[:error] = "Failed to create comment: #{@comment.errors.full_messages.to_sentence}."
-               :unprocessable_entity
-             end
+    if @comment.save
+      flash.now[:success] = 'Comment created successfully.'
+    else
+      flash.now[:error] = "Failed to create comment: #{@comment.errors.full_messages.to_sentence}."
+    end
 
     if Flipper.enabled?(:request_show_redesign, User.session) && %w[BsRequest BsRequestAction].include?(@comment.commentable_type)
       render(partial: 'webui/comment/beta/comments_thread',
-             locals: { comment: @comment.root, commentable: @commentable, level: 1, diff: diff },
-             status: status)
+             locals: { comment: @comment.root, commentable: @commentable, level: 1, diff: diff })
     else
       render(partial: 'webui/comment/comment_list',
-             locals: { commentable: @commentable },
-             status: status)
+             locals: { commentable: @commentable })
     end
   end
 
@@ -35,24 +31,20 @@ class Webui::CommentsController < Webui::WebuiController
     authorize @comment, :update?
     @comment.assign_attributes(permitted_params)
 
-    status = if @comment.save
-               flash.now[:success] = 'Comment updated successfully.'
-               :ok
-             else
-               flash.now[:error] = "Failed to update comment: #{@comment.errors.full_messages.to_sentence}."
-               :unprocessable_entity
-             end
+    if @comment.save
+      flash.now[:success] = 'Comment updated successfully.'
+    else
+      flash.now[:error] = "Failed to update comment: #{@comment.errors.full_messages.to_sentence}."
+    end
 
     respond_to do |format|
       format.html do
         if Flipper.enabled?(:request_show_redesign, User.session) && %w[BsRequest BsRequestAction].include?(@comment.commentable_type)
           render(partial: 'webui/comment/beta/comments_thread',
-                 locals: { comment: @comment.root, commentable: @comment.commentable, level: 1, diff: diff },
-                 status: status)
+                 locals: { comment: @comment.root, commentable: @comment.commentable, level: 1, diff: diff })
         else
           render(partial: 'webui/comment/comment_list',
-                 locals: { commentable: @comment.commentable },
-                 status: status)
+                 locals: { commentable: @comment.commentable })
         end
       end
     end
@@ -67,20 +59,17 @@ class Webui::CommentsController < Webui::WebuiController
     authorize @comment, :destroy?
     @commentable = @comment.commentable
 
-    status = if @comment.blank_or_destroy
-               flash.now[:success] = 'Comment deleted successfully.'
-               :ok
-             else
-               flash.now[:error] = "Failed to delete comment: #{@comment.errors.full_messages.to_sentence}."
-               :unprocessable_entity
-             end
+    if @comment.blank_or_destroy
+      flash.now[:success] = 'Comment deleted successfully.'
+    else
+      flash.now[:error] = "Failed to delete comment: #{@comment.errors.full_messages.to_sentence}."
+    end
 
     if Flipper.enabled?(:request_show_redesign, User.session) && %w[BsRequest BsRequestAction].include?(@comment.commentable_type)
       if @comment.commentable_type == 'BsRequestAction' &&
          Comment.where(commentable: @comment.commentable, diff_file_index: @comment.root.diff_file_index, diff_line_number: @comment.root.diff_line_number).count.zero?
         return render(partial: 'webui/request/add_inline_comment',
-                      locals: { commentable: @comment.root.commentable, diff_file_index: @comment.root.diff_file_index, diff_line_number: @comment.root.diff_line_number },
-                      status: status)
+                      locals: { commentable: @comment.root.commentable, diff_file_index: @comment.root.diff_file_index, diff_line_number: @comment.root.diff_line_number })
       end
       # if we're a root comment with no replies there is no need to re-render anything
       return head(:ok) if @comment.root? && @comment.leaf?
@@ -92,9 +81,9 @@ class Webui::CommentsController < Webui::WebuiController
       return head(:ok) if !@comment.root? && @comment.ancestors.all?(&:destroyed?)
 
       # if we're a reply or a comment with replies we should re-render the updated thread
-      render(partial: 'webui/comment/beta/comments_thread', locals: { comment: @comment.root, commentable: @commentable, level: 1, diff: diff }, status: status)
+      render(partial: 'webui/comment/beta/comments_thread', locals: { comment: @comment.root, commentable: @commentable, level: 1, diff: diff })
     else
-      render(partial: 'webui/comment/comment_list', locals: { commentable: @commentable }, status: status)
+      render(partial: 'webui/comment/comment_list', locals: { commentable: @commentable })
     end
   end
   # rubocop: enable Metrics/CyclomaticComplexity
@@ -112,22 +101,18 @@ class Webui::CommentsController < Webui::WebuiController
 
     state = ActiveModel::Type::Boolean.new.cast(params[:moderation_state])
 
-    status = if @comment.moderate(state)
-               flash.now[:success] = 'Comment moderated successfully.'
-               :ok
-             else
-               flash.now[:error] = "Failed to moderate comment: #{@comment.errors.full_messages.to_sentence}."
-               :unprocessable_entity
-             end
+    if @comment.moderate(state)
+      flash.now[:success] = 'Comment moderated successfully.'
+    else
+      flash.now[:error] = "Failed to moderate comment: #{@comment.errors.full_messages.to_sentence}."
+    end
 
     if Flipper.enabled?(:request_show_redesign, User.session) && %w[BsRequest BsRequestAction].include?(@comment.commentable_type)
       render(partial: 'webui/comment/beta/comments_thread',
-             locals: { comment: @comment.root, commentable: @comment.commentable, level: 1, diff: diff },
-             status: status)
+             locals: { comment: @comment.root, commentable: @comment.commentable, level: 1, diff: diff })
     else
       render(partial: 'webui/comment/comment_list',
-             locals: { commentable: @comment.commentable },
-             status: status)
+             locals: { commentable: @comment.commentable })
     end
   end
 


### PR DESCRIPTION
All proper responses from the controller now return status code 200, while any other kind of response will render an alert at the top of the page

Fixes #17750
Fixes #4524
