### PR TITLE
Fix rendering of `BsRequestActionSourceAndTargetComponent`

### DIFF
--- a/src/api/app/components/bs_request_action_description_component.rb
+++ b/src/api/app/components/bs_request_action_description_component.rb
@@ -19,20 +19,9 @@ class BsRequestActionDescriptionComponent < ApplicationComponent
   def description
     creator = action.bs_request.creator
 
-    source_project_hash = { project: action.source_project, package: action.source_package, trim_to: nil }
     target_project_hash = { project: action.target_project, package: action.target_package, trim_to: nil }
 
-    source_and_target_component = BsRequestActionSourceAndTargetComponent.new(action.bs_request)
-
-    if text_only
-      source_container = source_and_target_component.source
-      target_container = source_and_target_component.target
-    else
-      source_container = project_or_package_link(source_project_hash)
-      target_container = project_or_package_link(target_project_hash)
-    end
-
-    source_and_target_container = source_and_target_component.combine(source_container, target_container)
+    source_and_target_container = render(BsRequestActionSourceAndTargetComponent.new(action.bs_request, text_only: text_only))
 
     description = case action.type
                   when 'submit'

--- a/src/api/app/components/bs_request_action_source_and_target_component.html.haml
+++ b/src/api/app/components/bs_request_action_source_and_target_component.html.haml
@@ -1,0 +1,6 @@
+- if source.present?
+  %span
+    = source
+  %i.fas.fa-long-arrow-alt-right.text-info.mx-2
+%span
+  = target

--- a/src/api/app/components/bs_request_action_source_and_target_component.rb
+++ b/src/api/app/components/bs_request_action_source_and_target_component.rb
@@ -1,34 +1,33 @@
 class BsRequestActionSourceAndTargetComponent < ApplicationComponent
-  attr_reader :bs_request_action, :number_of_bs_request_actions
+  attr_reader :bs_request_action, :number_of_bs_request_actions, :text_only
 
-  def initialize(bs_request)
+  delegate :project_or_package_link, to: :helpers
+
+  def initialize(bs_request, text_only: true)
     @bs_request_action = bs_request.bs_request_actions.first
     @number_of_bs_request_actions = bs_request.bs_request_actions.size
-  end
-
-  def call
-    combine(source, target)
+    @text_only = text_only
   end
 
   def source
-    @source ||= if number_of_bs_request_actions > 1
-                  ''
-                else
-                  [bs_request_action.source_project, bs_request_action.source_package].compact.join(' / ')
-                end
+    if text_only
+      @source ||= if number_of_bs_request_actions > 1
+                    ''
+                  else
+                    [bs_request_action.source_project, bs_request_action.source_package].compact.join(' / ')
+                  end
+    else
+      project_or_package_link({ project: @bs_request_action.source_project, package: @bs_request_action.source_package, trim_to: nil })
+    end
   end
 
   def target
-    return bs_request_action.target_project if number_of_bs_request_actions > 1
+    if text_only
+      return bs_request_action.target_project if number_of_bs_request_actions > 1
 
-    [bs_request_action.target_project, bs_request_action.target_package].compact.join(' / ')
-  end
-
-  def combine(source, target)
-    if source.present?
-      tag.span(source)
-      tag.i(nil, class: 'fas fa-long-arrow-alt-right text-info mx-2')
+      [bs_request_action.target_project, bs_request_action.target_package].compact.join(' / ')
+    else
+      project_or_package_link({ project: @bs_request_action.target_project, package: @bs_request_action.target_package, trim_to: nil })
     end
-    tag.span(target)
   end
 end


### PR DESCRIPTION
In the previous update of the ViewComponent Gem
(https://github.com/openSUSE/open-build-service/pull/18269), the `capture` block around the view code in the `combine` method was dropped. This led to only the last line (last view tag) being returned and therfore only the link to the target of the bs_reques_action being rendered.
Simply reintroducing the use of the `capture` helper doesn't workout since the usage of it depends on the view context that only exists once a ViewComponent is passed to the Rails render pipeline.

A little refactor of moving the view code to a view template and handling some of the logic previously handled outside of the view component is the easiest way of fixing it.

Fixes https://github.com/openSUSE/open-build-service/issues/18302