### PR TITLE
Fix rendering of RPM lint logs bar chart

### DIFF
--- a/src/api/app/components/rpm_lint_component.html.haml
+++ b/src/api/app/components/rpm_lint_component.html.haml
@@ -1,19 +1,19 @@
 .row
   .col-12.col-md-6
-    = bar_chart( issues_chart_data,
-                    width: '100%',
-                    height: '300px',
-                    stacked: true,
-                    responsive: true,
-                    colors: ['#DC3545', '#FFCC00'],
-                    library: { scales: { y: { ticks: { stepSize: 1 }}}},
-                  )
+    = helpers.bar_chart( issues_chart_data,
+                           width: '100%',
+                           height: '300px',
+                           stacked: true,
+                           responsive: true,
+                           colors: ['#DC3545', '#FFCC00'],
+                           library: { scales: { y: { ticks: { stepSize: 1 }}}},
+                       )
   .col-12.col-md-6
-    = bar_chart( badness_chart_data,
-                    width: '100%',
-                    height: '300px',
-                    stacked: true,
-                    responsive: true,
-                    colors: ['#DC3545'],
-                    library: { scales: { y: { ticks: { stepSize: 1 }}}},
-                  )
+    = helpers.bar_chart( badness_chart_data,
+                           width: '100%',
+                           height: '300px',
+                           stacked: true,
+                           responsive: true,
+                           colors: ['#DC3545'],
+                           library: { scales: { y: { ticks: { stepSize: 1 }}}},
+                       )


### PR DESCRIPTION
Fixes #18284.

This change should have been included in the update of view_components to 4.0.0. See #18280.