### PR TITLE
Avoid duplicated index in watchlist

### DIFF
--- a/src/api/app/controllers/webui/watched_items_controller.rb
+++ b/src/api/app/controllers/webui/watched_items_controller.rb
@@ -17,7 +17,7 @@ class Webui::WatchedItemsController < Webui::WebuiController
       watched_item.destroy
       flash[:success] = "Removed #{FLASH_PER_WATCHABLE_TYPE[@watchable.class]} from the watchlist"
     else
-      User.session.watched_items.create(watchable: @watchable)
+      User.session.watched_items.find_or_create_by(watchable: @watchable)
       flash[:success] = "Added #{FLASH_PER_WATCHABLE_TYPE[@watchable.class]} to the watchlist"
     end
 


### PR DESCRIPTION
If somehow the item was added to the watchlist in between the existence check and the creation attempt, we return the existing one instead of trying to create it and fail.
Adapt the flash message to fit both cases: just created or previously created.

Fixes #14700.