### PR TITLE
Revert "Fix crash when retrieving the build results of a package ..."

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -16,7 +16,7 @@ class Webui::PackageController < Webui::WebuiController
                                        save_person save_group remove_role view_file
                                        buildresult rpmlint_result rpmlint_log rpmlint_summary files]
 
-  before_action :check_scmsync, only: %i[buildresult requests revisions statistics users]
+  before_action :check_scmsync, only: %i[requests revisions statistics users]
 
   before_action :set_package, only: %i[edit update show requests statistics revisions
                                        branch_diff_info rdiff remove


### PR DESCRIPTION
This reverts commit 9f76f2f282f6f940cae35ee8fab4f34391cacde5.

Removes `buildresult` but keep `revisions` which was added later on to the `before_action`.

Fixes: #18377