### PR TITLE
Display the right request state badge in Pulse

### DIFF
--- a/src/api/app/views/webui/projects/pulse/_pulse_list_requests.html.haml
+++ b/src/api/app/views/webui/projects/pulse/_pulse_list_requests.html.haml
@@ -1,8 +1,7 @@
 .row
   - requests.take(30).each do |request|
     %dt.col-12.col-md-2.col-lg-1
-      %span{ class: "badge progress-state-#{request.state} text-light" }
-        = request.state.to_s
+      = render BsRequestStateBadgeComponent.new(state: request.state, css_class: 'mb-auto')
     %dd.col-12.col-md-10.col-lg-11
       = link_to(request_show_path(request.number), title: request.description) do
         = request.number


### PR DESCRIPTION
Fixes #10254

Before:

![Screenshot 2025-06-09 at 17-48-19 Pulse for home Admin - Open Build Service](https://github.com/user-attachments/assets/6424dd4c-f8d1-4736-8b4a-0bf61cd901aa)

After:

![Screenshot 2025-06-09 at 17-47-56 Pulse for home Admin - Open Build Service](https://github.com/user-attachments/assets/f26593d0-8dd2-49d3-bb3c-83c29c72c3bd)

