### PR TITLE
[ci] ensure that we do not refresh a dead end

### DIFF
--- a/dist/t/spec/features/0030_project_spec.rb
+++ b/dist/t/spec/features/0030_project_spec.rb
@@ -18,19 +18,18 @@ RSpec.describe 'Project', type: :feature do
   end
 
   it 'is able to add repositories' do
-    within('#left-navigation') do
-      click_link('Your Home Project')
-    end
-    click_link('Repositories')
-    click_link('Add from a Distribution')
     Timeout.timeout(300) do
       loop do
+        within('#left-navigation') do
+          click_link('Your Home Project')
+        end
+        click_link('Repositories')
+        click_link('Add from a Distribution')
         break unless have_content('There are no distributions configured. Maybe you want to connect to one of the public OBS instances?')
 
         break if have_content('Add Repositories to home:Admin')
 
         sleep 10
-        refresh
       end
     end
     check('openSUSE Leap 15.5')


### PR DESCRIPTION
repeat the whole way to the list of distributions
in each iteration of the loop until timeout should ensure that we do not end up in a dead end of the
workflow by just refreshing the last page.