### PR TITLE
Remove unnecesary `include_all_packages` parameter

### DIFF
--- a/src/api/app/controllers/source_project_command_controller.rb
+++ b/src/api/app/controllers/source_project_command_controller.rb
@@ -125,7 +125,7 @@ class SourceProjectCommandController < SourceController
   def project_command_release
     params[:user] = User.session.login
 
-    @project = Project.get_by_name(params[:project], include_all_packages: true)
+    @project = Project.get_by_name(params[:project])
     verify_release_targets!(@project, params[:arch])
 
     if @project.is_a?(String) # remote project
@@ -183,7 +183,7 @@ class SourceProjectCommandController < SourceController
     raise CmdExecutionNoPermission, "no permission to execute command 'copy'" unless (@project && User.session.can_modify?(@project)) ||
                                                                                      (@project.nil? && User.session.can_create_project?(project_name))
 
-    oprj = Project.get_by_name(params[:oproject], include_all_packages: true)
+    oprj = Project.get_by_name(params[:oproject])
     if (params.key?(:makeolder) || params.key?(:makeoriginolder)) && !User.session.can_modify?(oprj)
       raise CmdExecutionNoPermission,
             "no permission to execute command 'copy', requires modification permission in origin project"

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -230,18 +230,13 @@ class Project < ApplicationRecord
     #   - an instance of Project
     #   - a string for a Project from an interconnect
     #   - UnknownObjectError or ReadAccessError exceptions
-    def get_by_name(name, include_all_packages: false)
+    def get_by_name(name)
       dbp = find_by_name(name, skip_check_access: true)
       if dbp.nil?
         dbp, remote_name = find_remote_project(name)
         return "#{dbp.name}:#{remote_name}" if dbp
 
         raise Project::Errors::UnknownObjectError, "Project not found: #{name}"
-      end
-      if include_all_packages
-        Package.joins(:flags).where(project_id: dbp.id).where("flags.flag='sourceaccess'").find_each do |pkg|
-          raise ReadAccessError, name unless pkg.project.check_access?
-        end
       end
 
       raise ReadAccessError, name unless dbp.check_access?


### PR DESCRIPTION
Previously, when the `include_all_packages` parameter was set to true, the `Project#get_by_name` method would raise a `ReadAccessError` exception if there was a package that:

- had the 'sourceaccess' flag,

- belonged to the current project, and

- the current project could not be modified by the current user.

However, the check to determine whether the current project can be modified by the current user is performed immediately after this code anyway. Therefore, we can safely remove the `include_all_packages` parameter and all associated conditional logic.

This commit introduced this parameter: 0abb664c95794416c154f762db39ef70e0a88d14.

