### PR TITLE
Issue spec refactoring

### DIFF
--- a/src/api/spec/models/issue_spec.rb
+++ b/src/api/spec/models/issue_spec.rb
@@ -18,11 +18,13 @@ RSpec.describe Issue do
   describe 'name_validation' do
     let(:issue_tracker) { create(:issue_tracker) }
     let(:issue_tracker_v1) { create(:issue_tracker, name: 'v1_tracker', regex: '([BD]-[\d]+)', label: '(B-@@@)') }
-    let(:issue_tracker_cve) { create(:issue_tracker, name: 'cve_tracker', regex: '^(?:cve|CVE)-(\d\d\d\d-\d+)', label: 'CVE-@@@') }
+    let(:issue_tracker_cve) { IssueTracker.find_by(name: 'cve') } # Seeded in database. Regex: 'CVE-(\d\d\d\d-\d+)' label: 'CVE-@@@'
 
     let(:issue) { create(:issue, name: '1234', issue_tracker: issue_tracker) }
     let(:issue_v1) { create(:issue, name: '1234', issue_tracker: issue_tracker_v1) }
-    let(:issue_cve) { build(:issue, name: 'CVE-2019-12345', issue_tracker: issue_tracker_cve) }
+    let(:issue_cve_no_prefix) { build(:issue, name: '2019-12345', issue_tracker: issue_tracker_cve) }
+    let(:issue_cve_uppercase) { build(:issue, name: 'CVE-2019-12345', issue_tracker: issue_tracker_cve) }
+    let(:issue_cve_lowercase) { build(:issue, name: 'cve-2019-12345', issue_tracker: issue_tracker_cve) }
 
     it 'issue name should be valid' do
       expect(issue).to be_valid
@@ -32,8 +34,18 @@ RSpec.describe Issue do
       expect(issue_v1).to be_valid
     end
 
-    it 'CVE-XXXX-YYYY should be an invalid name' do
-      expect { issue_cve.save! }.to raise_error(ActiveRecord::RecordInvalid, /does not match defined regex/)
+    it 'CVE issue with pattern XXXX-YYYY should be valid name' do
+      expect(issue_cve_no_prefix).to be_valid
+    end
+
+    # TODO: this pattern shouldn't be valid at creation time
+    it 'CVE issue with pattern CVE-XXXX-YYYY should be valid name' do
+      expect(issue_cve_uppercase).to be_valid
+    end
+
+    it 'cve-XXXX-YYYY should be an invalid name' do
+      expect(issue_cve_lowercase).not_to be_valid
+      expect(issue_cve_lowercase.errors.full_messages).to contain_exactly("Name with value '#{issue_cve_lowercase.name}' does not match defined regex #{issue_tracker_cve.regex}")
     end
   end
 end


### PR DESCRIPTION
tl;dr

This PR refactors the spec to make it useful to test the move from cve.mitre.org to cve.org in PR #18106.

There is a bit of mess on how we handle CVE-related issues. The long-term goal will be doing a bit of refactoring, but, before that we need to finish PR #18106. 

---

After a long discussion https://github.com/openSUSE/open-build-service/pull/7291 about whether the name should be stored with a prefix (CVE- / cve-) or not, it was concluded that

- only digits and hyphens  are allowed in the name (as "CVE-" would be added as prefix in another part of the code)
- the validation will be triggered only on creation time to avoid problems with the existing wide variety of names in the DB (XXXX-YYYY, CVE-XXXX-YYYY, cve-XXXX-YYYY).

However, the test was not accurate enough. The intention was testing that an issue with name ‘CVE-XXXX-YYYY’ should fail. And the test fails but only by chance! Because it’s receiving ‘CVE-CVE-XXXX-YYYY’ (because of the label stuff). It’s easier to understand if you debug it a bit.

So since then, we are still accepting both XXXX-YYYY and CVE-XXXX-YYYY.
