### PR TITLE
Fixes deletion of devel tags from a package's meta

### DIFF
--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -756,6 +756,7 @@ class Package < ApplicationRecord
   def assign_devel_package_from_xml(xmlhash)
     #--- devel project/package ---#
     devel = xmlhash['devel']
+    self.develpackage = nil
     return unless devel
 
     devel_project_name = devel['project'] || xmlhash['project']

--- a/src/api/spec/models/package_spec.rb
+++ b/src/api/spec/models/package_spec.rb
@@ -733,10 +733,31 @@ RSpec.describe Package, :vcr do
         </package>
       XML_DATA2
     end
+    let(:valid_meta_with_devel) do
+      <<~XML_DATA3
+        <package name="test_package" project="home:tom">
+          <title/>
+          <description/>
+          <devel project="#{devel_package.project.name}" package="#{devel_package.name}" />
+        </package>
+      XML_DATA3
+    end
+    let(:devel_package) { create(:package, name: 'test_package') }
 
     it "doesn't crash on duplicated flags" do
       package.update_from_xml(Xmlhash.parse(invalid_meta_xml))
       expect(package.render_xml).to eq(corrected_meta_xml)
+    end
+
+    it 'sets the develpackage' do
+      package.update_from_xml(Xmlhash.parse(valid_meta_with_devel))
+      expect(package.develpackage).to eql(devel_package)
+    end
+
+    it 'removes the develpackage' do
+      package.update(develpackage: devel_package)
+      package.update_from_xml(Xmlhash.parse(corrected_meta_xml))
+      expect(package.develpackage).to be_nil
     end
   end
 


### PR DESCRIPTION
When we refactored Package#update_from_xml in
https://github.com/openSUSE/open-build-service/pull/16227 we forgot to clear the develpackage before updating the values coming from an xml.

This commit clears the develpackage before updating the values, so if someone deletes the devel tag from the xml meta, we remove it from the model as well.

Fixes #18084