### PR TITLE
Remove parsing of the no-longer-used `pkgrev` parameter

### DIFF
--- a/src/api/app/controllers/webui/webui_controller.rb
+++ b/src/api/app/controllers/webui/webui_controller.rb
@@ -96,7 +96,6 @@ class Webui::WebuiController < ActionController::Base
   end
 
   def require_package
-    params[:rev], params[:package] = params[:pkgrev].split('-', 2) if params[:pkgrev]
     @package_name = params[:package] || params[:package_name]
 
     return if @package_name.blank?


### PR DESCRIPTION
This parameter was introduced in 3b9d9020d61003d46858e4c3a38313669a75b002 and later removed in  ced3de2b347c6bd079e129063b48352db887a873. It has not being used for a long time.

Seen while reviewing #18273.