### PR TITLE
Disable diff request for files with no diff

### DIFF
--- a/src/api/app/components/sourcediff_component.rb
+++ b/src/api/app/components/sourcediff_component.rb
@@ -42,7 +42,7 @@ class SourcediffComponent < ApplicationComponent
     files = sourcediff['files'].sort_by { |k, _v| sourcediff['filenames'].find_index(k) }.to_h
 
     files.each_with_index do |(filename, contents), file_index|
-      files[filename]['disabled'] = contents['state'].in?(%w[deleted added]) && contents['diff']['_content'].nil?
+      files[filename]['disabled'] = contents['diff'].nil? || contents['diff']['_content'].nil?
       next if files[filename]['disabled']
 
       files[filename]['diff_url'] = request_changes_diff_path(number: @bs_request.number, request_action_id: @action.id, filename:, diff_to_superseded:, file_index:, commented_lines: @commented_lines[file_index])


### PR DESCRIPTION
follow-up of #18196

Sometimes we don’t receive a diff from the backend for certain files. In these cases, the diff content is just the number of lines changed without the actual diff, and sometimes the diff is not available at all. This does not depend on the state of the file. We were checking this based on the file’s state, but the file could be in any state (added, deleted, changed, or renamed) and still have no diff.