### PR TITLE
Prevent to hit rpmlint_log action if no builds yet

### DIFF
--- a/src/api/app/views/webui/package/_rpmlint_result.html.haml
+++ b/src/api/app/views/webui/package/_rpmlint_result.html.haml
@@ -1,16 +1,16 @@
 - index ||= ''
 
-.mt-3.mb-3{ id: "rpmlin-log-#{index}", data: { project: project.name, package: package.name } }
-  - if repository_list.empty?
-    = render partial: 'no_build_results', locals: { project: project }
-  - else
+- if repository_list.empty?
+  = render partial: 'no_build_results', locals: { project: project }
+- else
+  .mt-3.mb-3{ id: "rpmlin-log-#{index}", data: { project: project.name, package: package.name } }
     .row.row-cols-auto
       = select_tag("rpmlint_repo_select_#{index}", options_for_select(repository_list.sort),
-                   class: 'form-select', onchange: "updateArchDisplay('#{index}')")
+                  class: 'form-select', onchange: "updateArchDisplay('#{index}')")
       - repo_arch_hash.each do |repository, architectures|
         = select_tag("rpmlint_arch_select_#{index}_#{repository}", options_for_select(architectures.reverse),
-                     class: "rpmlint_arch_select_#{index} form-select", onchange: "updateRpmlintDisplay('#{index}')")
-%pre.rpmlint-result.text-pre-wrap{ id: "rpmlint_display_#{index}" }
+                    class: "rpmlint_arch_select_#{index} form-select", onchange: "updateRpmlintDisplay('#{index}')")
+  %pre.rpmlint-result.text-pre-wrap{ id: "rpmlint_display_#{index}" }
 
-:javascript
-  updateArchDisplay('#{index}');
+  :javascript
+    updateArchDisplay('#{index}');

--- a/src/api/app/views/webui/package/beta/rpmlint_result.html.haml
+++ b/src/api/app/views/webui/package/beta/rpmlint_result.html.haml
@@ -6,24 +6,27 @@
   .card-body
     %h3= @pagetitle
     .rpm-lint-content
-      .pt-1.bg-card.d-flex.flex-wrap-reverse.align-items-baseline.sticky-top
-        .result
-          #rpmlint-log{ data: { project: project.name, package: package.name } }
-            - unless repository_list.empty?
-              .row
-                .col-auto
-                  = select_tag('rpmlint_repo_select', options_for_select(repository_list.sort, repository),
-                              class: 'form-select mb-3', onchange: 'updateRpmLintArchitectures()' )
-                .col-auto
-                  - repo_arch_hash.each do |repository, architectures|
-                    = select_tag("rpmlint_arch_select_#{repository}", options_for_select(architectures.reverse, architecture),
-                                class: 'rpmlint_arch_select form-select mb-3', onchange: 'updateRpmLintLog()')
+      - if repository_list.empty?
+        = render partial: 'no_build_results', locals: { project: project }
+      - else
+        .pt-1.bg-card.d-flex.flex-wrap-reverse.align-items-baseline.sticky-top
+          .result
+            #rpmlint-log{ data: { project: project.name, package: package.name } }
+              - unless repository_list.empty?
+                .row
+                  .col-auto
+                    = select_tag('rpmlint_repo_select', options_for_select(repository_list.sort, repository),
+                                class: 'form-select mb-3', onchange: 'updateRpmLintArchitectures()' )
+                  .col-auto
+                    - repo_arch_hash.each do |repository, architectures|
+                      = select_tag("rpmlint_arch_select_#{repository}", options_for_select(architectures.reverse, architecture),
+                                  class: 'rpmlint_arch_select form-select mb-3', onchange: 'updateRpmLintLog()')
 
-        .btn.btn-outline-primary.rpm-lint-refresh.ms-auto.mb-3{ onclick: 'updateRpmLintLog()', accesskey: 'r', title: 'Refresh Rpm Lint Results' }
-          Refresh
-          %i.fas.fa-sync-alt{ id: 'rpm-lint-reload' }
+          .btn.btn-outline-primary.rpm-lint-refresh.ms-auto.mb-3{ onclick: 'updateRpmLintLog()', accesskey: 'r', title: 'Refresh Rpm Lint Results' }
+            Refresh
+            %i.fas.fa-sync-alt{ id: 'rpm-lint-reload' }
 
-      %pre.rpmlint-result.text-pre-wrap
+        %pre.rpmlint-result.text-pre-wrap
 
-    :javascript
-      updateRpmLintArchitectures();
+        :javascript
+          updateRpmLintArchitectures();


### PR DESCRIPTION
Fixes https://github.com/openSUSE/open-build-service/issues/17960

The changes look quite complex but it's just because of the indentation. It only wraps and prevents to run the js call in case of the condition `repository_list.empty?` that means that there are no builds yet available despite repositories are configured already in the related project.

Depends on https://github.com/openSUSE/open-build-service/pull/17970