### PR TITLE
Untangle SessionController from Proxy Mode

### DIFF
--- a/src/api/app/controllers/webui/session_controller.rb
+++ b/src/api/app/controllers/webui/session_controller.rb
@@ -15,7 +15,7 @@ class Webui::SessionController < Webui::WebuiController
     redirect_on_login
   end
 
-  def destroy
+  def reset
     reset_session
     User.session = nil
 
@@ -51,9 +51,7 @@ class Webui::SessionController < Webui::WebuiController
   end
 
   def redirect_on_logout
-    if ::Configuration.proxy_auth_mode_enabled?
-      redirect_to CONFIG['proxy_auth_logout_page']
-    elsif ::Configuration.anonymous
+    if ::Configuration.anonymous
       redirect_back_or_to root_path
     else
       redirect_to root_path

--- a/src/api/app/helpers/authentication_protocol_helper.rb
+++ b/src/api/app/helpers/authentication_protocol_helper.rb
@@ -24,6 +24,14 @@ module AuthenticationProtocolHelper
     end
   end
 
+  def log_out_url
+    if ::Configuration.proxy_auth_mode_enabled?
+      CONFIG['proxy_auth_logout_page']
+    else
+      reset_session_path
+    end
+  end
+
   def sign_up_params
     return { url: CONFIG['proxy_auth_register_page'] } if ::Configuration.proxy_auth_mode_enabled?
 

--- a/src/api/app/lib/routes_helper/session_auth_matcher.rb
+++ b/src/api/app/lib/routes_helper/session_auth_matcher.rb
@@ -1,0 +1,7 @@
+module RoutesHelper
+  class SessionAuthMatcher
+    def self.matches?(_request)
+      !::Configuration.proxy_auth_mode_enabled?
+    end
+  end
+end

--- a/src/api/app/views/layouts/webui/_footer.html.haml
+++ b/src/api/app/views/layouts/webui/_footer.html.haml
@@ -8,7 +8,7 @@
           %li= link_to('Home Project', project_show_path(User.session.home_project))
         - else
           %li= link_to('Create Home Project', new_project_path(name: User.session.home_project_name))
-        %li= link_to('Logout', session_path, method: :delete)
+        %li= link_to('Logout', log_out_url)
   .d-none.d-md-block
     %strong.text-uppercase Locations
     %ul

--- a/src/api/app/views/layouts/webui/_places.html.haml
+++ b/src/api/app/views/layouts/webui/_places.html.haml
@@ -70,7 +70,7 @@
       %li
         %hr
       %li.nav-item
-        = link_to(session_path, method: :delete, id: 'logout-link', class: 'nav-link') do
+        = link_to(log_out_url, id: 'logout-link', class: 'nav-link') do
           %i.fas.fa-sign-out-alt.fa-fw.me-2
           Logout
   - else

--- a/src/api/app/views/layouts/webui/_top_navigation.html.haml
+++ b/src/api/app/views/layouts/webui/_top_navigation.html.haml
@@ -49,7 +49,7 @@
             %li
               %hr.dropdown-divider
             %li.dropdown-item
-              = link_to(session_path, method: :delete, id: 'logout-link', class: 'nav-link p-0 w-100') do
+              = link_to(log_out_url, id: 'logout-link', class: 'nav-link p-0 w-100') do
                 %i.fas.fa-sign-out-alt.fa-fw.me-2
                 Logout
       - else

--- a/src/api/app/views/webui/main/index.html.haml
+++ b/src/api/app/views/webui/main/index.html.haml
@@ -16,7 +16,7 @@
                                                  host_title: @configuration['title'],
                                                  system_stats: @system_stats })
   .col-md-4.col-lg-5
-    - if !User.session && can_register?
+    - if !User.session && can_sign_up?
       .card.mb-3
         %h5.card-header New here? Sign up!
         .card-body

--- a/src/api/app/views/webui/users/_sign_up.html.haml
+++ b/src/api/app/views/webui/users/_sign_up.html.haml
@@ -4,7 +4,7 @@
   - if CONFIG['proxy_auth_register_page'].blank?
     %p Sorry, signing up is currently disabled
   - else
-    %p= link_to 'Use this link to Sign Up', proxy_auth_register_page
+    %p= link_to 'Use this link to Sign Up', CONFIG['proxy_auth_register_page']
 - else
   = form_tag(users_path, method: :post, class: 'sign-up', autocomplete: 'off') do
     .mb-3

--- a/src/api/config/routes/webui.rb
+++ b/src/api/config/routes/webui.rb
@@ -449,7 +449,13 @@ constraints(RoutesHelper::WebuiMatcher) do
   end
   # Legacy routes end
 
-  resource :session, only: %i[new create destroy], controller: 'webui/session'
+  constraints(RoutesHelper::SessionAuthMatcher) do
+    resource :session, only: %i[new create], controller: 'webui/session' do
+      collection do
+        get :reset
+      end
+    end
+  end
 
   resources :groups, only: %i[index show new create edit update], param: :title, constraints: cons, controller: 'webui/groups' do
     resources :user, only: %i[create destroy update], param: :user_login, constraints: cons, controller: 'webui/groups/users'

--- a/src/api/spec/support/features/features_authentication.rb
+++ b/src/api/spec/support/features/features_authentication.rb
@@ -12,7 +12,7 @@ module FeaturesAuthentication
   end
 
   def logout
-    visit session_path(method: :delete)
+    visit reset_session_path
     expect(page).to have_no_link('link-to-user-home')
     User.session = nil
   end


### PR DESCRIPTION
In Proxy Mode the #new and #create actions just did nothing, the #destroy action just redirected to CONFIG['proxy_auth_logout_page'].

We can have this redirect cheaper and hide the non-functional pages if Proxy Mode is enabled.