### PR TITLE
Fix retrieval of state of a request

### DIFF
--- a/src/api/app/views/webui/shared/bs_requests/_requests_filter.html.haml
+++ b/src/api/app/views/webui/shared/bs_requests/_requests_filter.html.haml
@@ -25,7 +25,7 @@
       .selected-content.small.ms-1
     .px-4.pb-2.accordion-collapse.collapse.show#request-filter-state
       - BsRequest::VALID_REQUEST_STATES.each do |state|
-        = render partial: 'webui/shared/check_box', locals: { label: render(BsRequestStateBadgeComponent.new(state: state)),
+        = render partial: 'webui/shared/check_box', locals: { label: render(BsRequestStateBadgeComponent.new(state: state.to_s)),
                                                               key: "states[#{state}]", name: 'states[]',
                                                               value: state,
                                                               checked: selected_filter[:states]&.include?(state.to_s) }

--- a/src/api/app/views/webui/users/notifications/_notification_filter.html.haml
+++ b/src/api/app/views/webui/users/notifications/_notification_filter.html.haml
@@ -103,7 +103,7 @@
                                                                 checked: selected_filter[:kind]&.include?('outgoing_requests') }
         - BsRequest::VALID_REQUEST_STATES.each do |request_state|
           .dropdown-item-text
-            = render partial: 'webui/shared/check_box', locals: { label: render(BsRequestStateBadgeComponent.new(state: request_state)),
+            = render partial: 'webui/shared/check_box', locals: { label: render(BsRequestStateBadgeComponent.new(state: request_state.to_s)),
                                                                   key: "request_state[#{request_state}]", name: 'request_state[]',
                                                                   value: request_state,
                                                                   checked: selected_filter[:request_state]&.include?(request_state.to_s) }


### PR DESCRIPTION
Instead of passing a symbol, we should have passed a string.

This change should have been included into #18173.

### Before

<img width="162" height="242" alt="Screenshot From 2025-08-12 18-21-49" src="https://github.com/user-attachments/assets/3792a5ab-7bca-49b2-aa52-715c5a80f92f" />


### After

<img width="162" height="242" alt="Screenshot From 2025-08-12 18-36-49" src="https://github.com/user-attachments/assets/a3879b67-e5f3-44a9-8e5f-4400c479bee3" />
