### PR TITLE
Remove the `with_actions_and_reviews` BsRequest scope

### DIFF
--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -52,8 +52,6 @@ class BsRequest < ApplicationRecord
       )
   }
 
-  scope :with_actions_and_reviews, -> { joins(:bs_request_actions).left_outer_joins(:reviews).distinct.order(priority: :asc, id: :desc) }
-
   scope :obsolete, -> { where(state: OBSOLETE_STATES) }
 
   has_many :bs_request_actions, dependent: :destroy

--- a/src/api/app/models/concerns/staging_project.rb
+++ b/src/api/app/models/concerns/staging_project.rb
@@ -99,7 +99,7 @@ module StagingProject
   # The requests to review are requests which are not related to the staging project (unless they are also staged).
   # They simply need a review from the maintainers of the staging project.
   def requests_to_review
-    @requests_to_review ||= BsRequest.with_actions_and_reviews.where(state: :review, reviews: { by_project: name, state: :new })
+    @requests_to_review ||= BsRequest.joins(:bs_request_actions).left_outer_joins(:reviews).where(state: :review, reviews: { by_project: name, state: :new })
   end
 
   def building_repositories

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -645,7 +645,7 @@ class User < ApplicationRecord
           BsRequest.where(reviews: { group: groups })
         )
       )
-    ).with_actions_and_reviews.where(state: :review, reviews: { state: :new }).where.not(creator: login)
+    ).joins(:bs_request_actions).left_outer_joins(:reviews).where(state: :review, reviews: { state: :new }).where.not(creator: login).distinct
     search.present? ? result.do_search(search) : result
   end
 


### PR DESCRIPTION
It included the `distinct` and `order` methods which were not needed and decrease the performance of counting queries.