### PR TITLE
Set dataType to handle the ajax returned data

### DIFF
--- a/src/api/app/views/webui/projects/pulse/show.html.haml
+++ b/src/api/app/views/webui/projects/pulse/show.html.haml
@@ -36,6 +36,7 @@
   $(document).ready(function() {
     $.ajax({
       url: "#{project_pulse_path(@project, from: @date_range_from.strftime('%Y-%m-%d'), to: @date_range_to.strftime('%Y-%m-%d'))}",
+      dataType: 'text',
       success: function(data) {
         $('#pulse').html(data);
       },


### PR DESCRIPTION
Fix https://github.com/openSUSE/open-build-service/issues/18122

Set the `dataType` in order to let ajax success callback to handle properly the data received. In the controller the request is distinguished by the format type, so it goes under the `format.js` but we do return a partial and the partial contains `js` and `html`. This generates unhandled errors like the issue reported. Defining it as `text` makes the handling to be flat with no specific treatment.