### PR TITLE
Drop CVE- prefix from the issue name before storing

### DIFF
--- a/src/api/app/models/issue_tracker/issue_summary.rb
+++ b/src/api/app/models/issue_tracker/issue_summary.rb
@@ -27,6 +27,7 @@ class IssueTracker::IssueSummary
   end
 
   def find_or_create_by_name_and_tracker
-    Issue.find_or_create_by_name_and_tracker(@issue_id, @issue_tracker.name)
+    # Only if the issue_id is prefixed with 'CVE-' (cve kind of issue), that prefix is removed
+    Issue.find_or_create_by_name_and_tracker(@issue_id.gsub(/^CVE-/, ''), @issue_tracker.name)
   end
 end


### PR DESCRIPTION
In production's database there is a mix of formats for the CVE kind of issues.

There has been [long discussions](https://github.com/openSUSE/open-build-service/pull/7291) already. The intention of that PR was storing the issue name without prefix but it wasn't correctly implemented.
Nowadays, the code extracts and stores cve issues from different places like the request changes, the [bulk issues update](https://github.com/openSUSE/open-build-service/blob/3f5eb45490e46a083fc50ed8da77b905b2d90b38/src/api/app/models/issue_tracker/cve_parser.rb#L15) or [patchinfos](https://github.com/openSUSE/open-build-service/blob/3f5eb45490e46a083fc50ed8da77b905b2d90b38/src/api/app/models/issue_tracker/issue_summary.rb#L30). The issues coming from patchinfos store them with prefix while the others don't.

This PR adapts the code that creates issues once the patchinfo is updated.


## Testing Tips

- Start from the data generated by `rake dev:test_data:create`
- Go to _openSUSE:Maintenance_ project
- Go to _Actions on this page_ menu and click on _Create Patchinfo_
- Fill in the required fields and add at least one CVE issue. For example: `CVE-2000-2222`
- Check the value is stored as `2000-2222` in the database
