### PR TITLE
Better `where` than object converted to array

### DIFF
--- a/src/api/app/models/event/base.rb
+++ b/src/api/app/models/event/base.rb
@@ -280,7 +280,7 @@ module Event
     end
 
     def assignees
-      [User.find_by(login: payload['assignee'])]
+      User.where(login: payload['assignee'])
     end
 
     def _roles(role, project, package = nil)

--- a/src/api/app/models/event/group.rb
+++ b/src/api/app/models/event/group.rb
@@ -9,7 +9,7 @@ module Event
     end
 
     def members
-      [User.find_by(login: payload['member'])]
+      User.where(login: payload['member'])
     end
 
     def originator

--- a/src/api/app/models/event/request.rb
+++ b/src/api/app/models/event/request.rb
@@ -79,7 +79,7 @@ module Event
     end
 
     def creators
-      [User.find_by_login(payload['author'])]
+      User.where(login: payload['author'])
     end
 
     def target_maintainers

--- a/src/api/app/models/notification_group.rb
+++ b/src/api/app/models/notification_group.rb
@@ -8,7 +8,7 @@ class NotificationGroup < Notification
   end
 
   def avatar_objects
-    [User.find_by(login: event_payload['who'])].compact
+    User.where(login: event_payload['who'])
   end
 
   def link_text

--- a/src/api/app/models/notification_package.rb
+++ b/src/api/app/models/notification_package.rb
@@ -19,7 +19,7 @@ class NotificationPackage < Notification
   end
 
   def avatar_objects
-    [User.find_by(login: event_payload['who'])].compact
+    User.where(login: event_payload['who'])
   end
 
   def link_text

--- a/src/api/app/models/notification_project.rb
+++ b/src/api/app/models/notification_project.rb
@@ -17,7 +17,7 @@ class NotificationProject < Notification
   end
 
   def avatar_objects
-    [User.find_by(login: event_payload['who'])].compact
+    User.where(login: event_payload['who'])
   end
 
   def link_text

--- a/src/api/app/models/notification_report.rb
+++ b/src/api/app/models/notification_report.rb
@@ -22,11 +22,11 @@ class NotificationReport < Notification
   def avatar_objects
     case event_type
     when 'Event::ReportForComment', 'Event::ReportForPackage', 'Event::ReportForProject', 'Event::ReportForUser', 'Event::ReportForRequest'
-      [User.find_by(login: event_payload['reporter'])].compact
+      User.where(login: event_payload['reporter'])
     when 'Event::FavoredDecision', 'Event::ClearedDecision'
-      [User.find(event_payload['moderator_id'])].compact
+      User.where(id: event_payload['moderator_id'])
     when 'Event::AppealCreated'
-      [User.find(event_payload['appellant_id'])].compact
+      User.where(id: event_payload['appellant_id'])
     end
   end
 


### PR DESCRIPTION
In many parts of the code we need to iterate over a bunch of objects, even if sometimes there is only one or none.

To retrieve those objects we better use `Model.where()` than `[Model.find_by()].compact` or similar.

The second option is considered an anti-pattern and returns an array that could includes nil values (that's why we need `.compact` sometimes). The second will return an ActiveRecord::Relation with zero, one or more elements but never nil. It also implies a better performance.