### PR TITLE
Hide subscription if content_moderation feature flag is disabled

### DIFF
--- a/src/api/app/models/event_subscription/form.rb
+++ b/src/api/app/models/event_subscription/form.rb
@@ -1,7 +1,7 @@
 class EventSubscription
   class Form
     EVENTS_FOR_CONTENT_MODERATORS = ['Event::Report', 'Event::AppealCreated'].freeze
-    EVENTS_IN_CONTENT_MODERATION_BETA = ['Event::Decision'].freeze
+    EVENTS_IN_CONTENT_MODERATION_BETA = ['Event::Decision', 'Event::CommentForReport'].freeze
 
     attr_reader :subscriber
 


### PR DESCRIPTION
Follow-up of #18024

The part of the subscription form related to the comment on report shouldn't be displayed if the `content_moderation` feature flag is disabled.
