### PR TITLE
Add `LimitReleaseSourceProject` attribute type to seeds

### DIFF
--- a/src/api/db/data/20250717112726_add_role_to_limit_release_source_project.rb
+++ b/src/api/db/data/20250717112726_add_role_to_limit_release_source_project.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class AddRoleToLimitReleaseSourceProject < ActiveRecord::Migration[7.2]
+  def up
+    ans = AttribNamespace.find_by(name: 'OBS')
+    at = ans.attrib_types.find_by(name: 'LimitReleaseSourceProject')
+    maintainer_role = Role.find_by(title: 'maintainer')
+
+    at.attrib_type_modifiable_bies.find_or_create_by(role_id: maintainer_role.id)
+  end
+
+  def down
+    ans = AttribNamespace.find_by(name: 'OBS')
+    at = ans.attrib_types.find_by(name: 'LimitReleaseSourceProject')
+    maintainer_role = Role.find_by(title: 'maintainer')
+
+    at.attrib_type_modifiable_bies.find_by(role_id: maintainer_role.id).destroy
+  end
+end

--- a/src/api/db/data_schema.rb
+++ b/src/api/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20250710191133)
+DataMigrate::Data.define(version: 20250717112726)

--- a/src/api/db/seeds.rb
+++ b/src/api/db/seeds.rb
@@ -174,6 +174,9 @@ at.attrib_type_modifiable_bies.where(role_id: maintainer_role.id).first_or_creat
 at = ans.attrib_types.where(name: 'RejectBranch').first_or_create(value_count: 1)
 at.attrib_type_modifiable_bies.where(role_id: maintainer_role.id).first_or_create
 
+at = ans.attrib_types.where(name: 'LimitReleaseSourceProject').first_or_create
+at.attrib_type_modifiable_bies.where(role_id: maintainer_role.id).first_or_create
+
 update_all_attrib_type_descriptions
 
 puts 'Seeding issue trackers ...'


### PR DESCRIPTION
This should have been included in #12506.

This is not the first time we forget about this. See #15181.