### PR TITLE
Rename `require_package` method to `set_package`

### DIFF
--- a/src/api/app/controllers/webui/attribute_controller.rb
+++ b/src/api/app/controllers/webui/attribute_controller.rb
@@ -87,12 +87,6 @@ class Webui::AttributeController < Webui::WebuiController
 
   private
 
-  def set_package
-    return unless params[:package]
-
-    require_package
-  end
-
   def set_container
     @container = @package || @project
   end

--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -18,10 +18,10 @@ class Webui::PackageController < Webui::WebuiController
 
   before_action :check_scmsync, only: %i[statistics users requests]
 
-  before_action :require_package, only: %i[edit update show requests statistics revisions
-                                           branch_diff_info rdiff remove
-                                           save_person save_group remove_role view_file
-                                           buildresult rpmlint_result rpmlint_log files users]
+  before_action :set_package, only: %i[edit update show requests statistics revisions
+                                       branch_diff_info rdiff remove
+                                       save_person save_group remove_role view_file
+                                       buildresult rpmlint_result rpmlint_log files users]
   # rubocop:enable Rails/LexicallyScopedActionFilter
 
   before_action :check_ajax, only: %i[devel_project buildresult]

--- a/src/api/app/controllers/webui/packages/bs_requests_controller.rb
+++ b/src/api/app/controllers/webui/packages/bs_requests_controller.rb
@@ -4,7 +4,7 @@ module Webui
       include Webui::RequestsFilter
 
       before_action :set_project
-      before_action :require_package
+      before_action :set_package
       before_action :redirect_legacy
       before_action :set_bs_requests
 

--- a/src/api/app/controllers/webui/packages/trigger_controller.rb
+++ b/src/api/app/controllers/webui/packages/trigger_controller.rb
@@ -3,7 +3,7 @@ module Webui
     class TriggerController < Webui::WebuiController
       before_action :require_login
       before_action :set_project
-      before_action :require_package
+      before_action :set_package
       before_action :set_object_to_authorize
 
       after_action :verify_authorized

--- a/src/api/app/controllers/webui/patchinfo_controller.rb
+++ b/src/api/app/controllers/webui/patchinfo_controller.rb
@@ -6,7 +6,7 @@ class Webui::PatchinfoController < Webui::WebuiController
   before_action :require_login, except: [:show]
   before_action :set_project
   before_action :set_binaries, except: %i[show destroy new_tracker]
-  before_action :require_package, except: %i[create new_tracker]
+  before_action :set_package, except: %i[create new_tracker]
   before_action :require_exists, except: %i[create new_tracker]
   before_action :set_patchinfo, only: %i[show edit]
 

--- a/src/api/app/controllers/webui/repositories_controller.rb
+++ b/src/api/app/controllers/webui/repositories_controller.rb
@@ -5,7 +5,7 @@ class Webui::RepositoriesController < Webui::WebuiController
   before_action :check_scmsync, if: -> { params[:package] }
   before_action :set_repository, only: [:state]
   before_action :set_architectures, only: %i[index change_flag]
-  before_action :require_package, only: %i[index change_flag], if: -> { params[:package] }
+  before_action :set_package, only: %i[index change_flag], if: -> { params[:package] }
   before_action :set_main_object, only: %i[index change_flag]
   before_action :check_ajax, only: :change_flag
   after_action :verify_authorized, except: %i[index state]

--- a/src/api/app/controllers/webui/webui_controller.rb
+++ b/src/api/app/controllers/webui/webui_controller.rb
@@ -95,7 +95,7 @@ class Webui::WebuiController < ActionController::Base
     @is_displayed_user = (User.session == @displayed_user)
   end
 
-  def require_package
+  def set_package
     @package_name = params[:package] || params[:package_name]
 
     return if @package_name.blank?
@@ -107,7 +107,6 @@ class Webui::WebuiController < ActionController::Base
       raise Package::UnknownObjectError, "Package not found: #{@project.name}/#{@package_name}"
     end
   end
-  alias set_package require_package
 
   def set_repository
     repository_name = params[:repository] || params[:repository_name]

--- a/src/api/spec/controllers/webui/webui_controller_spec.rb
+++ b/src/api/spec/controllers/webui/webui_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Webui::WebuiController do
     before_action :require_admin, only: :new
     before_action :require_login, only: :show
     before_action :set_project, only: %i[edit create]
-    before_action :require_package, only: :create
+    before_action :set_package, only: :create
     before_action :check_anonymous, only: :index
 
     def index
@@ -28,7 +28,7 @@ RSpec.describe Webui::WebuiController do
     end
 
     def create
-      render plain: 'anonymous controller - require_package'
+      render plain: 'anonymous controller - set_package'
     end
   end
 
@@ -87,7 +87,7 @@ RSpec.describe Webui::WebuiController do
     end
   end
 
-  describe 'require_package before filter' do
+  describe 'set_package before filter' do
     let(:project) { create(:project) }
 
     context 'with invalid package parameter' do


### PR DESCRIPTION
In the majority of controllers we use the `set_package` alias
to call `require_package`. Also the controllers that have their
own logic for this method and overwrite the inheritance of the
method use the `set_package` naming. Lets get rid of the
alias and stick to one name for it.

~~Depends on https://github.com/openSUSE/open-build-service/pull/18294~~