### PR TITLE
Add previews and previews' specs for DiffSubjectComponent

### DIFF
--- a/src/api/spec/components/diff_subject_component_spec.rb
+++ b/src/api/spec/components/diff_subject_component_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe DiffSubjectComponent, type: :component do
+  it 'renders the unmodified preview' do
+    render_preview('not_modified')
+
+    expect(rendered_content).to have_text('file.txt')
+  end
+
+  it 'renders the rest of the previews' do
+    %i[added deleted changed renamed].each do |preview_name|
+      render_preview(preview_name)
+
+      expect(rendered_content).to have_text(preview_name.capitalize)
+    end
+  end
+end

--- a/src/api/spec/components/previews/diff_subject_component_preview.rb
+++ b/src/api/spec/components/previews/diff_subject_component_preview.rb
@@ -1,6 +1,22 @@
 class DiffSubjectComponentPreview < ViewComponent::Preview
-  # Preview at http://HOST:PORT/rails/view_components/diff_subject_component/preview
-  def preview
-    render(DiffSubjectComponent.new(state: 'changed', new_filename: 'a_file_name', old_filename: 'old_filah'))
+  # Preview at http://HOST:PORT/rails/view_components/diff_subject_component/
+  def added
+    render(DiffSubjectComponent.new(state: 'added', new_filename: 'new_file.txt', old_filename: ''))
+  end
+
+  def deleted
+    render(DiffSubjectComponent.new(state: 'deleted', new_filename: 'file.txt', old_filename: 'file.txt'))
+  end
+
+  def changed
+    render(DiffSubjectComponent.new(state: 'changed', new_filename: 'file.txt', old_filename: 'file.txt'))
+  end
+
+  def renamed
+    render(DiffSubjectComponent.new(state: 'renamed', new_filename: 'new_file.txt', old_filename: 'old_file.txt'))
+  end
+
+  def not_modified
+    render(DiffSubjectComponent.new(state: '', new_filename: 'file.txt', old_filename: 'file.txt'))
   end
 end


### PR DESCRIPTION
### For reviewers

Check the add component previews in [this link](http://obs-reviewlab.opensuse.org/eduardoj-testsdiff_subject_component/rails/view_components/diff_subject_component) of the review app.