### PR TITLE
Remove session checking

### DIFF
--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -322,8 +322,6 @@ class Package < ApplicationRecord
 
   def check_source_access!
     return if check_source_access?
-    # TODO: Use pundit for authorization instead
-    raise Authenticator::AnonymousUser, 'Anonymous user is not allowed here - please login' unless User.session
 
     raise ReadSourceAccessError, "#{project.name}/#{name}"
   end


### PR DESCRIPTION
Authorization is not the place to check for Authentication.
    
The weak version of this method (`check_source_access?`) uses `User.possibly_nobody`. So only if someone makes the nobody user admin, gives it a `Role` with global `source_access` permission or adds this `User` to it's `Project`/`Package` this would hit. If someone so desperately tries to shoot themselves in the foot, let them.
