### PR TITLE
[backend] bs_srcserver: pass "service in progress" for new scmsync pr…

### DIFF
--- a/src/backend/BSSrcServer/Scmsync.pm
+++ b/src/backend/BSSrcServer/Scmsync.pm
@@ -320,7 +320,7 @@ sub sync_project {
     }
   }
   sync_config($cgi, $projid, $config, $info) if defined $config;
-  sync_projectinfo($cgi, $projid, $info) if $info;
+  sync_projectinfo($cgi, $projid, $info) if $info || ! -e "$projectsdir/$projid.pkg/_project.rev";
 
   $notify_repservers->('resumeproject', $projid, undef, 'suspend for scmsync');
 

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -1321,7 +1321,7 @@ sub getprojpack {
     if ($proj->{'scmsync'} && !$cgi->{'buildinfo'} && !$proj->{'remoteurl'} && !$jinfo->{'error'}) {
       my $servicemark = BSSrcServer::Service::genservicemark_obsscm($projid, '_project');
       my $serviceerror = BSSrcrep::getserviceerror($projid, '_project', $servicemark);
-      if ($serviceerror && $serviceerror !~ /service in progress/) {
+      if ($serviceerror && (($serviceerror !~ /service in progress/) || ! -e "$projectsdir/$projid.pkg/_project.rev")) {
 	$jinfo->{'error'} = $serviceerror;
       }
     }


### PR DESCRIPTION
…ojects

We want to make sure that the scheduler looks at the projecy only after the first scmsync service run is finished.