### PR TITLE
Block the access to the meta section of a package if the project is scmsync managed

### DIFF
--- a/src/api/app/controllers/webui/packages/meta_controller.rb
+++ b/src/api/app/controllers/webui/packages/meta_controller.rb
@@ -1,9 +1,12 @@
 module Webui
   module Packages
     class MetaController < Webui::WebuiController
+      include ScmsyncChecker
+
       before_action :set_project
       before_action :set_package
 
+      before_action :check_scmsync
       before_action :validate_xml, only: :update
       before_action :check_sourceaccess, only: :update
       before_action :changed_project, only: :update
@@ -12,13 +15,7 @@ module Webui
       after_action :verify_authorized, only: :update
 
       def show
-        if @project.scmsync.present?
-          flash.now[:error] = "Package sources for project #{@project.name} are received through scmsync." \
-                              'This is not supported by the OBS frontend'
-          head :not_found
-        else
-          @meta = @package.render_xml
-        end
+        @meta = @package.render_xml
       end
 
       def update

--- a/src/api/spec/controllers/webui/packages/meta_controller_spec.rb
+++ b/src/api/spec/controllers/webui/packages/meta_controller_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Webui::Packages::MetaController, :vcr do
         get :show, params: { project_name: source_project, package_name: 'some_package' }
       end
 
-      it { expect(response).to have_http_status(:not_found) }
+      it { expect(response).to redirect_to(project_show_path(source_project)) }
 
       it 'does not set the xml representation of a package' do
         expect(assigns(:meta)).to be_nil


### PR DESCRIPTION


Supersedes #18051
Fixes #18075