### PR TITLE
Remove commented method on IssueTracker model

### DIFF
--- a/src/api/app/models/issue_tracker.rb
+++ b/src/api/app/models/issue_tracker.rb
@@ -23,11 +23,6 @@ class IssueTracker < ApplicationRecord
     self.issues_updated ||= Time.now
   end
 
-  # Checks if the given issue belongs to this issue tracker
-  #  def matches?(issue)
-  #    return Regexp.new(regex).match(issue)
-  #  end
-
   # Generates a URL to display a given issue in the upstream issue tracker
   def show_url_for(issue, html = nil)
     return unless issue


### PR DESCRIPTION
This method was commented more than a decade ago in https://github.com/openSUSE/open-build-service/commit/9f77b138e2badab0bb6cbb2d098bb5bad1cd88d1. It's time to remove it.

