### PR TITLE
[backend] also update the digest file when signing the appimage

### DIFF
--- a/src/backend/bs_signer
+++ b/src/backend/bs_signer
@@ -1057,6 +1057,10 @@ sub signjob {
 	    rename("$jobdir/$signfile.zsync.new", "$jobdir/$signfile.zsync");
 	  }
 	}
+	if ($signfile =~ /\.AppImage$/ && -e "$jobdir/$signfile.digest") {
+	    my $newdigest = sha256file("$jobdir/$signfile");
+	    writestr("$jobdir/$signfile.digest", undef, "$newdigest\n");
+	}
       }
     };
     if ($@) {


### PR DESCRIPTION
if we change the file during signing we also have to update the .digest
currently this contains just the plain sha256 checksum, no sumtype or filename included.