### PR TITLE
Fix crash when retrieving the build results of a package belonging to an scmsync project

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -16,7 +16,7 @@ class Webui::PackageController < Webui::WebuiController
                                        save_person save_group remove_role view_file
                                        buildresult rpmlint_result rpmlint_log rpmlint_summary files]
 
-  before_action :check_scmsync, only: %i[statistics users requests]
+  before_action :check_scmsync, only: %i[buildresult requests statistics users]
 
   before_action :set_package, only: %i[edit update show requests statistics revisions
                                        branch_diff_info rdiff remove


### PR DESCRIPTION
Fix #17687. 