### PR TITLE
Avoid crash when calling `write_attributes` if a user is not logged in

### DIFF
--- a/src/api/app/lib/backend/api/sources/package.rb
+++ b/src/api/app/lib/backend/api/sources/package.rb
@@ -19,7 +19,7 @@ module Backend
         # Writes the content in xml for attributes
         # @return [String]
         def self.write_attributes(project_name, package_name, user_login, content)
-          params = { meta: 1, user: user_login }
+          params = { meta: 1, user: user_login }.compact
           http_put(['/source/:project/:package/_attribute', project_name, package_name || '_project'],
                    data: content, params: params)
         end

--- a/src/api/app/models/concerns/has_attributes.rb
+++ b/src/api/app/models/concerns/has_attributes.rb
@@ -10,9 +10,9 @@ module HasAttributes
 
     project_name = is_a?(Project) ? name : project.name
     if is_a?(Package)
-      Backend::Api::Sources::Package.write_attributes(project_name, name, User.session!.login, render_attribute_axml)
+      Backend::Api::Sources::Package.write_attributes(project_name, name, User.session&.login, render_attribute_axml)
     else
-      Backend::Api::Sources::Project.write_attributes(project_name, User.session!.login, render_attribute_axml)
+      Backend::Api::Sources::Project.write_attributes(project_name, User.session&.login, render_attribute_axml)
     end
   rescue Backend::Error => e
     raise AttributeSaveError, e.summary


### PR DESCRIPTION
Don't raise an exception when calling the backend API without a logged-in user. Checking for a logged in user needs to happen before the backend API call.