### PR TITLE
Allow expanding the diff if any changes are collapsed

### DIFF
--- a/src/api/app/components/sourcediff_component.html.haml
+++ b/src/api/app/components/sourcediff_component.html.haml
@@ -8,6 +8,11 @@
         = render partial: 'webui/shared/loading', locals: { text: 'Loading changes...', wrapper_css: ['loading', 'invisible'] }
     - else
       - @webui_sourcediff.each do |sourcediff|
+        - if expandable?(sourcediff)
+          .alert.alert-warning
+            Some of the changes are collapsed due to size.
+            = link_to(request_changes_path(@bs_request, @action, tarlimit: 0)) do
+              Expand changes
         - source_rev = sourcediff.dig('new', 'srcmd5') || @action.source_rev
         - target_rev = sourcediff.dig('old', 'srcmd5')
         .clearfix.mb-2

--- a/src/api/app/components/sourcediff_component.rb
+++ b/src/api/app/components/sourcediff_component.rb
@@ -43,12 +43,15 @@ class SourcediffComponent < ApplicationComponent
 
   def diff_list(sourcediff)
     files = sourcediff['files'].sort_by { |k, _v| sourcediff['filenames'].find_index(k) }.to_h
+    filelimit = [*files.map { |_n, f| f.dig('diff', 'lines').to_i }, BsRequestAction::Differ::ForSource::DEFAULT_FILE_LIMIT].max
 
     files.each_with_index do |(filename, contents), file_index|
       files[filename]['disabled'] = contents['diff'].nil? || contents['diff']['_content'].nil?
       next if files[filename]['disabled']
 
-      files[filename]['diff_url'] = request_changes_diff_path(number: @bs_request.number, request_action_id: @action.id, filename:, diff_to_superseded:, file_index:, commented_lines: @commented_lines[file_index])
+      files[filename]['diff_url'] = request_changes_diff_path(number: @bs_request.number, request_action_id: @action.id,
+                                                              filename:, diff_to_superseded:, file_index:,
+                                                              commented_lines: @commented_lines[file_index], filelimit:)
     end
 
     files

--- a/src/api/app/components/sourcediff_component.rb
+++ b/src/api/app/components/sourcediff_component.rb
@@ -62,8 +62,8 @@ class SourcediffComponent < ApplicationComponent
       next if files[filename]['disabled']
 
       files[filename]['diff_url'] = request_changes_diff_path(number: @bs_request.number, request_action_id: @action.id,
-                                                              filename:, diff_to_superseded:, file_index:, tarlimit: @tarlimit,
-                                                              commented_lines: @commented_lines[file_index], filelimit: 0)
+                                                              filename:, diff_to_superseded:, file_index:,
+                                                              commented_lines: @commented_lines[file_index])
     end
 
     files

--- a/src/api/app/components/sourcediff_component.rb
+++ b/src/api/app/components/sourcediff_component.rb
@@ -1,10 +1,10 @@
 class SourcediffComponent < ApplicationComponent
-  attr_accessor :bs_request, :action, :refresh, :diff_to_superseded, :diff_not_cached
+  attr_accessor :bs_request, :action, :refresh, :diff_to_superseded, :diff_not_cached, :tarlimit
 
   delegate :diff_label, to: :helpers
   delegate :diff_data, to: :helpers
 
-  def initialize(bs_request:, action:, diff_not_cached:, diff_to_superseded: nil)
+  def initialize(bs_request:, action:, diff_not_cached:, diff_to_superseded: nil, tarlimit: nil)
     super
 
     @bs_request = bs_request
@@ -13,6 +13,19 @@ class SourcediffComponent < ApplicationComponent
     @commented_lines = commented_lines
     @diff_not_cached = diff_not_cached
     @webui_sourcediff = @action.webui_sourcediff({ diff_to_superseded: @diff_to_superseded, cacheonly: 1 })
+    @tarlimit = tarlimit
+  end
+
+  def expandable?(sourcediff)
+    return false unless sourcediff.key?('files')
+
+    sourcediff['files'].filter_map do |files, diff|
+      next if diff.dig('diff', 'lines') == diff.dig('diff', 'shown')
+      next unless diff.dig('diff', 'shown') == '0'
+      next unless diff['state'] == 'changed'
+
+      files
+    end.any?
   end
 
   def commentable
@@ -43,15 +56,14 @@ class SourcediffComponent < ApplicationComponent
 
   def diff_list(sourcediff)
     files = sourcediff['files'].sort_by { |k, _v| sourcediff['filenames'].find_index(k) }.to_h
-    filelimit = [*files.map { |_n, f| f.dig('diff', 'lines').to_i }, BsRequestAction::Differ::ForSource::DEFAULT_FILE_LIMIT].max
 
     files.each_with_index do |(filename, contents), file_index|
       files[filename]['disabled'] = contents['diff'].nil? || contents['diff']['_content'].nil?
       next if files[filename]['disabled']
 
       files[filename]['diff_url'] = request_changes_diff_path(number: @bs_request.number, request_action_id: @action.id,
-                                                              filename:, diff_to_superseded:, file_index:,
-                                                              commented_lines: @commented_lines[file_index], filelimit:)
+                                                              filename:, diff_to_superseded:, file_index:, tarlimit: @tarlimit,
+                                                              commented_lines: @commented_lines[file_index], filelimit: 0)
     end
 
     files

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -337,7 +337,7 @@ class Webui::RequestController < Webui::WebuiController
 
   def changes_diff
     filename = params[:filename]
-    sourcediff = @action.webui_sourcediff({ diff_to_superseded: @diff_to_superseded, file: filename, tarlimit: params[:tarlimit] }.compact).first
+    sourcediff = @action.webui_sourcediff({ diff_to_superseded: @diff_to_superseded, file: filename, filelimit: 0, tarlimit: 0 }.compact).first
     source_rev = sourcediff.dig('new', 'srcmd5')
     if @action.source_package_object&.file_exists?(filename, { rev: source_rev, expand: 1 }.compact)
       source_file = project_package_file_path(@action.source_project_object, @action.source_package_object, filename, rev: source_rev, expand: 1)
@@ -351,7 +351,6 @@ class Webui::RequestController < Webui::WebuiController
                      diff: sourcediff.dig('files', filename, 'diff', '_content'),
                      file_index: params[:file_index], source_file: source_file,
                      target_file: target_file, source_rev: source_rev, target_rev: target_rev,
-                     tarlimit: params[:tarlimit],
                      shown_lines: sourcediff.dig('files', filename, 'diff', 'shown'),
                      total_lines: sourcediff.dig('files', filename, 'diff', 'lines'),
                      commented_lines: (params[:commented_lines] || []).map(&:to_i) }

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -352,6 +352,8 @@ class Webui::RequestController < Webui::WebuiController
                      file_index: params[:file_index], source_file: source_file,
                      target_file: target_file, source_rev: source_rev, target_rev: target_rev,
                      tarlimit: params[:tarlimit],
+                     shown_lines: sourcediff.dig('files', filename, 'diff', 'shown'),
+                     total_lines: sourcediff.dig('files', filename, 'diff', 'lines'),
                      commented_lines: (params[:commented_lines] || []).map(&:to_i) }
   end
 

--- a/src/api/app/models/bs_request_action.rb
+++ b/src/api/app/models/bs_request_action.rb
@@ -271,7 +271,7 @@ class BsRequestAction < ApplicationRecord
   end
 
   def diff_not_cached(opts = {})
-    sourcediff_results = webui_sourcediff({ cacheonly: 1, diff_to_superseded: opts[:diff_to_superseded] })
+    sourcediff_results = webui_sourcediff({ cacheonly: 1, diff_to_superseded: opts[:diff_to_superseded], tarlimit: opts[:tarlimit] }.compact)
     errors = sourcediff_results.pluck(:error).compact
 
     return false if sourcediff_results.present? && errors.empty?

--- a/src/api/app/views/webui/request/_changes_delete.html.haml
+++ b/src/api/app/views/webui/request/_changes_delete.html.haml
@@ -1,1 +1,2 @@
-= render SourcediffComponent.new(bs_request: bs_request, action: action, diff_to_superseded: diff_to_superseded, diff_not_cached: diff_not_cached)
+= render SourcediffComponent.new(bs_request: bs_request, action: action, diff_to_superseded: diff_to_superseded, diff_not_cached: diff_not_cached,
+                                 tarlimit: tarlimit)

--- a/src/api/app/views/webui/request/_changes_diff.html.haml
+++ b/src/api/app/views/webui/request/_changes_diff.html.haml
@@ -1,12 +1,3 @@
 = turbo_frame_tag "file-#{file_index}" do
   = render(DiffComponent.new(diff:, file_index:, commentable:, commented_lines:,
                              source_file:, target_file:, source_rev:, target_rev:))
-  - if shown_lines != total_lines
-    .card-body
-      Only displaying
-      = shown_lines
-      out of total of #{total_lines}.
-      - if target_file
-        = link_to('See the target file', target_file, title: 'See original file', target: '_top')
-      - if source_file
-        = link_to('See the source file', source_file, title: 'See submitted file', target: '_top')

--- a/src/api/app/views/webui/request/_changes_diff.html.haml
+++ b/src/api/app/views/webui/request/_changes_diff.html.haml
@@ -1,3 +1,12 @@
 = turbo_frame_tag "file-#{file_index}" do
   = render(DiffComponent.new(diff:, file_index:, commentable:, commented_lines:,
                              source_file:, target_file:, source_rev:, target_rev:))
+  - if shown_lines != total_lines
+    .card-body
+      Only displaying
+      = shown_lines
+      out of total of #{total_lines}.
+      - if target_file
+        = link_to('See the target file', target_file, title: 'See original file', target: '_top')
+      - if source_file
+        = link_to('See the source file', source_file, title: 'See submitted file', target: '_top')

--- a/src/api/app/views/webui/request/_changes_maintenance_incident.html.haml
+++ b/src/api/app/views/webui/request/_changes_maintenance_incident.html.haml
@@ -9,4 +9,5 @@
     See the changes from
     = link_to "superseded request ##{supersed.number}", request_changes_path(bs_request, diff_to_superseded: supersed)
 
-= render SourcediffComponent.new(bs_request: bs_request, action: action, diff_to_superseded: diff_to_superseded, diff_not_cached: diff_not_cached)
+= render SourcediffComponent.new(bs_request: bs_request, action: action, diff_to_superseded: diff_to_superseded,
+                                 diff_not_cached: diff_not_cached, tarlimit: tarlimit, tarlimit: tarlimit)

--- a/src/api/app/views/webui/request/_changes_maintenance_incident.html.haml
+++ b/src/api/app/views/webui/request/_changes_maintenance_incident.html.haml
@@ -10,4 +10,4 @@
     = link_to "superseded request ##{supersed.number}", request_changes_path(bs_request, diff_to_superseded: supersed)
 
 = render SourcediffComponent.new(bs_request: bs_request, action: action, diff_to_superseded: diff_to_superseded,
-                                 diff_not_cached: diff_not_cached, tarlimit: tarlimit, tarlimit: tarlimit)
+                                 diff_not_cached: diff_not_cached, tarlimit: tarlimit)

--- a/src/api/app/views/webui/request/_changes_maintenance_release.html.haml
+++ b/src/api/app/views/webui/request/_changes_maintenance_release.html.haml
@@ -9,4 +9,5 @@
     See the changes from
     = link_to "superseded request ##{supersed.number}", request_changes_path(bs_request, diff_to_superseded: supersed)
 
-= render SourcediffComponent.new(bs_request: bs_request, action: action, diff_to_superseded: diff_to_superseded, diff_not_cached: diff_not_cached)
+= render SourcediffComponent.new(bs_request: bs_request, action: action, diff_to_superseded: diff_to_superseded, diff_not_cached: diff_not_cached,
+                                 tarlimit: tarlimit)

--- a/src/api/app/views/webui/request/_changes_release.html.haml
+++ b/src/api/app/views/webui/request/_changes_release.html.haml
@@ -9,4 +9,5 @@
     See the changes from
     = link_to "superseded request ##{supersed.number}", request_changes_path(bs_request, diff_to_superseded: supersed)
 
-= render SourcediffComponent.new(bs_request: bs_request, action: action, diff_to_superseded: diff_to_superseded, diff_not_cached: diff_not_cached)
+= render SourcediffComponent.new(bs_request: bs_request, action: action, diff_to_superseded: diff_to_superseded, diff_not_cached: diff_not_cached,
+                                 tarlimit: tarlimit)

--- a/src/api/app/views/webui/request/_changes_submit.html.haml
+++ b/src/api/app/views/webui/request/_changes_submit.html.haml
@@ -9,4 +9,5 @@
     See the changes from
     = link_to "superseded request ##{supersed.number}", request_changes_path(bs_request, diff_to_superseded: supersed)
 
-= render SourcediffComponent.new(bs_request: bs_request, action: action, diff_to_superseded: diff_to_superseded, diff_not_cached: diff_not_cached)
+= render SourcediffComponent.new(bs_request: bs_request, action: action, diff_to_superseded: diff_to_superseded, diff_not_cached: diff_not_cached,
+                                 tarlimit: tarlimit)

--- a/src/api/app/views/webui/request/changes.html.haml
+++ b/src/api/app/views/webui/request/changes.html.haml
@@ -31,7 +31,7 @@
           = render partial: "webui/request/changes_#{@action.type}",
                    locals: { bs_request: @bs_request, action: @action,
                              diff_to_superseded: @diff_to_superseded, diff_not_cached: @diff_not_cached,
-                             current_notification: @current_notification }
+                             current_notification: @current_notification, tarlimit: @tarlimit }
 
   = render DeleteConfirmationDialogComponent.new(modal_id: 'delete-comment-modal',
                                                  method: :delete,

--- a/src/api/app/views/webui/request/changes.html.haml
+++ b/src/api/app/views/webui/request/changes.html.haml
@@ -21,7 +21,7 @@
                                                         page_name: 'request_changes', notification_id: @current_notification,
                                                         current_notification: @current_notification }
     .container.p-4
-      .tab-content.sourcediff{ data: { url: request_action_changes_path(@bs_request.number, @action.id),
+      .tab-content.sourcediff{ data: { url: request_action_changes_path(@bs_request.number, @action.id, tarlimit: @tarlimit),
                                        diff_to_superseded_id: @diff_to_superseded_id },
                                id: 'sourcediff-container' }
         - if @action.target_releaseproject

--- a/src/api/app/views/webui/request/request_action_changes.js.erb
+++ b/src/api/app/views/webui/request/request_action_changes.js.erb
@@ -1,1 +1,1 @@
-$('.tab-content.sourcediff').html(`<%= escape_javascript(render(partial: "webui/request/changes_#{@action.type}", locals: { bs_request: @bs_request, action: @action, diff_to_superseded: @diff_to_superseded, diff_not_cached: @diff_not_cached })) %>`);
+$('.tab-content.sourcediff').html(`<%= escape_javascript(render(partial: "webui/request/changes_#{@action.type}", locals: { bs_request: @bs_request, action: @action, diff_to_superseded: @diff_to_superseded, diff_not_cached: @diff_not_cached, tarlimit: @tarlimit })) %>`);

--- a/src/api/spec/cassettes/Comments_with_diff/create_diff_comment/displays_the_comment_in_the_conversation_tab.yml
+++ b/src/api/spec/cassettes/Comments_with_diff/create_diff_comment/displays_the_comment_in_the_conversation_tab.yml
@@ -2,12 +2,12 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/target_project/_meta?user=user_1
+    uri: http://backend:5352/source/target_project/_meta?user=user_7
     body:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>The Moving Toyshop</title>
+          <title>To a God Unknown</title>
           <description/>
         </project>
     headers:
@@ -29,24 +29,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '109'
+      - '107'
     body:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>The Moving Toyshop</title>
+          <title>To a God Unknown</title>
           <description></description>
         </project>
-  recorded_at: Fri, 26 Sep 2025 13:05:58 GMT
+  recorded_at: Fri, 03 Oct 2025 11:32:25 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/target_project/package_a/_meta?user=user_2
+    uri: http://backend:5352/source/target_project/package_a/_meta?user=user_8
     body:
       encoding: UTF-8
       string: |
         <package name="package_a" project="target_project">
-          <title>The Curious Incident of the Dog in the Night-Time</title>
-          <description>Incidunt nesciunt voluptatem reiciendis.</description>
+          <title>No Longer at Ease</title>
+          <description>Aut cum earum laboriosam.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -67,15 +67,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '200'
+      - '153'
     body:
       encoding: UTF-8
       string: |
         <package name="package_a" project="target_project">
-          <title>The Curious Incident of the Dog in the Night-Time</title>
-          <description>Incidunt nesciunt voluptatem reiciendis.</description>
+          <title>No Longer at Ease</title>
+          <description>Aut cum earum laboriosam.</description>
         </package>
-  recorded_at: Fri, 26 Sep 2025 13:05:58 GMT
+  recorded_at: Fri, 03 Oct 2025 11:32:25 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/package_a/package_a.changes
@@ -108,20 +108,20 @@ http_interactions:
         <revision rev="2" vrev="2">
           <srcmd5>a884751bbd575d6295dc91ee6f64cd02</srcmd5>
           <version>unknown</version>
-          <time>1758891958</time>
+          <time>1759491145</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Fri, 26 Sep 2025 13:05:58 GMT
+  recorded_at: Fri, 03 Oct 2025 11:32:25 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/source_project/_meta?user=user_3
+    uri: http://backend:5352/source/source_project/_meta?user=user_9
     body:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>Noli Me Tangere</title>
+          <title>Waiting for the Barbarians</title>
           <description/>
         </project>
     headers:
@@ -143,18 +143,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '106'
+      - '117'
     body:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>Noli Me Tangere</title>
+          <title>Waiting for the Barbarians</title>
           <description></description>
         </project>
-  recorded_at: Fri, 26 Sep 2025 13:05:58 GMT
+  recorded_at: Fri, 03 Oct 2025 11:32:25 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/source_project/_project/_attribute?meta=1&user=user_3
+    uri: http://backend:5352/source/source_project/_project/_attribute?meta=1&user=user_9
     body:
       encoding: UTF-8
       string: |
@@ -180,27 +180,27 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '169'
+      - '168'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="80">
-          <srcmd5>bcb3cb14c4feb6a2d6eeb835c3dc08fc</srcmd5>
-          <time>1758891958</time>
-          <user>user_3</user>
+        <revision rev="6">
+          <srcmd5>15d8be971488e2c1a8b057bbc0341931</srcmd5>
+          <time>1759491145</time>
+          <user>user_9</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Fri, 26 Sep 2025 13:05:58 GMT
+  recorded_at: Fri, 03 Oct 2025 11:32:25 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/source_project/package_a/_meta?user=user_4
+    uri: http://backend:5352/source/source_project/package_a/_meta?user=user_10
     body:
       encoding: UTF-8
       string: |
         <package name="package_a" project="source_project">
-          <title>Antic Hay</title>
-          <description>Repellendus ex porro dolores.</description>
+          <title>No Highway</title>
+          <description>Error cum quas aut.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -221,15 +221,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '149'
+      - '140'
     body:
       encoding: UTF-8
       string: |
         <package name="package_a" project="source_project">
-          <title>Antic Hay</title>
-          <description>Repellendus ex porro dolores.</description>
+          <title>No Highway</title>
+          <description>Error cum quas aut.</description>
         </package>
-  recorded_at: Fri, 26 Sep 2025 13:05:58 GMT
+  recorded_at: Fri, 03 Oct 2025 11:32:25 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/package_a/package_a.changes
@@ -266,19 +266,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '207'
+      - '201'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="2" vrev="2">
-          <srcmd5>2b6f6ed344df3b6bb58fc09d16391f61</srcmd5>
-          <version>unknown</version>
-          <time>1758891958</time>
+        <revision rev="5" vrev="5">
+          <srcmd5>1041aa8fee5e7c1e0a6fe1c7915ea068</srcmd5>
+          <version>1</version>
+          <time>1759491145</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Fri, 26 Sep 2025 13:05:58 GMT
+  recorded_at: Fri, 03 Oct 2025 11:32:25 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/package_a
@@ -304,14 +304,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '206'
+      - '405'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_a" rev="2" vrev="2" srcmd5="2b6f6ed344df3b6bb58fc09d16391f61">
-          <entry name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340" mtime="1758891729"/>
+        <directory name="package_a" rev="5" vrev="5" srcmd5="1041aa8fee5e7c1e0a6fe1c7915ea068">
+          <entry name="README.txt" md5="e3fd9a58eace21898fe551fcbefce466" size="43" mtime="1758802242"/>
+          <entry name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340" mtime="1758802253"/>
+          <entry name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470" mtime="1758802242"/>
         </directory>
-  recorded_at: Fri, 26 Sep 2025 13:05:58 GMT
+  recorded_at: Fri, 03 Oct 2025 11:32:25 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/package_a
@@ -337,17 +339,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '206'
+      - '405'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_a" rev="2" vrev="2" srcmd5="2b6f6ed344df3b6bb58fc09d16391f61">
-          <entry name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340" mtime="1758891729"/>
+        <directory name="package_a" rev="5" vrev="5" srcmd5="1041aa8fee5e7c1e0a6fe1c7915ea068">
+          <entry name="README.txt" md5="e3fd9a58eace21898fe551fcbefce466" size="43" mtime="1758802242"/>
+          <entry name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340" mtime="1758802253"/>
+          <entry name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470" mtime="1758802242"/>
         </directory>
-  recorded_at: Fri, 26 Sep 2025 13:05:59 GMT
+  recorded_at: Fri, 03 Oct 2025 11:32:26 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/source_project/package_a?cmd=diff&expand=1&filelimit=10000&opackage=package_a&oproject=target_project&rev=2b6f6ed344df3b6bb58fc09d16391f61&tarlimit=10000&view=xml&withissues=1
+    uri: http://backend:5352/source/source_project/package_a?cmd=diff&expand=1&filelimit=10000&opackage=package_a&oproject=target_project&rev=1041aa8fee5e7c1e0a6fe1c7915ea068&tarlimit=10000&view=xml&withissues=1
     body:
       encoding: UTF-8
       string: ''
@@ -372,13 +376,521 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '1043'
+      - '2220'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="0567ac05caceafbaa4b9fa453d80abfe">
+        <sourcediff key="6b03530c3dc11f2e69929c9b1f39aab4">
           <old project="target_project" package="package_a" rev="2" srcmd5="a884751bbd575d6295dc91ee6f64cd02"/>
-          <new project="source_project" package="package_a" rev="2b6f6ed344df3b6bb58fc09d16391f61" srcmd5="2b6f6ed344df3b6bb58fc09d16391f61"/>
+          <new project="source_project" package="package_a" rev="1041aa8fee5e7c1e0a6fe1c7915ea068" srcmd5="1041aa8fee5e7c1e0a6fe1c7915ea068"/>
+          <files>
+            <file state="changed">
+              <old name="package_a.changes" md5="46925b99894da759ec99d5ff638615c9" size="51"/>
+              <new name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340"/>
+              <diff lines="14">@@ -1,1 +1,11 @@
+        -Different content then source package changes file!
+        \ No newline at end of file
+        +-------------------------------------------------------------------
+        +Fri Aug 11 16:58:15 UTC 2017 - tom@opensuse.org
+        +
+        +- Testing the submit diff
+        +- Fixing issues boo#1111111 and CVE-2011-1111 among others.
+        +
+        +-------------------------------------------------------------------
+        +Wed Aug  2 14:59:15 UTC 2017 - iggy@opensuse.org
+        +
+        +- Temporary hack
+        +
+        </diff>
+            </file>
+            <file state="added">
+              <new name="README.txt" md5="e3fd9a58eace21898fe551fcbefce466" size="43"/>
+              <diff lines="3">@@ -0,0 +1,1 @@
+        +Et illo est. Quasi et vitae. Non aut fugit.
+        \ No newline at end of file
+        </diff>
+            </file>
+            <file state="added">
+              <new name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470"/>
+              <diff lines="28">@@ -0,0 +1,27 @@
+        +Name:       package_a
+        +Version:    1
+        +Release:    1
+        +Summary:    Most simple RPM package
+        +License:    CC0-1.0
+        +
+        +%description
+        +This is my first RPM package, which does nothing.
+        +
+        +%prep
+        +# we have no source, so nothing here
+        +
+        +%build
+        +cat &gt; package_a.sh &lt;&lt;EOF
+        +#!/usr/bin/bash
+        +echo Hello world, from package_a.
+        +EOF
+        +
+        +%install
+        +mkdir -p %{buildroot}/usr/bin/
+        +install -m 755 package_a.sh %{buildroot}/usr/bin/package_a.sh
+        +
+        +%files
+        +/usr/bin/package_a.sh
+        +
+        +%changelog
+        +# let skip this for now
+        </diff>
+            </file>
+          </files>
+          <issues>
+            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="https://www.cve.org/CVERecord?id=2011-1111"/>
+            <issue state="added" tracker="bnc" name="1111111" label="boo#1111111" url="https://bugzilla.opensuse.org/show_bug.cgi?id=1111111"/>
+          </issues>
+        </sourcediff>
+  recorded_at: Fri, 03 Oct 2025 11:32:26 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/source_project/package_a
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - a05ef3cb-c9ce-4dc5-963d-0ee91886de31
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '405'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_a" rev="5" vrev="5" srcmd5="1041aa8fee5e7c1e0a6fe1c7915ea068">
+          <entry name="README.txt" md5="e3fd9a58eace21898fe551fcbefce466" size="43" mtime="1758802242"/>
+          <entry name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340" mtime="1758802253"/>
+          <entry name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470" mtime="1758802242"/>
+        </directory>
+  recorded_at: Fri, 03 Oct 2025 11:32:26 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/source_project/package_a?cacheonly=1&cmd=diff&expand=1&nodiff=1&opackage=package_a&oproject=target_project&rev=1041aa8fee5e7c1e0a6fe1c7915ea068&view=xml&withissues=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      X-Request-Id:
+      - a05ef3cb-c9ce-4dc5-963d-0ee91886de31
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '1067'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="5e0b05e86bb2922514c76fb750f2bac5">
+          <old project="target_project" package="package_a" rev="2" srcmd5="a884751bbd575d6295dc91ee6f64cd02"/>
+          <new project="source_project" package="package_a" rev="1041aa8fee5e7c1e0a6fe1c7915ea068" srcmd5="1041aa8fee5e7c1e0a6fe1c7915ea068"/>
+          <files>
+            <file state="changed">
+              <old name="package_a.changes" md5="46925b99894da759ec99d5ff638615c9" size="51"/>
+              <new name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340"/>
+            </file>
+            <file state="added">
+              <new name="README.txt" md5="e3fd9a58eace21898fe551fcbefce466" size="43"/>
+            </file>
+            <file state="added">
+              <new name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470"/>
+            </file>
+          </files>
+          <issues>
+            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="https://www.cve.org/CVERecord?id=2011-1111"/>
+            <issue state="added" tracker="bnc" name="1111111" label="boo#1111111" url="https://bugzilla.opensuse.org/show_bug.cgi?id=1111111"/>
+          </issues>
+        </sourcediff>
+  recorded_at: Fri, 03 Oct 2025 11:32:26 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/source_project/package_a
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - a05ef3cb-c9ce-4dc5-963d-0ee91886de31
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '405'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_a" rev="5" vrev="5" srcmd5="1041aa8fee5e7c1e0a6fe1c7915ea068">
+          <entry name="README.txt" md5="e3fd9a58eace21898fe551fcbefce466" size="43" mtime="1758802242"/>
+          <entry name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340" mtime="1758802253"/>
+          <entry name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470" mtime="1758802242"/>
+        </directory>
+  recorded_at: Fri, 03 Oct 2025 11:32:26 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/source_project/package_a?cacheonly=1&cmd=diff&expand=1&filelimit=10000&opackage=package_a&oproject=target_project&rev=1041aa8fee5e7c1e0a6fe1c7915ea068&tarlimit=10000&view=xml&withissues=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      X-Request-Id:
+      - a05ef3cb-c9ce-4dc5-963d-0ee91886de31
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '2220'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="6b03530c3dc11f2e69929c9b1f39aab4">
+          <old project="target_project" package="package_a" rev="2" srcmd5="a884751bbd575d6295dc91ee6f64cd02"/>
+          <new project="source_project" package="package_a" rev="1041aa8fee5e7c1e0a6fe1c7915ea068" srcmd5="1041aa8fee5e7c1e0a6fe1c7915ea068"/>
+          <files>
+            <file state="changed">
+              <old name="package_a.changes" md5="46925b99894da759ec99d5ff638615c9" size="51"/>
+              <new name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340"/>
+              <diff lines="14">@@ -1,1 +1,11 @@
+        -Different content then source package changes file!
+        \ No newline at end of file
+        +-------------------------------------------------------------------
+        +Fri Aug 11 16:58:15 UTC 2017 - tom@opensuse.org
+        +
+        +- Testing the submit diff
+        +- Fixing issues boo#1111111 and CVE-2011-1111 among others.
+        +
+        +-------------------------------------------------------------------
+        +Wed Aug  2 14:59:15 UTC 2017 - iggy@opensuse.org
+        +
+        +- Temporary hack
+        +
+        </diff>
+            </file>
+            <file state="added">
+              <new name="README.txt" md5="e3fd9a58eace21898fe551fcbefce466" size="43"/>
+              <diff lines="3">@@ -0,0 +1,1 @@
+        +Et illo est. Quasi et vitae. Non aut fugit.
+        \ No newline at end of file
+        </diff>
+            </file>
+            <file state="added">
+              <new name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470"/>
+              <diff lines="28">@@ -0,0 +1,27 @@
+        +Name:       package_a
+        +Version:    1
+        +Release:    1
+        +Summary:    Most simple RPM package
+        +License:    CC0-1.0
+        +
+        +%description
+        +This is my first RPM package, which does nothing.
+        +
+        +%prep
+        +# we have no source, so nothing here
+        +
+        +%build
+        +cat &gt; package_a.sh &lt;&lt;EOF
+        +#!/usr/bin/bash
+        +echo Hello world, from package_a.
+        +EOF
+        +
+        +%install
+        +mkdir -p %{buildroot}/usr/bin/
+        +install -m 755 package_a.sh %{buildroot}/usr/bin/package_a.sh
+        +
+        +%files
+        +/usr/bin/package_a.sh
+        +
+        +%changelog
+        +# let skip this for now
+        </diff>
+            </file>
+          </files>
+          <issues>
+            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="https://www.cve.org/CVERecord?id=2011-1111"/>
+            <issue state="added" tracker="bnc" name="1111111" label="boo#1111111" url="https://bugzilla.opensuse.org/show_bug.cgi?id=1111111"/>
+          </issues>
+        </sourcediff>
+  recorded_at: Fri, 03 Oct 2025 11:32:26 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/source_project/package_a
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - a05ef3cb-c9ce-4dc5-963d-0ee91886de31
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '405'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_a" rev="5" vrev="5" srcmd5="1041aa8fee5e7c1e0a6fe1c7915ea068">
+          <entry name="README.txt" md5="e3fd9a58eace21898fe551fcbefce466" size="43" mtime="1758802242"/>
+          <entry name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340" mtime="1758802253"/>
+          <entry name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470" mtime="1758802242"/>
+        </directory>
+  recorded_at: Fri, 03 Oct 2025 11:32:26 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/source_project/package_a?cacheonly=1&cmd=diff&expand=1&filelimit=10000&opackage=package_a&oproject=target_project&rev=1041aa8fee5e7c1e0a6fe1c7915ea068&tarlimit=10000&view=xml&withissues=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      X-Request-Id:
+      - a05ef3cb-c9ce-4dc5-963d-0ee91886de31
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '2220'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="6b03530c3dc11f2e69929c9b1f39aab4">
+          <old project="target_project" package="package_a" rev="2" srcmd5="a884751bbd575d6295dc91ee6f64cd02"/>
+          <new project="source_project" package="package_a" rev="1041aa8fee5e7c1e0a6fe1c7915ea068" srcmd5="1041aa8fee5e7c1e0a6fe1c7915ea068"/>
+          <files>
+            <file state="changed">
+              <old name="package_a.changes" md5="46925b99894da759ec99d5ff638615c9" size="51"/>
+              <new name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340"/>
+              <diff lines="14">@@ -1,1 +1,11 @@
+        -Different content then source package changes file!
+        \ No newline at end of file
+        +-------------------------------------------------------------------
+        +Fri Aug 11 16:58:15 UTC 2017 - tom@opensuse.org
+        +
+        +- Testing the submit diff
+        +- Fixing issues boo#1111111 and CVE-2011-1111 among others.
+        +
+        +-------------------------------------------------------------------
+        +Wed Aug  2 14:59:15 UTC 2017 - iggy@opensuse.org
+        +
+        +- Temporary hack
+        +
+        </diff>
+            </file>
+            <file state="added">
+              <new name="README.txt" md5="e3fd9a58eace21898fe551fcbefce466" size="43"/>
+              <diff lines="3">@@ -0,0 +1,1 @@
+        +Et illo est. Quasi et vitae. Non aut fugit.
+        \ No newline at end of file
+        </diff>
+            </file>
+            <file state="added">
+              <new name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470"/>
+              <diff lines="28">@@ -0,0 +1,27 @@
+        +Name:       package_a
+        +Version:    1
+        +Release:    1
+        +Summary:    Most simple RPM package
+        +License:    CC0-1.0
+        +
+        +%description
+        +This is my first RPM package, which does nothing.
+        +
+        +%prep
+        +# we have no source, so nothing here
+        +
+        +%build
+        +cat &gt; package_a.sh &lt;&lt;EOF
+        +#!/usr/bin/bash
+        +echo Hello world, from package_a.
+        +EOF
+        +
+        +%install
+        +mkdir -p %{buildroot}/usr/bin/
+        +install -m 755 package_a.sh %{buildroot}/usr/bin/package_a.sh
+        +
+        +%files
+        +/usr/bin/package_a.sh
+        +
+        +%changelog
+        +# let skip this for now
+        </diff>
+            </file>
+          </files>
+          <issues>
+            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="https://www.cve.org/CVERecord?id=2011-1111"/>
+            <issue state="added" tracker="bnc" name="1111111" label="boo#1111111" url="https://bugzilla.opensuse.org/show_bug.cgi?id=1111111"/>
+          </issues>
+        </sourcediff>
+  recorded_at: Fri, 03 Oct 2025 11:32:26 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/source_project/package_a
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 95b6235f-aa9d-4683-8755-716b13910637
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '405'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_a" rev="5" vrev="5" srcmd5="1041aa8fee5e7c1e0a6fe1c7915ea068">
+          <entry name="README.txt" md5="e3fd9a58eace21898fe551fcbefce466" size="43" mtime="1758802242"/>
+          <entry name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340" mtime="1758802253"/>
+          <entry name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470" mtime="1758802242"/>
+        </directory>
+  recorded_at: Fri, 03 Oct 2025 11:32:26 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/source_project/package_a?cmd=diff&expand=1&file=package_a.changes&filelimit=0&opackage=package_a&oproject=target_project&rev=1041aa8fee5e7c1e0a6fe1c7915ea068&tarlimit=0&view=xml&withissues=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      X-Request-Id:
+      - 95b6235f-aa9d-4683-8755-716b13910637
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '1308'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="ce87774e5dd8886b5861488ea9b3662c">
+          <old project="target_project" package="package_a" rev="2" srcmd5="a884751bbd575d6295dc91ee6f64cd02"/>
+          <new project="source_project" package="package_a" rev="1041aa8fee5e7c1e0a6fe1c7915ea068" srcmd5="1041aa8fee5e7c1e0a6fe1c7915ea068"/>
           <files>
             <file state="changed">
               <old name="package_a.changes" md5="46925b99894da759ec99d5ff638615c9" size="51"/>
@@ -401,18 +913,20 @@ http_interactions:
             </file>
           </files>
           <issues>
+            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="https://www.cve.org/CVERecord?id=2011-1111"/>
+            <issue state="added" tracker="bnc" name="1111111" label="boo#1111111" url="https://bugzilla.opensuse.org/show_bug.cgi?id=1111111"/>
           </issues>
         </sourcediff>
-  recorded_at: Fri, 26 Sep 2025 13:05:59 GMT
+  recorded_at: Fri, 03 Oct 2025 11:32:26 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/source_project/package_a
+    uri: http://backend:5352/source/source_project/package_a?expand=1&rev=1041aa8fee5e7c1e0a6fe1c7915ea068
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - 2350e96c-1e4f-4c64-8fd3-748c0f15dd13
+      - 95b6235f-aa9d-4683-8755-716b13910637
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -431,69 +945,25 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '206'
+      - '427'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_a" rev="2" vrev="2" srcmd5="2b6f6ed344df3b6bb58fc09d16391f61">
-          <entry name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340" mtime="1758891729"/>
+        <directory name="package_a" rev="1041aa8fee5e7c1e0a6fe1c7915ea068" srcmd5="1041aa8fee5e7c1e0a6fe1c7915ea068">
+          <entry name="README.txt" md5="e3fd9a58eace21898fe551fcbefce466" size="43" mtime="1758802242"/>
+          <entry name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340" mtime="1758802253"/>
+          <entry name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470" mtime="1758802242"/>
         </directory>
-  recorded_at: Fri, 26 Sep 2025 13:05:59 GMT
-- request:
-    method: post
-    uri: http://backend:5352/source/source_project/package_a?cacheonly=1&cmd=diff&expand=1&nodiff=1&opackage=package_a&oproject=target_project&rev=2b6f6ed344df3b6bb58fc09d16391f61&view=xml&withissues=1
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      Content-Type:
-      - application/octet-stream
-      X-Request-Id:
-      - 2350e96c-1e4f-4c64-8fd3-748c0f15dd13
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '563'
-    body:
-      encoding: UTF-8
-      string: |
-        <sourcediff key="f20c2cb8fd720f519b2253ece5fd4872">
-          <old project="target_project" package="package_a" rev="2" srcmd5="a884751bbd575d6295dc91ee6f64cd02"/>
-          <new project="source_project" package="package_a" rev="2b6f6ed344df3b6bb58fc09d16391f61" srcmd5="2b6f6ed344df3b6bb58fc09d16391f61"/>
-          <files>
-            <file state="changed">
-              <old name="package_a.changes" md5="46925b99894da759ec99d5ff638615c9" size="51"/>
-              <new name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340"/>
-            </file>
-          </files>
-          <issues>
-          </issues>
-        </sourcediff>
-  recorded_at: Fri, 26 Sep 2025 13:05:59 GMT
+  recorded_at: Fri, 03 Oct 2025 11:32:26 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/source_project/package_a
+    uri: http://backend:5352/source/source_project/package_a?expand=1&rev=1041aa8fee5e7c1e0a6fe1c7915ea068
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - 2350e96c-1e4f-4c64-8fd3-748c0f15dd13
+      - 95b6235f-aa9d-4683-8755-716b13910637
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -512,337 +982,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '206'
+      - '427'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_a" rev="2" vrev="2" srcmd5="2b6f6ed344df3b6bb58fc09d16391f61">
-          <entry name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340" mtime="1758891729"/>
+        <directory name="package_a" rev="1041aa8fee5e7c1e0a6fe1c7915ea068" srcmd5="1041aa8fee5e7c1e0a6fe1c7915ea068">
+          <entry name="README.txt" md5="e3fd9a58eace21898fe551fcbefce466" size="43" mtime="1758802242"/>
+          <entry name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340" mtime="1758802253"/>
+          <entry name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470" mtime="1758802242"/>
         </directory>
-  recorded_at: Fri, 26 Sep 2025 13:05:59 GMT
-- request:
-    method: post
-    uri: http://backend:5352/source/source_project/package_a?cacheonly=1&cmd=diff&expand=1&filelimit=10000&opackage=package_a&oproject=target_project&rev=2b6f6ed344df3b6bb58fc09d16391f61&tarlimit=10000&view=xml&withissues=1
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      Content-Type:
-      - application/octet-stream
-      X-Request-Id:
-      - 2350e96c-1e4f-4c64-8fd3-748c0f15dd13
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Content-Length:
-      - '1043'
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-    body:
-      encoding: UTF-8
-      string: |
-        <sourcediff key="0567ac05caceafbaa4b9fa453d80abfe">
-          <old project="target_project" package="package_a" rev="2" srcmd5="a884751bbd575d6295dc91ee6f64cd02"/>
-          <new project="source_project" package="package_a" rev="2b6f6ed344df3b6bb58fc09d16391f61" srcmd5="2b6f6ed344df3b6bb58fc09d16391f61"/>
-          <files>
-            <file state="changed">
-              <old name="package_a.changes" md5="46925b99894da759ec99d5ff638615c9" size="51"/>
-              <new name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340"/>
-              <diff lines="14">@@ -1,1 +1,11 @@
-        -Different content then source package changes file!
-        \ No newline at end of file
-        +-------------------------------------------------------------------
-        +Fri Aug 11 16:58:15 UTC 2017 - tom@opensuse.org
-        +
-        +- Testing the submit diff
-        +- Fixing issues boo#1111111 and CVE-2011-1111 among others.
-        +
-        +-------------------------------------------------------------------
-        +Wed Aug  2 14:59:15 UTC 2017 - iggy@opensuse.org
-        +
-        +- Temporary hack
-        +
-        </diff>
-            </file>
-          </files>
-          <issues>
-          </issues>
-        </sourcediff>
-  recorded_at: Fri, 26 Sep 2025 13:05:59 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/source_project/package_a
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Request-Id:
-      - 2350e96c-1e4f-4c64-8fd3-748c0f15dd13
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '206'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="package_a" rev="2" vrev="2" srcmd5="2b6f6ed344df3b6bb58fc09d16391f61">
-          <entry name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340" mtime="1758891729"/>
-        </directory>
-  recorded_at: Fri, 26 Sep 2025 13:05:59 GMT
-- request:
-    method: post
-    uri: http://backend:5352/source/source_project/package_a?cacheonly=1&cmd=diff&expand=1&filelimit=10000&opackage=package_a&oproject=target_project&rev=2b6f6ed344df3b6bb58fc09d16391f61&tarlimit=10000&view=xml&withissues=1
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      Content-Type:
-      - application/octet-stream
-      X-Request-Id:
-      - 2350e96c-1e4f-4c64-8fd3-748c0f15dd13
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Content-Length:
-      - '1043'
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-    body:
-      encoding: UTF-8
-      string: |
-        <sourcediff key="0567ac05caceafbaa4b9fa453d80abfe">
-          <old project="target_project" package="package_a" rev="2" srcmd5="a884751bbd575d6295dc91ee6f64cd02"/>
-          <new project="source_project" package="package_a" rev="2b6f6ed344df3b6bb58fc09d16391f61" srcmd5="2b6f6ed344df3b6bb58fc09d16391f61"/>
-          <files>
-            <file state="changed">
-              <old name="package_a.changes" md5="46925b99894da759ec99d5ff638615c9" size="51"/>
-              <new name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340"/>
-              <diff lines="14">@@ -1,1 +1,11 @@
-        -Different content then source package changes file!
-        \ No newline at end of file
-        +-------------------------------------------------------------------
-        +Fri Aug 11 16:58:15 UTC 2017 - tom@opensuse.org
-        +
-        +- Testing the submit diff
-        +- Fixing issues boo#1111111 and CVE-2011-1111 among others.
-        +
-        +-------------------------------------------------------------------
-        +Wed Aug  2 14:59:15 UTC 2017 - iggy@opensuse.org
-        +
-        +- Temporary hack
-        +
-        </diff>
-            </file>
-          </files>
-          <issues>
-          </issues>
-        </sourcediff>
-  recorded_at: Fri, 26 Sep 2025 13:05:59 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/source_project/package_a
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Request-Id:
-      - 8b703150-b117-4cf6-beb8-0695e61d6e85
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '206'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="package_a" rev="2" vrev="2" srcmd5="2b6f6ed344df3b6bb58fc09d16391f61">
-          <entry name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340" mtime="1758891729"/>
-        </directory>
-  recorded_at: Fri, 26 Sep 2025 13:06:00 GMT
-- request:
-    method: post
-    uri: http://backend:5352/source/source_project/package_a?cmd=diff&expand=1&file=package_a.changes&filelimit=10000&opackage=package_a&oproject=target_project&rev=2b6f6ed344df3b6bb58fc09d16391f61&tarlimit=10000&view=xml&withissues=1
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      Content-Type:
-      - application/octet-stream
-      X-Request-Id:
-      - 8b703150-b117-4cf6-beb8-0695e61d6e85
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '1043'
-    body:
-      encoding: UTF-8
-      string: |
-        <sourcediff key="a2b408755a2ba4186b720c22a2721c52">
-          <old project="target_project" package="package_a" rev="2" srcmd5="a884751bbd575d6295dc91ee6f64cd02"/>
-          <new project="source_project" package="package_a" rev="2b6f6ed344df3b6bb58fc09d16391f61" srcmd5="2b6f6ed344df3b6bb58fc09d16391f61"/>
-          <files>
-            <file state="changed">
-              <old name="package_a.changes" md5="46925b99894da759ec99d5ff638615c9" size="51"/>
-              <new name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340"/>
-              <diff lines="14">@@ -1,1 +1,11 @@
-        -Different content then source package changes file!
-        \ No newline at end of file
-        +-------------------------------------------------------------------
-        +Fri Aug 11 16:58:15 UTC 2017 - tom@opensuse.org
-        +
-        +- Testing the submit diff
-        +- Fixing issues boo#1111111 and CVE-2011-1111 among others.
-        +
-        +-------------------------------------------------------------------
-        +Wed Aug  2 14:59:15 UTC 2017 - iggy@opensuse.org
-        +
-        +- Temporary hack
-        +
-        </diff>
-            </file>
-          </files>
-          <issues>
-          </issues>
-        </sourcediff>
-  recorded_at: Fri, 26 Sep 2025 13:06:00 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/source_project/package_a?expand=1&rev=2b6f6ed344df3b6bb58fc09d16391f61
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Request-Id:
-      - 8b703150-b117-4cf6-beb8-0695e61d6e85
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '228'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="package_a" rev="2b6f6ed344df3b6bb58fc09d16391f61" srcmd5="2b6f6ed344df3b6bb58fc09d16391f61">
-          <entry name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340" mtime="1758891729"/>
-        </directory>
-  recorded_at: Fri, 26 Sep 2025 13:06:00 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/source_project/package_a?expand=1&rev=2b6f6ed344df3b6bb58fc09d16391f61
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Request-Id:
-      - 8b703150-b117-4cf6-beb8-0695e61d6e85
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '228'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="package_a" rev="2b6f6ed344df3b6bb58fc09d16391f61" srcmd5="2b6f6ed344df3b6bb58fc09d16391f61">
-          <entry name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340" mtime="1758891729"/>
-        </directory>
-  recorded_at: Fri, 26 Sep 2025 13:06:00 GMT
+  recorded_at: Fri, 03 Oct 2025 11:32:26 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/package_a?expand=1&rev=a884751bbd575d6295dc91ee6f64cd02
@@ -851,7 +1000,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 8b703150-b117-4cf6-beb8-0695e61d6e85
+      - 95b6235f-aa9d-4683-8755-716b13910637
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -875,9 +1024,9 @@ http_interactions:
       encoding: UTF-8
       string: |
         <directory name="package_a" rev="a884751bbd575d6295dc91ee6f64cd02" srcmd5="a884751bbd575d6295dc91ee6f64cd02">
-          <entry name="package_a.changes" md5="46925b99894da759ec99d5ff638615c9" size="51" mtime="1758891729"/>
+          <entry name="package_a.changes" md5="46925b99894da759ec99d5ff638615c9" size="51" mtime="1759491141"/>
         </directory>
-  recorded_at: Fri, 26 Sep 2025 13:06:00 GMT
+  recorded_at: Fri, 03 Oct 2025 11:32:26 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/package_a?expand=1&rev=a884751bbd575d6295dc91ee6f64cd02
@@ -886,7 +1035,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 8b703150-b117-4cf6-beb8-0695e61d6e85
+      - 95b6235f-aa9d-4683-8755-716b13910637
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -910,9 +1059,9 @@ http_interactions:
       encoding: UTF-8
       string: |
         <directory name="package_a" rev="a884751bbd575d6295dc91ee6f64cd02" srcmd5="a884751bbd575d6295dc91ee6f64cd02">
-          <entry name="package_a.changes" md5="46925b99894da759ec99d5ff638615c9" size="51" mtime="1758891729"/>
+          <entry name="package_a.changes" md5="46925b99894da759ec99d5ff638615c9" size="51" mtime="1759491141"/>
         </directory>
-  recorded_at: Fri, 26 Sep 2025 13:06:00 GMT
+  recorded_at: Fri, 03 Oct 2025 11:32:26 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/package_a
@@ -921,7 +1070,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 5c5b4a0a-0746-48d0-870b-d6b7df383e64
+      - 635d770e-7fc6-406f-845f-1c9bab2ebe7d
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -940,17 +1089,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '206'
+      - '405'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_a" rev="2" vrev="2" srcmd5="2b6f6ed344df3b6bb58fc09d16391f61">
-          <entry name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340" mtime="1758891729"/>
+        <directory name="package_a" rev="5" vrev="5" srcmd5="1041aa8fee5e7c1e0a6fe1c7915ea068">
+          <entry name="README.txt" md5="e3fd9a58eace21898fe551fcbefce466" size="43" mtime="1758802242"/>
+          <entry name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340" mtime="1758802253"/>
+          <entry name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470" mtime="1758802242"/>
         </directory>
-  recorded_at: Fri, 26 Sep 2025 13:06:01 GMT
+  recorded_at: Fri, 03 Oct 2025 11:32:27 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/source_project/package_a?cmd=diff&expand=1&filelimit=10000&opackage=package_a&oproject=target_project&orev=a884751bbd575d6295dc91ee6f64cd02&rev=2b6f6ed344df3b6bb58fc09d16391f61&tarlimit=10000&view=xml&withissues=1
+    uri: http://backend:5352/source/source_project/package_a?cmd=diff&expand=1&file=package_a.spec&filelimit=0&opackage=package_a&oproject=target_project&rev=1041aa8fee5e7c1e0a6fe1c7915ea068&tarlimit=0&view=xml&withissues=1
     body:
       encoding: UTF-8
       string: ''
@@ -958,7 +1109,7 @@ http_interactions:
       Content-Type:
       - application/octet-stream
       X-Request-Id:
-      - 5c5b4a0a-0746-48d0-870b-d6b7df383e64
+      - 635d770e-7fc6-406f-845f-1c9bab2ebe7d
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -977,189 +1128,195 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '1074'
+      - '1025'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="5f14b74da1b6ee9778009605464ffb67">
-          <old project="target_project" package="package_a" rev="a884751bbd575d6295dc91ee6f64cd02" srcmd5="a884751bbd575d6295dc91ee6f64cd02"/>
-          <new project="source_project" package="package_a" rev="2b6f6ed344df3b6bb58fc09d16391f61" srcmd5="2b6f6ed344df3b6bb58fc09d16391f61"/>
-          <files>
-            <file state="changed">
-              <old name="package_a.changes" md5="46925b99894da759ec99d5ff638615c9" size="51"/>
-              <new name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340"/>
-              <diff lines="14">@@ -1,1 +1,11 @@
-        -Different content then source package changes file!
-        \ No newline at end of file
-        +-------------------------------------------------------------------
-        +Fri Aug 11 16:58:15 UTC 2017 - tom@opensuse.org
-        +
-        +- Testing the submit diff
-        +- Fixing issues boo#1111111 and CVE-2011-1111 among others.
-        +
-        +-------------------------------------------------------------------
-        +Wed Aug  2 14:59:15 UTC 2017 - iggy@opensuse.org
-        +
-        +- Temporary hack
-        +
-        </diff>
-            </file>
-          </files>
-          <issues>
-          </issues>
-        </sourcediff>
-  recorded_at: Fri, 26 Sep 2025 13:06:01 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/target_project/package_a
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Request-Id:
-      - 5c5b4a0a-0746-48d0-870b-d6b7df383e64
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '205'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="package_a" rev="2" vrev="2" srcmd5="a884751bbd575d6295dc91ee6f64cd02">
-          <entry name="package_a.changes" md5="46925b99894da759ec99d5ff638615c9" size="51" mtime="1758891729"/>
-        </directory>
-  recorded_at: Fri, 26 Sep 2025 13:06:01 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/target_project/package_a
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Request-Id:
-      - 4ec6af3f-f12d-4964-92c6-14b3f53e458c
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '205'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="package_a" rev="2" vrev="2" srcmd5="a884751bbd575d6295dc91ee6f64cd02">
-          <entry name="package_a.changes" md5="46925b99894da759ec99d5ff638615c9" size="51" mtime="1758891729"/>
-        </directory>
-  recorded_at: Fri, 26 Sep 2025 13:06:01 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/source_project/package_a
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Request-Id:
-      - a2b8a3ed-db51-4275-bc4e-48a2a92a7f55
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '206'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="package_a" rev="2" vrev="2" srcmd5="2b6f6ed344df3b6bb58fc09d16391f61">
-          <entry name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340" mtime="1758891729"/>
-        </directory>
-  recorded_at: Fri, 26 Sep 2025 13:06:01 GMT
-- request:
-    method: post
-    uri: http://backend:5352/source/source_project/package_a?cacheonly=1&cmd=diff&expand=1&nodiff=1&opackage=package_a&oproject=target_project&rev=2b6f6ed344df3b6bb58fc09d16391f61&view=xml&withissues=1
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      Content-Type:
-      - application/octet-stream
-      X-Request-Id:
-      - a2b8a3ed-db51-4275-bc4e-48a2a92a7f55
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '563'
-    body:
-      encoding: UTF-8
-      string: |
-        <sourcediff key="f20c2cb8fd720f519b2253ece5fd4872">
+        <sourcediff key="0dbddf563e69e4d50eb871c56a04a353">
           <old project="target_project" package="package_a" rev="2" srcmd5="a884751bbd575d6295dc91ee6f64cd02"/>
-          <new project="source_project" package="package_a" rev="2b6f6ed344df3b6bb58fc09d16391f61" srcmd5="2b6f6ed344df3b6bb58fc09d16391f61"/>
+          <new project="source_project" package="package_a" rev="1041aa8fee5e7c1e0a6fe1c7915ea068" srcmd5="1041aa8fee5e7c1e0a6fe1c7915ea068"/>
           <files>
-            <file state="changed">
-              <old name="package_a.changes" md5="46925b99894da759ec99d5ff638615c9" size="51"/>
-              <new name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340"/>
+            <file state="added">
+              <new name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470"/>
+              <diff lines="28">@@ -0,0 +1,27 @@
+        +Name:       package_a
+        +Version:    1
+        +Release:    1
+        +Summary:    Most simple RPM package
+        +License:    CC0-1.0
+        +
+        +%description
+        +This is my first RPM package, which does nothing.
+        +
+        +%prep
+        +# we have no source, so nothing here
+        +
+        +%build
+        +cat &gt; package_a.sh &lt;&lt;EOF
+        +#!/usr/bin/bash
+        +echo Hello world, from package_a.
+        +EOF
+        +
+        +%install
+        +mkdir -p %{buildroot}/usr/bin/
+        +install -m 755 package_a.sh %{buildroot}/usr/bin/package_a.sh
+        +
+        +%files
+        +/usr/bin/package_a.sh
+        +
+        +%changelog
+        +# let skip this for now
+        </diff>
             </file>
           </files>
           <issues>
           </issues>
         </sourcediff>
-  recorded_at: Fri, 26 Sep 2025 13:06:01 GMT
+  recorded_at: Fri, 03 Oct 2025 11:32:27 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/source_project/package_a?expand=1&rev=1041aa8fee5e7c1e0a6fe1c7915ea068
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 635d770e-7fc6-406f-845f-1c9bab2ebe7d
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '427'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_a" rev="1041aa8fee5e7c1e0a6fe1c7915ea068" srcmd5="1041aa8fee5e7c1e0a6fe1c7915ea068">
+          <entry name="README.txt" md5="e3fd9a58eace21898fe551fcbefce466" size="43" mtime="1758802242"/>
+          <entry name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340" mtime="1758802253"/>
+          <entry name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470" mtime="1758802242"/>
+        </directory>
+  recorded_at: Fri, 03 Oct 2025 11:32:27 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/source_project/package_a?expand=1&rev=1041aa8fee5e7c1e0a6fe1c7915ea068
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 635d770e-7fc6-406f-845f-1c9bab2ebe7d
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '427'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_a" rev="1041aa8fee5e7c1e0a6fe1c7915ea068" srcmd5="1041aa8fee5e7c1e0a6fe1c7915ea068">
+          <entry name="README.txt" md5="e3fd9a58eace21898fe551fcbefce466" size="43" mtime="1758802242"/>
+          <entry name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340" mtime="1758802253"/>
+          <entry name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470" mtime="1758802242"/>
+        </directory>
+  recorded_at: Fri, 03 Oct 2025 11:32:27 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/target_project/package_a?expand=1&rev=a884751bbd575d6295dc91ee6f64cd02
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 635d770e-7fc6-406f-845f-1c9bab2ebe7d
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '227'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_a" rev="a884751bbd575d6295dc91ee6f64cd02" srcmd5="a884751bbd575d6295dc91ee6f64cd02">
+          <entry name="package_a.changes" md5="46925b99894da759ec99d5ff638615c9" size="51" mtime="1759491141"/>
+        </directory>
+  recorded_at: Fri, 03 Oct 2025 11:32:27 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/target_project/package_a?expand=1&rev=a884751bbd575d6295dc91ee6f64cd02
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 635d770e-7fc6-406f-845f-1c9bab2ebe7d
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '227'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_a" rev="a884751bbd575d6295dc91ee6f64cd02" srcmd5="a884751bbd575d6295dc91ee6f64cd02">
+          <entry name="package_a.changes" md5="46925b99894da759ec99d5ff638615c9" size="51" mtime="1759491141"/>
+        </directory>
+  recorded_at: Fri, 03 Oct 2025 11:32:27 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/package_a
@@ -1168,7 +1325,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - a2b8a3ed-db51-4275-bc4e-48a2a92a7f55
+      - 7d4c39bb-6eec-44cd-bbb1-f861636dac6e
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1187,17 +1344,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '206'
+      - '405'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_a" rev="2" vrev="2" srcmd5="2b6f6ed344df3b6bb58fc09d16391f61">
-          <entry name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340" mtime="1758891729"/>
+        <directory name="package_a" rev="5" vrev="5" srcmd5="1041aa8fee5e7c1e0a6fe1c7915ea068">
+          <entry name="README.txt" md5="e3fd9a58eace21898fe551fcbefce466" size="43" mtime="1758802242"/>
+          <entry name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340" mtime="1758802253"/>
+          <entry name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470" mtime="1758802242"/>
         </directory>
-  recorded_at: Fri, 26 Sep 2025 13:06:01 GMT
+  recorded_at: Fri, 03 Oct 2025 11:32:28 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/source_project/package_a?cmd=diff&expand=1&filelimit=10000&opackage=package_a&oproject=target_project&orev=a884751bbd575d6295dc91ee6f64cd02&rev=2b6f6ed344df3b6bb58fc09d16391f61&tarlimit=10000&view=xml&withissues=1
+    uri: http://backend:5352/source/source_project/package_a?cmd=diff&expand=1&filelimit=10000&opackage=package_a&oproject=target_project&orev=a884751bbd575d6295dc91ee6f64cd02&rev=1041aa8fee5e7c1e0a6fe1c7915ea068&tarlimit=10000&view=xml&withissues=1
     body:
       encoding: UTF-8
       string: ''
@@ -1205,7 +1364,7 @@ http_interactions:
       Content-Type:
       - application/octet-stream
       X-Request-Id:
-      - a2b8a3ed-db51-4275-bc4e-48a2a92a7f55
+      - 7d4c39bb-6eec-44cd-bbb1-f861636dac6e
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1220,7 +1379,7 @@ http_interactions:
       Content-Type:
       - text/xml
       Content-Length:
-      - '1074'
+      - '2251'
       Cache-Control:
       - no-cache
       Connection:
@@ -1228,9 +1387,9 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="5f14b74da1b6ee9778009605464ffb67">
+        <sourcediff key="d14394ddb340d58690636d3f4d640fa6">
           <old project="target_project" package="package_a" rev="a884751bbd575d6295dc91ee6f64cd02" srcmd5="a884751bbd575d6295dc91ee6f64cd02"/>
-          <new project="source_project" package="package_a" rev="2b6f6ed344df3b6bb58fc09d16391f61" srcmd5="2b6f6ed344df3b6bb58fc09d16391f61"/>
+          <new project="source_project" package="package_a" rev="1041aa8fee5e7c1e0a6fe1c7915ea068" srcmd5="1041aa8fee5e7c1e0a6fe1c7915ea068"/>
           <files>
             <file state="changed">
               <old name="package_a.changes" md5="46925b99894da759ec99d5ff638615c9" size="51"/>
@@ -1251,11 +1410,52 @@ http_interactions:
         +
         </diff>
             </file>
+            <file state="added">
+              <new name="README.txt" md5="e3fd9a58eace21898fe551fcbefce466" size="43"/>
+              <diff lines="3">@@ -0,0 +1,1 @@
+        +Et illo est. Quasi et vitae. Non aut fugit.
+        \ No newline at end of file
+        </diff>
+            </file>
+            <file state="added">
+              <new name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470"/>
+              <diff lines="28">@@ -0,0 +1,27 @@
+        +Name:       package_a
+        +Version:    1
+        +Release:    1
+        +Summary:    Most simple RPM package
+        +License:    CC0-1.0
+        +
+        +%description
+        +This is my first RPM package, which does nothing.
+        +
+        +%prep
+        +# we have no source, so nothing here
+        +
+        +%build
+        +cat &gt; package_a.sh &lt;&lt;EOF
+        +#!/usr/bin/bash
+        +echo Hello world, from package_a.
+        +EOF
+        +
+        +%install
+        +mkdir -p %{buildroot}/usr/bin/
+        +install -m 755 package_a.sh %{buildroot}/usr/bin/package_a.sh
+        +
+        +%files
+        +/usr/bin/package_a.sh
+        +
+        +%changelog
+        +# let skip this for now
+        </diff>
+            </file>
           </files>
           <issues>
+            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="https://www.cve.org/CVERecord?id=2011-1111"/>
+            <issue state="added" tracker="bnc" name="1111111" label="boo#1111111" url="https://bugzilla.opensuse.org/show_bug.cgi?id=1111111"/>
           </issues>
         </sourcediff>
-  recorded_at: Fri, 26 Sep 2025 13:06:01 GMT
+  recorded_at: Fri, 03 Oct 2025 11:32:28 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/package_a
@@ -1264,7 +1464,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - a2b8a3ed-db51-4275-bc4e-48a2a92a7f55
+      - 7d4c39bb-6eec-44cd-bbb1-f861636dac6e
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1288,9 +1488,9 @@ http_interactions:
       encoding: UTF-8
       string: |
         <directory name="package_a" rev="2" vrev="2" srcmd5="a884751bbd575d6295dc91ee6f64cd02">
-          <entry name="package_a.changes" md5="46925b99894da759ec99d5ff638615c9" size="51" mtime="1758891729"/>
+          <entry name="package_a.changes" md5="46925b99894da759ec99d5ff638615c9" size="51" mtime="1759491141"/>
         </directory>
-  recorded_at: Fri, 26 Sep 2025 13:06:01 GMT
+  recorded_at: Fri, 03 Oct 2025 11:32:28 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/package_a
@@ -1299,7 +1499,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - a2b8a3ed-db51-4275-bc4e-48a2a92a7f55
+      - f9e73c99-c898-4ed8-a847-b99f6550710b
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1323,9 +1523,239 @@ http_interactions:
       encoding: UTF-8
       string: |
         <directory name="package_a" rev="2" vrev="2" srcmd5="a884751bbd575d6295dc91ee6f64cd02">
-          <entry name="package_a.changes" md5="46925b99894da759ec99d5ff638615c9" size="51" mtime="1758891729"/>
+          <entry name="package_a.changes" md5="46925b99894da759ec99d5ff638615c9" size="51" mtime="1759491141"/>
         </directory>
-  recorded_at: Fri, 26 Sep 2025 13:06:02 GMT
+  recorded_at: Fri, 03 Oct 2025 11:32:28 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/source_project/package_a
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 2432a48c-fe7a-4a05-acd4-7b20b8f4fa5e
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '405'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_a" rev="5" vrev="5" srcmd5="1041aa8fee5e7c1e0a6fe1c7915ea068">
+          <entry name="README.txt" md5="e3fd9a58eace21898fe551fcbefce466" size="43" mtime="1758802242"/>
+          <entry name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340" mtime="1758802253"/>
+          <entry name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470" mtime="1758802242"/>
+        </directory>
+  recorded_at: Fri, 03 Oct 2025 11:32:28 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/source_project/package_a?cacheonly=1&cmd=diff&expand=1&nodiff=1&opackage=package_a&oproject=target_project&rev=1041aa8fee5e7c1e0a6fe1c7915ea068&view=xml&withissues=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      X-Request-Id:
+      - 2432a48c-fe7a-4a05-acd4-7b20b8f4fa5e
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '1067'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="5e0b05e86bb2922514c76fb750f2bac5">
+          <old project="target_project" package="package_a" rev="2" srcmd5="a884751bbd575d6295dc91ee6f64cd02"/>
+          <new project="source_project" package="package_a" rev="1041aa8fee5e7c1e0a6fe1c7915ea068" srcmd5="1041aa8fee5e7c1e0a6fe1c7915ea068"/>
+          <files>
+            <file state="changed">
+              <old name="package_a.changes" md5="46925b99894da759ec99d5ff638615c9" size="51"/>
+              <new name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340"/>
+            </file>
+            <file state="added">
+              <new name="README.txt" md5="e3fd9a58eace21898fe551fcbefce466" size="43"/>
+            </file>
+            <file state="added">
+              <new name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470"/>
+            </file>
+          </files>
+          <issues>
+            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="https://www.cve.org/CVERecord?id=2011-1111"/>
+            <issue state="added" tracker="bnc" name="1111111" label="boo#1111111" url="https://bugzilla.opensuse.org/show_bug.cgi?id=1111111"/>
+          </issues>
+        </sourcediff>
+  recorded_at: Fri, 03 Oct 2025 11:32:28 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/source_project/package_a
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 2432a48c-fe7a-4a05-acd4-7b20b8f4fa5e
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '405'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_a" rev="5" vrev="5" srcmd5="1041aa8fee5e7c1e0a6fe1c7915ea068">
+          <entry name="README.txt" md5="e3fd9a58eace21898fe551fcbefce466" size="43" mtime="1758802242"/>
+          <entry name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340" mtime="1758802253"/>
+          <entry name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470" mtime="1758802242"/>
+        </directory>
+  recorded_at: Fri, 03 Oct 2025 11:32:28 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/source_project/package_a?cmd=diff&expand=1&filelimit=10000&opackage=package_a&oproject=target_project&orev=a884751bbd575d6295dc91ee6f64cd02&rev=1041aa8fee5e7c1e0a6fe1c7915ea068&tarlimit=10000&view=xml&withissues=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      X-Request-Id:
+      - 2432a48c-fe7a-4a05-acd4-7b20b8f4fa5e
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '2251'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="d14394ddb340d58690636d3f4d640fa6">
+          <old project="target_project" package="package_a" rev="a884751bbd575d6295dc91ee6f64cd02" srcmd5="a884751bbd575d6295dc91ee6f64cd02"/>
+          <new project="source_project" package="package_a" rev="1041aa8fee5e7c1e0a6fe1c7915ea068" srcmd5="1041aa8fee5e7c1e0a6fe1c7915ea068"/>
+          <files>
+            <file state="changed">
+              <old name="package_a.changes" md5="46925b99894da759ec99d5ff638615c9" size="51"/>
+              <new name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340"/>
+              <diff lines="14">@@ -1,1 +1,11 @@
+        -Different content then source package changes file!
+        \ No newline at end of file
+        +-------------------------------------------------------------------
+        +Fri Aug 11 16:58:15 UTC 2017 - tom@opensuse.org
+        +
+        +- Testing the submit diff
+        +- Fixing issues boo#1111111 and CVE-2011-1111 among others.
+        +
+        +-------------------------------------------------------------------
+        +Wed Aug  2 14:59:15 UTC 2017 - iggy@opensuse.org
+        +
+        +- Temporary hack
+        +
+        </diff>
+            </file>
+            <file state="added">
+              <new name="README.txt" md5="e3fd9a58eace21898fe551fcbefce466" size="43"/>
+              <diff lines="3">@@ -0,0 +1,1 @@
+        +Et illo est. Quasi et vitae. Non aut fugit.
+        \ No newline at end of file
+        </diff>
+            </file>
+            <file state="added">
+              <new name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470"/>
+              <diff lines="28">@@ -0,0 +1,27 @@
+        +Name:       package_a
+        +Version:    1
+        +Release:    1
+        +Summary:    Most simple RPM package
+        +License:    CC0-1.0
+        +
+        +%description
+        +This is my first RPM package, which does nothing.
+        +
+        +%prep
+        +# we have no source, so nothing here
+        +
+        +%build
+        +cat &gt; package_a.sh &lt;&lt;EOF
+        +#!/usr/bin/bash
+        +echo Hello world, from package_a.
+        +EOF
+        +
+        +%install
+        +mkdir -p %{buildroot}/usr/bin/
+        +install -m 755 package_a.sh %{buildroot}/usr/bin/package_a.sh
+        +
+        +%files
+        +/usr/bin/package_a.sh
+        +
+        +%changelog
+        +# let skip this for now
+        </diff>
+            </file>
+          </files>
+          <issues>
+            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="https://www.cve.org/CVERecord?id=2011-1111"/>
+            <issue state="added" tracker="bnc" name="1111111" label="boo#1111111" url="https://bugzilla.opensuse.org/show_bug.cgi?id=1111111"/>
+          </issues>
+        </sourcediff>
+  recorded_at: Fri, 03 Oct 2025 11:32:28 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/package_a
@@ -1334,7 +1764,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - a2b8a3ed-db51-4275-bc4e-48a2a92a7f55
+      - 2432a48c-fe7a-4a05-acd4-7b20b8f4fa5e
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1358,9 +1788,9 @@ http_interactions:
       encoding: UTF-8
       string: |
         <directory name="package_a" rev="2" vrev="2" srcmd5="a884751bbd575d6295dc91ee6f64cd02">
-          <entry name="package_a.changes" md5="46925b99894da759ec99d5ff638615c9" size="51" mtime="1758891729"/>
+          <entry name="package_a.changes" md5="46925b99894da759ec99d5ff638615c9" size="51" mtime="1759491141"/>
         </directory>
-  recorded_at: Fri, 26 Sep 2025 13:06:02 GMT
+  recorded_at: Fri, 03 Oct 2025 11:32:28 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/package_a
@@ -1369,7 +1799,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - a2b8a3ed-db51-4275-bc4e-48a2a92a7f55
+      - 2432a48c-fe7a-4a05-acd4-7b20b8f4fa5e
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1393,9 +1823,9 @@ http_interactions:
       encoding: UTF-8
       string: |
         <directory name="package_a" rev="2" vrev="2" srcmd5="a884751bbd575d6295dc91ee6f64cd02">
-          <entry name="package_a.changes" md5="46925b99894da759ec99d5ff638615c9" size="51" mtime="1758891729"/>
+          <entry name="package_a.changes" md5="46925b99894da759ec99d5ff638615c9" size="51" mtime="1759491141"/>
         </directory>
-  recorded_at: Fri, 26 Sep 2025 13:06:02 GMT
+  recorded_at: Fri, 03 Oct 2025 11:32:28 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/package_a
@@ -1404,7 +1834,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - a2b8a3ed-db51-4275-bc4e-48a2a92a7f55
+      - 2432a48c-fe7a-4a05-acd4-7b20b8f4fa5e
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1428,9 +1858,79 @@ http_interactions:
       encoding: UTF-8
       string: |
         <directory name="package_a" rev="2" vrev="2" srcmd5="a884751bbd575d6295dc91ee6f64cd02">
-          <entry name="package_a.changes" md5="46925b99894da759ec99d5ff638615c9" size="51" mtime="1758891729"/>
+          <entry name="package_a.changes" md5="46925b99894da759ec99d5ff638615c9" size="51" mtime="1759491141"/>
         </directory>
-  recorded_at: Fri, 26 Sep 2025 13:06:02 GMT
+  recorded_at: Fri, 03 Oct 2025 11:32:28 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/target_project/package_a
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 2432a48c-fe7a-4a05-acd4-7b20b8f4fa5e
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '205'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_a" rev="2" vrev="2" srcmd5="a884751bbd575d6295dc91ee6f64cd02">
+          <entry name="package_a.changes" md5="46925b99894da759ec99d5ff638615c9" size="51" mtime="1759491141"/>
+        </directory>
+  recorded_at: Fri, 03 Oct 2025 11:32:28 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/target_project/package_a
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 2432a48c-fe7a-4a05-acd4-7b20b8f4fa5e
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '205'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_a" rev="2" vrev="2" srcmd5="a884751bbd575d6295dc91ee6f64cd02">
+          <entry name="package_a.changes" md5="46925b99894da759ec99d5ff638615c9" size="51" mtime="1759491141"/>
+        </directory>
+  recorded_at: Fri, 03 Oct 2025 11:32:28 GMT
 - request:
     method: get
     uri: http://backend:5352/build/source_project/_result?lastbuild=0&locallink=1&multibuild=1&package=package_a&view=status
@@ -1439,7 +1939,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 7657b542-c246-443b-8877-c14623bfc84c
+      - a30ebdbb-24ab-47a3-86ad-035c894b815f
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1464,5 +1964,5 @@ http_interactions:
       string: '<resultlist state="00000000000000000000000000000000"/>
 
 '
-  recorded_at: Fri, 26 Sep 2025 13:06:02 GMT
+  recorded_at: Fri, 03 Oct 2025 11:32:29 GMT
 recorded_with: VCR 6.3.1

--- a/src/api/spec/cassettes/Comments_with_diff/create_diff_comment/displays_the_comment_on_the_file_diff_in_the_changes_tab.yml
+++ b/src/api/spec/cassettes/Comments_with_diff/create_diff_comment/displays_the_comment_on_the_file_diff_in_the_changes_tab.yml
@@ -2,12 +2,12 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/target_project/_meta?user=Admin
+    uri: http://backend:5352/source/target_project/_meta?user=user_2
     body:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>What's Become of Waring</title>
+          <title>Surprised by Joy</title>
           <description/>
         </project>
     headers:
@@ -29,24 +29,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '114'
+      - '107'
     body:
       encoding: UTF-8
       string: |
         <project name="target_project">
-          <title>What's Become of Waring</title>
+          <title>Surprised by Joy</title>
           <description></description>
         </project>
-  recorded_at: Thu, 22 May 2025 09:23:42 GMT
+  recorded_at: Fri, 03 Oct 2025 11:32:21 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/target_project/package_a/_meta?user=Admin
+    uri: http://backend:5352/source/target_project/package_a/_meta?user=user_3
     body:
       encoding: UTF-8
       string: |
         <package name="package_a" project="target_project">
-          <title>All Passion Spent</title>
-          <description>Sit dignissimos dolor nihil.</description>
+          <title>Frequent Hearses</title>
+          <description>Ipsum sed at eius.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -67,15 +67,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '156'
+      - '145'
     body:
       encoding: UTF-8
       string: |
         <package name="package_a" project="target_project">
-          <title>All Passion Spent</title>
-          <description>Sit dignissimos dolor nihil.</description>
+          <title>Frequent Hearses</title>
+          <description>Ipsum sed at eius.</description>
         </package>
-  recorded_at: Thu, 22 May 2025 09:23:42 GMT
+  recorded_at: Fri, 03 Oct 2025 11:32:21 GMT
 - request:
     method: put
     uri: http://backend:5352/source/target_project/package_a/package_a.changes
@@ -101,27 +101,27 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '211'
+      - '207'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="252" vrev="252">
+        <revision rev="1" vrev="1">
           <srcmd5>a884751bbd575d6295dc91ee6f64cd02</srcmd5>
           <version>unknown</version>
-          <time>1747905822</time>
+          <time>1759491141</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 22 May 2025 09:23:42 GMT
+  recorded_at: Fri, 03 Oct 2025 11:32:21 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/source_project/_meta?user=Admin
+    uri: http://backend:5352/source/source_project/_meta?user=user_4
     body:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>Of Mice and Men</title>
+          <title>Dance Dance Dance</title>
           <description/>
         </project>
     headers:
@@ -143,18 +143,18 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '106'
+      - '108'
     body:
       encoding: UTF-8
       string: |
         <project name="source_project">
-          <title>Of Mice and Men</title>
+          <title>Dance Dance Dance</title>
           <description></description>
         </project>
-  recorded_at: Thu, 22 May 2025 09:23:43 GMT
+  recorded_at: Fri, 03 Oct 2025 11:32:21 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/source_project/_project/_attribute?meta=1&user=Admin
+    uri: http://backend:5352/source/source_project/_project/_attribute?meta=1&user=user_4
     body:
       encoding: UTF-8
       string: |
@@ -180,27 +180,27 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '169'
+      - '168'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="406">
-          <srcmd5>8283e35ebaccd9cc3c75d1abc61265e4</srcmd5>
-          <time>1747905823</time>
-          <user>Admin</user>
+        <revision rev="4">
+          <srcmd5>ae99470e831fd63b655d9b8dfc09de57</srcmd5>
+          <time>1759491141</time>
+          <user>user_4</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 22 May 2025 09:23:43 GMT
+  recorded_at: Fri, 03 Oct 2025 11:32:21 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/source_project/package_a/_meta?user=Admin
+    uri: http://backend:5352/source/source_project/package_a/_meta?user=user_5
     body:
       encoding: UTF-8
       string: |
         <package name="package_a" project="source_project">
-          <title>Stranger in a Strange Land</title>
-          <description>Et nostrum asperiores molestiae.</description>
+          <title>For Whom the Bell Tolls</title>
+          <description>Ut voluptas cupiditate beatae.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -221,15 +221,15 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '169'
+      - '164'
     body:
       encoding: UTF-8
       string: |
         <package name="package_a" project="source_project">
-          <title>Stranger in a Strange Land</title>
-          <description>Et nostrum asperiores molestiae.</description>
+          <title>For Whom the Bell Tolls</title>
+          <description>Ut voluptas cupiditate beatae.</description>
         </package>
-  recorded_at: Thu, 22 May 2025 09:23:43 GMT
+  recorded_at: Fri, 03 Oct 2025 11:32:21 GMT
 - request:
     method: put
     uri: http://backend:5352/source/source_project/package_a/package_a.changes
@@ -266,19 +266,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '205'
+      - '201'
     body:
       encoding: UTF-8
       string: |
-        <revision rev="270" vrev="270">
-          <srcmd5>2f2573726c11468785b453b563eb25b3</srcmd5>
+        <revision rev="4" vrev="4">
+          <srcmd5>1041aa8fee5e7c1e0a6fe1c7915ea068</srcmd5>
           <version>1</version>
-          <time>1747905823</time>
+          <time>1759491141</time>
           <user>unknown</user>
           <comment></comment>
           <requestid/>
         </revision>
-  recorded_at: Thu, 22 May 2025 09:23:43 GMT
+  recorded_at: Fri, 03 Oct 2025 11:32:21 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/package_a
@@ -304,16 +304,16 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '409'
+      - '405'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_a" rev="270" vrev="270" srcmd5="2f2573726c11468785b453b563eb25b3">
-          <entry name="README.txt" md5="45b3f38b6735653b3fdd19f32fa1b657" size="70" mtime="1746545204"/>
-          <entry name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340" mtime="1746441226"/>
-          <entry name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470" mtime="1746441166"/>
+        <directory name="package_a" rev="4" vrev="4" srcmd5="1041aa8fee5e7c1e0a6fe1c7915ea068">
+          <entry name="README.txt" md5="e3fd9a58eace21898fe551fcbefce466" size="43" mtime="1758802242"/>
+          <entry name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340" mtime="1758802253"/>
+          <entry name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470" mtime="1758802242"/>
         </directory>
-  recorded_at: Thu, 22 May 2025 09:23:43 GMT
+  recorded_at: Fri, 03 Oct 2025 11:32:21 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/package_a
@@ -339,19 +339,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '409'
+      - '405'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_a" rev="270" vrev="270" srcmd5="2f2573726c11468785b453b563eb25b3">
-          <entry name="README.txt" md5="45b3f38b6735653b3fdd19f32fa1b657" size="70" mtime="1746545204"/>
-          <entry name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340" mtime="1746441226"/>
-          <entry name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470" mtime="1746441166"/>
+        <directory name="package_a" rev="4" vrev="4" srcmd5="1041aa8fee5e7c1e0a6fe1c7915ea068">
+          <entry name="README.txt" md5="e3fd9a58eace21898fe551fcbefce466" size="43" mtime="1758802242"/>
+          <entry name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340" mtime="1758802253"/>
+          <entry name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470" mtime="1758802242"/>
         </directory>
-  recorded_at: Thu, 22 May 2025 09:23:44 GMT
+  recorded_at: Fri, 03 Oct 2025 11:32:21 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/source_project/package_a?cmd=diff&expand=1&filelimit=10000&opackage=package_a&oproject=target_project&rev=2f2573726c11468785b453b563eb25b3&tarlimit=10000&view=xml&withissues=1
+    uri: http://backend:5352/source/source_project/package_a?cmd=diff&expand=1&filelimit=10000&opackage=package_a&oproject=target_project&rev=1041aa8fee5e7c1e0a6fe1c7915ea068&tarlimit=10000&view=xml&withissues=1
     body:
       encoding: UTF-8
       string: ''
@@ -376,13 +376,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '2262'
+      - '2220'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="e11bbd5e70d3e9cbb636be0b8a3b4ade">
-          <old project="target_project" package="package_a" rev="252" srcmd5="a884751bbd575d6295dc91ee6f64cd02"/>
-          <new project="source_project" package="package_a" rev="2f2573726c11468785b453b563eb25b3" srcmd5="2f2573726c11468785b453b563eb25b3"/>
+        <sourcediff key="f118f3aac934801f652580c8b6838503">
+          <old project="target_project" package="package_a" rev="1" srcmd5="a884751bbd575d6295dc91ee6f64cd02"/>
+          <new project="source_project" package="package_a" rev="1041aa8fee5e7c1e0a6fe1c7915ea068" srcmd5="1041aa8fee5e7c1e0a6fe1c7915ea068"/>
           <files>
             <file state="changed">
               <old name="package_a.changes" md5="46925b99894da759ec99d5ff638615c9" size="51"/>
@@ -404,9 +404,9 @@ http_interactions:
         </diff>
             </file>
             <file state="added">
-              <new name="README.txt" md5="45b3f38b6735653b3fdd19f32fa1b657" size="70"/>
+              <new name="README.txt" md5="e3fd9a58eace21898fe551fcbefce466" size="43"/>
               <diff lines="3">@@ -0,0 +1,1 @@
-        +Qui voluptatem architecto. Aperiam quaerat ut. Nihil dolor temporibus.
+        +Et illo est. Quasi et vitae. Non aut fugit.
         \ No newline at end of file
         </diff>
             </file>
@@ -444,11 +444,11 @@ http_interactions:
             </file>
           </files>
           <issues>
-            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="https://www.cve.org/CVERecord?id=CVE-2011-1111"/>
+            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="https://www.cve.org/CVERecord?id=2011-1111"/>
             <issue state="added" tracker="bnc" name="1111111" label="boo#1111111" url="https://bugzilla.opensuse.org/show_bug.cgi?id=1111111"/>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 22 May 2025 09:23:44 GMT
+  recorded_at: Fri, 03 Oct 2025 11:32:22 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/package_a
@@ -457,7 +457,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 5e29f84b-7f19-4ff3-b18b-959b98e4d5a9
+      - 19691599-0449-43fa-a506-25f3628543f4
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -476,19 +476,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '409'
+      - '405'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_a" rev="270" vrev="270" srcmd5="2f2573726c11468785b453b563eb25b3">
-          <entry name="README.txt" md5="45b3f38b6735653b3fdd19f32fa1b657" size="70" mtime="1746545204"/>
-          <entry name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340" mtime="1746441226"/>
-          <entry name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470" mtime="1746441166"/>
+        <directory name="package_a" rev="4" vrev="4" srcmd5="1041aa8fee5e7c1e0a6fe1c7915ea068">
+          <entry name="README.txt" md5="e3fd9a58eace21898fe551fcbefce466" size="43" mtime="1758802242"/>
+          <entry name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340" mtime="1758802253"/>
+          <entry name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470" mtime="1758802242"/>
         </directory>
-  recorded_at: Thu, 22 May 2025 09:23:44 GMT
+  recorded_at: Fri, 03 Oct 2025 11:32:22 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/source_project/package_a?cacheonly=1&cmd=diff&expand=1&nodiff=1&opackage=package_a&oproject=target_project&rev=2f2573726c11468785b453b563eb25b3&view=xml&withissues=1
+    uri: http://backend:5352/source/source_project/package_a?cacheonly=1&cmd=diff&expand=1&nodiff=1&opackage=package_a&oproject=target_project&rev=1041aa8fee5e7c1e0a6fe1c7915ea068&view=xml&withissues=1
     body:
       encoding: UTF-8
       string: ''
@@ -496,7 +496,7 @@ http_interactions:
       Content-Type:
       - application/octet-stream
       X-Request-Id:
-      - 5e29f84b-7f19-4ff3-b18b-959b98e4d5a9
+      - 19691599-0449-43fa-a506-25f3628543f4
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -515,31 +515,31 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '1082'
+      - '1067'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="f1198e45891e2b0550e2b0d2c3b8f0c4">
-          <old project="target_project" package="package_a" rev="252" srcmd5="a884751bbd575d6295dc91ee6f64cd02"/>
-          <new project="source_project" package="package_a" rev="2f2573726c11468785b453b563eb25b3" srcmd5="2f2573726c11468785b453b563eb25b3"/>
+        <sourcediff key="59153f646f0afd4a3f98072ecc6f1d6e">
+          <old project="target_project" package="package_a" rev="1" srcmd5="a884751bbd575d6295dc91ee6f64cd02"/>
+          <new project="source_project" package="package_a" rev="1041aa8fee5e7c1e0a6fe1c7915ea068" srcmd5="1041aa8fee5e7c1e0a6fe1c7915ea068"/>
           <files>
             <file state="changed">
               <old name="package_a.changes" md5="46925b99894da759ec99d5ff638615c9" size="51"/>
               <new name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340"/>
             </file>
             <file state="added">
-              <new name="README.txt" md5="45b3f38b6735653b3fdd19f32fa1b657" size="70"/>
+              <new name="README.txt" md5="e3fd9a58eace21898fe551fcbefce466" size="43"/>
             </file>
             <file state="added">
               <new name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470"/>
             </file>
           </files>
           <issues>
-            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="https://www.cve.org/CVERecord?id=CVE-2011-1111"/>
+            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="https://www.cve.org/CVERecord?id=2011-1111"/>
             <issue state="added" tracker="bnc" name="1111111" label="boo#1111111" url="https://bugzilla.opensuse.org/show_bug.cgi?id=1111111"/>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 22 May 2025 09:23:44 GMT
+  recorded_at: Fri, 03 Oct 2025 11:32:22 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/package_a
@@ -548,7 +548,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 5e29f84b-7f19-4ff3-b18b-959b98e4d5a9
+      - 19691599-0449-43fa-a506-25f3628543f4
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -567,19 +567,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '409'
+      - '405'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_a" rev="270" vrev="270" srcmd5="2f2573726c11468785b453b563eb25b3">
-          <entry name="README.txt" md5="45b3f38b6735653b3fdd19f32fa1b657" size="70" mtime="1746545204"/>
-          <entry name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340" mtime="1746441226"/>
-          <entry name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470" mtime="1746441166"/>
+        <directory name="package_a" rev="4" vrev="4" srcmd5="1041aa8fee5e7c1e0a6fe1c7915ea068">
+          <entry name="README.txt" md5="e3fd9a58eace21898fe551fcbefce466" size="43" mtime="1758802242"/>
+          <entry name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340" mtime="1758802253"/>
+          <entry name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470" mtime="1758802242"/>
         </directory>
-  recorded_at: Thu, 22 May 2025 09:23:44 GMT
+  recorded_at: Fri, 03 Oct 2025 11:32:22 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/source_project/package_a?cacheonly=1&cmd=diff&expand=1&nodiff=1&opackage=package_a&oproject=target_project&rev=2f2573726c11468785b453b563eb25b3&view=xml&withissues=1
+    uri: http://backend:5352/source/source_project/package_a?cacheonly=1&cmd=diff&expand=1&filelimit=10000&opackage=package_a&oproject=target_project&rev=1041aa8fee5e7c1e0a6fe1c7915ea068&tarlimit=10000&view=xml&withissues=1
     body:
       encoding: UTF-8
       string: ''
@@ -587,98 +587,7 @@ http_interactions:
       Content-Type:
       - application/octet-stream
       X-Request-Id:
-      - 5e29f84b-7f19-4ff3-b18b-959b98e4d5a9
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '1082'
-    body:
-      encoding: UTF-8
-      string: |
-        <sourcediff key="f1198e45891e2b0550e2b0d2c3b8f0c4">
-          <old project="target_project" package="package_a" rev="252" srcmd5="a884751bbd575d6295dc91ee6f64cd02"/>
-          <new project="source_project" package="package_a" rev="2f2573726c11468785b453b563eb25b3" srcmd5="2f2573726c11468785b453b563eb25b3"/>
-          <files>
-            <file state="changed">
-              <old name="package_a.changes" md5="46925b99894da759ec99d5ff638615c9" size="51"/>
-              <new name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340"/>
-            </file>
-            <file state="added">
-              <new name="README.txt" md5="45b3f38b6735653b3fdd19f32fa1b657" size="70"/>
-            </file>
-            <file state="added">
-              <new name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470"/>
-            </file>
-          </files>
-          <issues>
-            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="https://www.cve.org/CVERecord?id=CVE-2011-1111"/>
-            <issue state="added" tracker="bnc" name="1111111" label="boo#1111111" url="https://bugzilla.opensuse.org/show_bug.cgi?id=1111111"/>
-          </issues>
-        </sourcediff>
-  recorded_at: Thu, 22 May 2025 09:23:44 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/source_project/package_a
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Request-Id:
-      - 5e29f84b-7f19-4ff3-b18b-959b98e4d5a9
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '409'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="package_a" rev="270" vrev="270" srcmd5="2f2573726c11468785b453b563eb25b3">
-          <entry name="README.txt" md5="45b3f38b6735653b3fdd19f32fa1b657" size="70" mtime="1746545204"/>
-          <entry name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340" mtime="1746441226"/>
-          <entry name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470" mtime="1746441166"/>
-        </directory>
-  recorded_at: Thu, 22 May 2025 09:23:44 GMT
-- request:
-    method: post
-    uri: http://backend:5352/source/source_project/package_a?cacheonly=1&cmd=diff&expand=1&filelimit=10000&opackage=package_a&oproject=target_project&rev=2f2573726c11468785b453b563eb25b3&tarlimit=10000&view=xml&withissues=1
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      Content-Type:
-      - application/octet-stream
-      X-Request-Id:
-      - 5e29f84b-7f19-4ff3-b18b-959b98e4d5a9
+      - 19691599-0449-43fa-a506-25f3628543f4
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -693,7 +602,7 @@ http_interactions:
       Content-Type:
       - text/xml
       Content-Length:
-      - '2262'
+      - '2220'
       Cache-Control:
       - no-cache
       Connection:
@@ -701,9 +610,9 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="e11bbd5e70d3e9cbb636be0b8a3b4ade">
-          <old project="target_project" package="package_a" rev="252" srcmd5="a884751bbd575d6295dc91ee6f64cd02"/>
-          <new project="source_project" package="package_a" rev="2f2573726c11468785b453b563eb25b3" srcmd5="2f2573726c11468785b453b563eb25b3"/>
+        <sourcediff key="f118f3aac934801f652580c8b6838503">
+          <old project="target_project" package="package_a" rev="1" srcmd5="a884751bbd575d6295dc91ee6f64cd02"/>
+          <new project="source_project" package="package_a" rev="1041aa8fee5e7c1e0a6fe1c7915ea068" srcmd5="1041aa8fee5e7c1e0a6fe1c7915ea068"/>
           <files>
             <file state="changed">
               <old name="package_a.changes" md5="46925b99894da759ec99d5ff638615c9" size="51"/>
@@ -725,9 +634,9 @@ http_interactions:
         </diff>
             </file>
             <file state="added">
-              <new name="README.txt" md5="45b3f38b6735653b3fdd19f32fa1b657" size="70"/>
+              <new name="README.txt" md5="e3fd9a58eace21898fe551fcbefce466" size="43"/>
               <diff lines="3">@@ -0,0 +1,1 @@
-        +Qui voluptatem architecto. Aperiam quaerat ut. Nihil dolor temporibus.
+        +Et illo est. Quasi et vitae. Non aut fugit.
         \ No newline at end of file
         </diff>
             </file>
@@ -765,11 +674,11 @@ http_interactions:
             </file>
           </files>
           <issues>
-            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="https://www.cve.org/CVERecord?id=CVE-2011-1111"/>
+            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="https://www.cve.org/CVERecord?id=2011-1111"/>
             <issue state="added" tracker="bnc" name="1111111" label="boo#1111111" url="https://bugzilla.opensuse.org/show_bug.cgi?id=1111111"/>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 22 May 2025 09:23:44 GMT
+  recorded_at: Fri, 03 Oct 2025 11:32:22 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/package_a
@@ -778,7 +687,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 5e29f84b-7f19-4ff3-b18b-959b98e4d5a9
+      - 19691599-0449-43fa-a506-25f3628543f4
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -797,19 +706,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '409'
+      - '405'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_a" rev="270" vrev="270" srcmd5="2f2573726c11468785b453b563eb25b3">
-          <entry name="README.txt" md5="45b3f38b6735653b3fdd19f32fa1b657" size="70" mtime="1746545204"/>
-          <entry name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340" mtime="1746441226"/>
-          <entry name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470" mtime="1746441166"/>
+        <directory name="package_a" rev="4" vrev="4" srcmd5="1041aa8fee5e7c1e0a6fe1c7915ea068">
+          <entry name="README.txt" md5="e3fd9a58eace21898fe551fcbefce466" size="43" mtime="1758802242"/>
+          <entry name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340" mtime="1758802253"/>
+          <entry name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470" mtime="1758802242"/>
         </directory>
-  recorded_at: Thu, 22 May 2025 09:23:44 GMT
+  recorded_at: Fri, 03 Oct 2025 11:32:22 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/source_project/package_a?cacheonly=1&cmd=diff&expand=1&filelimit=10000&opackage=package_a&oproject=target_project&rev=2f2573726c11468785b453b563eb25b3&tarlimit=10000&view=xml&withissues=1
+    uri: http://backend:5352/source/source_project/package_a?cacheonly=1&cmd=diff&expand=1&filelimit=10000&opackage=package_a&oproject=target_project&rev=1041aa8fee5e7c1e0a6fe1c7915ea068&tarlimit=10000&view=xml&withissues=1
     body:
       encoding: UTF-8
       string: ''
@@ -817,7 +726,7 @@ http_interactions:
       Content-Type:
       - application/octet-stream
       X-Request-Id:
-      - 5e29f84b-7f19-4ff3-b18b-959b98e4d5a9
+      - 19691599-0449-43fa-a506-25f3628543f4
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -832,7 +741,7 @@ http_interactions:
       Content-Type:
       - text/xml
       Content-Length:
-      - '2262'
+      - '2220'
       Cache-Control:
       - no-cache
       Connection:
@@ -840,9 +749,9 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="e11bbd5e70d3e9cbb636be0b8a3b4ade">
-          <old project="target_project" package="package_a" rev="252" srcmd5="a884751bbd575d6295dc91ee6f64cd02"/>
-          <new project="source_project" package="package_a" rev="2f2573726c11468785b453b563eb25b3" srcmd5="2f2573726c11468785b453b563eb25b3"/>
+        <sourcediff key="f118f3aac934801f652580c8b6838503">
+          <old project="target_project" package="package_a" rev="1" srcmd5="a884751bbd575d6295dc91ee6f64cd02"/>
+          <new project="source_project" package="package_a" rev="1041aa8fee5e7c1e0a6fe1c7915ea068" srcmd5="1041aa8fee5e7c1e0a6fe1c7915ea068"/>
           <files>
             <file state="changed">
               <old name="package_a.changes" md5="46925b99894da759ec99d5ff638615c9" size="51"/>
@@ -864,9 +773,9 @@ http_interactions:
         </diff>
             </file>
             <file state="added">
-              <new name="README.txt" md5="45b3f38b6735653b3fdd19f32fa1b657" size="70"/>
+              <new name="README.txt" md5="e3fd9a58eace21898fe551fcbefce466" size="43"/>
               <diff lines="3">@@ -0,0 +1,1 @@
-        +Qui voluptatem architecto. Aperiam quaerat ut. Nihil dolor temporibus.
+        +Et illo est. Quasi et vitae. Non aut fugit.
         \ No newline at end of file
         </diff>
             </file>
@@ -904,11 +813,11 @@ http_interactions:
             </file>
           </files>
           <issues>
-            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="https://www.cve.org/CVERecord?id=CVE-2011-1111"/>
+            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="https://www.cve.org/CVERecord?id=2011-1111"/>
             <issue state="added" tracker="bnc" name="1111111" label="boo#1111111" url="https://bugzilla.opensuse.org/show_bug.cgi?id=1111111"/>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 22 May 2025 09:23:44 GMT
+  recorded_at: Fri, 03 Oct 2025 11:32:22 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/package_a
@@ -917,7 +826,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - a4353050-7a23-40a8-b851-6f71401646e7
+      - f99cb2c9-54a6-4398-82ac-ae4f6f549ba8
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -936,19 +845,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '409'
+      - '405'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_a" rev="270" vrev="270" srcmd5="2f2573726c11468785b453b563eb25b3">
-          <entry name="README.txt" md5="45b3f38b6735653b3fdd19f32fa1b657" size="70" mtime="1746545204"/>
-          <entry name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340" mtime="1746441226"/>
-          <entry name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470" mtime="1746441166"/>
+        <directory name="package_a" rev="4" vrev="4" srcmd5="1041aa8fee5e7c1e0a6fe1c7915ea068">
+          <entry name="README.txt" md5="e3fd9a58eace21898fe551fcbefce466" size="43" mtime="1758802242"/>
+          <entry name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340" mtime="1758802253"/>
+          <entry name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470" mtime="1758802242"/>
         </directory>
-  recorded_at: Thu, 22 May 2025 09:23:44 GMT
+  recorded_at: Fri, 03 Oct 2025 11:32:22 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/source_project/package_a?cmd=diff&expand=1&file=package_a.spec&filelimit=10000&opackage=package_a&oproject=target_project&rev=2f2573726c11468785b453b563eb25b3&tarlimit=10000&view=xml&withissues=1
+    uri: http://backend:5352/source/source_project/package_a?cmd=diff&expand=1&file=package_a.changes&filelimit=0&opackage=package_a&oproject=target_project&rev=1041aa8fee5e7c1e0a6fe1c7915ea068&tarlimit=0&view=xml&withissues=1
     body:
       encoding: UTF-8
       string: ''
@@ -956,7 +865,7 @@ http_interactions:
       Content-Type:
       - application/octet-stream
       X-Request-Id:
-      - a4353050-7a23-40a8-b851-6f71401646e7
+      - f99cb2c9-54a6-4398-82ac-ae4f6f549ba8
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -975,268 +884,13 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '1027'
+      - '1308'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="7358dc9b1ef5fe435357e891f4567f73">
-          <old project="target_project" package="package_a" rev="252" srcmd5="a884751bbd575d6295dc91ee6f64cd02"/>
-          <new project="source_project" package="package_a" rev="2f2573726c11468785b453b563eb25b3" srcmd5="2f2573726c11468785b453b563eb25b3"/>
-          <files>
-            <file state="added">
-              <new name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470"/>
-              <diff lines="28">@@ -0,0 +1,27 @@
-        +Name:       package_a
-        +Version:    1
-        +Release:    1
-        +Summary:    Most simple RPM package
-        +License:    CC0-1.0
-        +
-        +%description
-        +This is my first RPM package, which does nothing.
-        +
-        +%prep
-        +# we have no source, so nothing here
-        +
-        +%build
-        +cat &gt; package_a.sh &lt;&lt;EOF
-        +#!/usr/bin/bash
-        +echo Hello world, from package_a.
-        +EOF
-        +
-        +%install
-        +mkdir -p %{buildroot}/usr/bin/
-        +install -m 755 package_a.sh %{buildroot}/usr/bin/package_a.sh
-        +
-        +%files
-        +/usr/bin/package_a.sh
-        +
-        +%changelog
-        +# let skip this for now
-        </diff>
-            </file>
-          </files>
-          <issues>
-          </issues>
-        </sourcediff>
-  recorded_at: Thu, 22 May 2025 09:23:45 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/source_project/package_a?expand=1&rev=2f2573726c11468785b453b563eb25b3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Request-Id:
-      - a4353050-7a23-40a8-b851-6f71401646e7
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '427'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="package_a" rev="2f2573726c11468785b453b563eb25b3" srcmd5="2f2573726c11468785b453b563eb25b3">
-          <entry name="README.txt" md5="45b3f38b6735653b3fdd19f32fa1b657" size="70" mtime="1746545204"/>
-          <entry name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340" mtime="1746441226"/>
-          <entry name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470" mtime="1746441166"/>
-        </directory>
-  recorded_at: Thu, 22 May 2025 09:23:45 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/source_project/package_a?expand=1&rev=2f2573726c11468785b453b563eb25b3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Request-Id:
-      - a4353050-7a23-40a8-b851-6f71401646e7
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '427'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="package_a" rev="2f2573726c11468785b453b563eb25b3" srcmd5="2f2573726c11468785b453b563eb25b3">
-          <entry name="README.txt" md5="45b3f38b6735653b3fdd19f32fa1b657" size="70" mtime="1746545204"/>
-          <entry name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340" mtime="1746441226"/>
-          <entry name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470" mtime="1746441166"/>
-        </directory>
-  recorded_at: Thu, 22 May 2025 09:23:45 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/target_project/package_a?expand=1&rev=a884751bbd575d6295dc91ee6f64cd02
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Request-Id:
-      - a4353050-7a23-40a8-b851-6f71401646e7
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '227'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="package_a" rev="a884751bbd575d6295dc91ee6f64cd02" srcmd5="a884751bbd575d6295dc91ee6f64cd02">
-          <entry name="package_a.changes" md5="46925b99894da759ec99d5ff638615c9" size="51" mtime="1747229284"/>
-        </directory>
-  recorded_at: Thu, 22 May 2025 09:23:45 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/target_project/package_a?expand=1&rev=a884751bbd575d6295dc91ee6f64cd02
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Request-Id:
-      - a4353050-7a23-40a8-b851-6f71401646e7
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '227'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="package_a" rev="a884751bbd575d6295dc91ee6f64cd02" srcmd5="a884751bbd575d6295dc91ee6f64cd02">
-          <entry name="package_a.changes" md5="46925b99894da759ec99d5ff638615c9" size="51" mtime="1747229284"/>
-        </directory>
-  recorded_at: Thu, 22 May 2025 09:23:45 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/source_project/package_a
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Request-Id:
-      - 6a291cae-68dc-4df3-9864-d7b947dfcf6c
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '409'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="package_a" rev="270" vrev="270" srcmd5="2f2573726c11468785b453b563eb25b3">
-          <entry name="README.txt" md5="45b3f38b6735653b3fdd19f32fa1b657" size="70" mtime="1746545204"/>
-          <entry name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340" mtime="1746441226"/>
-          <entry name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470" mtime="1746441166"/>
-        </directory>
-  recorded_at: Thu, 22 May 2025 09:23:45 GMT
-- request:
-    method: post
-    uri: http://backend:5352/source/source_project/package_a?cmd=diff&expand=1&file=package_a.changes&filelimit=10000&opackage=package_a&oproject=target_project&rev=2f2573726c11468785b453b563eb25b3&tarlimit=10000&view=xml&withissues=1
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      Content-Type:
-      - application/octet-stream
-      X-Request-Id:
-      - 6a291cae-68dc-4df3-9864-d7b947dfcf6c
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '1323'
-    body:
-      encoding: UTF-8
-      string: |
-        <sourcediff key="230a98fc1dabcce5fa7833f9377a5a8d">
-          <old project="target_project" package="package_a" rev="252" srcmd5="a884751bbd575d6295dc91ee6f64cd02"/>
-          <new project="source_project" package="package_a" rev="2f2573726c11468785b453b563eb25b3" srcmd5="2f2573726c11468785b453b563eb25b3"/>
+        <sourcediff key="61d03b9664d450d225a686a576140b9f">
+          <old project="target_project" package="package_a" rev="1" srcmd5="a884751bbd575d6295dc91ee6f64cd02"/>
+          <new project="source_project" package="package_a" rev="1041aa8fee5e7c1e0a6fe1c7915ea068" srcmd5="1041aa8fee5e7c1e0a6fe1c7915ea068"/>
           <files>
             <file state="changed">
               <old name="package_a.changes" md5="46925b99894da759ec99d5ff638615c9" size="51"/>
@@ -1259,20 +913,20 @@ http_interactions:
             </file>
           </files>
           <issues>
-            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="https://www.cve.org/CVERecord?id=CVE-2011-1111"/>
+            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="https://www.cve.org/CVERecord?id=2011-1111"/>
             <issue state="added" tracker="bnc" name="1111111" label="boo#1111111" url="https://bugzilla.opensuse.org/show_bug.cgi?id=1111111"/>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 22 May 2025 09:23:45 GMT
+  recorded_at: Fri, 03 Oct 2025 11:32:22 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/source_project/package_a?expand=1&rev=2f2573726c11468785b453b563eb25b3
+    uri: http://backend:5352/source/source_project/package_a?expand=1&rev=1041aa8fee5e7c1e0a6fe1c7915ea068
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - 6a291cae-68dc-4df3-9864-d7b947dfcf6c
+      - f99cb2c9-54a6-4398-82ac-ae4f6f549ba8
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1295,21 +949,21 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_a" rev="2f2573726c11468785b453b563eb25b3" srcmd5="2f2573726c11468785b453b563eb25b3">
-          <entry name="README.txt" md5="45b3f38b6735653b3fdd19f32fa1b657" size="70" mtime="1746545204"/>
-          <entry name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340" mtime="1746441226"/>
-          <entry name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470" mtime="1746441166"/>
+        <directory name="package_a" rev="1041aa8fee5e7c1e0a6fe1c7915ea068" srcmd5="1041aa8fee5e7c1e0a6fe1c7915ea068">
+          <entry name="README.txt" md5="e3fd9a58eace21898fe551fcbefce466" size="43" mtime="1758802242"/>
+          <entry name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340" mtime="1758802253"/>
+          <entry name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470" mtime="1758802242"/>
         </directory>
-  recorded_at: Thu, 22 May 2025 09:23:45 GMT
+  recorded_at: Fri, 03 Oct 2025 11:32:22 GMT
 - request:
     method: get
-    uri: http://backend:5352/source/source_project/package_a?expand=1&rev=2f2573726c11468785b453b563eb25b3
+    uri: http://backend:5352/source/source_project/package_a?expand=1&rev=1041aa8fee5e7c1e0a6fe1c7915ea068
     body:
       encoding: US-ASCII
       string: ''
     headers:
       X-Request-Id:
-      - 6a291cae-68dc-4df3-9864-d7b947dfcf6c
+      - f99cb2c9-54a6-4398-82ac-ae4f6f549ba8
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1332,12 +986,12 @@ http_interactions:
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_a" rev="2f2573726c11468785b453b563eb25b3" srcmd5="2f2573726c11468785b453b563eb25b3">
-          <entry name="README.txt" md5="45b3f38b6735653b3fdd19f32fa1b657" size="70" mtime="1746545204"/>
-          <entry name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340" mtime="1746441226"/>
-          <entry name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470" mtime="1746441166"/>
+        <directory name="package_a" rev="1041aa8fee5e7c1e0a6fe1c7915ea068" srcmd5="1041aa8fee5e7c1e0a6fe1c7915ea068">
+          <entry name="README.txt" md5="e3fd9a58eace21898fe551fcbefce466" size="43" mtime="1758802242"/>
+          <entry name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340" mtime="1758802253"/>
+          <entry name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470" mtime="1758802242"/>
         </directory>
-  recorded_at: Thu, 22 May 2025 09:23:45 GMT
+  recorded_at: Fri, 03 Oct 2025 11:32:22 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/package_a?expand=1&rev=a884751bbd575d6295dc91ee6f64cd02
@@ -1346,7 +1000,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 6a291cae-68dc-4df3-9864-d7b947dfcf6c
+      - f99cb2c9-54a6-4398-82ac-ae4f6f549ba8
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1370,9 +1024,9 @@ http_interactions:
       encoding: UTF-8
       string: |
         <directory name="package_a" rev="a884751bbd575d6295dc91ee6f64cd02" srcmd5="a884751bbd575d6295dc91ee6f64cd02">
-          <entry name="package_a.changes" md5="46925b99894da759ec99d5ff638615c9" size="51" mtime="1747229284"/>
+          <entry name="package_a.changes" md5="46925b99894da759ec99d5ff638615c9" size="51" mtime="1759491141"/>
         </directory>
-  recorded_at: Thu, 22 May 2025 09:23:45 GMT
+  recorded_at: Fri, 03 Oct 2025 11:32:22 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/package_a?expand=1&rev=a884751bbd575d6295dc91ee6f64cd02
@@ -1381,7 +1035,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - 6a291cae-68dc-4df3-9864-d7b947dfcf6c
+      - f99cb2c9-54a6-4398-82ac-ae4f6f549ba8
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1405,9 +1059,9 @@ http_interactions:
       encoding: UTF-8
       string: |
         <directory name="package_a" rev="a884751bbd575d6295dc91ee6f64cd02" srcmd5="a884751bbd575d6295dc91ee6f64cd02">
-          <entry name="package_a.changes" md5="46925b99894da759ec99d5ff638615c9" size="51" mtime="1747229284"/>
+          <entry name="package_a.changes" md5="46925b99894da759ec99d5ff638615c9" size="51" mtime="1759491141"/>
         </directory>
-  recorded_at: Thu, 22 May 2025 09:23:45 GMT
+  recorded_at: Fri, 03 Oct 2025 11:32:22 GMT
 - request:
     method: get
     uri: http://backend:5352/source/source_project/package_a
@@ -1416,7 +1070,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - ca1bd26c-80c9-47e7-a985-9fa765914ec8
+      - 7afa89c3-8051-4cf4-94e1-e6dbe2e73e67
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1435,19 +1089,19 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '409'
+      - '405'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_a" rev="270" vrev="270" srcmd5="2f2573726c11468785b453b563eb25b3">
-          <entry name="README.txt" md5="45b3f38b6735653b3fdd19f32fa1b657" size="70" mtime="1746545204"/>
-          <entry name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340" mtime="1746441226"/>
-          <entry name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470" mtime="1746441166"/>
+        <directory name="package_a" rev="4" vrev="4" srcmd5="1041aa8fee5e7c1e0a6fe1c7915ea068">
+          <entry name="README.txt" md5="e3fd9a58eace21898fe551fcbefce466" size="43" mtime="1758802242"/>
+          <entry name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340" mtime="1758802253"/>
+          <entry name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470" mtime="1758802242"/>
         </directory>
-  recorded_at: Thu, 22 May 2025 09:23:47 GMT
+  recorded_at: Fri, 03 Oct 2025 11:32:23 GMT
 - request:
     method: post
-    uri: http://backend:5352/source/source_project/package_a?cmd=diff&expand=1&filelimit=10000&opackage=package_a&oproject=target_project&orev=a884751bbd575d6295dc91ee6f64cd02&rev=2f2573726c11468785b453b563eb25b3&tarlimit=10000&view=xml&withissues=1
+    uri: http://backend:5352/source/source_project/package_a?cmd=diff&expand=1&file=package_a.spec&filelimit=0&opackage=package_a&oproject=target_project&rev=1041aa8fee5e7c1e0a6fe1c7915ea068&tarlimit=0&view=xml&withissues=1
     body:
       encoding: UTF-8
       string: ''
@@ -1455,7 +1109,7 @@ http_interactions:
       Content-Type:
       - application/octet-stream
       X-Request-Id:
-      - ca1bd26c-80c9-47e7-a985-9fa765914ec8
+      - 7afa89c3-8051-4cf4-94e1-e6dbe2e73e67
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1469,18 +1123,273 @@ http_interactions:
     headers:
       Content-Type:
       - text/xml
-      Content-Length:
-      - '2291'
       Cache-Control:
       - no-cache
       Connection:
       - close
+      Content-Length:
+      - '1025'
     body:
       encoding: UTF-8
       string: |
-        <sourcediff key="aab6e2b683540a9fb3aba14c3e662b2c">
+        <sourcediff key="588efd6ad0ff0602fc74da670539e5c5">
+          <old project="target_project" package="package_a" rev="1" srcmd5="a884751bbd575d6295dc91ee6f64cd02"/>
+          <new project="source_project" package="package_a" rev="1041aa8fee5e7c1e0a6fe1c7915ea068" srcmd5="1041aa8fee5e7c1e0a6fe1c7915ea068"/>
+          <files>
+            <file state="added">
+              <new name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470"/>
+              <diff lines="28">@@ -0,0 +1,27 @@
+        +Name:       package_a
+        +Version:    1
+        +Release:    1
+        +Summary:    Most simple RPM package
+        +License:    CC0-1.0
+        +
+        +%description
+        +This is my first RPM package, which does nothing.
+        +
+        +%prep
+        +# we have no source, so nothing here
+        +
+        +%build
+        +cat &gt; package_a.sh &lt;&lt;EOF
+        +#!/usr/bin/bash
+        +echo Hello world, from package_a.
+        +EOF
+        +
+        +%install
+        +mkdir -p %{buildroot}/usr/bin/
+        +install -m 755 package_a.sh %{buildroot}/usr/bin/package_a.sh
+        +
+        +%files
+        +/usr/bin/package_a.sh
+        +
+        +%changelog
+        +# let skip this for now
+        </diff>
+            </file>
+          </files>
+          <issues>
+          </issues>
+        </sourcediff>
+  recorded_at: Fri, 03 Oct 2025 11:32:23 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/source_project/package_a?expand=1&rev=1041aa8fee5e7c1e0a6fe1c7915ea068
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 7afa89c3-8051-4cf4-94e1-e6dbe2e73e67
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '427'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_a" rev="1041aa8fee5e7c1e0a6fe1c7915ea068" srcmd5="1041aa8fee5e7c1e0a6fe1c7915ea068">
+          <entry name="README.txt" md5="e3fd9a58eace21898fe551fcbefce466" size="43" mtime="1758802242"/>
+          <entry name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340" mtime="1758802253"/>
+          <entry name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470" mtime="1758802242"/>
+        </directory>
+  recorded_at: Fri, 03 Oct 2025 11:32:23 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/source_project/package_a?expand=1&rev=1041aa8fee5e7c1e0a6fe1c7915ea068
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 7afa89c3-8051-4cf4-94e1-e6dbe2e73e67
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '427'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_a" rev="1041aa8fee5e7c1e0a6fe1c7915ea068" srcmd5="1041aa8fee5e7c1e0a6fe1c7915ea068">
+          <entry name="README.txt" md5="e3fd9a58eace21898fe551fcbefce466" size="43" mtime="1758802242"/>
+          <entry name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340" mtime="1758802253"/>
+          <entry name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470" mtime="1758802242"/>
+        </directory>
+  recorded_at: Fri, 03 Oct 2025 11:32:23 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/target_project/package_a?expand=1&rev=a884751bbd575d6295dc91ee6f64cd02
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 7afa89c3-8051-4cf4-94e1-e6dbe2e73e67
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '227'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_a" rev="a884751bbd575d6295dc91ee6f64cd02" srcmd5="a884751bbd575d6295dc91ee6f64cd02">
+          <entry name="package_a.changes" md5="46925b99894da759ec99d5ff638615c9" size="51" mtime="1759491141"/>
+        </directory>
+  recorded_at: Fri, 03 Oct 2025 11:32:23 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/target_project/package_a?expand=1&rev=a884751bbd575d6295dc91ee6f64cd02
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - 7afa89c3-8051-4cf4-94e1-e6dbe2e73e67
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '227'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_a" rev="a884751bbd575d6295dc91ee6f64cd02" srcmd5="a884751bbd575d6295dc91ee6f64cd02">
+          <entry name="package_a.changes" md5="46925b99894da759ec99d5ff638615c9" size="51" mtime="1759491141"/>
+        </directory>
+  recorded_at: Fri, 03 Oct 2025 11:32:23 GMT
+- request:
+    method: get
+    uri: http://backend:5352/source/source_project/package_a
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Request-Id:
+      - be88476e-c63a-4edc-ac80-14ecf93a35bc
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '405'
+    body:
+      encoding: UTF-8
+      string: |
+        <directory name="package_a" rev="4" vrev="4" srcmd5="1041aa8fee5e7c1e0a6fe1c7915ea068">
+          <entry name="README.txt" md5="e3fd9a58eace21898fe551fcbefce466" size="43" mtime="1758802242"/>
+          <entry name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340" mtime="1758802253"/>
+          <entry name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470" mtime="1758802242"/>
+        </directory>
+  recorded_at: Fri, 03 Oct 2025 11:32:24 GMT
+- request:
+    method: post
+    uri: http://backend:5352/source/source_project/package_a?cmd=diff&expand=1&filelimit=10000&opackage=package_a&oproject=target_project&orev=a884751bbd575d6295dc91ee6f64cd02&rev=1041aa8fee5e7c1e0a6fe1c7915ea068&tarlimit=10000&view=xml&withissues=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/octet-stream
+      X-Request-Id:
+      - be88476e-c63a-4edc-ac80-14ecf93a35bc
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '2251'
+    body:
+      encoding: UTF-8
+      string: |
+        <sourcediff key="d14394ddb340d58690636d3f4d640fa6">
           <old project="target_project" package="package_a" rev="a884751bbd575d6295dc91ee6f64cd02" srcmd5="a884751bbd575d6295dc91ee6f64cd02"/>
-          <new project="source_project" package="package_a" rev="2f2573726c11468785b453b563eb25b3" srcmd5="2f2573726c11468785b453b563eb25b3"/>
+          <new project="source_project" package="package_a" rev="1041aa8fee5e7c1e0a6fe1c7915ea068" srcmd5="1041aa8fee5e7c1e0a6fe1c7915ea068"/>
           <files>
             <file state="changed">
               <old name="package_a.changes" md5="46925b99894da759ec99d5ff638615c9" size="51"/>
@@ -1502,9 +1411,9 @@ http_interactions:
         </diff>
             </file>
             <file state="added">
-              <new name="README.txt" md5="45b3f38b6735653b3fdd19f32fa1b657" size="70"/>
+              <new name="README.txt" md5="e3fd9a58eace21898fe551fcbefce466" size="43"/>
               <diff lines="3">@@ -0,0 +1,1 @@
-        +Qui voluptatem architecto. Aperiam quaerat ut. Nihil dolor temporibus.
+        +Et illo est. Quasi et vitae. Non aut fugit.
         \ No newline at end of file
         </diff>
             </file>
@@ -1542,11 +1451,11 @@ http_interactions:
             </file>
           </files>
           <issues>
-            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="https://www.cve.org/CVERecord?id=CVE-2011-1111"/>
+            <issue state="added" tracker="cve" name="2011-1111" label="CVE-2011-1111" url="https://www.cve.org/CVERecord?id=2011-1111"/>
             <issue state="added" tracker="bnc" name="1111111" label="boo#1111111" url="https://bugzilla.opensuse.org/show_bug.cgi?id=1111111"/>
           </issues>
         </sourcediff>
-  recorded_at: Thu, 22 May 2025 09:23:47 GMT
+  recorded_at: Fri, 03 Oct 2025 11:32:24 GMT
 - request:
     method: get
     uri: http://backend:5352/source/target_project/package_a
@@ -1555,7 +1464,7 @@ http_interactions:
       string: ''
     headers:
       X-Request-Id:
-      - ca1bd26c-80c9-47e7-a985-9fa765914ec8
+      - be88476e-c63a-4edc-ac80-14ecf93a35bc
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -1574,49 +1483,12 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '209'
+      - '205'
     body:
       encoding: UTF-8
       string: |
-        <directory name="package_a" rev="252" vrev="252" srcmd5="a884751bbd575d6295dc91ee6f64cd02">
-          <entry name="package_a.changes" md5="46925b99894da759ec99d5ff638615c9" size="51" mtime="1747229284"/>
+        <directory name="package_a" rev="1" vrev="1" srcmd5="a884751bbd575d6295dc91ee6f64cd02">
+          <entry name="package_a.changes" md5="46925b99894da759ec99d5ff638615c9" size="51" mtime="1759491141"/>
         </directory>
-  recorded_at: Thu, 22 May 2025 09:23:47 GMT
-- request:
-    method: get
-    uri: http://backend:5352/source/source_project/package_a?rev=2f2573726c11468785b453b563eb25b3
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      X-Request-Id:
-      - ca1bd26c-80c9-47e7-a985-9fa765914ec8
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '427'
-    body:
-      encoding: UTF-8
-      string: |
-        <directory name="package_a" rev="2f2573726c11468785b453b563eb25b3" srcmd5="2f2573726c11468785b453b563eb25b3">
-          <entry name="README.txt" md5="45b3f38b6735653b3fdd19f32fa1b657" size="70" mtime="1746545204"/>
-          <entry name="package_a.changes" md5="19ec220ee6298a72f80458a535c611e6" size="340" mtime="1746441226"/>
-          <entry name="package_a.spec" md5="674078c9d96283bf095d60ffe47009a0" size="470" mtime="1746441166"/>
-        </directory>
-  recorded_at: Thu, 22 May 2025 09:23:47 GMT
+  recorded_at: Fri, 03 Oct 2025 11:32:24 GMT
 recorded_with: VCR 6.3.1

--- a/src/api/spec/components/sourcediff_component_spec.rb
+++ b/src/api/spec/components/sourcediff_component_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe SourcediffComponent, :vcr, type: :component do
     Rails.application.routes.url_helpers.request_changes_diff_path(number: bs_request.number,
                                                                    request_action_id: bs_request.bs_request_actions.first.id,
                                                                    filename: file_name, file_index: 0,
-                                                                   filelimit: BsRequestAction::Differ::ForSource::DEFAULT_FILE_LIMIT)
+                                                                   filelimit: 0)
   end
 
   context 'with a request with a submit action' do

--- a/src/api/spec/components/sourcediff_component_spec.rb
+++ b/src/api/spec/components/sourcediff_component_spec.rb
@@ -12,8 +12,7 @@ RSpec.describe SourcediffComponent, :vcr, type: :component do
   let(:first_file_url) do
     Rails.application.routes.url_helpers.request_changes_diff_path(number: bs_request.number,
                                                                    request_action_id: bs_request.bs_request_actions.first.id,
-                                                                   filename: file_name, file_index: 0,
-                                                                   filelimit: 0)
+                                                                   filename: file_name, file_index: 0)
   end
 
   context 'with a request with a submit action' do

--- a/src/api/spec/components/sourcediff_component_spec.rb
+++ b/src/api/spec/components/sourcediff_component_spec.rb
@@ -9,7 +9,12 @@ RSpec.describe SourcediffComponent, :vcr, type: :component do
            target_package: target_package,
            source_package: source_package)
   end
-  let(:first_file_url) { Rails.application.routes.url_helpers.request_changes_diff_path(number: bs_request.number, request_action_id: bs_request.bs_request_actions.first.id, filename: file_name, file_index: 0) }
+  let(:first_file_url) do
+    Rails.application.routes.url_helpers.request_changes_diff_path(number: bs_request.number,
+                                                                   request_action_id: bs_request.bs_request_actions.first.id,
+                                                                   filename: file_name, file_index: 0,
+                                                                   filelimit: BsRequestAction::Differ::ForSource::DEFAULT_FILE_LIMIT)
+  end
 
   context 'with a request with a submit action' do
     before do


### PR DESCRIPTION
Allows users to expand changes that weren't covered before

<img width="996" height="301" alt="Screenshot From 2025-08-20 16-48-03" src="https://github.com/user-attachments/assets/1e15e865-707e-4375-bdce-9e8d7b30d80a" />
<img width="996" height="301" alt="Screenshot From 2025-08-20 16-48-18" src="https://github.com/user-attachments/assets/f21f8e37-aba8-44a5-8bb1-f89d17c38531" />