### PR TITLE
Remove `order` clause from `with_action_types` scope

### DIFF
--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -35,7 +35,7 @@ class BsRequest < ApplicationRecord
   scope :with_actions, -> { joins(:bs_request_actions).distinct.order(priority: :asc, id: :desc) }
 
   scope :with_action_types, lambda { |types|
-    includes(:bs_request_actions).where(bs_request_actions: { type: types }).distinct.order(priority: :asc, id: :desc)
+    includes(:bs_request_actions).where(bs_request_actions: { type: types }).distinct
   }
   scope :from_project, ->(project_name) { where('bs_request_actions.source_project like ?', project_name) }
   scope :to_project, ->(project_name) { where('bs_request_actions.target_project like ?', project_name) }

--- a/src/api/spec/models/project_spec.rb
+++ b/src/api/spec/models/project_spec.rb
@@ -380,7 +380,7 @@ RSpec.describe Project, :vcr do
         let(:package) { create(:package, project: subproject) }
 
         it 'does include maintenance_release' do
-          expect(subject[:maintenance_release]).to eq([other_release.number, release.number])
+          expect(subject[:maintenance_release]).to contain_exactly(other_release.number, release.number)
         end
       end
     end


### PR DESCRIPTION
It is not used and decreases performance of counting queries.