### PR TITLE
Add missing previews for request action description component

### DIFF
--- a/src/api/spec/components/bs_request_action_description_component_spec.rb
+++ b/src/api/spec/components/bs_request_action_description_component_spec.rb
@@ -1,0 +1,91 @@
+RSpec.describe BsRequestActionDescriptionComponent, type: :component do
+  context 'add_role' do
+    before do
+      create(:add_maintainer_request)
+    end
+
+    it 'renders the "add_role" preview' do
+      render_preview('add_role')
+
+      expect(rendered_content).to have_text('get the role')
+    end
+  end
+
+  context 'change_devel' do
+    before do
+      create(:bs_request_with_change_devel_action)
+    end
+
+    it 'renders the "change_devel" previews' do
+      %i[change_devel change_devel_text_only].each do |preview_name|
+        render_preview(preview_name)
+
+        expect(rendered_content).to have_text('be devel project/package of')
+      end
+    end
+  end
+
+  context 'delete' do
+    before do
+      create(:bs_request_action_delete, target_project: create(:project), bs_request: create(:delete_bs_request))
+    end
+
+    it 'renders the "delete" previews' do
+      %i[delete delete_text_only].each do |preview_name|
+        render_preview(preview_name)
+
+        expect(rendered_content).to have_text('Delete')
+      end
+    end
+  end
+
+  context 'maintenance_incident' do
+    before do
+      create(:bs_request_with_maintenance_incident_actions)
+    end
+
+    it 'renders the "maintenance_incident" preview' do
+      render_preview('maintenance_incident_text_only')
+
+      expect(rendered_content).to have_text('Submit update from')
+    end
+  end
+
+  context 'maintenance_release' do
+    before do
+      create(:bs_request_with_maintenance_release_actions)
+    end
+
+    it 'renders the "maintenance_release" preview' do
+      render_preview('maintenance_release_text_only')
+
+      expect(rendered_content).to have_text('Maintenance release')
+    end
+  end
+
+  context 'set_bugowner' do
+    before do
+      create(:set_bugowner_request)
+    end
+
+    it 'renders the "set_bugowner" preview' do
+      render_preview('set_bugowner_text_only')
+
+      expect(rendered_content).to have_text('become bugowner')
+    end
+  end
+
+  context 'submit' do
+    before do
+      create(:bs_request_with_submit_action)
+    end
+
+    it 'renders the "submit" previews' do
+      %i[submit submit_text_only].each do |preview_name|
+        render_preview(preview_name)
+
+        expect(rendered_content).to have_text('Submit')
+      end
+    end
+  end
+end

--- a/src/api/spec/components/previews/bs_request_action_description_component_preview.rb
+++ b/src/api/spec/components/previews/bs_request_action_description_component_preview.rb
@@ -1,37 +1,52 @@
 class BsRequestActionDescriptionComponentPreview < ViewComponent::Preview
-  # Preview at http://HOST:PORT/rails/view_components/bs_request_action_description_component/submit_preview
-  def submit_preview
-    action = BsRequestAction.where(type: :submit).last
+  # Previews at http://HOST:PORT/rails/view_components/bs_request_action_description_component/
+  def add_role
+    action = BsRequestAction.where(type: :add_role).last
     render(BsRequestActionDescriptionComponent.new(action: action))
   end
 
-  def submit_preview_text_only
-    action = BsRequestAction.where(type: :submit).last
+  def change_devel
+    action = BsRequestAction.where(type: :change_devel).last
+    render(BsRequestActionDescriptionComponent.new(action: action))
+  end
+
+  def change_devel_text_only
+    action = BsRequestAction.where(type: :change_devel).last
     render(BsRequestActionDescriptionComponent.new(action: action, text_only: true))
   end
 
-  def delete_preview
+  def delete
     action = BsRequestAction.where(type: :delete).last
     render(BsRequestActionDescriptionComponent.new(action: action))
   end
 
-  def delete_preview_text_only
+  def delete_text_only
     action = BsRequestAction.where(type: :delete).last
     render(BsRequestActionDescriptionComponent.new(action: action, text_only: true))
   end
 
-  def add_role_preview
-    action = BsRequestAction.where(type: :add_role).first
+  def maintenance_incident_text_only
+    action = BsRequestAction.where(type: :maintenance_incident).last
+    render(BsRequestActionDescriptionComponent.new(action: action, text_only: true))
+  end
+
+  def maintenance_release_text_only
+    action = BsRequestAction.where(type: :maintenance_release).last
+    render(BsRequestActionDescriptionComponent.new(action: action, text_only: true))
+  end
+
+  def set_bugowner_text_only
+    action = BsRequestAction.where(type: :set_bugowner).last
+    render(BsRequestActionDescriptionComponent.new(action: action, text_only: true))
+  end
+
+  def submit
+    action = BsRequestAction.where(type: :submit).last
     render(BsRequestActionDescriptionComponent.new(action: action))
   end
 
-  def change_devel_preview
-    action = BsRequestAction.where(type: :change_devel).first
-    render(BsRequestActionDescriptionComponent.new(action: action))
-  end
-
-  def change_devel_preview_text_only
-    action = BsRequestAction.where(type: :change_devel).first
+  def submit_text_only
+    action = BsRequestAction.where(type: :submit).last
     render(BsRequestActionDescriptionComponent.new(action: action, text_only: true))
   end
 end


### PR DESCRIPTION
Also, add specs to test previews of requests' descriptions.

All request action types have been included in previews and specs except for the `release` request action type. This will be addressed in a follow-up pull request.