### PR TITLE
Reuse write_and_preview component for canned_responses too

### DIFF
--- a/src/api/app/assets/javascripts/webui/comment.js
+++ b/src/api/app/assets/javascripts/webui/comment.js
@@ -30,10 +30,7 @@ function validateForm(e) {
 
 function handlingCommentEvents() {
   // Disable submit button if textarea is empty and enable otherwise
-  const commentFieldSelector = `.comments-list .comment-field, .comment_new .comment-field,
-                                .timeline .comment-field, .diff .comment-field,
-                                .diff-accordion .comment-field, .write-and-preview textarea`;
-  $(document).on('input', commentFieldSelector, function(e) {
+  $(document).on('input', '.write-and-preview textarea', function(e) {
     validateForm(e);
     resizeTextarea(this);
   });

--- a/src/api/app/assets/javascripts/webui/comment.js
+++ b/src/api/app/assets/javascripts/webui/comment.js
@@ -32,7 +32,7 @@ function handlingCommentEvents() {
   // Disable submit button if textarea is empty and enable otherwise
   const commentFieldSelector = `.comments-list .comment-field, .comment_new .comment-field,
                                 .timeline .comment-field, .diff .comment-field,
-                                .diff-accordion .comment-field`;
+                                .diff-accordion .comment-field, .write-and-preview textarea`;
   $(document).on('input', commentFieldSelector, function(e) {
     validateForm(e);
     resizeTextarea(this);

--- a/src/api/app/components/bs_request_comment_component.html.haml
+++ b/src/api/app/components/bs_request_comment_component.html.haml
@@ -66,7 +66,7 @@
         = helpers.render_as_markdown(comment)
 
       - if policy(comment).update?
-        .collapse.comment-edit{ id: "edit_form_of_#{comment.id}" }
+        .collapse.comment-edit.p-3{ id: "edit_form_of_#{comment.id}" }
           = render(partial: 'webui/comment/comment_field', locals: { form_method: :put,
           comment: comment, commentable: commentable, element_suffix: "edit_#{comment.id}", has_cancel: true })
 

--- a/src/api/app/components/request_decision_component.html.haml
+++ b/src/api/app/components/request_decision_component.html.haml
@@ -1,6 +1,5 @@
 .request-decision.mt-n1
-  = form_tag(request_changerequest_path, id: 'request_handle_form', class: 'write-and-preview',
-    data: { preview_message_url: preview_comments_path, message_body_param: 'comment[body]' }) do
+  = form_with(url: request_changerequest_path, html: { id: 'request_handle_form' }, local: true) do |form|
     = hidden_field_tag(:number, @bs_request.number)
     .pb-2{ 'data-canned-controller': '' }
       - if policy(Comment.new(commentable: @bs_request)).locked?
@@ -8,25 +7,11 @@
           Commenting on this is locked.
           - if CommentLockPolicy.new(User.session, @bs_request).create?
             = helpers.comment_lock_alert(@bs_request)
-      .card
-        %ul.card-header.nav.nav-tabs.px-3.pt-2.pb-0.disable-link-generation{ role: 'tablist' }
-          %li.nav-item
-            = link_to('Write', "#write_new_comment", class: 'nav-link active', data: { 'bs-toggle': 'tab' },
-            role: 'tab', aria: { controls: 'write-comment-tab', selected: 'true'})
-          %li.nav-item
-            = link_to('Preview', '#preview_new_comment', class: 'nav-link preview-message-tab', data: { 'bs-toggle': 'tab' },
-            role: 'tab', aria: { controls: 'preview-message-tab', selected: 'false' })
-        .tab-content.px-3
-          .tab-pane.fade.show.active.my-3{ id: 'write_new_comment', role: 'tabpanel',
-                                          'aria-labelledby': 'write-comment-tab', 'data-canned-controller': '' }
-            - if Flipper.enabled?(:canned_responses, User.session)
-              .d-flex.justify-content-end
-                = render CannedResponsesDropdownComponent.new(User.session.canned_responses.where(decision_type: nil).order(:title))
-            = text_area_tag(:reason, nil,
-                            placeholder: 'Write your comment or decision...(markdown is only supported for comments, not for decisions)',
-                            rows: 4, class: 'w-100 form-control mb-2 message-field')
-          .tab-pane.fade{ id: 'preview_new_comment', role: 'tabpanel', 'aria-labelledby': 'preview-message-tab' }
-            .comment-preview.message-preview.my-3
+      - decision_placeholder = "Write your comment or decision...(markdown is only supported for comments, not for decisions)"
+      = render WriteAndPreviewComponent.new(form: form, preview_message_url: preview_comments_path, canned_responses_enabled: true,
+                                            message_body_param: 'comment[body]',
+                                            text_area_attributes: { object_name: 'reason', id_suffix: 'new_comment',
+                                            placeholder: decision_placeholder})
       .mt-2
         - if policy(@bs_request).forward_request?
           - @action.forward.each_with_index do |forward, index|

--- a/src/api/app/components/write_and_preview_component.html.haml
+++ b/src/api/app/components/write_and_preview_component.html.haml
@@ -1,21 +1,22 @@
 .card.write-and-preview{ data: { preview_message_url: preview_message_url, message_body_param: message_body_param } }
   %ul.nav.nav-tabs.px-3.pt-2.disable-link-generation{ role: 'tablist' }
     %li.nav-item
-      = link_to('Write', '#write_message', class: 'nav-link active', data: { 'bs-toggle': 'tab' }, role: 'tab',
+      = link_to('Write', "#write_#{text_area_attributes[:id_suffix]}", class: 'nav-link active', data: { 'bs-toggle': 'tab' }, role: 'tab',
       aria: { controls: 'write-message-tab', selected: 'true' })
     %li.nav-item
-      = link_to('Preview', '#preview_message', class: 'nav-link preview-message-tab',
+      = link_to('Preview', "#preview_#{text_area_attributes[:id_suffix]}", class: 'nav-link preview-message-tab',
       data: { 'bs-toggle': 'tab', preview_message_url: preview_message_url },
       role: 'tab', aria: { controls: 'preview-message-tab', selected: 'false' })
   .tab-content.px-3
-    .tab-pane.fade.show.active.my-3{ id: 'write_message', role: 'tabpanel', 'aria-labelledby': 'write-message-tab', 'data-canned-controller': '' }
+    .tab-pane.fade.show.active.my-3{ id: "write_#{text_area_attributes[:id_suffix]}",
+                                     role: 'tabpanel', 'aria-labelledby': 'write-message-tab', 'data-canned-controller': '' }
       - if Flipper.enabled?(:canned_responses, User.session) && canned_responses_enabled
         .d-flex.justify-content-end
           = render CannedResponsesDropdownComponent.new(User.session.canned_responses.where(decision_type: nil).order(:title))
-      ~ form.text_area(text_area_attributes[:object_name], rows: text_area_attributes[:rows], required: text_area_attributes[:required],
-        placeholder: text_area_attributes[:placeholder],
-        class: 'w-100 form-control message-field')
-    .tab-pane.fade{ id: 'preview_message', role: 'tabpanel', 'aria-labelledby': 'preview-message-tab' }
+      ~ form.text_area(text_area_attributes[:object_name], id: "#{text_area_attributes[:id_suffix]}_body",
+        rows: text_area_attributes[:rows], required: text_area_attributes[:required],
+        placeholder: text_area_attributes[:placeholder], class: 'w-100 form-control message-field')
+    .tab-pane.fade{ id: "preview_#{text_area_attributes[:id_suffix]}", role: 'tabpanel', 'aria-labelledby': 'preview-message-tab' }
       .message-preview.my-3
 
 :javascript

--- a/src/api/app/components/write_and_preview_component.html.haml
+++ b/src/api/app/components/write_and_preview_component.html.haml
@@ -1,5 +1,5 @@
 .card.write-and-preview{ data: { preview_message_url: preview_message_url, message_body_param: message_body_param } }
-  %ul.nav.nav-tabs.px-3.pt-2.disable-link-generation{ role: 'tablist' }
+  %ul.card-header.nav.nav-tabs.px-3.pt-2.pb-0.disable-link-generation{ role: 'tablist' }
     %li.nav-item
       = link_to('Write', "#write_#{text_area_attributes[:id_suffix]}", class: 'nav-link active', data: { 'bs-toggle': 'tab' }, role: 'tab',
       aria: { controls: 'write-message-tab', selected: 'true' })

--- a/src/api/app/components/write_and_preview_component.html.haml
+++ b/src/api/app/components/write_and_preview_component.html.haml
@@ -8,7 +8,10 @@
       data: { 'bs-toggle': 'tab', preview_message_url: preview_message_url },
       role: 'tab', aria: { controls: 'preview-message-tab', selected: 'false' })
   .tab-content.px-3
-    .tab-pane.fade.show.active.my-3{ id: 'write_message', role: 'tabpanel', 'aria-labelledby': 'write-message-tab' }
+    .tab-pane.fade.show.active.my-3{ id: 'write_message', role: 'tabpanel', 'aria-labelledby': 'write-message-tab', 'data-canned-controller': '' }
+      - if Flipper.enabled?(:canned_responses, User.session) && canned_responses_enabled
+        .d-flex.justify-content-end
+          = render CannedResponsesDropdownComponent.new(User.session.canned_responses.where(decision_type: nil).order(:title))
       ~ form.text_area(text_area_attributes[:object_name], rows: text_area_attributes[:rows], required: text_area_attributes[:required],
         placeholder: text_area_attributes[:placeholder],
         class: 'w-100 form-control message-field')

--- a/src/api/app/components/write_and_preview_component.rb
+++ b/src/api/app/components/write_and_preview_component.rb
@@ -15,6 +15,6 @@ class WriteAndPreviewComponent < ApplicationComponent
 
   def text_area_attributes_defaults
     { rows: 4, placeholder: 'Write your message here... (Markdown markup is supported)', required: true,
-      object_name: :message }
+      object_name: :message, id_suffix: 'message' }
   end
 end

--- a/src/api/app/components/write_and_preview_component.rb
+++ b/src/api/app/components/write_and_preview_component.rb
@@ -1,13 +1,14 @@
 class WriteAndPreviewComponent < ApplicationComponent
-  attr_reader :form, :preview_message_url, :message_body_param, :text_area_attributes
+  attr_reader :form, :preview_message_url, :message_body_param, :text_area_attributes, :canned_responses_enabled
 
-  def initialize(form:, preview_message_url:, message_body_param:, text_area_attributes: {})
+  def initialize(form:, preview_message_url:, message_body_param:, text_area_attributes: {}, canned_responses_enabled: false)
     super
 
     @form = form
     @preview_message_url = preview_message_url
     @message_body_param = message_body_param
     @text_area_attributes = text_area_attributes_defaults.merge(text_area_attributes)
+    @canned_responses_enabled = canned_responses_enabled
   end
 
   private

--- a/src/api/app/views/webui/comment/_comment_field.html.haml
+++ b/src/api/app/views/webui/comment/_comment_field.html.haml
@@ -1,6 +1,6 @@
-= form_for(comment, method: form_method, remote: true, html: { id: "#{element_suffix}_form",
-class: "#{form_method}-comment-form write-and-preview" },
-data: { preview_message_url: preview_comments_path, message_body_param: 'comment[body]', turbo_frame: "_top" }) do |f|
+= form_for(comment, method: form_method, remote: true,
+           html: { id: "#{element_suffix}_form", class: "#{form_method}-comment-form" },
+           data: { turbo_frame: "_top" }) do |f|
   = hidden_field_tag :commentable_type, commentable.class.name, { id: "#{element_suffix}_commentable_type" }
   = hidden_field_tag :commentable_id, commentable.id, { id: "#{element_suffix}_commentable_id" }
   - if defined?(file_index)
@@ -10,34 +10,16 @@ data: { preview_message_url: preview_comments_path, message_body_param: 'comment
     = f.hidden_field :source_rev, value: source_rev, id: "#{element_suffix}_source_rev"
     = f.hidden_field :target_rev, value: target_rev, id: "#{element_suffix}_target_rev"
   = f.hidden_field :parent_id, value: comment.parent_id, id: "#{element_suffix}_parent_id"
-  .card
-    %ul.card-header.nav.nav-tabs.px-3.pt-2.pb-0.disable-link-generation{ role: 'tablist' }
-      %li.nav-item
-        = link_to('Write', "#write_#{element_suffix}", class: 'nav-link active', data: { 'bs-toggle': 'tab' }, role: 'tab',
-        aria: { controls: 'write-comment-tab', selected: 'true' })
-      %li.nav-item
-        = link_to('Preview', "#preview_#{element_suffix}", class: 'nav-link preview-message-tab', data: { 'bs-toggle': 'tab' },
-        role: 'tab', aria: { controls: 'preview-message-tab', selected: 'false' })
-    .tab-content.px-3
-      .tab-pane.fade.show.active.my-3{ id: "write_#{element_suffix}", role: 'tabpanel', 'aria-labelledby': 'write-comment-tab',
-                                       'data-canned-controller': '' }
-        - if Flipper.enabled?(:canned_responses, User.session)
-          .d-flex.justify-content-end
-            = render CannedResponsesDropdownComponent.new(User.session.canned_responses.where(decision_type: nil).order(:title))
-        ~ f.text_area :body, id: "#{element_suffix}_body", rows: '4',
-        placeholder: 'Write your comment here... (Markdown markup is supported)', required: true,
-        class: 'w-100 form-control comment-field message-field'
-      .tab-pane.fade{ id: "preview_#{element_suffix}", role: 'tabpanel', 'aria-labelledby': 'preview-message-tab' }
-        .comment-preview.message-preview.my-3
-      .comment-controls.mb-3
-        - case form_method
-        - when :post
-          = f.submit 'Add comment', class: 'btn btn-primary me-2', data: { disable_with: 'Creating comment...' }, disabled: true
-        - when :put
-          = f.submit 'Update comment', class: 'btn btn-primary me-2', data: { disable_with: 'Updating comment...' }
-        - if has_cancel
-          %a.cancel-comment.btn.btn-outline-secondary
-            Cancel
 
-:javascript
-  attachPreviewMessageOnCommentBoxes();
+  = render WriteAndPreviewComponent.new(form: f, preview_message_url: preview_comments_path, canned_responses_enabled: true,
+                                        message_body_param: 'comment[body]', text_area_attributes: { object_name: 'body', id_suffix: element_suffix,
+                                        placeholder: 'Write your comment here... (Markdown markup is supported)' })
+  .comment-controls.my-3
+    - case form_method
+    - when :post
+      = f.submit 'Add comment', class: 'btn btn-primary me-2', data: { disable_with: 'Creating comment...' }, disabled: true
+    - when :put
+      = f.submit 'Update comment', class: 'btn btn-primary me-2', data: { disable_with: 'Updating comment...' }
+    - if has_cancel
+      %a.cancel-comment.btn.btn-outline-secondary
+        Cancel

--- a/src/api/spec/features/webui/comment_locks_spec.rb
+++ b/src/api/spec/features/webui/comment_locks_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe 'CommentLocks', :vcr do
 
         it 'can comment' do
           expect(page).to have_no_text('Commenting on this is locked.')
-          fill_in 'new_comment_body', with: 'Comment Body'
+          fill_in 'comment[body]', with: 'Comment Body'
           find_button('Add comment')
         end
       end

--- a/src/api/spec/features/webui/comments_spec.rb
+++ b/src/api/spec/features/webui/comments_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Comments', :js, :vcr do
   it 'can be created' do
     login user
     visit project_show_path(user.home_project)
-    fill_in 'new_comment_body', with: 'Comment Body'
+    fill_in 'comment[body]', with: 'Comment Body'
     find_button('Add comment').click
 
     expect(page).to have_text('Comment Body')

--- a/src/api/spec/features/webui/packages_spec.rb
+++ b/src/api/spec/features/webui/packages_spec.rb
@@ -360,7 +360,7 @@ RSpec.describe 'Packages', :js, :vcr do
         visit new_package_path(project: user.home_project)
         fill_in 'package_name', with: 'coolstuff'
         fill_in 'package_title', with: 'cool stuff everyone needs'
-        fill_in 'package_description', with: very_long_description
+        fill_in 'package[description]', with: very_long_description
         click_button 'Create'
 
         expect(page).to have_text("Package 'coolstuff' was created successfully")

--- a/src/api/spec/features/webui/projects_spec.rb
+++ b/src/api/spec/features/webui/projects_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Projects', :js, :vcr do
         expect(page).to have_text("Edit Project #{project}")
 
         fill_in 'project_title', with: 'My Title "hopefully" got changed'
-        fill_in 'project_description', with: 'New description. No kidding.. Brand new!'
+        fill_in 'project[description]', with: 'New description. No kidding.. Brand new!'
         fill_in 'project_url', with: 'https://test.url'
         fill_in('project_report_bug_url', with: 'https://test-report-bug.url')
         click_button 'Update'
@@ -55,7 +55,7 @@ RSpec.describe 'Projects', :js, :vcr do
         expect(page).to have_text("Edit Project #{project}")
 
         fill_in 'project_title', with: 'My Title "hopefully" got changed'
-        fill_in 'project_description', with: 'New description. No kidding.. Brand new!'
+        fill_in 'project[description]', with: 'New description. No kidding.. Brand new!'
         click_link 'Cancel'
         wait_for_ajax
 


### PR DESCRIPTION
Deduplicate code by using always and only `write_and_preview` view component for comment fields for both when there can be canned responses and when  there aren't.

## How do I test it?
- Edit a News content (AKA StatusMessage) _to make sure the existing code is still working_
- Add a comment to a package|project|request either w/ or w/o canned responses _to make sure the new implementation works as expected_
- Add a **decision** comment to a request either w/ or w/o canned responses _to make sure the new implementation works as expected_


https://trello.com/c/URMPZfJT