### PR TITLE
Notify group managers when a user is added to a group

### DIFF
--- a/src/api/app/models/event/added_user_to_group.rb
+++ b/src/api/app/models/event/added_user_to_group.rb
@@ -1,12 +1,12 @@
 module Event
   class AddedUserToGroup < Group
     self.description = 'Added member to group'
-    self.notification_explanation = 'Receive notifications when you are added to a group.'
+    self.notification_explanation = 'Receive notifications when you are added as member of a group or when someone is added to a group you maintain.'
 
     def subject
-      return "You were added to the group '#{payload['group']}'" unless payload['who']
+      return "'#{payload['member']}' was added to the group '#{payload['group']}'" unless payload['who']
 
-      "'#{payload['who']}' added you to the group '#{payload['group']}'"
+      "'#{payload['who']}' added '#{payload['member']}' to the group '#{payload['group']}'"
     end
   end
 end

--- a/src/api/app/models/event/group.rb
+++ b/src/api/app/models/event/group.rb
@@ -2,7 +2,7 @@ module Event
   class Group < Base
     self.abstract_class = true
     payload_keys :group, :member, :who
-    receiver_roles :member
+    receiver_roles :member, :group_maintainer
 
     def subject
       raise AbstractMethodCalled
@@ -10,6 +10,10 @@ module Event
 
     def members
       User.where(login: payload['member'])
+    end
+
+    def group_maintainers
+      ::Group.find_by(title: payload['group']).maintainers
     end
 
     def originator

--- a/src/api/app/models/event/removed_user_from_group.rb
+++ b/src/api/app/models/event/removed_user_from_group.rb
@@ -1,12 +1,12 @@
 module Event
   class RemovedUserFromGroup < Group
     self.description = 'Removed member from group'
-    self.notification_explanation = 'Receive notifications when you are removed from a group.'
+    self.notification_explanation = 'Receive notifications when you are removed from a group or someone is removed from a group you maintain.'
 
     def subject
-      return "You were removed from the group '#{payload['group']}'" unless payload['who']
+      return "'#{payload['member']}' was removed from the group '#{payload['group']}'" unless payload['who']
 
-      "'#{payload['who']}' removed you from the group '#{payload['group']}'"
+      "'#{payload['who']}' removed '#{payload['member']}' from the group '#{payload['group']}'"
     end
   end
 end

--- a/src/api/app/models/event_subscription.rb
+++ b/src/api/app/models/event_subscription.rb
@@ -22,7 +22,8 @@ class EventSubscription < ApplicationRecord
     reporter: 'As a reporter of the content',
     offender: 'As the creator of the content',
     member: 'Member',
-    assignee: 'Assignee'
+    assignee: 'Assignee',
+    group_maintainer: 'Mantainer of the group'
   }.freeze
 
   enum :channel, {
@@ -50,7 +51,7 @@ class EventSubscription < ApplicationRecord
            reviewer commenter creator
            project_watcher source_project_watcher target_project_watcher
            package_watcher target_package_watcher source_package_watcher request_watcher any_role
-           moderator reporter offender token_executor token_member member assignee]
+           moderator reporter offender token_executor token_member member assignee group_maintainer]
   }
 
   scope :for_eventtype, ->(eventtype) { where(eventtype: eventtype) }

--- a/src/api/app/models/group.rb
+++ b/src/api/app/models/group.rb
@@ -7,6 +7,7 @@ class Group < ApplicationRecord
   has_many :groups_users, inverse_of: :group, dependent: :destroy
   has_many :users, -> { distinct.order(:login) }, through: :groups_users
   has_many :group_maintainers, inverse_of: :group, dependent: :destroy
+  has_many :maintainers, through: :group_maintainers, source: :user
   has_many :relationships, dependent: :destroy, inverse_of: :group
   has_many :event_subscriptions, dependent: :destroy, inverse_of: :group
   has_many :reviews, dependent: :nullify

--- a/src/api/app/models/notification_group.rb
+++ b/src/api/app/models/notification_group.rb
@@ -14,9 +14,9 @@ class NotificationGroup < Notification
   def link_text
     case event_type
     when 'Event::AddedUserToGroup'
-      "#{event_payload['who'] || 'Someone'} added you to the group '#{event_payload['group']}'"
+      "'#{event_payload['who'] || 'Someone'}' added '#{event_payload['member']}' to the group '#{event_payload['group']}'"
     when 'Event::RemovedUserFromGroup'
-      "#{event_payload['who'] || 'Someone'} removed you from the group '#{event_payload['group']}'"
+      "'#{event_payload['who'] || 'Someone'}' removed '#{event_payload['member']}' from the group '#{event_payload['group']}'"
     end
   end
 

--- a/src/api/app/queries/outdated_notifications_finder/group.rb
+++ b/src/api/app/queries/outdated_notifications_finder/group.rb
@@ -5,7 +5,9 @@ class OutdatedNotificationsFinder::Group
   end
 
   def call
-    # Notifications about added members shouldn't replace notifications about removed members and vice versa, so event_type should match.
-    @scope.where(notifiable_type: 'Group', notifiable_id: @parameters[:notifiable_id], event_type: @parameters[:event_type])
+    # Only replace the notification if it's identical: same member added/removed from the same group by the same person.
+    # That's why we need to compare with both event_type and event_payload.
+    @scope.where(notifiable_type: 'Group', notifiable_id: @parameters[:notifiable_id],
+                 event_type: @parameters[:event_type], event_payload: @parameters[:event_payload])
   end
 end

--- a/src/api/app/views/event_mailer/added_user_to_group.html.haml
+++ b/src/api/app/views/event_mailer/added_user_to_group.html.haml
@@ -1,2 +1,2 @@
 %p
-  You got added to group '#{event['group']}'
+  '#{event['member']}' got added to group '#{event['group']}'

--- a/src/api/app/views/event_mailer/added_user_to_group.text.erb
+++ b/src/api/app/views/event_mailer/added_user_to_group.text.erb
@@ -1,1 +1,1 @@
-<%= "You got added to group '#{event['group']}'" %>
+<%= "'#{event['member']}' got added to group '#{event['group']}'" %>

--- a/src/api/app/views/event_mailer/removed_user_from_group.html.haml
+++ b/src/api/app/views/event_mailer/removed_user_from_group.html.haml
@@ -1,2 +1,2 @@
 %p
-  You got removed from group '#{event['group']}'
+  '#{event['member']}' got removed from group '#{event['group']}'

--- a/src/api/app/views/event_mailer/removed_user_from_group.text.erb
+++ b/src/api/app/views/event_mailer/removed_user_from_group.text.erb
@@ -1,1 +1,1 @@
-<%= "You got removed from group '#{event['group']}'" %>
+<%= "'#{event['member']}' got removed from group '#{event['group']}'" %>

--- a/src/api/spec/mailers/event_mailer_spec.rb
+++ b/src/api/spec/mailers/event_mailer_spec.rb
@@ -651,11 +651,11 @@ RSpec.describe EventMailer, :vcr do
       end
 
       it 'contains the correct subject' do
-        expect(mail.subject).to include("'#{who}' added you to the group '#{group}'")
+        expect(mail.subject).to include("'#{who}' added '#{user}' to the group '#{group}'")
       end
 
       it 'contains the correct text' do
-        expect(mail.body.encoded).to include("You got added to group '#{group}'")
+        expect(mail.body.encoded).to include("'#{user}' got added to group '#{group}'")
       end
     end
 
@@ -681,11 +681,11 @@ RSpec.describe EventMailer, :vcr do
       end
 
       it 'contains the correct subject' do
-        expect(mail.subject).to include("'#{who}' removed you from the group '#{group}'")
+        expect(mail.subject).to include("'#{who}' removed '#{user}' from the group '#{group}'")
       end
 
       it 'contains the correct text' do
-        expect(mail.body.encoded).to include("You got removed from group '#{group}'")
+        expect(mail.body.encoded).to include("'#{user}' got removed from group '#{group}'")
       end
     end
 


### PR DESCRIPTION
Group maintainers will know when someone else add a user to "their"  group.

## Testing tips

- Open two sessions with two different users (for example Admin and Iggy)
- Login as Iggy and subscribe it to _Added member to group_ and _Removed member from group_ events
- As Admin go to _Configuration > Manage Group_; mark Iggy as Maintainer of any group you choose, for example group_1
- Add and remove users from the group
- After a few minutes Iggy should see notifications about all the additions and removals Admin did