### PR TITLE
Remove `required_parameters` from a couple of controllers

### DIFF
--- a/src/api/app/controllers/build_controller.rb
+++ b/src/api/app/controllers/build_controller.rb
@@ -161,7 +161,11 @@ class BuildController < ApplicationController
   end
 
   def result_lastsuccess
-    required_parameters :package, :pathproject
+    begin
+      params.require(%i[package pathproject])
+    rescue ActionController::ParameterMissing => e
+      raise MissingParameterError, e.message
+    end
 
     pkg = Package.get_by_project_and_name(params[:project], params[:package],
                                           use_source: false, follow_multibuild: true)

--- a/src/api/app/controllers/worker/command_controller.rb
+++ b/src/api/app/controllers/worker/command_controller.rb
@@ -1,6 +1,10 @@
 class Worker::CommandController < ApplicationController
   def run
-    required_parameters :cmd, :project, :package, :repository, :arch
+    begin
+      params.require(%i[cmd project package repository arch])
+    rescue ActionController::ParameterMissing => e
+      raise MissingParameterError, e.message
+    end
 
     raise UnknownCommandError, "Unknown command '#{params[:cmd]}' for path #{request.path}" unless params[:cmd] == 'checkconstraints'
 


### PR DESCRIPTION
For requiring query parameters on API endpoints we can use the method `require` from action controller parameters.

See: https://api.rubyonrails.org/v7.2.2.1/classes/ActionController/Parameters.html#method-i-require

Follow up to #18079.