### PR TITLE
Adapt task code to change the review state

### DIFF
--- a/src/api/lib/tasks/dev/rake_support.rb
+++ b/src/api/lib/tasks/dev/rake_support.rb
@@ -37,7 +37,7 @@ module RakeSupport
       staging_project: staging_project
     )
 
-    request.reviews.each { |review| review.change_state(:accepted, 'Accepted') }
+    request.reviews.each { |review| review.update(state: 'accepted', reason: 'Accepted!') }
   end
 
   def self.subscribe_to_all_notifications(user)


### PR DESCRIPTION
After the refactoring in https://github.com/openSUSE/open-build-service/pull/17913  we no longer have `Review#change_state`. The task is now adapted accordingly.