### PR TITLE
[dist] make output path for rspec tests configurable

### DIFF
--- a/dist/t/spec/spec_helper.rb
+++ b/dist/t/spec/spec_helper.rb
@@ -3,7 +3,7 @@
 # for capybara rspec support
 require 'support/capybara'
 
-SCREENSHOT_DIR = '/tmp/rspec_screens'.freeze
+SCREENSHOT_DIR = ENV.fetch('RSPEC_RESULT_DIR', '/tmp/rspec_screens').freeze
 
 RSpec.configure do |config|
   config.before(:suite) do

--- a/dist/t/spec/support/capybara.rb
+++ b/dist/t/spec/support/capybara.rb
@@ -18,7 +18,8 @@ end
 Capybara.default_driver = :selenium_chrome_headless
 Capybara.default_max_wait_time = 6
 Capybara.javascript_driver = :selenium_chrome_headless
-Capybara.save_path = '/tmp/rspec_screens'
+Capybara.save_path = ENV.fetch('RSPEC_RESULT_DIR', '/tmp/rspec_screens')
+
 # Attempt to click the associated label element if a checkbox/radio button are non-visible (This is especially useful for Bootstrap custom controls)
 Capybara.automatic_label_click = true
 


### PR DESCRIPTION
This patch makes the result dir of the rspec tests configurable.
In our kanku instance we use a jump host with a running apache2.
Saving the screenshots/html files in `/srv/www/htdocs` will allow easy access to the results.

Here you can find the corresponding patch in kanku's OBSServerTests handler:
https://github.com/M0ses/kanku/commit/ca5abf31a477af7ef3cf3ba4005f263c536b1add
The patch already has been tested successfully in our internal kanku instance.