### PR TITLE
Move require_login to the top of the before_action list

### DIFF
--- a/src/api/app/controllers/webui/kiwi/images_controller.rb
+++ b/src/api/app/controllers/webui/kiwi/images_controller.rb
@@ -1,10 +1,10 @@
 module Webui
   module Kiwi
     class ImagesController < WebuiController
+      before_action :require_login, only: :import_from_package
       before_action :set_image, except: [:import_from_package]
       before_action :authorize_update, except: [:import_from_package]
       before_action :check_ajax, only: :build_result
-      before_action :require_login, only: :import_from_package
 
       def import_from_package
         package = Package.find(params[:package_id])

--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -6,6 +6,10 @@ class Webui::PackageController < Webui::WebuiController
   include Webui::NotificationsHandler
 
   # rubocop:disable Rails/LexicallyScopedActionFilter
+  before_action :require_login, except: %i[show index branch_diff_info
+                                           users requests statistics revisions view_file
+                                           devel_project buildresult rpmlint_result rpmlint_log files]
+
   # The methods save_person, save_group and remove_role are defined in Webui::ManageRelationships
   before_action :set_project, only: %i[show edit update index users requests statistics revisions
                                        new branch_diff_info rdiff create remove
@@ -22,10 +26,6 @@ class Webui::PackageController < Webui::WebuiController
 
   before_action :check_ajax, only: %i[devel_project buildresult]
   # make sure it's after the require_, it requires both
-  before_action :require_login, except: %i[show index branch_diff_info
-                                           users requests statistics revisions view_file
-                                           devel_project buildresult rpmlint_result rpmlint_log files]
-
   prepend_before_action :lockout_spiders, only: %i[revisions rdiff requests]
 
   after_action :verify_authorized, only: %i[new create remove]

--- a/src/api/app/controllers/webui/packages/binaries_controller.rb
+++ b/src/api/app/controllers/webui/packages/binaries_controller.rb
@@ -10,6 +10,7 @@ module Webui
                                  Regexp.new('\.pkg\.tar(?:\.gz|\.xz|\.zst)?$'),
                                  Regexp.new('\.arch$')].freeze
 
+      before_action :require_login, except: [:index]
       before_action :set_project
       before_action :set_package
       before_action :set_multibuild_flavor
@@ -21,7 +22,6 @@ module Webui
 
       prepend_before_action :lockout_spiders
 
-      before_action :require_login, except: [:index]
       after_action :verify_authorized, only: [:destroy]
 
       def index

--- a/src/api/app/controllers/webui/patchinfo_controller.rb
+++ b/src/api/app/controllers/webui/patchinfo_controller.rb
@@ -2,11 +2,11 @@ require 'builder'
 
 class Webui::PatchinfoController < Webui::WebuiController
   include Webui::PackageHelper
+  before_action :require_login, except: [:show]
   before_action :set_project
   before_action :set_binaries, except: %i[show destroy new_tracker]
   before_action :require_package, except: %i[create new_tracker]
   before_action :require_exists, except: %i[create new_tracker]
-  before_action :require_login, except: [:show]
   before_action :set_patchinfo, only: %i[show edit]
 
   rescue_from Package::UnknownObjectError do

--- a/src/api/app/controllers/webui/projects/maintenance_incident_requests_controller.rb
+++ b/src/api/app/controllers/webui/projects/maintenance_incident_requests_controller.rb
@@ -1,9 +1,9 @@
 module Webui
   module Projects
     class MaintenanceIncidentRequestsController < WebuiController
-      before_action :set_project
-      before_action :lockout_spiders, only: [:new]
       before_action :require_login
+      before_action :lockout_spiders, only: [:new]
+      before_action :set_project
 
       after_action :verify_authorized
 

--- a/src/api/app/controllers/webui/projects/maintenance_incidents_controller.rb
+++ b/src/api/app/controllers/webui/projects/maintenance_incidents_controller.rb
@@ -1,9 +1,9 @@
 module Webui
   module Projects
     class MaintenanceIncidentsController < WebuiController
-      before_action :set_project, only: [:index]
-      before_action :lockout_spiders, only: [:index]
       before_action :require_login, only: [:create]
+      before_action :lockout_spiders, only: [:index]
+      before_action :set_project, only: [:index]
 
       after_action :verify_authorized, except: [:index]
 

--- a/src/api/app/controllers/webui/users/bs_requests_controller.rb
+++ b/src/api/app/controllers/webui/users/bs_requests_controller.rb
@@ -1,8 +1,8 @@
 module Webui
   module Users
     class BsRequestsController < WebuiController
-      before_action :redirect_legacy
       before_action :require_login
+      before_action :redirect_legacy
       before_action :set_bs_requests
 
       include Webui::RequestsFilter


### PR DESCRIPTION
Login is required for many actions before processing anything else, such as setting the project or similar. In some controllers, `require_login` appears further down the `before_action` list, causing certain helpers to run before authentication is checked. This PR addresses that issue.