### PR TITLE
Enable fetching diffs for individual files from binaries

### DIFF
--- a/src/api/app/components/sourcediff_component.rb
+++ b/src/api/app/components/sourcediff_component.rb
@@ -42,8 +42,6 @@ class SourcediffComponent < ApplicationComponent
     files = sourcediff['files'].sort_by { |k, _v| sourcediff['filenames'].find_index(k) }.to_h
 
     files.each_with_index do |(filename, _contents), file_index|
-      next if filename.include?('/')
-
       files[filename]['diff_url'] = request_changes_diff_path(number: @bs_request.number, request_action_id: @action.id, filename:, diff_to_superseded:, file_index:, commented_lines: @commented_lines[file_index])
     end
 

--- a/src/api/config/routes/webui.rb
+++ b/src/api/config/routes/webui.rb
@@ -348,7 +348,9 @@ constraints(RoutesHelper::WebuiMatcher) do
     get 'requests/:number/(actions/:request_action_id)' => :beta_show, as: 'request_beta_show', constraints: cons
     get 'requests/:number/(actions/:request_action_id)/build_results' => :build_results, as: 'request_build_results', constraints: cons
     get 'requests/:number/(actions/:request_action_id)/changes' => :changes, as: 'request_changes', constraints: cons
-    get 'requests/:number/actions/:request_action_id/changes/:filename' => :changes_diff, as: 'request_changes_diff', constraints: cons
+    # Note: `format: false` is used because file names can range from a simple `string` to more complex paths like `vendor.tar.gz/cel.dev/expr/CONTRIBUTING.md`.
+    # We can't apply the filename constraint, it prevents the use of `/` in file names.
+    get 'requests/:number/actions/:request_action_id/changes/*filename' => :changes_diff, as: 'request_changes_diff', format: false, constraints: cons.except(:filename)
     get 'requests/:number/(actions/:request_action_id)/mentioned_issues' => :mentioned_issues, as: 'request_mentioned_issues', constraints: cons
     post 'request/sourcediff' => :sourcediff
     post 'request/changerequest' => :changerequest


### PR DESCRIPTION
After resolving #17613, we can enable individual file diffs for binaries.
