### PR TITLE
Adapt appeal decision policy to consider all favored decision types

### DIFF
--- a/src/api/app/policies/appeal_policy.rb
+++ b/src/api/app/policies/appeal_policy.rb
@@ -36,7 +36,9 @@ class AppealPolicy < ApplicationPolicy
 
   def decision_favored_report_of_action_from_user?
     return false unless record.appellant == user
+    return false unless record.decision.type.in?(%w[DecisionFavored DecisionFavoredWithCommentModeration DecisionFavoredWithDeleteRequest
+                                                    DecisionFavoredWithUserCommentingRestriction DecisionFavoredWithUserDeletion])
 
-    record.decision.type == 'DecisionFavored' && "#{@report.reportable_type}Policy".constantize.new(user, @report.reportable).update?
+    "#{@report.reportable_type}Policy".constantize.new(user, @report.reportable).update?
   end
 end

--- a/src/api/spec/factories/decision_favored_with_user_commenting_restriction.rb
+++ b/src/api/spec/factories/decision_favored_with_user_commenting_restriction.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :decision_favored_with_user_commenting_restriction do
+    moderator factory: [:user]
+    reason { Faker::Markdown.emphasis }
+
+    after(:build) do |decision|
+      decision.reports << create(:report, reason: 'This is spam!') if decision.reports.empty?
+    end
+  end
+end

--- a/src/api/spec/policies/appeal_policy_spec.rb
+++ b/src/api/spec/policies/appeal_policy_spec.rb
@@ -104,18 +104,22 @@ RSpec.describe AppealPolicy do
       end
     end
 
-    context 'when the decision favored a report for something the appellant did' do
-      let(:report) { create(:report, reportable: create(:comment_package, user: appellant)) }
-      let(:decision) { create(:decision_favored, reports: [report]) }
-      let(:appeal) { create(:appeal, decision: decision, appellant: appellant) }
+    %i[decision_favored decision_favored_with_comment_moderation
+       decision_favored_with_delete_request_for_package decision_favored_with_user_deletion
+       decision_favored_with_user_commenting_restriction].each do |decision_type|
+      context "when the #{decision_type.to_s.tr('_', ' ')} for something the appellant did" do
+        let(:report) { create(:report, reportable: create(:comment_package, user: appellant)) }
+        let(:decision) { create(decision_type, reports: [report]) }
+        let(:appeal) { create(:appeal, decision: decision, appellant: appellant) }
 
-      permissions :create? do
-        it { is_expected.not_to permit(anonymous_user, appeal) }
-        it { is_expected.not_to permit(user, appeal) }
-        it { is_expected.to permit(appellant, appeal) }
-        it { is_expected.not_to permit(moderator, appeal) }
-        it { is_expected.to permit(staff_user, appeal) }
-        it { is_expected.to permit(admin_user, appeal) }
+        permissions :create? do
+          it { is_expected.not_to permit(anonymous_user, appeal) }
+          it { is_expected.not_to permit(user, appeal) }
+          it { is_expected.to permit(appellant, appeal) }
+          it { is_expected.not_to permit(moderator, appeal) }
+          it { is_expected.to permit(staff_user, appeal) }
+          it { is_expected.to permit(admin_user, appeal) }
+        end
       end
     end
   end


### PR DESCRIPTION
There are more decision types then "decision_favored"
which need to be considered in the policy to allow the user to
appeal against.