### PR TITLE
Admins and staff receive report-related notifications

### DIFF
--- a/src/api/app/policies/report_policy.rb
+++ b/src/api/app/policies/report_policy.rb
@@ -32,9 +32,7 @@ class ReportPolicy < ApplicationPolicy
 
   def notify?
     return false unless Flipper.enabled?(:content_moderation, user)
-    return true if User.moderators.blank? && (user.admin? || user.staff?)
-    return true if user.moderator?
 
-    false
+    user.moderator? || user.admin? || user.staff?
   end
 end

--- a/src/api/spec/policies/report_policy_spec.rb
+++ b/src/api/spec/policies/report_policy_spec.rb
@@ -112,31 +112,22 @@ RSpec.describe ReportPolicy, type: :policy do
   permissions :notify? do
     let(:staff_user) { create(:staff_user) }
     let(:admin_user) { create(:admin_user) }
+    let!(:moderator_user) { create(:moderator) }
 
-    context 'when there is no user with moderator role' do
-      it 'notifies admin users' do
-        expect(subject).to permit(admin_user, Report)
-      end
-
-      it 'notifies staff users' do
-        expect(subject).to permit(staff_user, Report)
-      end
+    it 'notifies the moderator' do
+      expect(subject).to permit(moderator_user, Report)
     end
 
-    context 'when there is a user with moderator role' do
-      let!(:moderator_user) { create(:moderator) }
+    it 'notifies admin users' do
+      expect(subject).to permit(admin_user, Report)
+    end
 
-      it 'does not notify admin users' do
-        expect(subject).not_to(permit(admin_user, Report))
-      end
+    it 'notifies staff users' do
+      expect(subject).to permit(staff_user, Report)
+    end
 
-      it 'does not notify staff users' do
-        expect(subject).not_to(permit(staff_user, Report))
-      end
-
-      it 'notifies the moderator' do
-        expect(subject).to permit(moderator_user, Report)
-      end
+    it 'does not notify common users' do
+      expect(subject).not_to(permit(user, Report))
     end
   end
 end


### PR DESCRIPTION
Even if there is a user with moderator role, admins and staff will receive report-related notifications and will see the Report filter.

The three roles are always involved to see and manage reports, decisions and appeals. It makes no sense to exclude any of them from the notifications.

**Who can see a report?**
Always admin, staff and moderator
https://github.com/openSUSE/open-build-service/blob/8f3aa3b99dbf0ba48fa34a72b38bc58d00a5b7df/src/api/app/policies/report_policy.rb#L3

**Who can take a decision regarding a report?**
Always admin, staff and moderator
https://github.com/openSUSE/open-build-service/blob/8f3aa3b99dbf0ba48fa34a72b38bc58d00a5b7df/src/api/app/policies/decision_policy.rb#L5

**Who can see an appeal?**
Always admin, staff and moderator
https://github.com/openSUSE/open-build-service/blob/8f3aa3b99dbf0ba48fa34a72b38bc58d00a5b7df/src/api/app/policies/appeal_policy.rb#L10

Moreover, admin and staff are always involved and can appeal to go against a moderator decision.
https://github.com/openSUSE/open-build-service/blob/8f3aa3b99dbf0ba48fa34a72b38bc58d00a5b7df/src/api/app/policies/appeal_policy.rb#L25

All those lines of code reflect that the three roles are always involved on a report/decision/appeal. So it makes sense they three are notified.