### PR TITLE
Fix qlty archive path

### DIFF
--- a/.circleci/conditional_config.yml
+++ b/.circleci/conditional_config.yml
@@ -388,7 +388,7 @@ jobs:
             QLTY_COVERAGE_TOKEN: qltcp_wbImki2Nq6aYQokf
           command: |
             curl -L https://qlty-releases.s3.amazonaws.com/qlty/latest/qlty-x86_64-unknown-linux-gnu.tar.xz > qlty.tar.xz
-            tar -xf qlty.tar.xz qlty-x86_64-unknown-linux-gnu/qlty --strip-components 1
+            tar -xf qlty.tar.xz ./qlty --strip-components 1
             ./qlty coverage transform --add-prefix src/api/ --report-format cobertura coverage/coverage.xml
             ./qlty coverage publish coverage.jsonl
       - run:


### PR DESCRIPTION
Using

  tar -xf qlty.tar.xz qlty-x86_64-unknown-linux-gnu/qlty
--strip-components 1

leads to this error

  tar: qlty-x86_64-unknown-linux-gnu/qlty: Not found in archive

So we fix the archive path of the qlty binary.

You can see it failing on

https://app.circleci.com/pipelines/github/openSUSE/open-build-service/25935/workflows/47be273c-4a9a-4e6e-95a3-86ea2e8151ee/jobs/242462