### PR TITLE
Control access to RPM Lint page

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -279,6 +279,12 @@ class Webui::PackageController < Webui::WebuiController
   end
 
   def rpmlint_result
+    unless Flipper.enabled?(:request_show_redesign, User.session)
+      flash[:error] = "You can't access the RPM Lint page unless you enable the 'Request show redesign' beta feature"
+      redirect_to package_show_path(@package.project, @package)
+      return
+    end
+
     repository = valid_xml_id(elide(params[:repository], 30)) if params[:repository].present?
     architecture = params[:architecture] if params[:architecture].present?
 


### PR DESCRIPTION
When the user is not in beta (or logged out) and tries to access the RPM Lint tab which is under beta, the user will be redirected to the package page with this error:

<img width="1501" height="71" alt="Screenshot 2025-08-22 at 13-57-26 Show home Admin _ hello_world - Open Build Service" src="https://github.com/user-attachments/assets/ae5887ef-d085-4db2-a66e-b045ac062cc6" />

# Testing Tips

1. Log in with a user in beta
2. Access the RPM Lint tab, for example the one in [home:Admin/hello_world](http://localhost:3000/package/rpmlint_result/home:Admin/hello_world).
3. Logout or disable the _Request show redesign_ beta feature
4. Refresh the page in step 2
5. See the error message.