### PR TITLE
Don't pass an empty user to the backend in `project.write_attributes`

### DIFF
--- a/src/api/app/lib/backend/api/sources/project.rb
+++ b/src/api/app/lib/backend/api/sources/project.rb
@@ -17,7 +17,7 @@ module Backend
         # Writes the xml for attributes
         # @return [String]
         def self.write_attributes(project_name, user_login, content)
-          params = { meta: 1, user: user_login }
+          params = { meta: 1, user: user_login }.compact
           http_put(['/source/:project/_project/_attribute', project_name], data: content, params: params)
         end
 


### PR DESCRIPTION
In case a user is empty, don't pass the `user` parameter to the backend.

This should have been included in #18292.