### PR TITLE
Add `status` field to table `bs_requests`

### DIFF
--- a/src/api/db/migrate/20250708130643_add_status_to_bs_requests.rb
+++ b/src/api/db/migrate/20250708130643_add_status_to_bs_requests.rb
@@ -1,0 +1,6 @@
+class AddStatusToBsRequests < ActiveRecord::Migration[7.2]
+  def change
+    add_column :bs_requests, :status, :integer
+    add_index :bs_requests, :status
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_06_12_085047) do
+ActiveRecord::Schema[7.2].define(version: 2025_07_08_130643) do
   create_table "active_storage_attachments", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -277,10 +277,12 @@ ActiveRecord::Schema[7.2].define(version: 2025_06_12_085047) do
     t.datetime "updated_when", precision: nil
     t.string "approver"
     t.integer "staging_project_id"
+    t.integer "status"
     t.index ["creator"], name: "index_bs_requests_on_creator"
     t.index ["number"], name: "index_bs_requests_on_number", unique: true
     t.index ["staging_project_id"], name: "index_bs_requests_on_staging_project_id"
     t.index ["state"], name: "index_bs_requests_on_state"
+    t.index ["status"], name: "index_bs_requests_on_status"
     t.index ["superseded_by"], name: "index_bs_requests_on_superseded_by"
   end
 


### PR DESCRIPTION
This is the first step to change the type of the field `state` from `string` to `enum`: "Create a new column `status`".

In order to not cause any downtime on our production systems, this will be performed in steps:

### Steps for changing the type of the column

1. Create a new column `status` <-
2. Write to both columns
3. Backfill data from the old column to the new column
4. Move reads from the old column to the new column
5. Stop writing to the old column `state`
6. Drop the old column `state`

### Steps for renaming a column

7. Create a new column `state`
8. Write to both columns
9. Backfill data from the old column to the new column
10. Move reads from the old column to the new column
11. Stop writing to the old column `status`
12. Drop the old column `status`

### References

- https://api.rubyonrails.org/v7.2.2.1/classes/ActiveRecord/Enum.html
- Safe approach to change the type of a column:
  - https://github.com/ankane/strong_migrations?tab=readme-ov-file#good-1
- Safe approach to rename a column:
  - https://github.com/ankane/strong_migrations?tab=readme-ov-file#good-2

