### PR TITLE
Remove `order` on queries using `count` in notifications

### DIFF
--- a/src/api/app/controllers/person/notifications_controller.rb
+++ b/src/api/app/controllers/person/notifications_controller.rb
@@ -15,7 +15,7 @@ module Person
     # GET /my/notifications
     def index
       @notifications_count = @notifications.count
-      @paged_notifications = @notifications.page(params[:page])
+      @paged_notifications = @notifications.order(created_at: :desc).page(params[:page])
 
       params[:page] = @paged_notifications.total_pages if @paged_notifications.out_of_range?
       params[:show_maximum] ? show_maximum(@notifications) : @paged_notifications

--- a/src/api/app/controllers/webui/users/notifications_controller.rb
+++ b/src/api/app/controllers/webui/users/notifications_controller.rb
@@ -14,6 +14,7 @@ class Webui::Users::NotificationsController < Webui::WebuiController
   before_action :set_counted_notifications, only: :index
   before_action :filter_notifications, only: :index
   before_action :set_selected_filter
+  before_action :set_ordered_notifications, only: :index
   before_action :paginate_notifications, only: :index
 
   skip_before_action :set_unread_notifications_count, only: :update
@@ -31,6 +32,7 @@ class Webui::Users::NotificationsController < Webui::WebuiController
     set_unread_notifications_count # before_action filter method defined in the Webui controller
     set_counted_notifications
     filter_notifications
+    set_ordered_notifications
     paginate_notifications
 
     respond_to do |format|
@@ -140,6 +142,10 @@ class Webui::Users::NotificationsController < Webui::WebuiController
   def send_notifications_information_rabbitmq(delivered, count)
     action = delivered ? 'read' : 'unread'
     RabbitmqBus.send_to_bus('metrics', "notification,action=#{action} value=#{count}") if count.positive?
+  end
+
+  def set_ordered_notifications
+    @notifications = @notifications.order(created_at: :desc)
   end
 
   def paginate_notifications

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -54,7 +54,7 @@ class User < ApplicationRecord
   has_one :azure_configuration, class_name: 'Cloud::Azure::Configuration', dependent: :destroy
   has_many :upload_jobs, class_name: 'Cloud::User::UploadJob', dependent: :destroy
 
-  has_many :notifications, -> { order(created_at: :desc) }, as: :subscriber, dependent: :destroy
+  has_many :notifications, as: :subscriber, dependent: :destroy
 
   has_many :commit_activities
 


### PR DESCRIPTION
Improve performance of notification queries using the `count` method. Since sorting has no effect on the result of a count, removing unnecessary `ORDER BY` clauses avoids overhead and improves query performance.