### PR TITLE
[api] remove rebuild? check from package policy

### DIFF
--- a/src/api/app/policies/package_policy.rb
+++ b/src/api/app/policies/package_policy.rb
@@ -24,16 +24,12 @@ class PackagePolicy < ApplicationPolicy
     user.can_modify_package?(record)
   end
 
-  def rebuild?
+  def runservice?
     if record.readonly?
       user.can_modify_project?(record.project)
     else
       user.can_modify_package?(record)
     end
-  end
-
-  def runservice?
-    rebuild?
   end
 
   def unlock?


### PR DESCRIPTION
It needs to be used in context of the building project and must not use the project object where the sources live. This would lead to functional breakage and security issues.

So removing since usage of that code is dangerous.

seems not to be used luckily (grep check)