### PR TITLE
Speedup owner search

### DIFF
--- a/src/api/app/lib/backend/api/search.rb
+++ b/src/api/app/lib/backend/api/search.rb
@@ -7,8 +7,8 @@ module Backend
       # Performs a search of the binary in a project list
       # @return [String]
       def self.binary(project_names, binary_name)
-        project_list = project_names.map { |project_name| "@project='#{CGI.escape(project_name)}'" }.join('+or+')
-        http_post("/search/published/binary/id?match=(@name='#{CGI.escape(binary_name)}'+and+(#{project_list}))")
+        project_list = project_names.map { |project_name| "project=#{CGI.escape(project_name)}" }.join('&')
+        http_get("/published?view=collection&name=#{CGI.escape(binary_name)}&#{project_list}")
       end
 
       def self.published_binaries_for_package(project_name, package_name)

--- a/src/api/spec/controllers/webui/search_controller_spec.rb
+++ b/src/api/spec/controllers/webui/search_controller_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Webui::SearchController, :vcr do
 
     it 'assigns results' do
       collection = file_fixture('owner_search_collection.xml').read
-      stub_request(:post, "#{CONFIG['source_url']}/search/published/binary/id?match=(@name='package'%20and%20(@project='home:Iggy'))").and_return(body: collection)
+      stub_request(:get, "#{CONFIG['source_url']}/published?view=collection&name=package&project=home:Iggy").and_return(body: collection)
       get :owner, params: { search_text: 'package', owner: 1 }
       expect(assigns(:results)[0].users).to eq('maintainer' => [user])
     end

--- a/src/api/spec/features/webui/search_spec.rb
+++ b/src/api/spec/features/webui/search_spec.rb
@@ -204,11 +204,11 @@ RSpec.describe 'Search', :js do
     let(:relationship_package_group) { create(:relationship_package_group, package: apache_package, group: group_maintainer) }
     let(:relationship_user_bugowner) { create(:relationship_package_user_as_bugowner, package: apache_package, user: other_confirmed_user) }
     let(:relationship_group_bugowner) { create(:relationship_package_group_as_bugowner, package: apache_package, group: group_bugowner) }
-    let(:backend_url) { "#{CONFIG['source_url']}/search/published/binary/id?match=(@name='#{apache_package}'+and+(@project='#{apache}'))" }
+    let(:backend_url) { "#{CONFIG['source_url']}/published?name=#{apache_package}&project=#{apache}&view=collection" }
     let(:backend_response) { file_fixture('apache_search.xml') }
 
     before do
-      stub_request(:post, backend_url).and_return(body: backend_response)
+      stub_request(:get, backend_url).and_return(body: backend_response)
       owner_root_project_attrib
       group_maintainer.add_user(confirmed_user)
       group_bugowner.add_user(other_confirmed_user)

--- a/src/api/test/functional/search_controller_test.rb
+++ b/src/api/test/functional/search_controller_test.rb
@@ -423,10 +423,6 @@ class SearchControllerTest < ActionDispatch::IntegrationTest
     # must be after first search controller call or backend might not be started on single test case runs
     run_publisher
 
-    get "/search/owner?binary='package'"
-    assert_response :bad_request
-    assert_xml_tag tag: 'status', attributes: { code: '400', origin: 'backend' }
-
     get "/search/owner?binary='package'&attribute='OBS:does_not_exist'"
     assert_response :not_found
     assert_xml_tag tag: 'status', attributes: { code: 'unknown_attribute_type' }

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -6203,6 +6203,46 @@ sub published_path {
   $ret->{'url'} = $url if defined $url;
   return ($ret, $BSXML::publishedpath);
 }
+
+sub published_collection {
+  my ($cgi) = @_;
+  my $projids = $cgi->{'project'};
+  my $names = $cgi->{'name'};
+  my $binarydb;
+  if ($BSConfig::published_db_sqlite) {
+    $binarydb = BSSrcServer::SQLite::opendb($extrepodb, 'binary');
+  } else {
+    $binarydb = BSDB::opendb($extrepodb, 'binary');
+  }
+  $binarydb->{'indexfunc'} = {'project' => \&published_binary_projectindexfunc };
+  my @k;
+  if ($names) {
+    for my $name (@$names) {
+      push @k, $binarydb->keys('name', $name);
+    }
+    @k = BSUtil::unify(sort @k);
+    return ({'matches' => 0}, $BSXML::collection) unless @k;
+  }
+  if ($projids) {
+    if (@k) {
+      my %projids = map {$_ => 1} @$projids;
+      @k = grep {$projids{binary_key_to_project($binarydb, $_)}} @k;
+    } else {
+      for my $projid (@$projids) {
+	push @k, $binarydb->keys('project', $projid);
+      }
+      @k = BSUtil::unify(sort @k);
+    }
+    return ({'matches' => 0}, $BSXML::collection) unless @k;
+  }
+  die("need at least one filter\n") unless @k;
+  for (@k) {
+    $_ = binary_key_to_data($binarydb, $_);
+    delete $_->{'path'};
+    delete $_->{'versrel'};
+  }
+  return ({'binary' => \@k, 'matches' => scalar(@k)}, $BSXML::collection);
+}
   
 ####################################################################
 
@@ -8085,6 +8125,7 @@ my $dispatches = [
   'DELETE:/source/$project/$package/$filename rev? user:? comment:? keeplink:bool? force:bool? meta:bool?' => \&delfile,
 
   # /published name spec: access published binaries
+  '/published view=collection name:* project*' => \&published_collection,
   '/published' => \&published,
   '/published/$project' => \&published,
   '/published/$project/$repository view=publishedpath medium:?' => \&published_path,


### PR DESCRIPTION
Add simple searching of published binaries to the backend and use it in `Backend::Api::Search`

Picked the non-controversial commits from #9964 