### PR TITLE
Add null validation on attrib_type_id column on AttribDefaultValue table

### DIFF
--- a/src/api/.database_consistency.todo.yml
+++ b/src/api/.database_consistency.todo.yml
@@ -18,9 +18,6 @@ AttribAllowedValue:
     PrimaryKeyTypeChecker:
       enabled: false
 AttribDefaultValue:
-  attrib_type_id:
-    NullConstraintChecker:
-      enabled: false
   id:
     PrimaryKeyTypeChecker:
       enabled: false

--- a/src/api/app/models/attrib_default_value.rb
+++ b/src/api/app/models/attrib_default_value.rb
@@ -1,6 +1,8 @@
 class AttribDefaultValue < ApplicationRecord
   belongs_to :attrib_type, optional: true
   acts_as_list scope: :attrib_type
+
+  validates :attrib_type, presence: true
 end
 
 # == Schema Information

--- a/src/api/test/unit/attrib_test.rb
+++ b/src/api/test/unit/attrib_test.rb
@@ -47,7 +47,7 @@ class AttribTest < ActiveSupport::TestCase
     attrib_type = AttribType.new(attrib_namespace: @namespace, name: 'AttribDefaultValues')
     attrib = Attrib.new(attrib_type: attrib_type, package: Package.first)
     # default value position 1
-    attrib_type.default_values << AttribDefaultValue.new(value: 'xxx', position: 1)
+    attrib_type.default_values.build(value: 'xxx', position: 1)
     attrib_type.save
     attrib.values.build(attrib: attrib, position: 1)
     assert_equal 'xxx', attrib.values[0].value


### PR DESCRIPTION
We have a database backed null constraint on that column but no validation in the model.