### PR TITLE
Fix pulse revoked icon color for darkmode

### DIFF
--- a/src/api/app/assets/stylesheets/webui/pulse.scss
+++ b/src/api/app/assets/stylesheets/webui/pulse.scss
@@ -16,7 +16,7 @@
   }
 
   .request-state-revoked {
-    color: $dark;
+    color: $gray-500;
   }
 
   .request-state-superseded {
@@ -40,7 +40,7 @@
   }
 
   .progress-state-revoked {
-    background-color: $dark;
+    background-color: $gray-500;
   }
 
   .progress-state-superseded {


### PR DESCRIPTION
Fix https://github.com/openSUSE/open-build-service/issues/18192

`Revoked` request status is commonly defined as gray: to keep it consistent using a middle gray that works with light and dark mode too lets the icon be always visible.


## After
<img width="1526" height="475" alt="image" src="https://github.com/user-attachments/assets/6a79ed7c-4844-480c-9a38-f4701e1ae5c1" />

<img width="1534" height="472" alt="image" src="https://github.com/user-attachments/assets/75151103-0a33-43ef-b8a8-affa6abee9d8" />
