### PR TITLE
Show reviewer in the review summary only if any

### DIFF
--- a/src/api/app/views/webui/request/beta_show_tabs/_review_summary.html.haml
+++ b/src/api/app/views/webui/request/beta_show_tabs/_review_summary.html.haml
@@ -18,6 +18,6 @@
       = project_or_package_link(project: review.by_project, package: review.by_package, short: true)
     - elsif review.for_project?
       = project_or_package_link(project: review.by_project, short: true)
-    - if (review.accepted? || review.declined?) && !review.for_user?
+    - if (review.accepted? || review.declined?) && review.reviewer && !review.for_user?
       by
       = link_to(review.reviewer, user_path(User.find_by(login: review.reviewer)))


### PR DESCRIPTION
I came across this issue when manually testing requests related to a Staging workflow. 
Sometimes `Review#reviewer` is nil, we shouldn't try to find the corresponding user in those cases.

The Review Summary will end up looking like this:

<img width="945" height="268" alt="Screenshot 2025-08-13 at 15-01-08 Request 26 - Open Build Service" src="https://github.com/user-attachments/assets/5b9caa30-a49c-4339-97f0-1027a07f480b" />
