### PR TITLE
Remove `with_actions` BsRequest scope

### DIFF
--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -31,8 +31,6 @@ class BsRequest < ApplicationRecord
   enum :status, VALID_REQUEST_STATES, instance_methods: false, scopes: false, validate: true
 
   scope :to_accept_by_time, -> { where(state: %w[new review]).where(accept_at: ...Time.now) }
-  # Scopes for collections
-  scope :with_actions, -> { joins(:bs_request_actions).distinct.order(priority: :asc, id: :desc) }
 
   scope :with_action_types, lambda { |types|
     includes(:bs_request_actions).where(bs_request_actions: { type: types }).distinct.order(priority: :asc, id: :desc)

--- a/src/api/app/models/bs_request/find_for/base.rb
+++ b/src/api/app/models/bs_request/find_for/base.rb
@@ -1,7 +1,7 @@
 class BsRequest
   module FindFor
     class Base
-      def initialize(parameters, relation = BsRequest.with_actions)
+      def initialize(parameters, relation = BsRequest.joins(:bs_request_actions))
         @parameters = parameters
         @relation = relation
       end

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -1154,9 +1154,10 @@ class Project < ApplicationRecord
       )
     ).where(state: :review).distinct.order(priority: :asc, id: :desc).pluck(:number)
 
-    targets = BsRequest.to_project(name)
+    targets = BsRequest.joins(:bs_request_actions)
+                       .to_project(name)
                        .or(BsRequest.from_project(name))
-                       .where(state: :new).with_actions
+                       .where(state: :new)
                        .pluck(:number)
 
     incidents = BsRequest.to_project(name)

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -651,7 +651,7 @@ class User < ApplicationRecord
 
   # list requests involving this user
   def declined_requests(search = nil)
-    result = requests_created.where(state: :declined).with_actions
+    result = requests_created.where(state: :declined)
     search.present? ? result.do_search(search) : result
   end
 
@@ -661,14 +661,14 @@ class User < ApplicationRecord
       BsRequest.where(id: BsRequestAction.bs_request_ids_of_involved_projects(involved_projects.pluck(:id))).or(
         BsRequest.where(id: BsRequestAction.bs_request_ids_of_involved_packages(involved_packages.pluck(:id)))
       )
-    ).with_actions
+    )
 
     search.present? ? result.do_search(search) : result
   end
 
   # list outgoing requests involving this user
   def outgoing_requests(search = nil, states: %i[new review])
-    result = requests_created.where(state: states).with_actions
+    result = requests_created.where(state: states)
     search.present? ? result.do_search(search) : result
   end
 
@@ -693,7 +693,7 @@ class User < ApplicationRecord
       BsRequest.where(id: actions).or(
         BsRequest.where(id: reviews)
       )
-    ).with_actions
+    ).joins(:bs_request_actions)
 
     search.present? ? result.do_search(search) : result
   end

--- a/src/api/spec/models/project_spec.rb
+++ b/src/api/spec/models/project_spec.rb
@@ -353,7 +353,7 @@ RSpec.describe Project, :vcr do
       end
 
       it 'does include targets' do
-        expect(subject[:targets]).to eq([incident, other_target, target].pluck(:number))
+        expect(subject[:targets]).to match_array([incident, other_target, target].pluck(:number))
       end
 
       it 'does include incidents' do


### PR DESCRIPTION
It included the `distinct` and `order` clauses, which are unnecessary and degrade the performance in counting queries.