### PR TITLE
Strip multibuild flavor from remote package name

### DIFF
--- a/src/api/app/controllers/concerns/triggerable.rb
+++ b/src/api/app/controllers/concerns/triggerable.rb
@@ -28,7 +28,7 @@ module Triggerable
     # The token has no package, we did not find a package in the database but the project has a link to remote.
     # See https://github.com/openSUSE/open-build-service/wiki/Links#project-links
     # In this case, we will try to trigger with the user input, no matter what it is
-    @package ||= @package_name
+    @package ||= Package.striping_multibuild_suffix(@package_name)
     # TODO: This should not happen right? But who knows...
     raise ActiveRecord::RecordNotFound unless @package
   end

--- a/src/api/spec/cassettes/TriggerController/_rebuild/with_package_multibuild_flavor/1_1_5_1.yml
+++ b/src/api/spec/cassettes/TriggerController/_rebuild/with_package_multibuild_flavor/1_1_5_1.yml
@@ -1,0 +1,127 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/project/_meta?user=user_1
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project">
+          <title>The Parliament of Man</title>
+          <description/>
+          <person userid="foo" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '148'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project">
+          <title>The Parliament of Man</title>
+          <description></description>
+          <person userid="foo" role="maintainer"/>
+        </project>
+  recorded_at: Fri, 15 Aug 2025 11:20:12 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project/_meta?user=user_1
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project">
+          <title>The Parliament of Man</title>
+          <description/>
+          <person userid="foo" role="maintainer"/>
+          <repository name="repository_1">
+            <arch>i586</arch>
+          </repository>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '221'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project">
+          <title>The Parliament of Man</title>
+          <description></description>
+          <person userid="foo" role="maintainer"/>
+          <repository name="repository_1">
+            <arch>i586</arch>
+          </repository>
+        </project>
+  recorded_at: Fri, 15 Aug 2025 11:20:12 GMT
+- request:
+    method: put
+    uri: http://backend:5352/source/project/package_trigger/_meta?user=user_2
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_trigger" project="project">
+          <title>Antic Hay</title>
+          <description>Ad quasi non numquam.</description>
+        </package>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '140'
+    body:
+      encoding: UTF-8
+      string: |
+        <package name="package_trigger" project="project">
+          <title>Antic Hay</title>
+          <description>Ad quasi non numquam.</description>
+        </package>
+  recorded_at: Fri, 15 Aug 2025 11:20:12 GMT
+recorded_with: VCR 6.3.1

--- a/src/api/spec/cassettes/TriggerController/_rebuild/with_project_that_links_to_remote_and_multibuild_flavor/1_1_6_1.yml
+++ b/src/api/spec/cassettes/TriggerController/_rebuild/with_project_that_links_to_remote_and_multibuild_flavor/1_1_6_1.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/project/_meta?user=user_1
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project">
+          <title>Those Barren Leaves, Thrones, Dominations</title>
+          <description/>
+          <scmsync>https://github.com/hennevogel/scmsync-project.git</scmsync>
+          <person userid="foo" role="maintainer"/>
+        </project>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '239'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project">
+          <title>Those Barren Leaves, Thrones, Dominations</title>
+          <description></description>
+          <scmsync>https://github.com/hennevogel/scmsync-project.git</scmsync>
+          <person userid="foo" role="maintainer"/>
+        </project>
+  recorded_at: Fri, 15 Aug 2025 11:43:39 GMT
+recorded_with: VCR 6.3.1

--- a/src/api/spec/controllers/trigger_controller_spec.rb
+++ b/src/api/spec/controllers/trigger_controller_spec.rb
@@ -46,6 +46,30 @@ RSpec.describe TriggerController do
       it { expect(subject).to have_http_status(:forbidden) }
       it { expect(subject.body).to include('This token is not enabled.') }
     end
+
+    context 'with package multibuild flavor' do
+      subject { post :rebuild, params: { project: project.name, package: multibuild_flavor, format: :xml } }
+
+      let(:multibuild_flavor) { "#{package.name}:test" }
+
+      before do
+        allow(Backend::Api::Sources::Package).to receive(:rebuild).with(project.name, multibuild_flavor, {}).and_return("<status code=\"ok\" />\n")
+      end
+
+      it { expect(subject).to have_http_status(:success) }
+    end
+
+    context 'with project that links to remote and multibuild flavor' do
+      subject { post :rebuild, params: { project: project.name, package: 'hans:franz', format: :xml } }
+
+      let(:project) { create(:project, name: 'project', maintainer: user, scmsync: 'https://github.com/hennevogel/scmsync-project.git') }
+
+      before do
+        allow(Backend::Api::Sources::Package).to receive(:rebuild).with(project.name, 'hans:franz', {}).and_return("<status code=\"ok\" />\n")
+      end
+
+      it { expect(subject).to have_http_status(:success) }
+    end
   end
 
   describe '#release', :vcr do


### PR DESCRIPTION
In case the package is remote we can't just take `params[:package]`, it might include a multibuild flavor. The flavor we already stored in `@multibuild_container` and pass on while triggering.

Fixes #18374 