### PR TITLE
[backend] fix regexp limit architecture filtering

### DIFF
--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -1171,7 +1171,7 @@ sub getprojpack {
     my $limit = $BSConfig::limit_projects->{$arch};
     if ($BSConfig::limit_projects_use_regex || $BSConfig::limit_projects_use_regex) {
       $limit_projids = {};
-      for my $projid (splice @$projids) {
+      for my $projid (@$projids) {
 	$limit_projids->{$projid} = 1 if grep {$projid =~ /^$_$/} @$limit;
       }
     } else {


### PR DESCRIPTION
We must not reset $projids via splice here