### PR TITLE
[backend] container publishing: move rekor upload into its own function

### DIFF
--- a/src/backend/BSConSign.pm
+++ b/src/backend/BSConSign.pm
@@ -122,12 +122,6 @@ sub create_cosign_attestation_ent {
   return create_entry($attestation, 'mimetype' => $mt_dsse, 'annotations' => \%annotations);
 }
 
-sub create_cosign_attestation_ents {
-  my ($attestations, $annotations, $predicatetypes) = @_;
-  $attestations = [ $attestations ] if ref($attestations) ne 'ARRAY';
-  return map { create_cosign_attestation_ent($_, $annotations, $predicatetypes->{$_}) } @$$attestations;
-}
-
 sub dsse_pae {
   my ($type, $payload) = @_;
   return sprintf("DSSEv1 %d %s %d ", length($type), $type, length($payload)).$payload;

--- a/src/backend/BSConSign.pm
+++ b/src/backend/BSConSign.pm
@@ -150,7 +150,7 @@ sub dsse_sign {
 
 # change the subject so that it matches the reference/digest and re-sign
 sub fixup_intoto_attestation {
-  my ($attestation, $signfunc, $digest, $reference, $predicatetypes) = @_;
+  my ($attestation, $signfunc, $digest, $reference) = @_;
   $attestation = JSON::XS::decode_json($attestation);
   die("bad attestation\n") unless $attestation && ref($attestation) eq 'HASH';
   if ($attestation->{'payload'}) {
@@ -174,8 +174,7 @@ sub fixup_intoto_attestation {
   $attestation->{'subject'} = [ { 'name' => $reference, 'digest' => { 'sha256' => $sha256digest } } ];
   $attestation = canonical_json($attestation);
   my $att = dsse_sign($attestation, $mt_intoto, $signfunc);
-  $predicatetypes->{$att} = $predicate_type if $predicatetypes && $predicate_type && !ref($predicate_type);
-  return $att;
+  return ($att, !ref($predicate_type) ? $predicate_type : undef);
 }
 
 sub create_cosign_cookie {

--- a/src/backend/BSPublisher/Registry.pm
+++ b/src/backend/BSPublisher/Registry.pm
@@ -449,6 +449,23 @@ sub reuse_cosign_manifest {
   return 1;
 }
 
+sub cosign_upload_rekor {
+  my ($rekorserver, $gpgpubkey, $sig, @layer_ents) = @_;
+  my $sslpubkey = BSX509::keydata2pubkey(BSPGP::pk2keydata($gpgpubkey));
+  $sslpubkey = BSASN1::der2pem($sslpubkey, 'PUBLIC KEY');
+  if ($sig) {
+    print "uploading cosign signature to $rekorserver\n";
+    die unless @layer_ents == 1;
+    my $hash = 'sha256:'.Digest::SHA::sha256_hex($layer_ents[0]->{'data'});	# must match signfunc
+    BSRekor::upload_hashedrekord($rekorserver, $hash, $sslpubkey, $sig);
+  } else {
+    print "uploading cosign attestations to $rekorserver\n";
+    for my $attestation_ent (@layer_ents) {
+      BSRekor::upload_intoto($rekorserver, $attestation_ent->{'data'}, $sslpubkey);
+    }
+  }
+}
+
 sub update_cosign {
   my ($prp, $repo, $gun, $digests_to_cosign, $pubkey, $signargs, $rekorserver, $knownmanifests, $knownblobs) = @_;
 
@@ -479,13 +496,7 @@ sub update_cosign {
     }
     print "creating cosign signature for $gun $digest\n";
     my ($cosign_ent, $sig) = BSConSign::create_cosign_signature_ent($signfunc, $digest, $gun, $creator);
-    if ($rekorserver) {
-      print "uploading cosign signature to $rekorserver\n";
-      my $sslpubkey = BSX509::keydata2pubkey(BSPGP::pk2keydata($gpgpubkey));
-      $sslpubkey = BSASN1::der2pem($sslpubkey, 'PUBLIC KEY');
-      my $hash = 'sha256:'.Digest::SHA::sha256_hex($cosign_ent->{'data'});	# must match signfunc
-      BSRekor::upload_hashedrekord($rekorserver, $hash, $sslpubkey, $sig);
-    }
+    cosign_upload_rekor($rekorserver, $gpgpubkey, $sig, $cosign_ent) if $rekorserver && $sig;
     my $mani_id = create_cosign_manifest($repodir, $oci, $knownmanifests, $knownblobs, $cosign_ent);
     $sigs->{'digests'}->{$digest} = $mani_id;
   }
@@ -512,14 +523,7 @@ sub update_cosign {
     push @attestations, BSConSign::fixup_intoto_attestation(readstr($containerinfo->{'cyclonedx_file'}), $signfunc, $digest, $gun, \%predicatetypes) if $containerinfo->{'cyclonedx_file'};
     push @attestations, BSConSign::fixup_intoto_attestation(readstr($_), $signfunc, $digest, $gun, \%predicatetypes) for @{$containerinfo->{'intoto_files'} || []};
     my @attestation_ents = BSConSign::create_cosign_attestation_ents(\@attestations, undef, \%predicatetypes);
-    if ($rekorserver) {
-      print "uploading cosign attestations to $rekorserver\n";
-      my $sslpubkey = BSX509::keydata2pubkey(BSPGP::pk2keydata($gpgpubkey));
-      $sslpubkey = BSASN1::der2pem($sslpubkey, 'PUBLIC KEY');
-      for my $attestation (@attestations) {
-        BSRekor::upload_intoto($rekorserver, $attestation, $sslpubkey);
-      }
-    }
+    cosign_upload_rekor($rekorserver, $gpgpubkey, undef, @attestation_ents) if $rekorserver && @attestation_ents;
     my $mani_id = create_cosign_manifest($repodir, $oci, $knownmanifests, $knownblobs, @attestation_ents);
     $sigs->{'attestations'}->{$digest} = $mani_id;
   }

--- a/src/backend/bs_regpush
+++ b/src/backend/bs_regpush
@@ -390,6 +390,12 @@ sub cosign_upload_rekor {
   }
 }
 
+sub fixup_intoto_attestation {
+  my ($attestation, $signfunc, $digest, $reference, $predicatetypes) = @_;
+  my ($att, $predicatetype) = BSConSign::fixup_intoto_attestation($attestation, $signfunc, $digest, $reference);
+  $predicatetypes->{$att} = $predicatetype;
+}
+
 sub get_all_tags {
   my ($missing_ok) = @_;
   my @regtags;
@@ -1223,10 +1229,10 @@ if ($cosign && %digests_to_sign) {
     my $annotations = { $cosign_cookie_name => $cosigncookie };
     my %predicatetypes;
     my @attestations;
-    push @attestations, BSConSign::fixup_intoto_attestation($provenance, $signfunc, $digest, $gun, \%predicatetypes) if $provenance;
-    push @attestations, BSConSign::fixup_intoto_attestation($spdx_json, $signfunc, $digest, $gun, \%predicatetypes) if $spdx_json;
-    push @attestations, BSConSign::fixup_intoto_attestation($cyclonedx_json, $signfunc, $digest, $gun, \%predicatetypes) if $cyclonedx_json;
-    push @attestations, BSConSign::fixup_intoto_attestation($_, $signfunc, $digest, $gun, \%predicatetypes) for @intoto_json;
+    push @attestations, fixup_intoto_attestation($provenance, $signfunc, $digest, $gun, \%predicatetypes) if $provenance;
+    push @attestations, fixup_intoto_attestation($spdx_json, $signfunc, $digest, $gun, \%predicatetypes) if $spdx_json;
+    push @attestations, fixup_intoto_attestation($cyclonedx_json, $signfunc, $digest, $gun, \%predicatetypes) if $cyclonedx_json;
+    push @attestations, fixup_intoto_attestation($_, $signfunc, $digest, $gun, \%predicatetypes) for @intoto_json;
     my @attestation_ents = BSConSign::create_cosign_attestation_ents(\@attestations, $annotations, \%predicatetypes);
     cosign_upload_rekor($gpgpubkey, undef, @attestation_ents) if $rekorserver && @attestation_ents;
     cosign_upload($att_tag, @attestation_ents);

--- a/src/backend/bs_regpush
+++ b/src/backend/bs_regpush
@@ -240,11 +240,11 @@ sub manifest_exists_head {
     my $size = length($manifest);
     if ($tag eq $maniid) {
       die("size mismatch?\n") if $replyheaders->{'content-length'} && $size != $replyheaders->{'content-length'};
-      return 0 if $replyheaders->{'docker-content-digest'} && $maniid ne $replyheaders->{'docker-content-digest'};
+      return $replyheaders->{'docker-content-digest'} eq $maniid ? 1 : 0 if $replyheaders->{'docker-content-digest'};
       return 1;
     }
     return 0 if $replyheaders->{'content-length'} && $size != $replyheaders->{'content-length'};
-    return 1 if $replyheaders->{'docker-content-digest'} && $maniid eq $replyheaders->{'docker-content-digest'};
+    return $replyheaders->{'docker-content-digest'} eq $maniid ? 1 : 0 if $replyheaders->{'docker-content-digest'};
   }
   return undef;	# undecided
 }

--- a/src/backend/bs_regpush
+++ b/src/backend/bs_regpush
@@ -373,6 +373,23 @@ sub cosign_upload {
   manifest_append_listfile($mani_json, $tag, $mani->{'mediaType'}, $extra) if defined $listfile;
 }
 
+sub cosign_upload_rekor {
+  my ($gpgpubkey, $sig, @layer_ents) = @_;
+  my $sslpubkey = BSX509::keydata2pubkey(BSPGP::pk2keydata(BSPGP::unarmor($gpgpubkey)));
+  $sslpubkey = BSASN1::der2pem($sslpubkey, 'PUBLIC KEY');
+  if ($sig) {
+    print "uploading cosign signature to $rekorserver\n";
+    die unless @layer_ents == 1;
+    my $hash = 'sha256:'.Digest::SHA::sha256_hex($layer_ents[0]->{'data'});	# must match signfunc
+    BSRekor::upload_hashedrekord($rekorserver, $hash, $sslpubkey, $sig);
+  } else {
+    print "uploading cosign attestations to $rekorserver\n";
+    for my $attestation_ent (@layer_ents) {
+      BSRekor::upload_intoto($rekorserver, $attestation_ent->{'data'}, $sslpubkey);
+    }
+  }
+}
+
 sub get_all_tags {
   my ($missing_ok) = @_;
   my @regtags;
@@ -1183,13 +1200,7 @@ if ($cosign && %digests_to_sign) {
     my $signfunc =  sub { BSUtil::xsystem($_[0], @signcmd, '-O', '-h', 'sha256') };
     my $annotations = { $cosign_cookie_name => $cosigncookie };
     my ($cosign_ent, $sig) = BSConSign::create_cosign_signature_ent($signfunc, $digest, $gun, $creator, undef, $annotations);
-    if ($rekorserver) {
-      print "uploading cosign signature to $rekorserver\n";
-      my $sslpubkey = BSX509::keydata2pubkey(BSPGP::pk2keydata(BSPGP::unarmor($gpgpubkey)));
-      $sslpubkey = BSASN1::der2pem($sslpubkey, 'PUBLIC KEY');
-      my $hash = 'sha256:'.Digest::SHA::sha256_hex($cosign_ent->{'data'});	# must match signfunc
-      BSRekor::upload_hashedrekord($rekorserver, $hash, $sslpubkey, $sig);
-    }
+    cosign_upload_rekor($gpgpubkey, $sig, $cosign_ent) if $rekorserver && $sig;
     cosign_upload($sig_tag, $cosign_ent);
   }
   # upload attestations
@@ -1217,14 +1228,7 @@ if ($cosign && %digests_to_sign) {
     push @attestations, BSConSign::fixup_intoto_attestation($cyclonedx_json, $signfunc, $digest, $gun, \%predicatetypes) if $cyclonedx_json;
     push @attestations, BSConSign::fixup_intoto_attestation($_, $signfunc, $digest, $gun, \%predicatetypes) for @intoto_json;
     my @attestation_ents = BSConSign::create_cosign_attestation_ents(\@attestations, $annotations, \%predicatetypes);
-    if ($rekorserver) {
-      print "uploading cosign attestations to $rekorserver\n";
-      my $sslpubkey = BSX509::keydata2pubkey(BSPGP::pk2keydata(BSPGP::unarmor($gpgpubkey)));
-      $sslpubkey = BSASN1::der2pem($sslpubkey, 'PUBLIC KEY');
-      for my $attestation (@attestations) {
-        BSRekor::upload_intoto($rekorserver, $attestation, $sslpubkey);
-      }
-    }
+    cosign_upload_rekor($gpgpubkey, undef, @attestation_ents) if $rekorserver && @attestation_ents;
     cosign_upload($att_tag, @attestation_ents);
   }
 }

--- a/src/backend/bs_regpush
+++ b/src/backend/bs_regpush
@@ -114,7 +114,7 @@ sub contenttype2manitype {
   return 'ocilist' if $ct eq $BSContar::mt_oci_index;
   return 'unknown';
 }
-  
+
 sub blob_exists {
   my ($blobid, $size) = @_;
   my $replyheaders;
@@ -390,10 +390,10 @@ sub cosign_upload_rekor {
   }
 }
 
-sub fixup_intoto_attestation {
-  my ($attestation, $signfunc, $digest, $reference, $predicatetypes) = @_;
+sub create_cosign_attestation_ent {
+  my ($attestation, $signfunc, $digest, $reference, $annotations) = @_;
   my ($att, $predicatetype) = BSConSign::fixup_intoto_attestation($attestation, $signfunc, $digest, $reference);
-  $predicatetypes->{$att} = $predicatetype;
+  return BSConSign::create_cosign_attestation_ent($att, $annotations, $predicatetype);
 }
 
 sub get_all_tags {
@@ -1227,13 +1227,11 @@ if ($cosign && %digests_to_sign) {
     print "creating $numlayers cosign attestations for $gun $digest\n";
     my $signfunc =  sub { BSUtil::xsystem($_[0], @signcmd, '-O', '-h', 'sha256') };
     my $annotations = { $cosign_cookie_name => $cosigncookie };
-    my %predicatetypes;
-    my @attestations;
-    push @attestations, fixup_intoto_attestation($provenance, $signfunc, $digest, $gun, \%predicatetypes) if $provenance;
-    push @attestations, fixup_intoto_attestation($spdx_json, $signfunc, $digest, $gun, \%predicatetypes) if $spdx_json;
-    push @attestations, fixup_intoto_attestation($cyclonedx_json, $signfunc, $digest, $gun, \%predicatetypes) if $cyclonedx_json;
-    push @attestations, fixup_intoto_attestation($_, $signfunc, $digest, $gun, \%predicatetypes) for @intoto_json;
-    my @attestation_ents = BSConSign::create_cosign_attestation_ents(\@attestations, $annotations, \%predicatetypes);
+    my @attestation_ents;
+    push @attestation_ents, create_cosign_attestation_ent($provenance, $signfunc, $digest, $gun, $annotations) if $provenance;
+    push @attestation_ents, create_cosign_attestation_ent($spdx_json, $signfunc, $digest, $gun, $annotations) if $spdx_json;
+    push @attestation_ents, create_cosign_attestation_ent($cyclonedx_json, $signfunc, $digest, $gun, $annotations) if $cyclonedx_json;
+    push @attestation_ents, create_cosign_attestation_ent($_, $signfunc, $digest, $gun, $annotations) for @intoto_json;
     cosign_upload_rekor($gpgpubkey, undef, @attestation_ents) if $rekorserver && @attestation_ents;
     cosign_upload($att_tag, @attestation_ents);
   }


### PR DESCRIPTION
Also use the attestation_ents instead of the raw attestation data. The attestation data is just the 'data' element from the ent. This will allow a code simplification in a future commit.