### PR TITLE
Update list of crawler user agents

### DIFF
--- a/src/api/config/crawler-user-agents.json
+++ b/src/api/config/crawler-user-agents.json
@@ -5004,6 +5004,15 @@
     "url": "https://developers.facebook.com/docs/sharing/webmasters/web-crawlers"
   },
   {
+    "pattern": "meta-externalads\\/",
+    "addition_date": "2025/08/08",
+    "instances": [
+      "meta-externalads/1.1 (+https://developers.facebook.com/docs/sharing/webmasters/crawler)",
+      "meta-externalads/1.1"
+    ],
+    "url": "https://developers.facebook.com/docs/sharing/webmasters/web-crawlers"
+  },
+  {
     "pattern": "meta-externalagent\\/",
     "addition_date": "2024/10/03",
     "instances": [
@@ -5131,6 +5140,30 @@
     "url": "https://www.sbintuitions.co.jp/bot/",
     "instances": [
       "Mozilla/5.0 (compatible; SBIntuitionsBot/0.1; +https://www.sbintuitions.co.jp/bot/)"
+    ]
+  },
+  {
+    "pattern": "sitebulb",
+    "addition_date": "2025/04/30",
+    "url": "https://sitebulb.com/",
+    "instances": [
+      "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.6439.0 Mobile Safari/537.36 +https://sitebulb.com"
+    ]
+  },
+  {
+    "pattern": "YextBot\\/",
+    "addition_date": "2025/08/08",
+    "url": "https://hitchhikers.yext.com/modules/kg140-yext-site-crawler/01-create-a-crawler/",
+    "instances": [
+      "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/87.0.4280.88 YextBot/Java Safari/537.36"
+    ]
+  },
+  {
+    "pattern": "DatadogSynthetics",
+    "addition_date": "2025/08/19",
+    "url": "https://docs.datadoghq.com/synthetics/",
+    "instances": [
+      "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.7204.168 Safari/537.36 DatadogSynthetics"
     ]
   }
 ]


### PR DESCRIPTION
The list was updated using `rake voight_kampff:import_user_agents`.

This is a recurring task. Last time we did it in #17760.