### PR TITLE
Log Voight-Kampff result

### DIFF
--- a/src/api/config/environments/production.rb
+++ b/src/api/config/environments/production.rb
@@ -127,9 +127,13 @@ OBSApi::Application.configure do
     {
       params: event.payload[:params].except(*exceptions),
       host: event.payload[:headers].env['HTTP_X_FORWARDED_FOR']&.split(',')&.first || event.payload[:headers].env['REMOTE_ADDR'],
-      time: event.time,
       backend: event.payload[:backend_runtime],
       user: User.possibly_nobody
+    }
+  end
+  config.lograge.custom_payload do |controller|
+    {
+      bot: controller.request.bot?
     }
   end
 


### PR DESCRIPTION
Will help us to debug if a request was identified as coming from a known crawler, spider or bot.

Also: Stop logging the `ActiveSupport::Notifications::Event` time, we already have a time stamp in the log.

Result: 

```
I, [2025-06-05T16:07:51.933179 #6328]  INFO -- : [2e8aa000-6dc5-41fa-bb50-b96d5103211e] [6328:238.44] method=GET path=/about format=xml controller=AboutController action=index status=200 allocations=1575 duration=3.11 view=0.76 db=0.23 params={} host=some.i.p backend=0 user=_nobody_ bot=false
```