### PR TITLE
Display the correct name in rpmlint for multibuild packages

### DIFF
--- a/src/api/app/views/webui/package/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui/package/_breadcrumb_items.html.haml
@@ -7,11 +7,13 @@
 - else
   %li.breadcrumb-item.text-word-break-all
     %i.fa.fa-archive
-    = precede link_to(@package, package_show_path(@project, @package)) do
-      - if @multibuild_flavor.present?
-        %span.active :#{@multibuild_flavor}
+    = link_to(package_show_path(@project, @package)) do
+      - if @package_name.present?
+        = @package_name
       - else
-        = nil
+        = @package
+        - if @multibuild_flavor.present?
+          %span.active :#{@multibuild_flavor}
   - if current_page?(package_view_revisions_path(@project, @package))
     %li.breadcrumb-item.active{ 'aria-current' => 'page' }
       Revisions

--- a/src/api/app/views/webui/packages/rpmlint/show.html.haml
+++ b/src/api/app/views/webui/packages/rpmlint/show.html.haml
@@ -1,4 +1,4 @@
-- @pagetitle = "RPM Lint of #{@package} for #{@repository} #{@architecture}"
+- @pagetitle = "RPM Lint of #{@package_name} for #{@repository} #{@architecture}"
 
 .card
   = render(partial: 'webui/package/tabs', locals: { project: @project, package: @package })


### PR DESCRIPTION
The page was displaying a multibuild lint log, but that wasn't reflected in the page title or breadcrumbs