### PR TITLE
Refactoring: remove methods to require parameters

### DIFF
--- a/src/api/app/controllers/application_controller.rb
+++ b/src/api/app/controllers/application_controller.rb
@@ -107,14 +107,6 @@ class ApplicationController < ActionController::Base
     response.headers['X-Opensuse-APIVersion'] = CONFIG['version'].to_s
   end
 
-  def require_parameter!(parameter)
-    raise MissingParameterError, "Required Parameter #{parameter} missing" unless params.include?(parameter.to_s)
-  end
-
-  def required_parameters(*parameters)
-    parameters.each { |parameter| require_parameter!(parameter) }
-  end
-
   def gather_exception_defaults(opt)
     if opt[:message]
       @summary = opt[:message].to_s

--- a/src/api/app/controllers/build_controller.rb
+++ b/src/api/app/controllers/build_controller.rb
@@ -161,11 +161,7 @@ class BuildController < ApplicationController
   end
 
   def result_lastsuccess
-    begin
-      params.require(%i[package pathproject])
-    rescue ActionController::ParameterMissing => e
-      raise MissingParameterError, e.message
-    end
+    params.require(%i[package pathproject])
 
     pkg = Package.get_by_project_and_name(params[:project], params[:package],
                                           use_source: false, follow_multibuild: true)

--- a/src/api/app/controllers/concerns/rescue_handler.rb
+++ b/src/api/app/controllers/concerns/rescue_handler.rb
@@ -2,6 +2,10 @@ module RescueHandler
   extend ActiveSupport::Concern
 
   included do
+    rescue_from ActionController::ParameterMissing do |exception|
+      render_error status: 400, errorcode: 'missing_parameter', message: exception.message
+    end
+
     rescue_from ActiveRecord::RecordInvalid do |exception|
       render_error status: 400, errorcode: 'invalid_record', message: exception.record.errors.full_messages.join('\n')
     end

--- a/src/api/app/controllers/source_package_command_controller.rb
+++ b/src/api/app/controllers/source_package_command_controller.rb
@@ -43,7 +43,7 @@ class SourcePackageCommandController < SourceController
 
   # POST /source/<project>/<package>?cmd=unlock
   def unlock
-    required_parameters :comment
+    params.require(:comment)
 
     p = { comment: params[:comment] }
 
@@ -113,7 +113,7 @@ class SourcePackageCommandController < SourceController
 
   # POST /source/<project>/<package>?cmd=collectbuildenv
   def collectbuildenv
-    required_parameters :oproject, :opackage
+    params.require(%i[oproject opackage])
 
     Package.get_by_project_and_name(@target_project_name, @target_package_name)
 
@@ -410,14 +410,15 @@ class SourcePackageCommandController < SourceController
 
   # POST /source/<project>/<package>?cmd=set_flag&repository=:opt&arch=:opt&flag=flag&status=status
   def set_flag
-    required_parameters :flag, :status
+    params.require(%i[flag status])
 
     obj_set_flag(@package)
   end
 
   # POST /source/<project>/<package>?cmd=remove_flag&repository=:opt&arch=:opt&flag=flag
   def remove_flag
-    required_parameters :flag
+    params.require(:flag)
+
     obj_remove_flag(@package)
   end
 
@@ -452,7 +453,8 @@ class SourcePackageCommandController < SourceController
   def set_origin_package
     return nil unless params[:opackage]
 
-    required_parameters(:oproject)
+    params.require(:oproject)
+
     raise InvalidPackageNameError, "invalid package name '#{params[:opackage]}'" unless Package.valid_name?(params[:opackage])
     raise InvalidProjectNameError, "invalid project name '#{params[:oproject]}'" unless Project.valid_name?(params[:oproject])
 

--- a/src/api/app/controllers/source_project_command_controller.rb
+++ b/src/api/app/controllers/source_project_command_controller.rb
@@ -6,7 +6,7 @@ class SourceProjectCommandController < SourceController
   def project_command
     # init and validation
     #--------------------
-    required_parameters(:cmd)
+    params.require(:cmd)
 
     valid_commands = %w[undelete showlinked remove_flag set_flag createpatchinfo
                         createkey extendkey copy createmaintenanceincident lock
@@ -51,7 +51,7 @@ class SourceProjectCommandController < SourceController
   # unlock a project
   # POST /source/<project>?cmd=unlock
   def project_command_unlock
-    required_parameters :comment
+    params.require(:comment)
 
     @project.unlock!(params[:comment])
 
@@ -268,7 +268,7 @@ class SourceProjectCommandController < SourceController
 
   # POST /source/<project>?cmd=set_flag&repository=:opt&arch=:opt&flag=flag&status=status
   def project_command_set_flag
-    required_parameters :flag, :status
+    params.require(%i[flag status])
 
     # Raising permissions afterwards is not secure. Do not allow this by default.
     unless User.admin_session?
@@ -284,7 +284,8 @@ class SourceProjectCommandController < SourceController
 
   # POST /source/<project>?cmd=remove_flag&repository=:opt&arch=:opt&flag=flag
   def project_command_remove_flag
-    required_parameters :flag
+    params.require(:flag)
+
     obj_remove_flag(@project)
   end
 

--- a/src/api/app/controllers/worker/command_controller.rb
+++ b/src/api/app/controllers/worker/command_controller.rb
@@ -1,10 +1,6 @@
 class Worker::CommandController < ApplicationController
   def run
-    begin
-      params.require(%i[cmd project package repository arch])
-    rescue ActionController::ParameterMissing => e
-      raise MissingParameterError, e.message
-    end
+    params.require(%i[cmd project package repository arch])
 
     raise UnknownCommandError, "Unknown command '#{params[:cmd]}' for path #{request.path}" unless params[:cmd] == 'checkconstraints'
 

--- a/src/api/test/functional/source_controller_test.rb
+++ b/src/api/test/functional/source_controller_test.rb
@@ -3995,7 +3995,7 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
 
     post '/source/home:Iggy?cmd=set_flag&repository=10.2&arch=i586&flag=build'
     assert_response :bad_request
-    assert_match(/Required Parameter status missing/, @response.body)
+    assert_xml_tag tag: 'status', attributes: { code: 'missing_parameter' }
 
     post '/source/home:Iggy?cmd=set_flag&repository=10.2&arch=i586&flag=build&status=anything'
     assert_response :bad_request


### PR DESCRIPTION
For requiring query parameters on API endpoints we can use the method `require` from action controller parameters.

Follow-up to #18104.