### PR TITLE
Fix qlty config param

### DIFF
--- a/.circleci/conditional_config.yml
+++ b/.circleci/conditional_config.yml
@@ -389,7 +389,7 @@ jobs:
           command: |
             curl -L https://qlty-releases.s3.amazonaws.com/qlty/latest/qlty-x86_64-unknown-linux-gnu.tar.xz > qlty.tar.xz
             tar -xf qlty.tar.xz qlty-x86_64-unknown-linux-gnu/qlty --strip-components 1
-            ./qlty coverage transform --strip-prefix src/api/ --report-format cobertura coverage/coverage.xml
+            ./qlty coverage transform --strip-prefix src/api/ --format cobertura coverage/coverage.xml
             ./qlty coverage publish coverage.jsonl
       - run:
           name: Compress coverage results


### PR DESCRIPTION
Depends on https://github.com/openSUSE/open-build-service/pull/18317

`--report-format` is deprecated (https://github.com/qltysh/qlty/blob/c00990c8c7c509a7a4de5cdf42593cb84dcdadcb/qlty-cli/src/commands/coverage/publish.rs#L277) , use `--format` instead.