### PR TITLE
Fix page selector and filters not working together

### DIFF
--- a/src/api/app/views/webui/users/notifications/_notification_filter.html.haml
+++ b/src/api/app/views/webui/users/notifications/_notification_filter.html.haml
@@ -1,5 +1,7 @@
 -# haml-lint:disable ViewLength
 = form_for(:notification, url: my_notifications_path, method: :get, id: 'content-selector-filters-form') do |form|
+  - if params[:page_size]
+    = hidden_field_tag 'page_size', params[:page_size]
   .accordion.accordion-flush
     .mt-2.mb-2.accordion-item.border-0.auto-submit-on-change
       .px-3.py-2.accordion-button.no-style{ data: { 'bs-toggle': 'collapse', 'bs-target': '#notification-filter-state' },

--- a/src/api/app/views/webui/users/notifications/_page_size_navigation.html.haml
+++ b/src/api/app/views/webui/users/notifications/_page_size_navigation.html.haml
@@ -10,5 +10,5 @@
         - page_size = params[:page_size]&.to_i || paginated_objects.default_per_page
         - [paginated_objects.default_per_page, 100, 300].each do |size|
           - active = 'active' if page_size == size
-          = link_to(url_for( page_size: size ), class: "dropdown-item #{active}") do
+          = link_to(url_for(request.query_parameters.merge(page_size: size)), class: "dropdown-item #{active}") do
             = size


### PR DESCRIPTION
Previously the pager control and the notifications filters on the users notifications page didn't work together: you set some filters and you lost the pager per page setting, and if you set the pager per page setting, you lost the notifications filter you had.

This PR fixes both components to work well together.

**How to test this**
- Go into the review app's users notifications
- Set some notification filters and let it reload
- Now you can go to the end of the page, and change the pager to 100 items per page, the notifications filters you had should be there.
- If you change the notification filters now, the pager configuration should stay set to whatever you set before.