### PR TITLE
[dist] fix E: permissions-world-writable for gemspec files

### DIFF
--- a/dist/obs-bundled-gems.spec
+++ b/dist/obs-bundled-gems.spec
@@ -193,6 +193,9 @@ done
 chrpath -d %{buildroot}%_libdir/obs-api/ruby/*/extensions/*/*/mysql2-*/mysql2/mysql2.so || true
 chrpath -d %{buildroot}%_libdir/obs-api/ruby/*/gems/mysql2-*/lib/mysql2/mysql2.so || true
 
+# fix E: permissions-world-writable for gemspec files
+chmod 0644 %{buildroot}%_libdir/obs-api/ruby/*/specifications/*.gemspec || true
+
 %files
 %defattr(-,root,root,755)
 %_libdir/obs-api


### PR DESCRIPTION
From [OBS:Server:Unstable/obs-server:obs-bundled-gems/15.7/x86_64](https://build.opensuse.org/package/live_build_log/OBS:Server:Unstable/obs-server:obs-bundled-gems/15.7/x86_64)
```
[  249s] obs-bundled-gems.x86_64: E: permissions-world-writable (Badness: 10000) /usr/lib64/obs-api/ruby/3.4.0/specifications/crass-1.0.6.gemspec is packaged with world writable permissions (0666)
[  249s] If the package is intended for inclusion in any SUSE product please open a bug
[  249s] report to request review of the package by the security team. Please refer to
[  249s] https://en.opensuse.org/openSUSE:Package_security_guidelines#audit_bugs for
[  249s] more information.
```