### PR TITLE
Remove `text-dark` CSS class from link icon

### DIFF
--- a/src/api/app/views/webui/package/side_links/_show_linkinfo.html.haml
+++ b/src/api/app/views/webui/package/side_links/_show_linkinfo.html.haml
@@ -1,6 +1,6 @@
 - linked_package = linkinfo[:package]
 %li
-  %i.fas.fa-link.text-dark
+  %i.fas.fa-link
   Links to
   - if linkinfo[:remote_project]
     remote


### PR DESCRIPTION
Fix rendering of link icon in dark mode.

## For reviewers

See it in action in the review app:
-  Access this [link](https://obs-reviewlab.opensuse.org/eduardoj-fixfa_link_text_dark/package/show/home:Admin/linked_package).
- Change the theme of the user you log in with to dark mode.

### Before

| Light mode | Dark mode |
| --- | --- |
| <img width="520" height="119" alt="Screenshot From 2025-08-11 17-24-28" src="https://github.com/user-attachments/assets/98d2885b-c137-4ea7-b896-ae810c72c75f" /> | <img width="520" height="119" alt="Screenshot From 2025-08-11 17-24-57" src="https://github.com/user-attachments/assets/4bf7aa32-4bdb-4fba-8ecb-b8c9c43370d8" /> |


### After

| Light mode (no changes) | Dark mode |
| --- | --- |
| <img width="520" height="119" alt="Screenshot From 2025-08-11 17-24-28" src="https://github.com/user-attachments/assets/98d2885b-c137-4ea7-b896-ae810c72c75f" />  | <img width="520" height="119" alt="Screenshot From 2025-08-11 17-25-20" src="https://github.com/user-attachments/assets/0c9247df-7991-4282-8104-db59b29e270a" /> |