### PR TITLE
Fix rendering the architectures of a repository

### DIFF
--- a/src/api/app/components/card_component.html.haml
+++ b/src/api/app/components/card_component.html.haml
@@ -1,9 +1,13 @@
 .card
-  .card-header.d-flex.justify-content-between
-    = header
+  .card-header
     - if delete_button?
-      .ms-4
-        = delete_button
+      .row
+        .col
+          = header
+        .col.col-auto
+          = delete_button
+    - else
+      = header
   .card-body
     = content
 

--- a/src/api/app/views/webui/repositories/_repository_entry.html.haml
+++ b/src/api/app/views/webui/repositories/_repository_entry.html.haml
@@ -9,10 +9,9 @@
           action: destroy_repository_path(project: project, target: repository.name), repository: repository.name }) do
           %i.fas.fa-times-circle.text-danger
       - elsif User.session
-        .col
-          = link_to('#', title: 'Request Delete Repository', data: { 'bs-toggle': 'modal', 'bs-target': '#request-delete-repository',
-            action: project_remove_target_request_path(project: project, target: repository), repository: repository.name }) do
-            %i.fas.fa-user-times.text-danger
+        = link_to('#', title: 'Request Delete Repository', data: { 'bs-toggle': 'modal', 'bs-target': '#request-delete-repository',
+          action: project_remove_target_request_path(project: project, target: repository), repository: repository.name }) do
+          %i.fas.fa-user-times.text-danger
     - if user_can_modify
       - component.with_action do
         = link_to('#', title: 'Add Download on Demand Source', class: 'nav-link p-1', data: { 'bs-toggle': 'modal',


### PR DESCRIPTION
Fixes #17975.

### For reviewers

Go to the review app, here: https://obs-reviewlab.opensuse.org/eduardoj-fixissue_17975/repositories/home:Admin


#### Before

<img width="936" height="323" alt="Screenshot From 2025-08-12 15-29-28" src="https://github.com/user-attachments/assets/01e39201-8cc8-4bd1-ad12-2ab66de46bc6" />


#### After

<img width="936" height="323" alt="Screenshot From 2025-08-12 15-29-31" src="https://github.com/user-attachments/assets/5fddb487-c24d-43cc-87c9-3281fe1f5bc8" />
