### PR TITLE
Let diff subject component find old file names

### DIFF
--- a/src/api/app/components/bs_request_comment_component.html.haml
+++ b/src/api/app/components/bs_request_comment_component.html.haml
@@ -54,7 +54,7 @@
               = link_to(action.uniq_key, request_show_path(number: action.bs_request, request_action_id: action))
               >
               = link_to request_changes_path(number: action.bs_request, request_action_id: action, anchor:) do
-                = render(DiffSubjectComponent.new(state: diff['state'], old_filename: diff.dig('old', 'name'), new_filename: diff.dig('new', 'name')))
+                = render(DiffSubjectComponent.new(state: diff['state'], file_info: diff))
               - if comment.outdated?
                 %span.badge.text-bg-warning Outdated
             = render(DiffComponent.new(diff: diff.dig('diff', '_content'), range:))

--- a/src/api/app/components/diff_list_component.html.haml
+++ b/src/api/app/components/diff_list_component.html.haml
@@ -1,20 +1,19 @@
 - diff_list.each_with_index do |(name, file_info), file_index|
   :ruby
     state = file_info['state']
-    old_filename = file_info.dig('old', 'name')
     expanded = expand?(name, state, file_index)
   .accordion.mb-2.diff-accordion{ id: "diff-list-#{name.parameterize}" }
     .accordion-item
       %h2.accordion-header
         - if file_info['disabled']
           %button.accordion-button.disabled-accordion{ disabled: true }
-            = render(DiffSubjectComponent.new(state:, old_filename:, new_filename: name))
+            = render(DiffSubjectComponent.new(state:, file_info:))
         - else
           %button.accordion-button{ type: 'button', data: { 'bs-toggle': 'collapse',
                                                             'bs-target': "#diff-item-#{name.parameterize}" },
                                     aria: { expanded: 'true', controls: "diff-item-#{name.parameterize}" },
                                     class: expanded ? '' : 'collapsed' }
-            = render(DiffSubjectComponent.new(state:, old_filename:, new_filename: name))
+            = render(DiffSubjectComponent.new(state:, file_info:))
       .accordion-collapse.collapse{ class: expanded ? 'show' : '', id: "diff-item-#{name.parameterize}", 'data-object': view_id }
         - if file_info.key?('diff_url')
           %turbo-frame{ id: "file-#{file_index}", src: file_info['diff_url'], loading: 'lazy' }
@@ -23,4 +22,4 @@
         - else
           = render(DiffComponent.new(diff: file_info.dig('diff', '_content'), file_index:, commentable:,
                                      commented_lines: commented_lines[file_index] || [],
-                                     source_file: source_file(old_filename), target_file: target_file(name), source_rev:, target_rev:))
+                                     source_file: source_file(file_info.dig('old', 'name')), target_file: target_file(name), source_rev:, target_rev:))

--- a/src/api/app/components/diff_subject_component.rb
+++ b/src/api/app/components/diff_subject_component.rb
@@ -1,11 +1,11 @@
 class DiffSubjectComponent < ApplicationComponent
   attr_reader :state, :old_filename, :new_filename
 
-  def initialize(state:, old_filename:, new_filename:)
+  def initialize(state:, file_info:)
     super
     @state = state
-    @old_filename = old_filename
-    @new_filename = new_filename
+    @old_filename = file_info.dig('old', 'name')
+    @new_filename = file_info.dig('new', 'name')
   end
 
   def badge
@@ -16,10 +16,9 @@ class DiffSubjectComponent < ApplicationComponent
   end
 
   def changed_filename
-    return @new_filename unless %w[changed renamed].include?(@state)
-    return @new_filename if @old_filename == @new_filename
-    return @new_filename unless @old_filename
+    return @old_filename if @state == 'deleted'
+    return "#{@old_filename} -> #{@new_filename}" if @state == 'renamed'
 
-    "#{@old_filename} -> #{@new_filename}"
+    @new_filename
   end
 end

--- a/src/api/spec/components/diff_subject_component_spec.rb
+++ b/src/api/spec/components/diff_subject_component_spec.rb
@@ -12,4 +12,39 @@ RSpec.describe DiffSubjectComponent, type: :component do
       expect(rendered_content).to have_text(preview_name.capitalize)
     end
   end
+
+  context 'when the state is added' do
+    it 'renders the new filename' do
+      render_inline(described_class.new(state: 'added', new_filename: 'new_file.txt', old_filename: ''))
+      expect(rendered_content).to have_text('new_file.txt')
+    end
+  end
+
+  context 'when the state is deleted' do
+    it 'renders the new filename' do
+      render_inline(described_class.new(state: 'deleted', new_filename: 'new_file.txt', old_filename: ''))
+      expect(rendered_content).to have_text('new_file.txt')
+    end
+  end
+
+  context 'when the state is changed' do
+    it 'renders the new filename' do
+      render_inline(described_class.new(state: 'changed', new_filename: 'new_file.txt', old_filename: 'new_file.txt'))
+      expect(rendered_content).to have_text('new_file.txt')
+    end
+  end
+
+  context 'when the state is renamed' do
+    it 'renders the new filename' do
+      render_inline(described_class.new(state: 'renamed', new_filename: 'new_file.txt', old_filename: 'old_file.txt'))
+      expect(rendered_content).to have_text('old_file.txt')
+    end
+  end
+
+  context 'when the state is blank' do
+    it 'renders the new filename' do
+      render_inline(described_class.new(state: '', new_filename: 'new_file.txt', old_filename: ''))
+      expect(rendered_content).to have_text('new_file.txt')
+    end
+  end
 end

--- a/src/api/spec/components/diff_subject_component_spec.rb
+++ b/src/api/spec/components/diff_subject_component_spec.rb
@@ -15,35 +15,35 @@ RSpec.describe DiffSubjectComponent, type: :component do
 
   context 'when the state is added' do
     it 'renders the new filename' do
-      render_inline(described_class.new(state: 'added', new_filename: 'new_file.txt', old_filename: ''))
+      render_inline(described_class.new(state: 'added', file_info: { 'new' => { 'name' => 'new_file.txt' }, 'old' => { 'name' => '' } }))
       expect(rendered_content).to have_text('new_file.txt')
     end
   end
 
   context 'when the state is deleted' do
     it 'renders the new filename' do
-      render_inline(described_class.new(state: 'deleted', new_filename: 'new_file.txt', old_filename: ''))
-      expect(rendered_content).to have_text('new_file.txt')
+      render_inline(described_class.new(state: 'deleted', file_info: { 'new' => { 'name' => '' }, 'old' => { 'name' => 'old_file.txt' } }))
+      expect(rendered_content).to have_text('old_file.txt')
     end
   end
 
   context 'when the state is changed' do
     it 'renders the new filename' do
-      render_inline(described_class.new(state: 'changed', new_filename: 'new_file.txt', old_filename: 'new_file.txt'))
+      render_inline(described_class.new(state: 'changed', file_info: { 'new' => { 'name' => 'new_file.txt' }, 'old' => { 'name' => 'new_file.txt' } }))
       expect(rendered_content).to have_text('new_file.txt')
     end
   end
 
   context 'when the state is renamed' do
     it 'renders the new filename' do
-      render_inline(described_class.new(state: 'renamed', new_filename: 'new_file.txt', old_filename: 'old_file.txt'))
+      render_inline(described_class.new(state: 'renamed', file_info: { 'new' => { 'name' => 'new_file.txt' }, 'old' => { 'name' => 'old_file.txt' } }))
       expect(rendered_content).to have_text('old_file.txt')
     end
   end
 
   context 'when the state is blank' do
     it 'renders the new filename' do
-      render_inline(described_class.new(state: '', new_filename: 'new_file.txt', old_filename: ''))
+      render_inline(described_class.new(state: '', file_info: { 'new' => { 'name' => 'new_file.txt' }, 'old' => { 'name' => '' } }))
       expect(rendered_content).to have_text('new_file.txt')
     end
   end

--- a/src/api/spec/components/previews/diff_subject_component_preview.rb
+++ b/src/api/spec/components/previews/diff_subject_component_preview.rb
@@ -1,22 +1,22 @@
 class DiffSubjectComponentPreview < ViewComponent::Preview
   # Preview at http://HOST:PORT/rails/view_components/diff_subject_component/
   def added
-    render(DiffSubjectComponent.new(state: 'added', new_filename: 'new_file.txt', old_filename: ''))
+    render(DiffSubjectComponent.new(state: 'added', file_info: { 'new' => { 'name' => 'new_file.txt' }}))
   end
 
   def deleted
-    render(DiffSubjectComponent.new(state: 'deleted', new_filename: 'file.txt', old_filename: 'file.txt'))
+    render(DiffSubjectComponent.new(state: 'deleted', file_info: { 'new' => { 'name' => 'new_file.txt' }}))
   end
 
   def changed
-    render(DiffSubjectComponent.new(state: 'changed', new_filename: 'file.txt', old_filename: 'file.txt'))
+    render(DiffSubjectComponent.new(state: 'changed', file_info: { 'new' => { 'name' => 'file.txt' }}))
   end
 
   def renamed
-    render(DiffSubjectComponent.new(state: 'renamed', new_filename: 'new_file.txt', old_filename: 'old_file.txt'))
+    render(DiffSubjectComponent.new(state: 'renamed', file_info: { 'new' => { 'name' => 'file.txt' }}))
   end
 
   def not_modified
-    render(DiffSubjectComponent.new(state: '', new_filename: 'file.txt', old_filename: 'file.txt'))
+    render(DiffSubjectComponent.new(state: '', file_info: { 'new' => { 'name' => 'file.txt' }}))
   end
 end


### PR DESCRIPTION
The component can extract the old file name info by itself, there is no need for us to feed it. Remember: [Tell, don't
ask](https://martinfowler.com/bliki/TellDontAsk.html)