### PR TITLE
Revert PRs related to the third step of the change of `state` to enum

### DIFF
--- a/src/api/app/components/bs_request_state_badge_component.rb
+++ b/src/api/app/components/bs_request_state_badge_component.rb
@@ -18,15 +18,15 @@ class BsRequestStateBadgeComponent < ApplicationComponent
 
   def decode_state_color
     case state
-    when 'review', 'new'
+    when :review, :new
       'secondary'
-    when 'declined'
+    when :declined
       'danger'
-    when 'superseded'
+    when :superseded
       'warning'
-    when 'accepted'
+    when :accepted
       'success'
-    when 'revoked'
+    when :revoked
       'dismissed'
     else
       'dark'
@@ -37,13 +37,13 @@ class BsRequestStateBadgeComponent < ApplicationComponent
 
   def decode_state_icon
     case state
-    when 'new'
+    when :new
       'code-branch'
-    when 'review', 'declined', 'revoked'
+    when :review, :declined, :revoked
       'code-pull-request'
-    when 'superseded'
+    when :superseded
       'code-compare'
-    when 'accepted'
+    when :accepted
       'code-merge'
     else
       'code-fork'

--- a/src/api/app/components/request_decision_component.rb
+++ b/src/api/app/components/request_decision_component.rb
@@ -22,7 +22,7 @@ class RequestDecisionComponent < ApplicationComponent
   end
 
   def confirmation
-    if @bs_request.status == :review
+    if @bs_request.state == :review
       { confirm: "Accept this request, despite the open reviews?\n\n#{@package_maintainers_hint}" }
     else
       { confirm: 'Accept this request? This will commit the changes to the target!' }

--- a/src/api/app/components/watched_items_list_component.html.haml
+++ b/src/api/app/components/watched_items_list_component.html.haml
@@ -38,7 +38,7 @@
         - name = "##{item.number} #{helpers.request_type_of_action(item)}"
         .d-flex.flex-row.flex-wrap.align-items-baseline.collapsible-tooltip-parent
           = link_to(request_show_path(item.number), class: 'text-word-break-all') do
-            = render BsRequestStateBadgeComponent.new(state: item.status)
+            = render BsRequestStateBadgeComponent.new(state: item.state)
             = name
           %i.fa.fa-question-circle.px-2.collapsible-tooltip{ title: 'Click to keep it open' }
           = link_to('#', class: 'ms-auto',

--- a/src/api/app/controllers/concerns/webui/requests_filter.rb
+++ b/src/api/app/controllers/concerns/webui/requests_filter.rb
@@ -26,7 +26,7 @@ module Webui::RequestsFilter
 
   def filter_states
     @selected_filter['states'] = params[:states] if params[:states]&.compact_blank.present?
-    @bs_requests = @bs_requests.where(status: @selected_filter['states'])
+    @bs_requests = @bs_requests.where(state: @selected_filter['states'])
   end
 
   def filter_action_types

--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -478,7 +478,7 @@ class Webui::PackageController < Webui::WebuiController
 
     return if last_req.blank?
 
-    last_req.bs_request if bs_request.status == :declined
+    last_req.bs_request if bs_request.state == :declined
   end
 
   def get_diff(project, package, options = {})

--- a/src/api/app/controllers/webui/projects/pulse_controller.rb
+++ b/src/api/app/controllers/webui/projects/pulse_controller.rb
@@ -11,7 +11,7 @@ module Webui
             pulse = @project.project_log_entries.where(datetime: @date_range).order(datetime: :asc)
 
             requests = @project.target_of_bs_requests.where(updated_at: @date_range).order(updated_at: :desc)
-            requests_by_state = requests.group(:status).count.sort_by { |_, v| -v }.to_h
+            requests_by_state = requests.group(:state).count.sort_by { |_, v| -v }.to_h
             requests_by_percentage = requests_by_state.each_with_object({}) do |(k, v), hash|
               hash[k] = (v * 100.0 / requests_by_state.values.sum).round.to_s
             end

--- a/src/api/app/controllers/webui/projects/status_controller.rb
+++ b/src/api/app/controllers/webui/projects/status_controller.rb
@@ -178,9 +178,9 @@ module Webui
       def status_gather_requests
         # we do not filter requests for project because we need devel projects too later on and as long as the
         # number of open requests is limited this is the easiest solution
-        raw_requests = BsRequest.order(:number).where(status: %i[new review declined]).joins(:bs_request_actions)
+        raw_requests = BsRequest.order(:number).where(state: %i[new review declined]).joins(:bs_request_actions)
                                 .where(bs_request_actions: { type: %w[submit delete] }).pluck('bs_requests.number',
-                                                                                              'bs_requests.status',
+                                                                                              'bs_requests.state',
                                                                                               'bs_request_actions.target_project',
                                                                                               'bs_request_actions.target_package')
 

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -56,7 +56,7 @@ class Webui::RequestController < Webui::WebuiController
     @is_author = @bs_request.creator == User.possibly_nobody.login
 
     @is_target_maintainer = @bs_request.target_maintainer?(User.session)
-    @can_handle_request = @bs_request.status.in?(%w[new review declined]) && (@is_target_maintainer || @is_author)
+    @can_handle_request = @bs_request.state.in?(%i[new review declined]) && (@is_target_maintainer || @is_author)
 
     @history = @bs_request.history_elements.includes(:user)
 
@@ -82,7 +82,7 @@ class Webui::RequestController < Webui::WebuiController
     reviews = @bs_request.reviews.where(state: 'new')
     user = User.session # might be nil
     @my_open_reviews = reviews.select { |review| review.matches_user?(user) }.reject(&:staging_project?)
-    @can_add_reviews = @bs_request.status.in?(%w[new review]) && (@is_author || @is_target_maintainer || @my_open_reviews.present?)
+    @can_add_reviews = @bs_request.state.in?(%i[new review]) && (@is_author || @is_target_maintainer || @my_open_reviews.present?)
 
     respond_to do |format|
       format.html

--- a/src/api/app/helpers/webui/maintenance_incident_helper.rb
+++ b/src/api/app/helpers/webui/maintenance_incident_helper.rb
@@ -108,7 +108,7 @@ module Webui::MaintenanceIncidentHelper
       safe_join(
         [
           link_to(request_show_path(request['number'])) do
-            tag.i(nil, class: "fas fa-flag pe-1 request-flag-#{request['status']}", title: "Release request in state '#{request['status']}'")
+            tag.i(nil, class: "fas fa-flag pe-1 request-flag-#{request['state']}", title: "Release request in state '#{request['state']}'")
           end,
           # rubocop:disable Rails/OutputSafety
           TimeComponent.new(time: request.created_at).human_time.html_safe

--- a/src/api/app/jobs/project_create_auto_cleanup_requests_job.rb
+++ b/src/api/app/jobs/project_create_auto_cleanup_requests_job.rb
@@ -93,7 +93,7 @@ These requests are not created for projects with open requests or if you remove 
   end
 
   def relation
-    BsRequest.where(status: %i[new review declined])
+    BsRequest.where(state: %i[new review declined])
              .joins(:bs_request_actions)
   end
 end

--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -63,7 +63,7 @@ class BsRequest < ApplicationRecord
   has_many :target_project_objects, through: :bs_request_actions
   belongs_to :staging_project, class_name: 'Project', optional: true
   has_one :request_exclusion, class_name: 'Staging::RequestExclusion', dependent: :destroy
-  has_many :not_accepted_reviews, -> { where.not(state: :accepted) }, class_name: 'Review'
+  has_many :not_accepted_reviews, -> { where.not(status: :accepted) }, class_name: 'Review'
   has_many :notifications, as: :notifiable, dependent: :delete_all
   has_many :watched_items, as: :watchable, dependent: :destroy
   has_many :reports, as: :reportable, dependent: :nullify

--- a/src/api/app/models/bs_request/find_for/query.rb
+++ b/src/api/app/models/bs_request/find_for/query.rb
@@ -6,7 +6,7 @@ class BsRequest
         @relation = @relation.where(creator: creator) if creator.present?
         @relation = @relation.from_project_names(@parameters['project_name']).or(@relation.to_project_names(@parameters['project_name'])) if @parameters['project_name'].present?
         @relation = @relation.with_action_types(types) if types.present?
-        @relation = @relation.where(status: states) if states.present?
+        @relation = @relation.where(state: states) if states.present?
         @relation = @relation.where(priority: priorities) if priorities.present?
         @relation = @relation.from_project(source_project_name) if source_project_name.present?
         @relation = @relation.joins(:reviews).where('reviews.by_user IN (?) OR reviews.by_group IN (?)', reviewers, reviewers) if reviewers.present?

--- a/src/api/app/models/concerns/staging_project.rb
+++ b/src/api/app/models/concerns/staging_project.rb
@@ -82,7 +82,7 @@ module StagingProject
     requests = (requests_to_review | staged_requests.includes(:not_accepted_reviews, :bs_request_actions)).map do |request|
       {
         number: request.number,
-        status: request.status,
+        state: request.state,
         package: request.first_target_package,
         request_type: request.bs_request_actions.first.type,
         missing_reviews: missing_reviews_for_classified_requests(request, request.not_accepted_reviews)
@@ -99,7 +99,7 @@ module StagingProject
   # The requests to review are requests which are not related to the staging project (unless they are also staged).
   # They simply need a review from the maintainers of the staging project.
   def requests_to_review
-    @requests_to_review ||= BsRequest.joins(:bs_request_actions).left_outer_joins(:reviews).where(status: :review, reviews: { by_project: name, state: :new })
+    @requests_to_review ||= BsRequest.joins(:bs_request_actions).left_outer_joins(:reviews).where(state: :review, reviews: { by_project: name, state: :new })
   end
 
   def building_repositories
@@ -271,7 +271,7 @@ module StagingProject
   end
 
   def request_weight(request)
-    weight = if request[:status].in?(BsRequest::OBSOLETE_STATES) # obsolete
+    weight = if request[:state].in?(BsRequest::OBSOLETE_STATES) # obsolete
                '0'
              elsif request[:missing_reviews].present? # in review
                '1'

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -1152,24 +1152,24 @@ class Project < ApplicationRecord
       BsRequest.where(id: BsRequestAction.bs_request_ids_by_source_projects(name)).or(
         BsRequest.where(id: Review.bs_request_ids_of_involved_projects(id))
       )
-    ).where(status: 'review').distinct.pluck(:number)
+    ).where(state: :review).distinct.pluck(:number)
 
     targets = BsRequest.joins(:bs_request_actions)
                        .to_project(name)
                        .or(BsRequest.from_project(name))
-                       .where(status: 'new')
+                       .where(state: :new)
                        .pluck(:number)
 
     incidents = BsRequest.to_project(name)
                          .or(BsRequest.from_project(name))
-                         .where(status: 'new')
+                         .where(state: :new)
                          .with_action_types(:maintenance_incident)
                          .pluck(:number)
 
     maintenance_release = if maintenance?
                             BsRequest.to_project("#{name}:%")
                                      .or(BsRequest.from_project("#{name}:%"))
-                                     .where(status: 'new')
+                                     .where(state: :new)
                                      .with_action_types(:maintenance_release)
                                      .pluck(:number)
                           else

--- a/src/api/app/models/staging/staged_requests.rb
+++ b/src/api/app/models/staging/staged_requests.rb
@@ -38,7 +38,7 @@ class Staging::StagedRequests
         package_name: request.first_target_package
       )
 
-      add_review_for_unstaged_request(request, staging_project) if request.status.in?(%w[new review declined])
+      add_review_for_unstaged_request(request, staging_project) if request.state.in?(%i[new review declined])
       staging_project.staged_requests.delete(request)
     end
 
@@ -117,7 +117,7 @@ class Staging::StagedRequests
 
   def add_review_for_unstaged_request(request, staging_project)
     # request.addreview / request.change_review_state would also change the state of a declined request, avoid this.
-    if request.status == 'declined'
+    if request.state == :declined
       request.reviews.create!(by_group: staging_workflow.managers_group.title, reason: "Being evaluated by group \"#{staging_workflow.managers_group}\"")
       staging_project_review = request.reviews.find_by!(by_project: staging_project.name)
       staging_project_review.update!(state: :accepted, reason: "Unstaged from project \"#{staging_project.name}\"")

--- a/src/api/app/models/staging/workflow.rb
+++ b/src/api/app/models/staging/workflow.rb
@@ -18,7 +18,7 @@ class Staging::Workflow < ApplicationRecord
   has_many :target_of_bs_requests, through: :project, foreign_key: 'staging_workflow_id' do
     def stageable(managers_group_title = nil)
       managers_group_title ||= proxy_association.owner.managers_group.try(:title)
-      includes(:reviews).where(status: :review, staging_project_id: nil, reviews: { state: :new, by_group: managers_group_title })
+      includes(:reviews).where(state: :review, staging_project_id: nil, reviews: { state: :new, by_group: managers_group_title })
     end
   end
 
@@ -41,7 +41,7 @@ class Staging::Workflow < ApplicationRecord
   end
 
   def ready_requests
-    target_of_bs_requests.where(status: :new).where.not(id: excluded_requests)
+    target_of_bs_requests.where(state: :new).where.not(id: excluded_requests)
   end
 
   def write_to_backend

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -644,19 +644,19 @@ class User < ApplicationRecord
           BsRequest.where(reviews: { group: groups })
         )
       )
-    ).joins(:bs_request_actions).left_outer_joins(:reviews).where(status: 'review', reviews: { state: :new }).where.not(creator: login).distinct
+    ).joins(:bs_request_actions).left_outer_joins(:reviews).where(state: :review, reviews: { state: :new }).where.not(creator: login).distinct
     search.present? ? result.do_search(search) : result
   end
 
   # list requests involving this user
   def declined_requests(search = nil)
-    result = requests_created.where(status: 'declined')
+    result = requests_created.where(state: :declined)
     search.present? ? result.do_search(search) : result
   end
 
   # list incoming requests involving this user
-  def incoming_requests(search = nil, states: ['new'])
-    result = BsRequest.where(status: states).and(
+  def incoming_requests(search = nil, states: [:new])
+    result = BsRequest.where(state: states).and(
       BsRequest.where(id: BsRequestAction.bs_request_ids_of_involved_projects(involved_projects.pluck(:id))).or(
         BsRequest.where(id: BsRequestAction.bs_request_ids_of_involved_packages(involved_packages.pluck(:id)))
       )

--- a/src/api/app/models/workflow/step/submit_request.rb
+++ b/src/api/app/models/workflow/step/submit_request.rb
@@ -42,7 +42,7 @@ class Workflow::Step::SubmitRequest < Workflow::Step
     @bs_request.save!
 
     Workflows::ScmEventSubscriptionCreator.new(token, workflow_run, @bs_request).call
-    SCMStatusReporter.new(event_payload: { number: @bs_request.number, state: @bs_request.status },
+    SCMStatusReporter.new(event_payload: { number: @bs_request.number, state: @bs_request.state },
                           event_subscription_payload: workflow_run.payload,
                           scm_token: @token.scm_token,
                           workflow_run: workflow_run,
@@ -62,7 +62,7 @@ class Workflow::Step::SubmitRequest < Workflow::Step
       request.change_state(newstate: 'superseded',
                            reason: "Superseded by request #{new_submit_request.number}",
                            superseded_by: new_submit_request.number)
-      (@request_numbers_and_state_for_artifacts[request.status.to_s] ||= []) << request.number
+      (@request_numbers_and_state_for_artifacts[request.state.to_s] ||= []) << request.number
     end
   end
 

--- a/src/api/app/policies/bs_request_policy.rb
+++ b/src/api/app/policies/bs_request_policy.rb
@@ -13,7 +13,7 @@ class BsRequestPolicy < ApplicationPolicy
   end
 
   def handle_request?
-    return false if %w[new review declined].exclude?(record.status)
+    return false if %i[new review declined].exclude?(record.state)
 
     author? || record.target_maintainer?(user) || record.source_maintainer?(user)
   end
@@ -21,11 +21,11 @@ class BsRequestPolicy < ApplicationPolicy
   def add_reviews?
     is_target_maintainer = record.target_maintainer?(user)
     has_open_reviews = record.reviews.where(state: 'new').any? { |review| review.matches_user?(user) }
-    record.status.in?(%w[new review]) && (author? || is_target_maintainer || has_open_reviews.present?)
+    record.state.in?(%i[new review]) && (author? || is_target_maintainer || has_open_reviews.present?)
   end
 
   def revoke_request?
-    return false if %w[new review declined].exclude?(record.status)
+    return false if %i[new review declined].exclude?(record.state)
 
     author? || record.source_maintainer?(user)
   end
@@ -41,11 +41,11 @@ class BsRequestPolicy < ApplicationPolicy
   end
 
   def accept_request?
-    record.status.in?(%w[new review]) && record.target_maintainer?(user)
+    record.state.in?(%i[new review]) && record.target_maintainer?(user)
   end
 
   def reopen_request?
-    record.status == 'declined'
+    record.state == :declined
   end
 
   def forward_request?

--- a/src/api/app/views/staging/shared/_requests.xml.builder
+++ b/src/api/app/views/staging/shared/_requests.xml.builder
@@ -2,7 +2,7 @@ requests.each do |bs_request|
   builder.request(id: bs_request.number,
                   type: bs_request.bs_request_actions.first.action_type,
                   creator: bs_request.creator,
-                  state: bs_request.status,
+                  state: bs_request.state,
                   package: bs_request.first_target_package,
                   superseded_by: bs_request.superseded_by,
                   updated: bs_request.updated_at.xmlschema)

--- a/src/api/app/views/webui/projects/pulse/_pulse_list_requests.html.haml
+++ b/src/api/app/views/webui/projects/pulse/_pulse_list_requests.html.haml
@@ -1,7 +1,7 @@
 .row
   - requests.take(30).each do |request|
     %dt.col-12.col-md-2.col-lg-1
-      = render BsRequestStateBadgeComponent.new(state: request.status, css_class: 'mb-auto')
+      = render BsRequestStateBadgeComponent.new(state: request.state, css_class: 'mb-auto')
     %dd.col-12.col-md-10.col-lg-11
       = link_to(request_show_path(request.number), title: request.description) do
         = request.number

--- a/src/api/app/views/webui/request/_request_header.html.haml
+++ b/src/api/app/views/webui/request/_request_header.html.haml
@@ -1,5 +1,5 @@
 -# TODO: replace by helper
-- badge_state = BsRequestStateBadgeComponent.new(state: bs_request.status, css_class: 'ms-2')
+- badge_state = BsRequestStateBadgeComponent.new(state: bs_request.state, css_class: 'ms-2')
 
 .card-title.d-flex.justify-content-between.mb-2.pt-4.px-4
   %h3

--- a/src/api/app/views/webui/request/_show_overview.html.haml
+++ b/src/api/app/views/webui/request/_show_overview.html.haml
@@ -2,7 +2,7 @@
   Request #{bs_request.number}
   %small
     = render BsRequestPriorityBadgeComponent.new(priority: bs_request.priority, css_class: 'ms-1', overview: true)
-    = render BsRequestStateBadgeComponent.new(state: bs_request.status, css_class: 'ms-1')
+    = render BsRequestStateBadgeComponent.new(state: bs_request.state, css_class: 'ms-1')
   - if User.session
     .d-inline.ms-2#watchlist-icon-wrapper
       = render WatchlistIconComponent.new(user: User.session,

--- a/src/api/app/views/webui/request/_show_side_links.html.haml
+++ b/src/api/app/views/webui/request/_show_side_links.html.haml
@@ -7,7 +7,7 @@
   %li
     %i.fas.fa-info-circle.text-info
     In state
-    = link_to(bs_request.status, { anchor: 'request-history' }, style: "color: #{request_state_color(bs_request.status.to_s)};")
+    = link_to(bs_request.state, { anchor: 'request-history' }, style: "color: #{request_state_color(bs_request.state.to_s)};")
   - unless package_maintainers.empty?
     %li
       %i.fas.fa-info-circle.text-info
@@ -26,7 +26,7 @@
   - if bs_request.accept_at.present?
     %li
       %i.fas.fa-exclamation-circle.text-danger
-      - if BsRequest::FINAL_REQUEST_STATES.include?(bs_request.status.to_sym)
+      - if BsRequest::FINAL_REQUEST_STATES.include?(bs_request.state)
         Auto-accept was set to
         %span{ title: "#{I18n.l bs_request.accept_at}" }
         = succeed '.' do

--- a/src/api/app/views/webui/request/show.html.haml
+++ b/src/api/app/views/webui/request/show.html.haml
@@ -1,5 +1,5 @@
 :ruby
-  content_for(:meta_title, "Request #{@bs_request.number} (#{@bs_request.status})")
+  content_for(:meta_title, "Request #{@bs_request.number} (#{@bs_request.state})")
   content_for(:meta_description, @bs_request.description)
   content_for(:meta_image, gravatar_url(User.find_by_login(@bs_request.creator).email))
   @pagetitle = "Request #{@bs_request.number}"

--- a/src/api/app/views/webui/shared/bs_requests/_request_item.html.haml
+++ b/src/api/app/views/webui/shared/bs_requests/_request_item.html.haml
@@ -15,7 +15,7 @@
             = bs_request.bs_request_actions.first.type.humanize.titleize
           Request ##{bs_request.number}
         = render BsRequestPriorityBadgeComponent.new(priority: bs_request.priority, css_class: 'mb-auto mx-2')
-        = render BsRequestStateBadgeComponent.new(state: bs_request.status, css_class: 'mb-auto')
+        = render BsRequestStateBadgeComponent.new(state: bs_request.state, css_class: 'mb-auto')
       - if Flipper.enabled?(:labels, User.session) && bs_request.labels
         .mb-1
           = render partial: 'webui/shared/label', collection: bs_request.labels, as: :label

--- a/src/api/app/views/webui/shared/bs_requests/_requests_filter.html.haml
+++ b/src/api/app/views/webui/shared/bs_requests/_requests_filter.html.haml
@@ -25,7 +25,7 @@
       .selected-content.small.ms-1
     .px-4.pb-2.accordion-collapse.collapse.show#request-filter-state
       - BsRequest::VALID_REQUEST_STATES.each do |state|
-        = render partial: 'webui/shared/check_box', locals: { label: render(BsRequestStateBadgeComponent.new(state: state.to_s)),
+        = render partial: 'webui/shared/check_box', locals: { label: render(BsRequestStateBadgeComponent.new(state: state)),
                                                               key: "states[#{state}]", name: 'states[]',
                                                               value: state,
                                                               checked: selected_filter[:states]&.include?(state.to_s) }

--- a/src/api/app/views/webui/users/notifications/_notification.html.haml
+++ b/src/api/app/views/webui/users/notifications/_notification.html.haml
@@ -17,7 +17,7 @@
           %small.text-nowrap
             = render TimeComponent.new(time: notification.created_at)
           - if notification.notifiable_type == 'BsRequest'
-            = render BsRequestStateBadgeComponent.new(state: notification.notifiable.status)
+            = render BsRequestStateBadgeComponent.new(state: notification.notifiable.state)
           - elsif notification.notifiable_type == 'WorkflowRun'
             = render WorkflowRunStatusBadgeComponent.new(status: notification.notifiable.status, css_class: 'ms-1')
           - elsif notification.notifiable_type == 'Report' && count_of_additional_reports_for_reportable(notification) >= 1

--- a/src/api/app/views/webui/users/notifications/_notification_filter.html.haml
+++ b/src/api/app/views/webui/users/notifications/_notification_filter.html.haml
@@ -103,7 +103,7 @@
                                                                 checked: selected_filter[:kind]&.include?('outgoing_requests') }
         - BsRequest::VALID_REQUEST_STATES.each do |request_state|
           .dropdown-item-text
-            = render partial: 'webui/shared/check_box', locals: { label: render(BsRequestStateBadgeComponent.new(state: request_state.to_s)),
+            = render partial: 'webui/shared/check_box', locals: { label: render(BsRequestStateBadgeComponent.new(state: request_state)),
                                                                   key: "request_state[#{request_state}]", name: 'request_state[]',
                                                                   value: request_state,
                                                                   checked: selected_filter[:request_state]&.include?(request_state.to_s) }

--- a/src/api/config/brakeman.ignore
+++ b/src/api/config/brakeman.ignore
@@ -831,50 +831,6 @@
     {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 2,
-      "fingerprint": "c91b196a3c702b30eea3f7814ba9b43d86b1571dab639e3463db2168d6837fee",
-      "check_name": "CrossSiteScripting",
-      "message": "Unescaped model attribute",
-      "file": "app/views/webui/request/_request_header.html.haml",
-      "line": 32,
-      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
-      "code": "::Haml::AttributeBuilder.build_class(true, \"text-nowrap\", \"text-bg-#{BsRequestStateBadgeComponent.new(:state => BsRequest.find_by!(:number => params[:number]).status, :css_class => \"ms-2\").decode_state_color}\")",
-      "render_path": [
-        {
-          "type": "controller",
-          "class": "Webui::RequestController",
-          "method": "beta_show",
-          "line": 50,
-          "file": "app/controllers/webui/request_controller.rb",
-          "rendered": {
-            "name": "webui/request/beta_show",
-            "file": "app/views/webui/request/beta_show.html.haml"
-          }
-        },
-        {
-          "type": "template",
-          "name": "webui/request/beta_show",
-          "line": 11,
-          "file": "app/views/webui/request/beta_show.html.haml",
-          "rendered": {
-            "name": "webui/request/_request_header",
-            "file": "app/views/webui/request/_request_header.html.haml"
-          }
-        }
-      ],
-      "location": {
-        "type": "template",
-        "template": "webui/request/_request_header"
-      },
-      "user_input": "BsRequest.find_by!(:number => params[:number]).status",
-      "confidence": "Weak",
-      "cwe_id": [
-        79
-      ],
-      "note": ""
-    },
-    {
-      "warning_type": "Cross-Site Scripting",
-      "warning_code": 2,
       "fingerprint": "cc22f4e269dc27cb215adb737fb4a3d6e0e05f20294c13f5c4ed2028c7187e08",
       "check_name": "CrossSiteScripting",
       "message": "Unescaped model attribute",
@@ -969,6 +925,50 @@
       "cwe_id": [
         565,
         502
+      ],
+      "note": ""
+    },
+    {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 2,
+      "fingerprint": "e3619f234f977eb7c864ec9a7528d0a8571e50a570ece0db9e189e66c3816176",
+      "check_name": "CrossSiteScripting",
+      "message": "Unescaped model attribute",
+      "file": "app/views/webui/request/_request_header.html.haml",
+      "line": 32,
+      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
+      "code": "::Haml::AttributeBuilder.build_class(true, \"text-nowrap\", \"text-bg-#{BsRequestStateBadgeComponent.new(:state => BsRequest.find_by!(:number => params[:number]).state, :css_class => \"ms-2\").decode_state_color}\")",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "Webui::RequestController",
+          "method": "beta_show",
+          "line": 50,
+          "file": "app/controllers/webui/request_controller.rb",
+          "rendered": {
+            "name": "webui/request/beta_show",
+            "file": "app/views/webui/request/beta_show.html.haml"
+          }
+        },
+        {
+          "type": "template",
+          "name": "webui/request/beta_show",
+          "line": 11,
+          "file": "app/views/webui/request/beta_show.html.haml",
+          "rendered": {
+            "name": "webui/request/_request_header",
+            "file": "app/views/webui/request/_request_header.html.haml"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "webui/request/_request_header"
+      },
+      "user_input": "BsRequest.find_by!(:number => params[:number]).state",
+      "confidence": "Weak",
+      "cwe_id": [
+        79
       ],
       "note": ""
     },

--- a/src/api/config/brakeman.ignore
+++ b/src/api/config/brakeman.ignore
@@ -410,30 +410,6 @@
       "note": ""
     },
     {
-      "warning_type": "Dangerous Eval",
-      "warning_code": 13,
-      "fingerprint": "37b84da525b0246afb83a170715adef530eb9ec8f5168c07a359b5ebbd7e9453",
-      "check_name": "Evaluation",
-      "message": "Dynamic code evaluation",
-      "file": "lib/xpath_engine.rb",
-      "line": 453,
-      "link": "https://brakemanscanner.org/docs/warning_types/dangerous_eval/",
-      "code": "eval(@attribs[:BRAKEMAN_SAFE_LITERAL][@last_key][:function].sub(\"$VALUE\", (escape_for_like(:literal) or :literal)))",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "XpathEngine",
-        "method": "evaluate_expr"
-      },
-      "user_input": null,
-      "confidence": "Weak",
-      "cwe_id": [
-        913,
-        95
-      ],
-      "note": ""
-    },
-    {
       "warning_type": "SQL Injection",
       "warning_code": 0,
       "fingerprint": "45840f44547aeced1506343b80e3fe0ad1b6262ae3799e5086907ff71bddb03c",

--- a/src/api/lib/tasks/dev/rake_support.rb
+++ b/src/api/lib/tasks/dev/rake_support.rb
@@ -31,7 +31,6 @@ module RakeSupport
     request = create(
       :bs_request_with_submit_action,
       state: :new,
-      status: :new,
       creator: requester,
       target_package: target_package,
       source_package: source_package,

--- a/src/api/lib/tasks/dev/requests.rake
+++ b/src/api/lib/tasks/dev/requests.rake
@@ -322,8 +322,7 @@ namespace :dev do
             bs_request: {
               description: "Bs request ##{req['id']}",
               creator: alias_for_login(req['creator']),
-              state: req['state']['name'],
-              status: req['state']['name']
+              state: req['state']['name']
             },
             bs_request_actions: {
               target_project: 'openSUSE:Factory',

--- a/src/api/lib/xpath_engine.rb
+++ b/src/api/lib/xpath_engine.rb
@@ -198,7 +198,7 @@ class XpathEngine
       'requests' => {
         '@id' => { cpart: 'bs_requests.number' },
         '@creator' => { cpart: 'bs_requests.creator' },
-        'state/@name' => { cpart: 'bs_requests.status', function: "BsRequest.statuses['$VALUE']" },
+        'state/@name' => { cpart: 'bs_requests.status' },
         'state/@who' => { cpart: 'bs_requests.commenter' },
         'state/@when' => { cpart: 'bs_requests.updated_at' },
         'action/@type' => { cpart: 'a.type',
@@ -445,12 +445,6 @@ class XpathEngine
           raise IllegalXpathError, 'attributes must be $NAMESPACE:$NAME' if tvalues.size != 2
 
           @condition_values_needed.times { @condition_values << tvalues }
-        elsif @last_key && @attribs[table][@last_key][:function]
-          raise IllegalXpathError, 'this attribute must follow a word pattern' unless value.match?(/^[a-zA-Z]+$/)
-
-          function = @attribs[table][@last_key][:function].sub('$VALUE'.freeze, value)
-
-          @condition_values_needed.times { @condition_values << eval(function) } # rubocop:disable Security/Eval
         else
           @condition_values_needed.times { @condition_values << value }
         end

--- a/src/api/lib/xpath_engine.rb
+++ b/src/api/lib/xpath_engine.rb
@@ -198,7 +198,7 @@ class XpathEngine
       'requests' => {
         '@id' => { cpart: 'bs_requests.number' },
         '@creator' => { cpart: 'bs_requests.creator' },
-        'state/@name' => { cpart: 'bs_requests.status' },
+        'state/@name' => { cpart: 'bs_requests.state' },
         'state/@who' => { cpart: 'bs_requests.commenter' },
         'state/@when' => { cpart: 'bs_requests.updated_at' },
         'action/@type' => { cpart: 'a.type',

--- a/src/api/spec/controllers/search_controller_spec.rb
+++ b/src/api/spec/controllers/search_controller_spec.rb
@@ -93,20 +93,6 @@ RSpec.describe SearchController, :vcr do
     end
   end
 
-  describe 'search for requests' do
-    let(:group) { create(:group) }
-    let(:bs_request) { create(:set_bugowner_request, state: :review, status: :review) }
-    let!(:review) { create(:review, by_group: group.title, bs_request: bs_request) }
-
-    before do
-      get :bs_request, params: { match: "state/@name='review'" }, format: :xml
-    end
-
-    it { expect(response).to have_http_status(:success) }
-    it { expect(Nokogiri::XML(response.body).xpath('//request/review').attribute('by_group').value).to eq(group.title) }
-    it { expect(Nokogiri::XML(response.body).xpath('//request/state').attribute('name').value).to eq('review') }
-  end
-
   describe 'illegal predicates' do
     describe 'non closed parenthesis' do
       it 'shows an error', :aggregate_failures do

--- a/src/api/spec/controllers/webui/groups/bs_requests_controller_spec.rb
+++ b/src/api/spec/controllers/webui/groups/bs_requests_controller_spec.rb
@@ -72,10 +72,8 @@ RSpec.describe Webui::Groups::BsRequestsController do
       before do
         login user
         bs_request.state = :review
-        bs_request.status = :review
         bs_request.save
         another_bs_request.state = :review
-        another_bs_request.status = :review
         another_bs_request.save
         get :index, params: params
       end

--- a/src/api/spec/controllers/webui/request_controller_spec.rb
+++ b/src/api/spec/controllers/webui/request_controller_spec.rb
@@ -242,12 +242,12 @@ RSpec.describe Webui::RequestController, :vcr do
       end
 
       it 'with invalid transition' do
-        request_with_review.update(status: 'declined')
+        request_with_review.update(state: 'declined')
         post :modify_review, params: { comment: 'yeah',
                                        review_id: request_with_review.reviews.first,
                                        new_state: 'Approve' }
         expect(flash[:error]).to eq('Not permitted to change review state: The request is neither in state review nor new')
-        expect(request_with_review.reload.status).to eq('declined')
+        expect(request_with_review.reload.state).to eq(:declined)
       end
     end
   end

--- a/src/api/spec/db/data/regenerate_notifications_spec.rb
+++ b/src/api/spec/db/data/regenerate_notifications_spec.rb
@@ -1,0 +1,200 @@
+require Rails.root.join('db/data/20200326221616_regenerate_notifications.rb')
+
+RSpec.describe RegenerateNotifications, type: :migration do
+  describe 'up' do
+    subject { RegenerateNotifications.new.up }
+
+    let(:owner) { create(:confirmed_user, login: 'bob') }
+    let(:requester) { create(:confirmed_user, login: 'ann') }
+    let(:project) { create(:project, name: 'bob_project', maintainer: [owner]) }
+    let(:package) { create(:package, name: 'bob_package', project: project) }
+    let(:another_package) { create(:package) }
+
+    let!(:new_bs_request) do
+      create(:bs_request_with_submit_action,
+             state: :new,
+             creator: requester,
+             target_project: project,
+             target_package: package,
+             source_package: another_package)
+    end
+    let!(:declined_bs_request) do
+      bs_request_to_decline =
+        create(:bs_request_with_submit_action,
+               state: :new,
+               creator: requester,
+               target_project: project,
+               target_package: package,
+               source_package: another_package,
+               created_at: 3.days.ago,
+               updated_at: 2.days.ago)
+      bs_request_to_decline.update(state: 'declined')
+      bs_request_to_decline
+    end
+    let!(:old_declined_bs_request) do
+      bs_request_to_decline =
+        create(:bs_request_with_submit_action,
+               state: :new,
+               creator: requester,
+               target_project: project,
+               target_package: package,
+               source_package: another_package,
+               created_at: 101.days.ago)
+      bs_request_to_decline.update(state: 'declined')
+      bs_request_to_decline
+    end
+    let!(:revoked_bs_request) { create(:bs_request, type: 'maintenance_release', state: :revoked) } # This shouldn't regenerate notification
+
+    before do
+      owner.regenerate_rss_secret
+    end
+
+    context 'for RequestCreate Notifications' do
+      let!(:rss_subscription) { create(:event_subscription_request_created, receiver_role: 'target_maintainer', user: owner, channel: :rss) }
+      let!(:web_subscription) { create(:event_subscription_request_created, receiver_role: 'target_maintainer', user: owner, channel: :web) }
+
+      before do
+        subject
+      end
+
+      it 'creates a RequestCreate Notification' do
+        expect(Notification.where(event_type: 'Event::RequestCreate').count).to eq(1)
+        notification = Notification.find_by(event_type: 'Event::RequestCreate')
+
+        # Checks the Notification's attributes have correct values:
+        expect(notification.event_payload['number']).to eq(new_bs_request.number)
+        expect(notification.notifiable).to eq(new_bs_request)
+        # Timestamps compared with .to_s because they have different precision and the values differ slightly.
+        expect(notification.created_at.to_s).to eq(new_bs_request.updated_when.to_s)
+        expect(notification.title).to eq("Request #{new_bs_request.number} created by #{requester} (submit #{project}/#{package})")
+        expect(notification).to be_web
+        expect(notification).to be_rss
+      end
+    end
+
+    context 'for RequestStatechange Notifications' do
+      let!(:subscription) { create(:event_subscription_request_statechange, receiver_role: 'target_maintainer', user: owner, channel: :rss) }
+
+      before do
+        subject
+      end
+
+      it 'creates a RequestStatechange Notification' do
+        expect(Notification.where(event_type: 'Event::RequestStatechange').count).to eq(1)
+        notification = Notification.find_by(event_type: 'Event::RequestStatechange')
+
+        # Checks the Notification's attributes have correct values:
+        expect(notification.event_payload['number']).to eq(declined_bs_request.number)
+        expect(notification.notifiable).to eq(declined_bs_request)
+        expect(notification.title).to eq("Request #{declined_bs_request.number} changed from new to declined (submit #{project}/#{package})")
+        expect(notification.created_at.to_s).to eq(declined_bs_request.updated_when.to_s)
+        expect(notification.bs_request_oldstate).to eq('new')
+      end
+    end
+
+    context 'for ReviewWanted Notifications' do
+      let!(:review_request) do # The type, submit, shouldn't matter
+        create(:bs_request_with_submit_action,
+               state: :review,
+               creator: requester,
+               target_project: project,
+               target_package: package,
+               source_package: another_package,
+               updated_at: 15.days.ago)
+      end
+      let!(:accepted_review) { create(:review, bs_request: review_request, by_user: owner, state: :accepted) }
+
+      context 'with review by user' do
+        let!(:subscription) { create(:event_subscription_review_wanted, receiver_role: 'reviewer', user: owner, channel: :rss) }
+        let!(:review) { create(:review, bs_request: review_request, by_user: owner, state: :new, updated_at: 10.days.ago) }
+
+        before do
+          subject
+        end
+
+        it 'creates a ReviewWanted Notification of type Request' do
+          expect(Notification.where(event_type: 'Event::ReviewWanted').count).to eq(1)
+          notification = Notification.find_by(event_type: 'Event::ReviewWanted')
+
+          # Checks the Notification's attributes have correct values:
+          expect(notification.event_payload['number']).to eq(review_request.number)
+          expect(notification.notifiable).to eq(review_request)
+          expect(notification.created_at.to_s).to eq(review.updated_at.to_s)
+          expect(notification.title).to eq("Request #{review_request.number} requires review (submit #{project}/#{package})")
+        end
+      end
+
+      context 'with review by project and by package' do
+        let(:reviewer1) { create(:confirmed_user, login: 'reviewer_1') }
+        let(:package2) { create(:package, name: 'package_2') }
+        let!(:relationship) { create(:relationship_package_user, user: reviewer1, package: package2) }
+        let!(:web_subscription) { create(:event_subscription_review_wanted, receiver_role: 'reviewer', user: reviewer1, channel: :web) }
+        let!(:rss_subscription) { create(:event_subscription_review_wanted, receiver_role: 'reviewer', user: reviewer1, channel: :rss) }
+        let!(:review_by_package) { create(:review, bs_request: review_request, by_project: package2.project, by_package: package2, state: :new) }
+
+        before do
+          subject
+        end
+
+        it 'creates a ReviewWanted Notification of type Request' do
+          expect(Notification.where(event_type: 'Event::ReviewWanted').count).to eq(1)
+          notification = Notification.find_by(event_type: 'Event::ReviewWanted')
+
+          # Checks the Notification's attributes have correct values:
+          expect(notification.event_payload['number']).to eq(review_request.number)
+          expect(notification.notifiable).to eq(review_request)
+          expect(notification.title).to eq("Request #{review_request.number} requires review (submit #{project}/#{package})")
+          expect(notification).to be_web
+          expect(notification).not_to be_rss
+        end
+      end
+    end
+
+    context 'for CommentForRequest Notifications' do
+      let!(:subscription) { create(:event_subscription_comment_for_request, receiver_role: 'target_maintainer', user: owner, channel: :rss) }
+      let!(:old_comment_for_request) { create(:comment_request, commentable: new_bs_request, user: requester, created_at: 4.weeks.ago) }
+      let!(:comment_for_request) { create(:comment_request, commentable: new_bs_request, user: requester, updated_at: 1.week.ago) }
+      let!(:comment_for_project) { create(:comment_project, commentable: project, user: requester) } # Shouldn't regenerate notification
+      let!(:comment_for_package) { create(:comment_package, commentable: package, user: requester) } # Shouldn't regenerate notification
+
+      before do
+        subject
+      end
+
+      it 'creates a CommentForRequest Notification' do
+        expect(Notification.where(notifiable_type: 'Comment').count).to eq(1)
+        notification = Notification.find_by(notifiable_type: 'Comment')
+
+        # Checks the Notification's attributes have correct values:
+        expect(notification.event_type).to eq('Event::CommentForRequest')
+        expect(notification.event_payload['number']).to eq(new_bs_request.number)
+        expect(notification.notifiable).to eq(comment_for_request)
+        expect(notification.created_at.to_s).to eq(comment_for_request.updated_at.to_s)
+        expect(notification.title).to eq("Request #{new_bs_request.number} commented by #{requester} (submit #{project}/#{package})")
+      end
+    end
+
+    context 'when running the job after running the data migration' do
+      let!(:subscription) { create(:event_subscription_comment_for_request, receiver_role: 'target_maintainer', user: owner, channel: :rss) }
+      let!(:comment_for_request) { create(:comment_request, commentable: new_bs_request, user: requester, body: 'bla') }
+      let(:events) { Event::Base.where(eventtype: 'Event::CommentForRequest') }
+      let(:comment_notifications) { Notification.where(notifiable_type: 'Comment') }
+
+      before do
+        subject
+      end
+
+      it 'creates only one CommentForRequest Notification' do
+        expect(comment_notifications.count).to eq(1)
+        expect(events.count).to eq(1)
+        expect(events.last.mails_sent).to be_falsey
+
+        # we run this to ensure the job doesn't duplicate notifications
+        SendEventEmailsJob.new.perform
+        expect(events.last.mails_sent).to be_truthy
+        expect(comment_notifications.count).to eq(1)
+        expect(events.last.payload['id']).to eq(comment_notifications.last.notifiable_id)
+      end
+    end
+  end
+end

--- a/src/api/spec/features/webui/requests_spec.rb
+++ b/src/api/spec/features/webui/requests_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe 'Requests', :js, :vcr do
         expect(page).to have_text("#{submitter.realname} (#{submitter.login}) wants the group #{roleaddition_group} to get the role bugowner for project #{target_project}")
         expect(page).to have_css('#description-text', text: 'I can fix bugs too.')
         expect(page).to have_text('In state new')
-        expect(BsRequest.where(description: 'I can fix bugs too.', status: 'new').count).to be(1)
+        expect(BsRequest.where(description: 'I can fix bugs too.', state: 'new').count).to be(1)
       end
 
       it 'can be accepted' do
@@ -116,7 +116,7 @@ RSpec.describe 'Requests', :js, :vcr do
                                   "for package #{target_project} / #{target_package}")
         expect(page).to have_css('#description-text', text: 'I can produce bugs too.')
         expect(page).to have_text('In state new')
-        expect(BsRequest.where(description: 'I can produce bugs too.', status: 'new').count).to be(1)
+        expect(BsRequest.where(description: 'I can produce bugs too.', state: 'new').count).to be(1)
       end
 
       it 'can be accepted' do
@@ -145,7 +145,7 @@ RSpec.describe 'Requests', :js, :vcr do
         expect(page).to have_text("#{submitter.realname} (#{submitter.login}) wants to get the role bugowner for project #{target_project}")
         expect(page).to have_css('#description-text', text: 'I can fix bugs too.')
         expect(page).to have_text('In state new')
-        expect(BsRequest.where(description: 'I can fix bugs too.', status: 'new').count).to be(1)
+        expect(BsRequest.where(description: 'I can fix bugs too.', state: 'new').count).to be(1)
       end
 
       it 'can be accepted' do
@@ -184,7 +184,7 @@ RSpec.describe 'Requests', :js, :vcr do
                                   "for package #{target_project} / #{target_package}")
         expect(page).to have_css('#description-text', text: 'I can produce bugs too.')
         expect(page).to have_text('In state new')
-        expect(BsRequest.where(description: 'I can produce bugs too.', status: 'new').count).to be(1)
+        expect(BsRequest.where(description: 'I can produce bugs too.', state: 'new').count).to be(1)
       end
 
       it 'can be accepted' do
@@ -227,7 +227,7 @@ RSpec.describe 'Requests', :js, :vcr do
         end
         expect(page).to have_text('Ok for the project')
         expect(Review.first.state).to eq(:accepted)
-        expect(BsRequest.first.status).to eq('new')
+        expect(BsRequest.first.state).to eq(:new)
       end
     end
 
@@ -329,7 +329,7 @@ RSpec.describe 'Requests', :js, :vcr do
     end
 
     it 'when request is in a final state' do
-      bs_request.update(status: 'accepted')
+      bs_request.update(status: :accepted)
       visit request_show_path(bs_request)
       expect(page).to have_text("Auto-accept was set to #{I18n.l(bs_request.accept_at, format: :only_date)}.")
     end
@@ -369,7 +369,7 @@ RSpec.describe 'Requests', :js, :vcr do
 
   describe 'for a request with a deleted target project' do
     let!(:delete_bs_request) do
-      create(:delete_bs_request, target_project: target_project, description: 'a long text - ' * 200, creator: submitter, state: 'accepted')
+      create(:delete_bs_request, target_project: target_project, description: 'a long text - ' * 200, creator: submitter, status: :accepted)
     end
 
     before do

--- a/src/api/spec/features/webui/requests_spec.rb
+++ b/src/api/spec/features/webui/requests_spec.rb
@@ -329,7 +329,7 @@ RSpec.describe 'Requests', :js, :vcr do
     end
 
     it 'when request is in a final state' do
-      bs_request.update(status: :accepted)
+      bs_request.update(state: :accepted)
       visit request_show_path(bs_request)
       expect(page).to have_text("Auto-accept was set to #{I18n.l(bs_request.accept_at, format: :only_date)}.")
     end
@@ -369,7 +369,7 @@ RSpec.describe 'Requests', :js, :vcr do
 
   describe 'for a request with a deleted target project' do
     let!(:delete_bs_request) do
-      create(:delete_bs_request, target_project: target_project, description: 'a long text - ' * 200, creator: submitter, status: :accepted)
+      create(:delete_bs_request, target_project: target_project, description: 'a long text - ' * 200, creator: submitter, state: :accepted)
     end
 
     before do

--- a/src/api/spec/models/bs_request_spec.rb
+++ b/src/api/spec/models/bs_request_spec.rb
@@ -471,7 +471,7 @@ RSpec.describe BsRequest, :vcr do
         subject { request.auto_accept }
 
         before do
-          request.update(status: 'declined')
+          request.update(state: :declined)
           subject
         end
 
@@ -667,7 +667,7 @@ RSpec.describe BsRequest, :vcr do
         'description' => submit_request.description,
         'project' => 'target_project',
         'package' => 'target_package',
-        'status' => 'new',
+        'state' => 'new',
         'request_type' => 'submit',
         'priority' => 'moderate',
         'created_at' => submit_request.created_at.as_json,

--- a/src/api/spec/models/project/staging_project_spec.rb
+++ b/src/api/spec/models/project/staging_project_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe Project, :vcr do
 
       context 'when request got revoked' do
         before do
-          submit_request.update(status: 'revoked')
+          submit_request.update(state: 'revoked')
         end
 
         it { expect(staging_project.overall_state).to eq(:unacceptable) }

--- a/src/api/spec/models/user_requests_spec.rb
+++ b/src/api/spec/models/user_requests_spec.rb
@@ -273,7 +273,7 @@ RSpec.describe User do
       end
 
       it 'does not include requests in any other state expect new' do
-        maintained_request.status = 'review'
+        maintained_request.state = :review
         maintained_request.save
         expect(subject).not_to include(maintained_request)
       end

--- a/src/api/spec/models/workflow/step/submit_request_step_spec.rb
+++ b/src/api/spec/models/workflow/step/submit_request_step_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Workflow::Step::SubmitRequest, :vcr do
           expect do
             subject.call
             bs_request.reload
-          end.to(change(bs_request, :status).from('new').to('revoked'))
+          end.to(change(bs_request, :state).from(:new).to(:revoked))
           expect { subject.call }.not_to change(BsRequest, :count)
         end
       end

--- a/src/api/test/fixtures/bs_requests.yml
+++ b/src/api/test/fixtures/bs_requests.yml
@@ -3,7 +3,7 @@ bs_requests_1000:
   number: 1000
   description: want to see their reaction
   creator: tom
-  status: review
+  state: review
   commenter: tom
   created_at: 2013-09-09 19:15:16.000000000 Z
   updated_at: 2013-09-09 19:15:16.000000000 Z
@@ -12,7 +12,7 @@ missing_projects:
   number: 2
   description: ''
   creator: tom
-  status: new
+  state: new
   commenter: tom
   created_at: 2012-09-02 13:08:02.000000000 Z
   updated_at: 2012-09-02 13:08:02.000000000 Z
@@ -21,7 +21,7 @@ missing_source_project:
   number: 1
   description: ''
   creator: tom
-  status: new
+  state: new
   commenter: tom
   created_at: 2012-09-01 13:08:02.000000000 Z
   updated_at: 2012-09-01 13:08:02.000000000 Z
@@ -30,7 +30,7 @@ missing_target_project:
   number: 3
   description: ''
   creator: tom
-  status: new
+  state: new
   commenter: tom
   created_at: 2012-09-03 13:08:02.000000000 Z
   updated_at: 2012-09-03 13:08:02.000000000 Z
@@ -39,7 +39,7 @@ multiple_test:
   number: 10
   description: multiple test
   creator: tom
-  status: review
+  state: review
   commenter: tom
   created_at: 2013-09-09 19:20:44.000000000 Z
   updated_at: 2013-09-09 19:20:44.000000000 Z
@@ -48,7 +48,7 @@ submit_from_home_project:
   number: 4
   description: test home project shortening
   creator: Iggy
-  status: review
+  state: review
   comment: another group review
   commenter: king
   created_at: 2012-09-04 13:08:02.000000000 Z
@@ -58,7 +58,7 @@ submit_from_home_project_new:
   number: 5
   description: test open requests for My:Maintenance
   creator: Iggy
-  status: new
+  state: new
   comment: A new request
   commenter: king
   created_at: 2012-09-04 13:08:02.000000000 Z
@@ -68,7 +68,7 @@ submit_from_home_project_maintenance_incident:
   number: 6
   description: test open requests
   creator: Iggy
-  status: new
+  state: new
   comment: A new maintenance incident
   commenter: king
   created_at: 2012-08-04 13:08:02.000000000 Z
@@ -78,7 +78,7 @@ submit_from_home_project_maintenance_release:
   number: 7
   description: test open requests
   creator: Iggy
-  status: new
+  state: new
   comment: A new maintenance release
   commenter: king
   created_at: 2012-08-04 13:08:02.000000000 Z


### PR DESCRIPTION
We need to revisit the PR #18173 "_Change the type of the colum state to enum, step III_",
it required some other fixes after its deployment.

We are reverting all of them to avoid major issues. After that, we'll double-check the code to add any other fix, if needed, and push them all together.

Revert the commits of PRs #18351, #18348 and #18173.