### PR TITLE
Revert "Fix qlty archive path"

### DIFF
--- a/.circleci/conditional_config.yml
+++ b/.circleci/conditional_config.yml
@@ -388,7 +388,7 @@ jobs:
             QLTY_COVERAGE_TOKEN: qltcp_wbImki2Nq6aYQokf
           command: |
             curl -L https://qlty-releases.s3.amazonaws.com/qlty/latest/qlty-x86_64-unknown-linux-gnu.tar.xz > qlty.tar.xz
-            tar -xf qlty.tar.xz ./qlty --strip-components 1
+            tar -xf qlty.tar.xz qlty-x86_64-unknown-linux-gnu/qlty --strip-components 1
             ./qlty coverage transform --add-prefix src/api/ --report-format cobertura coverage/coverage.xml
             ./qlty coverage publish coverage.jsonl
       - run:


### PR DESCRIPTION
Reverts openSUSE/open-build-service#18148

I they fixed the contents of the archive now. So the path is wrong again.

```
~/tmp ❯ tar --list -f qlty.tar
qlty-x86_64-unknown-linux-gnu/
qlty-x86_64-unknown-linux-gnu/LICENSE.md
qlty-x86_64-unknown-linux-gnu/README.md
qlty-x86_64-unknown-linux-gnu/CHANGELOG.md
qlty-x86_64-unknown-linux-gnu/qlty
```