### PR TITLE
Fix comment on diff wrongly marked as outdated

### DIFF
--- a/src/api/app/models/bs_request_action_submit.rb
+++ b/src/api/app/models/bs_request_action_submit.rb
@@ -163,11 +163,13 @@ class BsRequestActionSubmit < BsRequestAction
   end
 
   def source_srcmd5
-    source_package_object&.dir_hash({ rev: source_rev }.compact)&.[]('srcmd5')
+    backend_package = source_package_object&.dir_hash({ rev: source_rev }.compact)
+    backend_package&.[]('linkinfo')&.[]('xsrcmd5') || backend_package&.[]('srcmd5')
   end
 
   def target_srcmd5
-    target_package_object&.dir_hash&.[]('srcmd5')
+    backend_package = target_package_object&.dir_hash&.[]('srcmd5')
+    backend_package&.[]('linkinfo')&.[]('xsrcmd5') || backend_package&.[]('srcmd5')
   end
 
   #### Alias of methods


### PR DESCRIPTION
When retrieving the srcmd5 of a source package of a submit request, if this source package has a link, return the xsrcmd5 field from the linkinfo hash stored in the backend package.