### PR TITLE
Fix cleaning up notifications job

### DIFF
--- a/src/api/app/jobs/cleanup_notifications_job.rb
+++ b/src/api/app/jobs/cleanup_notifications_job.rb
@@ -1,5 +1,5 @@
 class CleanupNotificationsJob < ApplicationJob
   def perform
-    Notification.stale.delete_all
+    Notification.stale.in_batches.destroy_all
   end
 end

--- a/src/api/app/models/notification.rb
+++ b/src/api/app/models/notification.rb
@@ -15,6 +15,8 @@ class Notification < ApplicationRecord
 
   validates :type, length: { maximum: 255 }
 
+  before_destroy { groups.clear }
+
   after_create :track_notification_creation
 
   after_save :track_notification_delivered, if: :saved_change_to_delivered?

--- a/src/api/db/data/20250717142701_delete_orphan_records_from_notified_project.rb
+++ b/src/api/db/data/20250717142701_delete_orphan_records_from_notified_project.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class DeleteOrphanRecordsFromNotifiedProject < ActiveRecord::Migration[7.2]
+  def up
+    say_with_time 'Removing orphaned records from notified projects' do
+      NotifiedProject.where.not(notification_id: Notification.select(:id)).delete_all
+    end
+  end
+
+  def down; end
+end

--- a/src/api/db/data/20250717152701_delete_orphan_records_from_groups_notifications.rb
+++ b/src/api/db/data/20250717152701_delete_orphan_records_from_groups_notifications.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class GroupsNotification < ActiveRecord::Base
+  self.table_name = 'groups_notifications'
+end
+
+class DeleteOrphanRecordsFromGroupsNotifications < ActiveRecord::Migration[7.2]
+  def up
+    say_with_time 'Removing orphaned records from groups_notifications' do
+      GroupsNotification.where.not(notification_id: Notification.select(:id)).delete_all
+    end
+  end
+
+  def down; end
+end

--- a/src/api/db/data_schema.rb
+++ b/src/api/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20250717112726)
+DataMigrate::Data.define(version: 20250717152701)


### PR DESCRIPTION
Previously, the job responsible for cleaning up stale notifications used `delete_all`, which bypassed callbacks and left associated records (in `notified_projects` and `groups_notifications`) orphaned.

Replace `delete_all` with `destroy_all` to ensure that associations are properly cleaned up via callbacks.

Also, add data migrations to remove the orphan entries in the affected tables.

This was the output when running the data migrations in a development environment:

```
:/obs/src/api> rake db:migrate:with_data
== 20250717142701 DeleteOrphanRecordsFromNotifiedProject: migrating ===========
-- Removing orphaned records from notified projects
   -> 0.0370s
   -> 11 rows
== 20250717142701 DeleteOrphanRecordsFromNotifiedProject: migrated (0.0371s) ==

== 20250717152701 DeleteOrphanRecordsFromGroupsNotifications: migrating =======
-- Removing orphaned records from groups_notifications
   -> 0.0107s
   -> 2 rows
== 20250717152701 DeleteOrphanRecordsFromGroupsNotifications: migrated (0.0108s) 

:/obs/src/api>
```