### PR TITLE
[backend] bs_publish: make sure that no rekor uploads are lost

### DIFF
--- a/src/backend/bs_regpush
+++ b/src/backend/bs_regpush
@@ -73,6 +73,7 @@ my @signcmd;
 my $pubkeyfile;
 
 my $rekorserver;
+my $force_rekor_upload;
 
 my $registryserver;
 my $repository;
@@ -801,6 +802,9 @@ while (@ARGV) {
     shift @ARGV;
   } elsif ($ARGV[0] eq '--rekor') {
     (undef, $rekorserver) = splice(@ARGV, 0, 2);
+  } elsif ($ARGV[0] eq '--force-rekor-upload') {
+    $force_rekor_upload = 1;
+    shift @ARGV;
   } elsif ($ARGV[0] eq '-G') {
     (undef, $gun) = splice(@ARGV, 0, 2);
   } elsif ($ARGV[0] eq '-p') {
@@ -1111,6 +1115,7 @@ if ($cosign && %digests_to_sign) {
     my $sig_tag = "$digest.sig";
     $sig_tag =~ s/:/-/;
     my ($sig_mani, $sig_maniid, $sig_mani_json) = get_manifest_for_tag($sig_tag);
+    undef $sig_mani if $force_rekor_upload && $rekorserver;
     if ($sig_mani && $sig_mani->{'mediaType'} && $sig_mani->{'mediaType'} eq $BSContar::mt_oci_manifest && @{$sig_mani->{'layers'} || []} == 1 && $BSConSign::mt_cosign && $sig_mani->{'layers'}->[0]->{'mediaType'} eq $BSConSign::mt_cosign) {
       my $annotations = $sig_mani->{'layers'}->[0]->{'annotations'} || {};
       next if ($annotations->{$cosign_cookie_name} || '') eq $cosigncookie;
@@ -1138,6 +1143,7 @@ if ($cosign && %digests_to_sign) {
     my $att_tag = "$digest.att";
     $att_tag =~ s/:/-/;
     my ($att_mani, $att_maniid, $att_mani_json) = get_manifest_for_tag($att_tag);
+    undef $att_mani if $force_rekor_upload && $rekorserver;
     my $numlayers = ($provenance ? 1 : 0) + ($spdx_json ? 1 : 0) + ($cyclonedx_json ? 1 : 0) + scalar(@intoto_json);
     if ($att_mani && $att_mani->{'mediaType'} && $att_mani->{'mediaType'} eq $BSContar::mt_oci_manifest && @{$att_mani->{'layers'} || []} == $numlayers && $BSConSign::mt_dsse) {
       next unless grep {$_->{'mediaType'} ne $BSConSign::mt_dsse || (($_->{'annotations'} || {})->{$cosign_cookie_name} || '') ne $cosigncookie} @{$att_mani->{'layers'}};


### PR DESCRIPTION
We do this by creating an "in progress" marker before syncing the repository. If we get interrupted (system crash, rekor not available, etc) and we see the marker is still there on the next run, we'll force the rekor upload.