### PR TITLE
Create comments for report event

### DIFF
--- a/src/api/app/models/comment.rb
+++ b/src/api/app/models/comment.rb
@@ -106,6 +106,8 @@ class Comment < ApplicationRecord
       Event::CommentForRequest.create(event_parameters)
     when 'BsRequestAction'
       Event::CommentForRequest.create(event_parameters.merge({ id: id, diff_file_index: diff_file_index, diff_line_number: diff_line_number }))
+    when 'Report'
+      Event::CommentForReport.create(event_parameters.merge({ report_id: commentable.id }))
     end
   end
 

--- a/src/api/app/models/event/base.rb
+++ b/src/api/app/models/event/base.rb
@@ -19,7 +19,7 @@ module Event
       def notification_events
         [Event::BuildFail, Event::ServiceFail, Event::ReviewWanted, Event::RequestCreate,
          Event::RequestStatechange, Event::CommentForProject, Event::CommentForPackage,
-         Event::CommentForRequest,
+         Event::CommentForRequest, Event::CommentForReport,
          Event::RelationshipCreate, Event::RelationshipDelete,
          Event::Report, Event::Decision, Event::AppealCreated,
          Event::WorkflowRunFail,

--- a/src/api/app/models/event/comment_for_report.rb
+++ b/src/api/app/models/event/comment_for_report.rb
@@ -1,0 +1,34 @@
+module Event
+  class CommentForReport < Base
+    include CommentEvent
+
+    self.message_bus_routing_key = 'report.comment'
+    self.description = 'New comment for report created'
+    payload_keys :report_id, :reporter, :reportable_id, :reportable_type, :reason, :category
+
+    self.notification_explanation = 'Receive notifications for comments created on a report for which you are...'
+
+    def subject
+      "New comment in report ##{payload['report_id']}"
+    end
+  end
+end
+
+# == Schema Information
+#
+# Table name: events
+#
+#  id          :bigint           not null, primary key
+#  eventtype   :string(255)      not null, indexed
+#  mails_sent  :boolean          default(FALSE), indexed
+#  payload     :text(16777215)
+#  undone_jobs :integer          default(0)
+#  created_at  :datetime         indexed
+#  updated_at  :datetime
+#
+# Indexes
+#
+#  index_events_on_created_at  (created_at)
+#  index_events_on_eventtype   (eventtype)
+#  index_events_on_mails_sent  (mails_sent)
+#

--- a/src/api/app/models/event/comment_for_report.rb
+++ b/src/api/app/models/event/comment_for_report.rb
@@ -5,11 +5,16 @@ module Event
     self.message_bus_routing_key = 'report.comment'
     self.description = 'New comment for report created'
     payload_keys :report_id, :reporter, :reportable_id, :reportable_type, :reason, :category
+    receiver_roles :moderator, :reporter
 
     self.notification_explanation = 'Receive notifications for comments created on a report for which you are...'
 
     def subject
       "New comment in report ##{payload['report_id']}"
+    end
+
+    def reporters
+      User.where(login: payload['reporter'])
     end
   end
 end

--- a/src/api/app/models/event_subscription/for_channel_form.rb
+++ b/src/api/app/models/event_subscription/for_channel_form.rb
@@ -3,7 +3,7 @@ class EventSubscription
     DISABLE_FOR_EVENTS = ['Event::ServiceFail'].freeze
     DISABLE_RSS_FOR_EVENTS = ['Event::ReportForProject', 'Event::ReportForPackage',
                               'Event::ReportForComment', 'Event::ReportForUser',
-                              'Event::ReportForRequest',
+                              'Event::ReportForRequest', 'Event::CommentForReport',
                               'Event::WorkflowRunFail', 'Event::AppealCreated',
                               'Event::FavoredDecision', 'Event::ClearedDecision',
                               'Event::AddedUserToGroup', 'Event::RemovedUserFromGroup',

--- a/src/api/app/models/report.rb
+++ b/src/api/app/models/report.rb
@@ -34,6 +34,10 @@ class Report < ApplicationRecord
 
   scope :without_decision, -> { where(decision: nil) }
 
+  def event_parameters
+    { id: id, reporter: reporter.login, reportable_id: reportable_id, reportable_type: reportable_type, reason: reason, category: category }
+  end
+
   private
 
   def create_event
@@ -50,10 +54,6 @@ class Report < ApplicationRecord
     when 'BsRequest'
       Event::ReportForRequest.create(event_parameters.merge(bs_request_number: reportable.number))
     end
-  end
-
-  def event_parameters
-    { id: id, reporter: reporter.login, reportable_id: reportable_id, reportable_type: reportable_type, reason: reason, category: category }
   end
 
   def event_parameters_for_comment(commentable:)

--- a/src/api/spec/models/event/comment_for_report_spec.rb
+++ b/src/api/spec/models/event/comment_for_report_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe Event::CommentForReport do
+  describe 'event is created with proper receiver roles' do
+    let(:moderator) { create(:moderator) }
+    let!(:report) { create(:report) }
+
+    before do
+      login moderator
+      create(:comment, user: moderator, body: 'Are you sure this is spam?', commentable: report)
+    end
+
+    it 'creates an event when adding a comment to report' do
+      expect(Event::CommentForReport.count).to eq(1)
+    end
+
+    it  { expect(Event::CommentForReport.last.moderators).to contain_exactly(moderator) }
+    it  { expect(Event::CommentForReport.last.reporters).to contain_exactly(report.reporter) }
+    it  { expect(Event::CommentForReport.last.commenters).to contain_exactly(moderator) }
+  end
+end


### PR DESCRIPTION
The new CommentForReport event is created. This type of event is tracked every time someone comments on a Report.