### PR TITLE
Revert "Use the buildtype to determine when to display RPM lint links"

### DIFF
--- a/src/api/app/components/build_results_monitor_component.html.haml
+++ b/src/api/app/components/build_results_monitor_component.html.haml
@@ -50,7 +50,6 @@
                                                                                                              package_name,
                                                                                                              repository_name,
                                                                                                              result[:architecture]),
-                                                                                                             buildtype: result[:buildtype],
                                                                                      rpm_lint_url: project_package_repository_architecture_rpmlint_path(project_name, package_name,
                                                                                                                                                         repository_name,
                                                                                                                                                         result[:architecture] ) }

--- a/src/api/app/components/chart_component.html.haml
+++ b/src/api/app/components/chart_component.html.haml
@@ -34,7 +34,6 @@
                                                                                  text: result[:status].humanize,
                                                                                  details: result[:details],
                                                                                  architecture: result[:architecture],
-                                                                                 buildtype: result[:buildtype],
                                                                                  url: helpers.live_build_log_url(result[:status],
                                                                                                          result[:project_name],
                                                                                                          result[:package_name],

--- a/src/api/app/models/local_build_result.rb
+++ b/src/api/app/models/local_build_result.rb
@@ -1,5 +1,5 @@
 class LocalBuildResult
   include ActiveModel::Model
 
-  attr_accessor :repository, :architecture, :code, :state, :details, :summary, :is_repository_in_db, :buildtype
+  attr_accessor :repository, :architecture, :code, :state, :details, :summary, :is_repository_in_db
 end

--- a/src/api/app/models/local_build_result/for_package.rb
+++ b/src/api/app/models/local_build_result/for_package.rb
@@ -2,12 +2,11 @@ class LocalBuildResult
   class ForPackage
     include ActiveModel::Model
 
-    attr_accessor :package, :project, :show_all, :lastbuild, :view
+    attr_accessor :package, :project, :show_all, :lastbuild
     attr_reader :excluded_counter, :results
 
     def initialize(attributes = {})
       super
-      self.view ||= 'status'
       buildresults
     end
 
@@ -33,8 +32,7 @@ class LocalBuildResult
 
     def local_build_result(result, status)
       LocalBuildResult.new(repository: result['repository'], is_repository_in_db: repository_in_db?(result['repository'], result['arch']),
-                           architecture: result['arch'], code: status['code'], state: result['state'], details: status['details'],
-                           buildtype: result.dig('info', 'buildtype'))
+                           architecture: result['arch'], code: status['code'], state: result['state'], details: status['details'])
     end
 
     def repository_in_db?(repository, architecture)
@@ -59,7 +57,7 @@ class LocalBuildResult
     end
 
     def backend_build_result
-      backend_results = Buildresult.find_hashed(project: project, package: package, view: view, multibuild: '1', locallink: '1', lastbuild: lastbuild ? '1' : '0')
+      backend_results = Buildresult.find_hashed(project: project, package: package, view: 'status', multibuild: '1', locallink: '1', lastbuild: lastbuild ? '1' : '0')
       backend_results.elements('result').sort_by { |a| a['repository'] }
     end
   end

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -925,8 +925,8 @@ class Package < ApplicationRecord
     Service.new(package: self)
   end
 
-  def buildresult(prj = project, show_all: false, lastbuild: false, view: 'status')
-    LocalBuildResult::ForPackage.new(package: self, project: prj, show_all: show_all, lastbuild: lastbuild, view: view)
+  def buildresult(prj = project, show_all: false, lastbuild: false)
+    LocalBuildResult::ForPackage.new(package: self, project: prj, show_all: show_all, lastbuild: lastbuild)
   end
 
   # FIXME: That you can overwrite package_name is rather confusing, but needed because of multibuild :-/

--- a/src/api/app/services/action_build_results_service/chart_data_extractor.rb
+++ b/src/api/app/services/action_build_results_service/chart_data_extractor.rb
@@ -38,7 +38,7 @@ module ActionBuildResultsService
     end
 
     def package_build_results(package, project)
-      results = package.buildresult(project, show_all: true, view: %w[info status]).results
+      results = package.buildresult(project, show_all: true).results
       results.flat_map do |pkg, build_results|
         build_results.map do |result|
           {
@@ -49,8 +49,7 @@ module ActionBuildResultsService
             project_name: project.name,
             repository_status: result.state,
             is_repository_in_db: result.is_repository_in_db,
-            details: result.details,
-            buildtype: result.buildtype
+            details: result.details
           }
         end
       end

--- a/src/api/app/views/webui/shared/_build_status_badge.html.haml
+++ b/src/api/app/views/webui/shared/_build_status_badge.html.haml
@@ -4,11 +4,9 @@
       %i.fa.me-2{ class: build_status_icon(status), title: status.humanize }
       %span.architecture #{architecture} :
       = text
-    -# For historical builds the buildtype is nil. In this case the RPM lint links will be visible
-    - if buildtype.in?([nil, 'spec'])
-      = link_to(rpm_lint_url, class: "btn btn-sm btn-outline-secondary") do
-        %i.fas.fa-gauge-high
-        RPM Lint
+    = link_to(rpm_lint_url, class: "btn btn-sm btn-outline-secondary") do
+      %i.fas.fa-gauge-high
+      RPM Lint
 - else
   %span.badge{ class: build_status_category_color(status), title: details }
     %i.fa.me-2{ class: build_status_icon(status) }

--- a/src/api/spec/services/action_build_results_service/chart_data_extractor_spec.rb
+++ b/src/api/spec/services/action_build_results_service/chart_data_extractor_spec.rb
@@ -36,28 +36,6 @@ RSpec.describe ActionBuildResultsService::ChartDataExtractor do
       HEREDOC
     end
 
-    let(:build_results_with_info) do
-      <<-HEREDOC
-        <resultlist state="89404e94496aebc9a61c552c7b0eea78">
-          <result project="home:Iggy" repository="xUbuntu_25.04" arch="x86_64" code="finished" state="finished">
-            <status package="vlogger" code="succeeded"/>
-            <info package="vlogger">
-              <buildtype>dsc</buildtype>
-            </info>
-          </result>
-          <result project="home:Iggy" repository="Debian_12" arch="i586" code="finished" state="finished">
-            <status package="vlogger" code="disabled"/>
-          </result>
-          <result project="home:Iggy" repository="Debian_12" arch="x86_64" code="finished" state="finished">
-            <status package="vlogger" code="succeeded"/>
-            <info package="vlogger">
-              <buildtype>dsc</buildtype>
-            </info>
-          </result>
-        </resultlist>
-      HEREDOC
-    end
-
     context 'with build results' do
       before do
         allow(Backend::Api::BuildResults::Status).to receive(:result_swiss_knife).and_return(fake_build_results)
@@ -79,16 +57,6 @@ RSpec.describe ActionBuildResultsService::ChartDataExtractor do
       let(:actions) { nil }
 
       it { expect(subject).to eq([]) }
-    end
-
-    context 'for non-rpm builds' do
-      before do
-        allow(Backend::Api::BuildResults::Status).to receive(:result_swiss_knife).and_return(build_results_with_info)
-      end
-
-      it 'returns correct buildtype in the response' do
-        expect(subject.any? { |h| h[:buildtype] == 'dsc' }).to be true
-      end
     end
   end
 


### PR DESCRIPTION
Reverts openSUSE/open-build-service#18370.

Fix #18415.