### PR TITLE
[backend] implement aggregations from the 'local' architecture

### DIFF
--- a/docs/api/api/aggregate.rng
+++ b/docs/api/api/aggregate.rng
@@ -23,6 +23,16 @@
           <attribute name="project">
             <text/>
           </attribute>
+          <optional>
+            <attribute name="arch">
+              <text/>
+            </attribute>
+          </optional>
+          <optional>
+            <attribute name="sourcearch"> <!-- is only working for local atm -->
+              <text/>
+            </attribute>
+          </optional>
           <interleave> 
             <zeroOrMore>
               <element ns="" name="binary">

--- a/src/backend/BSVerify.pm
+++ b/src/backend/BSVerify.pm
@@ -362,6 +362,8 @@ sub verify_aggregatelist {
   }
   for my $a (@{$al->{'aggregate'} || []}) {
     verify_projid($a->{'project'});
+    verify_arch($a->{'arch'}) if exists $a->{'arch'};
+    verify_arch($a->{'sourcearch'}) if exists $a->{'sourcearch'};
     if (defined($a->{'nosources'})) {
       die("'nosources' element must be empty\n") if $a->{'nosources'} ne '';
     }

--- a/src/backend/BSXML.pm
+++ b/src/backend/BSXML.pm
@@ -229,6 +229,8 @@ our $aggregatelist = [
       'resign',
      [[ 'aggregate' =>
 	    'project',
+	    'arch',
+	    'sourcearch',
 	    [],
             'nosources',
 	  [ 'package' ],


### PR DESCRIPTION
This is done with two new attributes of an aggregate element:
- arch: limit the aggregate to the specified architecture
- sourcearch: aggregate from this architecture

Currently we only support cross-arch aggregates from the 'local' architecture.