### PR TITLE
Deny access to binaries page if project is scmsync managed

### DIFF
--- a/src/api/app/controllers/webui/packages/binaries_controller.rb
+++ b/src/api/app/controllers/webui/packages/binaries_controller.rb
@@ -2,6 +2,7 @@ module Webui
   module Packages
     class BinariesController < Webui::WebuiController
       include Webui::Packages::BinariesHelper
+      include ScmsyncChecker
 
       # TODO: Keep in sync with Build::query in backend/build/Build.pm.
       #       Regexp.new('\.iso$') would be Build::Kiwi::queryiso which isn't implemented yet...
@@ -12,6 +13,7 @@ module Webui
 
       before_action :require_login, except: [:index]
       before_action :set_project
+      before_action :check_scmsync
       before_action :set_package
       before_action :set_multibuild_flavor
       before_action :set_repository


### PR DESCRIPTION
It makes no sense to access the page given we have no local packages and the page will break left and right.

We just block the access to the binaries with an error and redirect to the project index.

Fixes #17684