### PR TITLE
It makes no sense to access the package requests page given we have no local packages.

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -16,7 +16,7 @@ class Webui::PackageController < Webui::WebuiController
                                        save_person save_group remove_role view_file
                                        buildresult rpmlint_result rpmlint_log files]
 
-  before_action :check_scmsync, only: %i[statistics users]
+  before_action :check_scmsync, only: %i[statistics users requests]
 
   before_action :require_package, only: %i[edit update show requests statistics revisions
                                            branch_diff_info rdiff remove


### PR DESCRIPTION
We just block the access to the package requests page with an error and redirect to the project index.

Fixes #17618
Related to #18129