### PR TITLE
Fix CSRF security warning on the Pulse page

### DIFF
--- a/src/api/app/views/webui/projects/pulse/show.html.haml
+++ b/src/api/app/views/webui/projects/pulse/show.html.haml
@@ -15,7 +15,7 @@
                                                      'data-bs-toggle': 'dropdown',
                                                      type: 'button' }
             Change Time Range
-          %form.dropdown-menu.dropdown-menu-end.p-4
+          = form_with(class: 'dropdown-menu dropdown-menu-end p-4') do
             = link_to("Yesterday", project_pulse_path(@project, from: 1.day.ago.strftime('%Y-%m-%d')), class: 'dropdown-item')
             = link_to("1 Week", project_pulse_path(@project, from: 1.week.ago.strftime('%Y-%m-%d')), class: 'dropdown-item')
             = link_to("1 Month", project_pulse_path(@project, from: 1.month.ago.strftime('%Y-%m-%d')), class: 'dropdown-item')


### PR DESCRIPTION
Our application enforces request forgery protection for all HTTP requests, including GET.

Replace the raw `<form>` element with the Rails `form_with` helper, which automatically includes a hidden authenticity token field.

Fixes #17818.

See the official documentation:

https://guides.rubyonrails.org/v7.2/form_helpers.html#working-with-basic-forms