### PR TITLE
Move direct calls to `project/_config` into `Backend::Api`

### DIFF
--- a/src/api/app/lib/backend/api/sources/project.rb
+++ b/src/api/app/lib/backend/api/sources/project.rb
@@ -41,6 +41,12 @@ module Backend
           http_put(['/source/:project/_meta', project_name], data: meta, params: options, accepted: %i[user comment requestid lowprio])
         end
 
+        # Returns the configuration of a project
+        # @return [String]
+        def self.configuration(project_name)
+          http_get(['/source/:project/_config', project_name])
+        end
+
         # Writes a Project configuration
         # @return [String]
         def self.write_configuration(project_name, configuration)

--- a/src/api/app/models/repository.rb
+++ b/src/api/app/models/repository.rb
@@ -288,7 +288,7 @@ class Repository < ApplicationRecord
         path_elements.create(link: pa.link, position: pa.position, kind: pa.kind)
       end
       # and set type in prjconf
-      prjconf = project.source_file('_config')
+      prjconf = Backend::Api::Sources::Project.configuration(project.name)
       unless /^Type:/.match?(prjconf)
         prjconf = +"%if \"%_repository\" == \"images\"\nType: kiwi\nRepotype: none\nPatterntype: none\n%endif\n" << prjconf
         Backend::Api::Sources::Project.write_configuration(project.name, prjconf)

--- a/src/api/spec/controllers/public_controller_spec.rb
+++ b/src/api/spec/controllers/public_controller_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe PublicController, :vcr do
 
     it { expect(response).to have_http_status(:success) }
     it { expect(a_request(:get, %r{.*/source/public_controller_project/_config})).to have_been_made }
-    it { expect(response.body).to eq(project.source_file('_config')) }
+    it { expect(response.body).to eq(Backend::Api::Sources::Project.configuration(project.name)) }
   end
 
   describe 'GET #package_index' do


### PR DESCRIPTION
This is one of a series of changes to refactor direct calls to `Backend::Connection` into the `Backend::Api` library.