### PR TITLE
Skip rendering the view if the packages project is managed under SCM

### DIFF
--- a/src/api/app/controllers/webui/packages/meta_controller.rb
+++ b/src/api/app/controllers/webui/packages/meta_controller.rb
@@ -15,7 +15,7 @@ module Webui
         if @project.scmsync.present?
           flash.now[:error] = "Package sources for project #{@project.name} are received through scmsync." \
                               'This is not supported by the OBS frontend'
-          render :show, status: :not_found
+          head :not_found
         else
           @meta = @package.render_xml
         end


### PR DESCRIPTION
Do not render the view when trying to access the meta tab from a package belonging to a project managed under SCM.

The package does not exist locally so we cannot render any url for any of the tabs.

Fixes #18009