### PR TITLE
Disable diff requests for newly added or deleted binary files

### DIFF
--- a/src/api/app/assets/stylesheets/webui/diff.scss
+++ b/src/api/app/assets/stylesheets/webui/diff.scss
@@ -18,6 +18,10 @@
   --bs-accordion-active-bg: var(--bs-secondary-bg);
 }
 
+.accordion-button.disabled-accordion::after {
+  display: none;
+}
+
 .pre.scroll {
   --line-index-digits: 6ch;
   --additional-padding: 0px;

--- a/src/api/app/components/diff_list_component.html.haml
+++ b/src/api/app/components/diff_list_component.html.haml
@@ -4,24 +4,23 @@
     old_filename = file_info.dig('old', 'name')
     expanded = expand?(name, state, file_index)
   .accordion.mb-2.diff-accordion{ id: "diff-list-#{name.parameterize}" }
-    - if file_info.dig("diff", "binary") == "1"
-      .card.p-3.mb-2
-        %span
-          = render(DiffSubjectComponent.new(state:, old_filename:, new_filename: name))
-    - else
-      .accordion-item
-        %h2.accordion-header
+    .accordion-item
+      %h2.accordion-header
+        - if file_info['disabled']
+          %button.accordion-button.disabled-accordion{ disabled: true }
+            = render(DiffSubjectComponent.new(state:, old_filename:, new_filename: name))
+        - else
           %button.accordion-button{ type: 'button', data: { 'bs-toggle': 'collapse',
                                                             'bs-target': "#diff-item-#{name.parameterize}" },
                                     aria: { expanded: 'true', controls: "diff-item-#{name.parameterize}" },
                                     class: expanded ? '' : 'collapsed' }
             = render(DiffSubjectComponent.new(state:, old_filename:, new_filename: name))
-        .accordion-collapse.collapse{ class: expanded ? 'show' : '', id: "diff-item-#{name.parameterize}", 'data-object': view_id }
-          - if file_info.key?('diff_url')
-            %turbo-frame{ id: "file-#{file_index}", src: file_info['diff_url'], loading: 'lazy' }
-              .d-flex.justify-content-center.p-4
-                %i.fas.fa-2xl.fa-spinner.fa-spin
-          - else
-            = render(DiffComponent.new(diff: file_info.dig('diff', '_content'), file_index:, commentable:,
-                                       commented_lines: commented_lines[file_index] || [],
-                                       source_file: source_file(old_filename), target_file: target_file(name), source_rev:, target_rev:))
+      .accordion-collapse.collapse{ class: expanded ? 'show' : '', id: "diff-item-#{name.parameterize}", 'data-object': view_id }
+        - if file_info.key?('diff_url')
+          %turbo-frame{ id: "file-#{file_index}", src: file_info['diff_url'], loading: 'lazy' }
+            .d-flex.justify-content-center.p-4
+              %i.fas.fa-2xl.fa-spinner.fa-spin
+        - else
+          = render(DiffComponent.new(diff: file_info.dig('diff', '_content'), file_index:, commentable:,
+                                     commented_lines: commented_lines[file_index] || [],
+                                     source_file: source_file(old_filename), target_file: target_file(name), source_rev:, target_rev:))

--- a/src/api/app/components/sourcediff_component.rb
+++ b/src/api/app/components/sourcediff_component.rb
@@ -41,7 +41,10 @@ class SourcediffComponent < ApplicationComponent
   def diff_list(sourcediff)
     files = sourcediff['files'].sort_by { |k, _v| sourcediff['filenames'].find_index(k) }.to_h
 
-    files.each_with_index do |(filename, _contents), file_index|
+    files.each_with_index do |(filename, contents), file_index|
+      files[filename]['disabled'] = contents['state'].in?(%w[deleted added]) && contents['diff']['_content'].nil?
+      next if files[filename]['disabled']
+
       files[filename]['diff_url'] = request_changes_diff_path(number: @bs_request.number, request_action_id: @action.id, filename:, diff_to_superseded:, file_index:, commented_lines: @commented_lines[file_index])
     end
 

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -345,12 +345,9 @@ class Webui::RequestController < Webui::WebuiController
     if @action.target_package_object&.file_exists?(filename, { rev: target_rev, expand: 1 }.compact)
       target_file = project_package_file_path(@action.target_project_object, @action.target_package_object, filename, rev: target_rev, expand: 1)
     end
-    diff = sourcediff.dig('files', filename, 'diff', '_content')
-    disabled = diff.nil? && sourcediff.dig('files', filename, 'state').in?(%w[deleted added])
-    diff = "#{sourcediff.dig('files', filename, 'diff', 'lines')} lines skipped" if diff.nil? && !disabled
     render partial: 'webui/request/changes_diff',
            locals: { commentable: @action,
-                     diff: diff,
+                     diff: sourcediff.dig('files', filename, 'diff', '_content'),
                      file_index: params[:file_index], source_file: source_file,
                      target_file: target_file, source_rev: source_rev, target_rev: target_rev,
                      commented_lines: (params[:commented_lines] || []).map(&:to_i) }

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -345,9 +345,12 @@ class Webui::RequestController < Webui::WebuiController
     if @action.target_package_object&.file_exists?(filename, { rev: target_rev, expand: 1 }.compact)
       target_file = project_package_file_path(@action.target_project_object, @action.target_package_object, filename, rev: target_rev, expand: 1)
     end
+    diff = sourcediff.dig('files', filename, 'diff', '_content')
+    disabled = diff.nil? && sourcediff.dig('files', filename, 'state').in?(%w[deleted added])
+    diff = "#{sourcediff.dig('files', filename, 'diff', 'lines')} lines skipped" if diff.nil? && !disabled
     render partial: 'webui/request/changes_diff',
            locals: { commentable: @action,
-                     diff: sourcediff.dig('files', filename, 'diff', '_content'),
+                     diff: diff,
                      file_index: params[:file_index], source_file: source_file,
                      target_file: target_file, source_rev: source_rev, target_rev: target_rev,
                      commented_lines: (params[:commented_lines] || []).map(&:to_i) }


### PR DESCRIPTION
Disable diff requests for newly added or deleted binary files. Also, disable diff requests for files without available diffs, and instead display the number of lines changed when only that information is provided by the backend without the actual diff content.

**This is how it looks now**
<img width="1865" height="2514" alt="Screenshot 2025-08-05 at 09-33-31 Request 20 - Open Build Service" src="https://github.com/user-attachments/assets/535f14f5-0fa1-43f8-89d9-854e3d812fe2" />