### PR TITLE
[backend] bs_mkarchrepo: add make/check depends fields to desc in db

### DIFF
--- a/src/backend/bs_mkarchrepo
+++ b/src/backend/bs_mkarchrepo
@@ -39,6 +39,8 @@ my %todo = (
     'CONFLICTS' => 'conflict',
     'PROVIDES' => 'provides',
     'OPTDEPENDS' => 'optdepend',
+    'MAKEDEPENDS' => 'makedepend',
+    'CHECKDEPENDS' => 'checkdepend',
   ],
   'files' => [
     'FILES' => 'files',


### PR DESCRIPTION
See `repo-add` command in `pacman`: ([src](https://gitlab.archlinux.org/pacman/pacman/-/blob/master/scripts/repo-add.sh.in#L326))

```
		format_entry "DEPENDS" "${_depends[@]}"
		format_entry "OPTDEPENDS" "${_optdepends[@]}"
		format_entry "MAKEDEPENDS" "${_makedepends[@]}"
		format_entry "CHECKDEPENDS" "${_checkdepends[@]}"
```

`MAKEDEPENDS` and `CHECKDEPENDS` are included in `desc` file in db.