### PR TITLE
[api] fix behaviour on project meta change of scmsync project

### DIFF
--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -1037,6 +1037,12 @@ class Project < ApplicationRecord
                                                                .joins(:bs_request_actions), name).call
   end
 
+  def open_requests_with_project_as_target
+    # Includes also requests for packages contained in this project
+    OpenRequestsWithProjectAsTargetFinder.new(BsRequest.where(state: %i[new review declined])
+                                                               .joins(:bs_request_actions), name).call
+  end
+
   def open_requests_with_by_project_review
     # Includes also by_package reviews for packages contained in this project
     OpenRequestsWithByProjectReviewFinder.new(BsRequest.where(state: %i[new review])

--- a/src/api/app/models/project/update_from_xml_command.rb
+++ b/src/api/app/models/project/update_from_xml_command.rb
@@ -49,7 +49,10 @@ class Project
 
       return if project.scmsync.blank?
 
-      project.revoke_requests
+      # decline all requests targeting this project (using it as source is fine)
+      project.open_requests_with_project_as_target.each do |request|
+        request.change_state(newstate: 'declined', comment: "The target project '#{project.name}' has been switched to scmsync")
+      end
       project.cleanup_packages
     end
 

--- a/src/api/app/queries/open_requests_with_project_as_source_or_target_finder.rb
+++ b/src/api/app/queries/open_requests_with_project_as_source_or_target_finder.rb
@@ -1,9 +1,4 @@
 class OpenRequestsWithProjectAsSourceOrTargetFinder < OpenRequestsFinder
-  def initialize(relation, project_name)
-    @relation = relation
-    @project_name = project_name
-  end
-
   def requests_finder
     @relation.where('bs_request_actions.source_project = ? or bs_request_actions.target_project = ?', @project_name, @project_name)
   end

--- a/src/api/app/queries/open_requests_with_project_as_target_finder.rb
+++ b/src/api/app/queries/open_requests_with_project_as_target_finder.rb
@@ -1,0 +1,5 @@
+class OpenRequestsWithProjectAsTargetFinder < OpenRequestsFinder
+  def requests_finder
+    @relation.where(bs_request_actions: { target_project: @project_name })
+  end
+end

--- a/src/api/spec/queries/open_requests_with_by_project_review_finder_spec.rb
+++ b/src/api/spec/queries/open_requests_with_by_project_review_finder_spec.rb
@@ -10,8 +10,6 @@ RSpec.describe OpenRequestsWithByProjectReviewFinder do
                                                         .joins(:reviews), project.name).call
     end
 
-    it { expect(subject).not_to be_empty }
-
-    it { expect(subject).to include(bs_request) }
+    it { expect(subject).to contain_exactly(bs_request) }
   end
 end

--- a/src/api/spec/queries/open_requests_with_project_as_target_finder_spec.rb
+++ b/src/api/spec/queries/open_requests_with_project_as_target_finder_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe OpenRequestsWithProjectAsSourceOrTargetFinder do
+RSpec.describe OpenRequestsWithProjectAsTargetFinder do
   let(:target_project) { create(:project, name: 'target_project') }
   let(:source_project) { create(:project, name: 'source_project') }
   let(:target_package) { create(:package, name: 'target_package', project: target_project) }
@@ -15,14 +15,8 @@ RSpec.describe OpenRequestsWithProjectAsSourceOrTargetFinder do
 
   describe 'call' do
     subject do
-      OpenRequestsWithProjectAsSourceOrTargetFinder.new(BsRequest.where(state: %i[new review declined])
-                                                       .joins(:bs_request_actions), project.name).call
-    end
-
-    context 'project as source' do
-      let(:project) { source_project }
-
-      it { expect(subject).to contain_exactly(submit_request) }
+      OpenRequestsWithProjectAsTargetFinder.new(BsRequest.where(state: %i[new review declined])
+                                                .joins(:bs_request_actions), project.name).call
     end
 
     context 'project as target' do


### PR DESCRIPTION
We must only decline requests using the project as target, but not as source.

Otherwise any random meta change leads to revoke requests when a project meta change happens.