### PR TITLE
Fix requests index breadcrumbs

### DIFF
--- a/src/api/app/views/webui/packages/bs_requests/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui/packages/bs_requests/_breadcrumb_items.html.haml
@@ -1,6 +1,6 @@
 - if Flipper.enabled?(:request_index, User.session)
   %li.breadcrumb-item.text-word-break-all
-    %i.fa.fa-archive
+    %i.fa.fa-cubes
     = link_to @project, project_show_path(@project)
   %li.breadcrumb-item.text-word-break-all
     %i.fa.fa-archive

--- a/src/api/app/views/webui/projects/bs_requests/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui/projects/bs_requests/_breadcrumb_items.html.haml
@@ -1,3 +1,6 @@
 - if Flipper.enabled?(:request_index, User.session)
+  %li.breadcrumb-item.text-word-break-all
+    %i.fa.fa-cubes
+    = link_to @project, project_show_path(@project)
   %li.breadcrumb-item.active{ 'aria-current' => 'page' }
     Requests

--- a/src/api/app/views/webui/users/bs_requests/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui/users/bs_requests/_breadcrumb_items.html.haml
@@ -1,3 +1,3 @@
 - if Flipper.enabled?(:request_index, User.session)
   %li.breadcrumb-item.active{ 'aria-current' => 'page' }
-    Requests
+    Your Requests


### PR DESCRIPTION
- `Project > Requests` did not have a `project` link prefix
- `Package > Requests` had a wrong project icon
- `Your Requests` was missing `Your` prefix


## Before
![image](https://github.com/user-attachments/assets/06da3d77-cae6-47e0-a0d6-6366b3ab7ac6)
![image](https://github.com/user-attachments/assets/04648639-4d72-4128-851c-143cd43a3219)
![image](https://github.com/user-attachments/assets/7199eb8f-4a47-4521-957d-c8661ccb54ee)


## After
![image](https://github.com/user-attachments/assets/db7e3582-34a4-4948-baf8-5bf74755a599)
![image](https://github.com/user-attachments/assets/12d16c05-31ea-4da3-b43c-8d61ad1f2c43)
![image](https://github.com/user-attachments/assets/e72d43a2-eb79-40de-9848-39803677d9dc)
