### PR TITLE
[backend] ProductCompose: fix debuginfo binary filtering when there i…

### DIFF
--- a/src/backend/BSSched/BuildJob/ProductCompose.pm
+++ b/src/backend/BSSched/BuildJob/ProductCompose.pm
@@ -530,7 +530,7 @@ sub check {
 	      last;
 	    }
 	    $nafilter->{"$srcbn.src"} = $nafilter->{"$srcbn.nosrc"} = 1 unless $nosrcpkgs;
-	    $nafilter->{"$srcbn-debugsource.$ba"} = $nafilter->{"$bn-debuginfo.$ba"} = 1 unless $nodbgpkgs;
+	    $nafilter->{"$srcbn-debugsource.$ba"} = $nafilter->{"$srcbn-debuginfo.$ba"} = $nafilter->{"$bn-debuginfo.$ba"} = 1 unless $nodbgpkgs;
 	  }
 	}
 


### PR DESCRIPTION
…s no main rpm

A debuginfo package may exist even if the corresponding main package is missing, as it may contain shared data for all other debuginfo packages. Take this into account when creating the binary name filter.