### PR TITLE
Remove `order` clause in `open_requests`

### DIFF
--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -1152,7 +1152,7 @@ class Project < ApplicationRecord
       BsRequest.where(id: BsRequestAction.bs_request_ids_by_source_projects(name)).or(
         BsRequest.where(id: Review.bs_request_ids_of_involved_projects(id))
       )
-    ).where(state: :review).distinct.order(priority: :asc, id: :desc).pluck(:number)
+    ).where(state: :review).distinct.pluck(:number)
 
     targets = BsRequest.to_project(name)
                        .or(BsRequest.from_project(name))

--- a/src/api/test/unit/project_test.rb
+++ b/src/api/test/unit/project_test.rb
@@ -994,7 +994,9 @@ class ProjectTest < ActiveSupport::TestCase
 
   def test_open_requests
     expected = { reviews: [1000, 10, 4], targets: [5], incidents: [], maintenance_release: [] }
-    assert_equal expected, projects(:Apache).open_requests
+    # We don't care about the order of items inside the arrays returned as hash values in `open_requests`.
+    # This sorting is handled outside of `open_requests`.
+    assert_equal expected.transform_values(&:sort), projects(:Apache).open_requests.transform_values(&:sort)
 
     expected = { reviews: [], targets: [6], incidents: [6], maintenance_release: [7] }
     assert_equal expected, projects(:My_Maintenance).open_requests


### PR DESCRIPTION
Follow-up to #18219.

The `open_requests` method is only called once in the codebase. After this call, the retrieved results are sorted again.
