### PR TITLE
[issuetracker] Update CVE tracker to point to cve.org

### DIFF
--- a/docs/api/api/issue_trackers.xml
+++ b/docs/api/api/issue_trackers.xml
@@ -223,9 +223,9 @@
     <name>cve</name>
     <kind>cve</kind>
     <description>CVE Numbers</description>
-    <url>http://cve.mitre.org/</url>
-    <show-url>http://cve.mitre.org/cgi-bin/cvename.cgi?name=@@@</show-url>
-    <regex>(CVE-\d\d\d\d-\d+)</regex>
+    <url>https://www.cve.org/</url>
+    <show-url>https://www.cve.org/CVERecord?id=@@@</show-url>
+    <regex>CVE-(\d\d\d\d-\d+)</regex>
     <label>@@@</label>
     <enable-fetch>false</enable-fetch>
   </issue-tracker>

--- a/src/api/db/data/20250707110214_update_cve_issue_tracker.rb
+++ b/src/api/db/data/20250707110214_update_cve_issue_tracker.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class UpdateCveIssueTracker < ActiveRecord::Migration[7.2]
+  def up
+    cve_issue_tracker = IssueTracker.find_by(name: 'cve')
+    return unless cve_issue_tracker
+
+    # rubocop:disable Rails/SkipsModelValidations
+    cve_issue_tracker.update_columns(url: 'https://www.cve.org', show_url: 'https://www.cve.org/CVERecord?id=@@@')
+    # rubocop:enable Rails/SkipsModelValidations
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/src/api/db/data_schema.rb
+++ b/src/api/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20250411000109)
+DataMigrate::Data.define(version: 20250707110214)

--- a/src/api/db/seeds.rb
+++ b/src/api/db/seeds.rb
@@ -199,9 +199,9 @@ IssueTracker.where(name: 'RT').first_or_create(description: 'CPAN Bugs',
 IssueTracker.where(name: 'cve').first_or_create(description: 'CVE Numbers',
                                                 kind: 'cve',
                                                 regex: 'CVE-(\d\d\d\d-\d+)',
-                                                url: 'http://cve.mitre.org/',
+                                                url: 'https://www.cve.org',
                                                 label: 'CVE-@@@',
-                                                show_url: 'http://cve.mitre.org/cgi-bin/cvename.cgi?name=@@@')
+                                                show_url: 'https://www.cve.org/CVERecord?id=@@@')
 IssueTracker.where(name: 'deb').first_or_create(description: 'Debian Bugzilla',
                                                 kind: 'bugzilla',
                                                 regex: 'deb#(\d+)',

--- a/src/api/spec/cassettes/Comments_with_diff/create_diff_comment/displays_the_comment_in_the_conversation_tab.yml
+++ b/src/api/spec/cassettes/Comments_with_diff/create_diff_comment/displays_the_comment_in_the_conversation_tab.yml
@@ -444,7 +444,7 @@ http_interactions:
             </file>
           </files>
           <issues>
-            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=2011-1111"/>
+            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="https://www.cve.org/CVERecord?id=CVE-2011-1111"/>
             <issue state="added" tracker="bnc" name="1111111" label="boo#1111111" url="https://bugzilla.opensuse.org/show_bug.cgi?id=1111111"/>
           </issues>
         </sourcediff>
@@ -535,7 +535,7 @@ http_interactions:
             </file>
           </files>
           <issues>
-            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=2011-1111"/>
+            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="https://www.cve.org/CVERecord?id=CVE-2011-1111"/>
             <issue state="added" tracker="bnc" name="1111111" label="boo#1111111" url="https://bugzilla.opensuse.org/show_bug.cgi?id=1111111"/>
           </issues>
         </sourcediff>
@@ -626,7 +626,7 @@ http_interactions:
             </file>
           </files>
           <issues>
-            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=2011-1111"/>
+            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="https://www.cve.org/CVERecord?id=CVE-2011-1111"/>
             <issue state="added" tracker="bnc" name="1111111" label="boo#1111111" url="https://bugzilla.opensuse.org/show_bug.cgi?id=1111111"/>
           </issues>
         </sourcediff>
@@ -765,7 +765,7 @@ http_interactions:
             </file>
           </files>
           <issues>
-            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=2011-1111"/>
+            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="https://www.cve.org/CVERecord?id=CVE-2011-1111"/>
             <issue state="added" tracker="bnc" name="1111111" label="boo#1111111" url="https://bugzilla.opensuse.org/show_bug.cgi?id=1111111"/>
           </issues>
         </sourcediff>
@@ -904,7 +904,7 @@ http_interactions:
             </file>
           </files>
           <issues>
-            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=2011-1111"/>
+            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="https://www.cve.org/CVERecord?id=CVE-2011-1111"/>
             <issue state="added" tracker="bnc" name="1111111" label="boo#1111111" url="https://bugzilla.opensuse.org/show_bug.cgi?id=1111111"/>
           </issues>
         </sourcediff>
@@ -1004,7 +1004,7 @@ http_interactions:
             </file>
           </files>
           <issues>
-            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=2011-1111"/>
+            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="https://www.cve.org/CVERecord?id=CVE-2011-1111"/>
             <issue state="added" tracker="bnc" name="1111111" label="boo#1111111" url="https://bugzilla.opensuse.org/show_bug.cgi?id=1111111"/>
           </issues>
         </sourcediff>
@@ -1542,7 +1542,7 @@ http_interactions:
             </file>
           </files>
           <issues>
-            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=2011-1111"/>
+            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="https://www.cve.org/CVERecord?id=CVE-2011-1111"/>
             <issue state="added" tracker="bnc" name="1111111" label="boo#1111111" url="https://bugzilla.opensuse.org/show_bug.cgi?id=1111111"/>
           </issues>
         </sourcediff>
@@ -1740,7 +1740,7 @@ http_interactions:
             </file>
           </files>
           <issues>
-            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=2011-1111"/>
+            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="https://www.cve.org/CVERecord?id=CVE-2011-1111"/>
             <issue state="added" tracker="bnc" name="1111111" label="boo#1111111" url="https://bugzilla.opensuse.org/show_bug.cgi?id=1111111"/>
           </issues>
         </sourcediff>
@@ -1831,7 +1831,7 @@ http_interactions:
             </file>
           </files>
           <issues>
-            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=2011-1111"/>
+            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="https://www.cve.org/CVERecord?id=CVE-2011-1111"/>
             <issue state="added" tracker="bnc" name="1111111" label="boo#1111111" url="https://bugzilla.opensuse.org/show_bug.cgi?id=1111111"/>
           </issues>
         </sourcediff>
@@ -1970,7 +1970,7 @@ http_interactions:
             </file>
           </files>
           <issues>
-            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=2011-1111"/>
+            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="https://www.cve.org/CVERecord?id=CVE-2011-1111"/>
             <issue state="added" tracker="bnc" name="1111111" label="boo#1111111" url="https://bugzilla.opensuse.org/show_bug.cgi?id=1111111"/>
           </issues>
         </sourcediff>

--- a/src/api/spec/cassettes/Comments_with_diff/create_diff_comment/displays_the_comment_on_the_file_diff_in_the_changes_tab.yml
+++ b/src/api/spec/cassettes/Comments_with_diff/create_diff_comment/displays_the_comment_on_the_file_diff_in_the_changes_tab.yml
@@ -444,7 +444,7 @@ http_interactions:
             </file>
           </files>
           <issues>
-            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=2011-1111"/>
+            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="https://www.cve.org/CVERecord?id=CVE-2011-1111"/>
             <issue state="added" tracker="bnc" name="1111111" label="boo#1111111" url="https://bugzilla.opensuse.org/show_bug.cgi?id=1111111"/>
           </issues>
         </sourcediff>
@@ -535,7 +535,7 @@ http_interactions:
             </file>
           </files>
           <issues>
-            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=2011-1111"/>
+            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="https://www.cve.org/CVERecord?id=CVE-2011-1111"/>
             <issue state="added" tracker="bnc" name="1111111" label="boo#1111111" url="https://bugzilla.opensuse.org/show_bug.cgi?id=1111111"/>
           </issues>
         </sourcediff>
@@ -626,7 +626,7 @@ http_interactions:
             </file>
           </files>
           <issues>
-            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=2011-1111"/>
+            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="https://www.cve.org/CVERecord?id=CVE-2011-1111"/>
             <issue state="added" tracker="bnc" name="1111111" label="boo#1111111" url="https://bugzilla.opensuse.org/show_bug.cgi?id=1111111"/>
           </issues>
         </sourcediff>
@@ -765,7 +765,7 @@ http_interactions:
             </file>
           </files>
           <issues>
-            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=2011-1111"/>
+            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="https://www.cve.org/CVERecord?id=CVE-2011-1111"/>
             <issue state="added" tracker="bnc" name="1111111" label="boo#1111111" url="https://bugzilla.opensuse.org/show_bug.cgi?id=1111111"/>
           </issues>
         </sourcediff>
@@ -904,7 +904,7 @@ http_interactions:
             </file>
           </files>
           <issues>
-            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=2011-1111"/>
+            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="https://www.cve.org/CVERecord?id=CVE-2011-1111"/>
             <issue state="added" tracker="bnc" name="1111111" label="boo#1111111" url="https://bugzilla.opensuse.org/show_bug.cgi?id=1111111"/>
           </issues>
         </sourcediff>
@@ -1259,7 +1259,7 @@ http_interactions:
             </file>
           </files>
           <issues>
-            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=2011-1111"/>
+            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="https://www.cve.org/CVERecord?id=CVE-2011-1111"/>
             <issue state="added" tracker="bnc" name="1111111" label="boo#1111111" url="https://bugzilla.opensuse.org/show_bug.cgi?id=1111111"/>
           </issues>
         </sourcediff>
@@ -1542,7 +1542,7 @@ http_interactions:
             </file>
           </files>
           <issues>
-            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=2011-1111"/>
+            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="https://www.cve.org/CVERecord?id=CVE-2011-1111"/>
             <issue state="added" tracker="bnc" name="1111111" label="boo#1111111" url="https://bugzilla.opensuse.org/show_bug.cgi?id=1111111"/>
           </issues>
         </sourcediff>

--- a/src/api/spec/cassettes/Comments_with_diff/diff_comment_in_legacy_view/displays_the_comment_with_a_hint_to_the_corresponding_file_and_line.yml
+++ b/src/api/spec/cassettes/Comments_with_diff/diff_comment_in_legacy_view/displays_the_comment_with_a_hint_to_the_corresponding_file_and_line.yml
@@ -204,7 +204,7 @@ http_interactions:
             </file>
           </files>
           <issues>
-            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=2011-1111"/>
+            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="https://www.cve.org/CVERecord?id=CVE-2011-1111"/>
             <issue state="added" tracker="bnc" name="1111111" label="boo#1111111" url="https://bugzilla.opensuse.org/show_bug.cgi?id=1111111"/>
           </issues>
         </sourcediff>

--- a/src/api/spec/cassettes/Comments_with_diff/reply_comment/when_under_the_beta_program/displays_the_changes_after_adding_a_new_comment.yml
+++ b/src/api/spec/cassettes/Comments_with_diff/reply_comment/when_under_the_beta_program/displays_the_changes_after_adding_a_new_comment.yml
@@ -444,7 +444,7 @@ http_interactions:
             </file>
           </files>
           <issues>
-            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=2011-1111"/>
+            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="https://www.cve.org/CVERecord?id=CVE-2011-1111"/>
             <issue state="added" tracker="bnc" name="1111111" label="boo#1111111" url="https://bugzilla.opensuse.org/show_bug.cgi?id=1111111"/>
           </issues>
         </sourcediff>
@@ -570,7 +570,7 @@ http_interactions:
             </file>
           </files>
           <issues>
-            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=2011-1111"/>
+            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="https://www.cve.org/CVERecord?id=CVE-2011-1111"/>
             <issue state="added" tracker="bnc" name="1111111" label="boo#1111111" url="https://bugzilla.opensuse.org/show_bug.cgi?id=1111111"/>
           </issues>
         </sourcediff>
@@ -661,7 +661,7 @@ http_interactions:
             </file>
           </files>
           <issues>
-            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=2011-1111"/>
+            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="https://www.cve.org/CVERecord?id=CVE-2011-1111"/>
             <issue state="added" tracker="bnc" name="1111111" label="boo#1111111" url="https://bugzilla.opensuse.org/show_bug.cgi?id=1111111"/>
           </issues>
         </sourcediff>
@@ -800,7 +800,7 @@ http_interactions:
             </file>
           </files>
           <issues>
-            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=2011-1111"/>
+            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="https://www.cve.org/CVERecord?id=CVE-2011-1111"/>
             <issue state="added" tracker="bnc" name="1111111" label="boo#1111111" url="https://bugzilla.opensuse.org/show_bug.cgi?id=1111111"/>
           </issues>
         </sourcediff>
@@ -1008,7 +1008,7 @@ http_interactions:
             </file>
           </files>
           <issues>
-            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=2011-1111"/>
+            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="https://www.cve.org/CVERecord?id=CVE-2011-1111"/>
             <issue state="added" tracker="bnc" name="1111111" label="boo#1111111" url="https://bugzilla.opensuse.org/show_bug.cgi?id=1111111"/>
           </issues>
         </sourcediff>

--- a/src/api/spec/cassettes/Requests_Submissions/submit_package/when_under_the_beta_program/submit_several_packages_at_once_against_a_factory_staging_project/shows_the_beta_version_of_the_requests_page.yml
+++ b/src/api/spec/cassettes/Requests_Submissions/submit_package/when_under_the_beta_program/submit_several_packages_at_once_against_a_factory_staging_project/shows_the_beta_version_of_the_requests_page.yml
@@ -765,7 +765,7 @@ http_interactions:
             </file>
           </files>
           <issues>
-            <issue state="added" tracker="cve" name="2011-1101" label="CVE-2011-1101" url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=2011-1101"/>
+            <issue state="added" tracker="cve" name="2011-1101" label="CVE-2011-1101" url="https://www.cve.org/CVERecord?id=CVE-2011-1101"/>
             <issue state="added" tracker="bnc" name="1111101" label="boo#1111101" url="https://bugzilla.opensuse.org/show_bug.cgi?id=1111101"/>
           </issues>
         </sourcediff>
@@ -926,7 +926,7 @@ http_interactions:
             </file>
           </files>
           <issues>
-            <issue state="added" tracker="cve" name="2011-1101" label="CVE-2011-1101" url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=2011-1101"/>
+            <issue state="added" tracker="cve" name="2011-1101" label="CVE-2011-1101" url="https://www.cve.org/CVERecord?id=CVE-2011-1101"/>
             <issue state="added" tracker="bnc" name="1111101" label="boo#1111101" url="https://bugzilla.opensuse.org/show_bug.cgi?id=1111101"/>
           </issues>
         </sourcediff>
@@ -1192,7 +1192,7 @@ http_interactions:
             </file>
           </files>
           <issues>
-            <issue state="added" tracker="cve" name="2011-1101" label="CVE-2011-1101" url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=2011-1101"/>
+            <issue state="added" tracker="cve" name="2011-1101" label="CVE-2011-1101" url="https://www.cve.org/CVERecord?id=CVE-2011-1101"/>
             <issue state="added" tracker="bnc" name="1111101" label="boo#1111101" url="https://bugzilla.opensuse.org/show_bug.cgi?id=1111101"/>
           </issues>
         </sourcediff>
@@ -1356,7 +1356,7 @@ http_interactions:
             </file>
           </files>
           <issues>
-            <issue state="added" tracker="cve" name="2011-1101" label="CVE-2011-1101" url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=2011-1101"/>
+            <issue state="added" tracker="cve" name="2011-1101" label="CVE-2011-1101" url="https://www.cve.org/CVERecord?id=CVE-2011-1101"/>
             <issue state="added" tracker="bnc" name="1111101" label="boo#1111101" url="https://bugzilla.opensuse.org/show_bug.cgi?id=1111101"/>
           </issues>
         </sourcediff>

--- a/src/api/spec/controllers/webui/patchinfo_controller_spec.rb
+++ b/src/api/spec/controllers/webui/patchinfo_controller_spec.rb
@@ -286,7 +286,7 @@ RSpec.describe Webui::PatchinfoController, :vcr do
 
         it do
           expect(response.parsed_body).to eq('error' => '',
-                                             'issues' => [['cve', 'CVE-2010-31337', 'http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2010-31337', '']])
+                                             'issues' => [['cve', 'CVE-2010-31337', 'https://www.cve.org/CVERecord?id=CVE-2010-31337', '']])
         end
 
         it { expect(response).to have_http_status(:success) }

--- a/src/api/test/fixtures/issue_trackers.yml
+++ b/src/api/test/fixtures/issue_trackers.yml
@@ -58,9 +58,9 @@ cve_numbers:
   name: cve
   kind: cve
   description: CVE numbers
-  url: http://cve.mitre.org
-  show_url: http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-@@@
-  regex: (?:cve|CVE)-(\d\d\d\d-\d+)
+  url: https://www.cve.org/
+  show_url: https://www.cve.org/CVERecord?id=CVE-@@@
+  regex: (?:cve-|CVE-)(\d\d\d\d-\d+)
   label: 'CVE-@@@'
   issues_updated: 2011-07-29 14:00:21.000000000 Z
   enable_fetch: 0

--- a/src/api/test/functional/maintenance_test.rb
+++ b/src/api/test/functional/maintenance_test.rb
@@ -1222,7 +1222,7 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     assert_xml_tag parent: { tag: 'update', attributes: { from: 'maintenance_coord', status: 'stable', type: 'security', version: '1' } }, tag: 'id', content: nil
     assert_xml_tag tag: 'reference', attributes: { href: 'https://bugzilla.novell.com/show_bug.cgi?id=1042', id: '1042', type: 'bugzilla' }
     assert_xml_tag tag: 'reference', attributes: { href: 'https://bugzilla.novell.com/show_bug.cgi?id=4201', id: '4201', type: 'bugzilla' }
-    assert_xml_tag tag: 'reference', attributes: { href: 'http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2009-0815', id: 'CVE-2009-0815', type: 'cve' }
+    assert_xml_tag tag: 'reference', attributes: { href: 'https://www.cve.org/CVERecord?id=CVE-2009-0815', id: 'CVE-2009-0815', type: 'cve' }
     assert_no_xml_tag tag: 'reference', attributes: { href: 'https://bugzilla.novell.com/show_bug.cgi?id=' }
     assert_no_xml_tag tag: 'reference', attributes: { id: '' }
     # check updateinfo


### PR DESCRIPTION
from mitre.org:

NOTICE: This legacy website is in the process of being retired.
Please use the new [WWW.CVE.ORG](https://www.cve.org/) website.

First step towards replacing cve.mitre.org with cve.org... the rest of the replacement will be done once we work on https://github.com/openSUSE/open-build-service/issues/18105

## Testing Tips

From patchinfo:

- Go to a project show page
- Click on _Create Patchinfo_ on the _Actions on this page_ menu item
- Fill in the form. Don't forget about the _Issues_ field. Real values: "CVE-2025-52891" or "CVE-2011-3651"
- Save
- Check the added issues are listed in the _Fixed Bugs_ section and point to the new URL.

From a request:

- Branch a package and do some changes
- In the x.changes file, mention one or more issues
- Submit the request
- Check that the issues are listed in the _Mentioned Issues_ tab and point to the new URL.
