### PR TITLE
Remove no longer used `double` key on definition of XPath table

### DIFF
--- a/src/api/lib/xpath_engine.rb
+++ b/src/api/lib/xpath_engine.rb
@@ -445,8 +445,6 @@ class XpathEngine
           raise IllegalXpathError, 'attributes must be $NAMESPACE:$NAME' if tvalues.size != 2
 
           @condition_values_needed.times { @condition_values << tvalues }
-        elsif @last_key && @attribs[table][@last_key][:double]
-          @condition_values_needed.times { @condition_values << [value, value] }
         else
           @condition_values_needed.times { @condition_values << value }
         end


### PR DESCRIPTION
This feature was introduced in 66d69b29e10bc9b5acc6a1b3d4f3bb464693c902 and later removed in bcf8de8f8ece584878bb6a703bab65585094a790. The code being removed now is a leftover.

Seen while working on #18173.