### PR TITLE
Move direct calls to the backend of source package controller into `Backend::Api`

### DIFF
--- a/src/api/app/controllers/source_package_controller.rb
+++ b/src/api/app/controllers/source_package_controller.rb
@@ -134,8 +134,7 @@ class SourcePackageController < SourceController
 
     raise DeleteFileNoPermission, 'Insufficient permissions to delete file' unless @allowed
 
-    @path += build_query_from_hash(params, %i[user comment meta rev keeplink])
-    Backend::Connection.delete @path
+    Backend::Api::Sources::File.delete(@project_name, @package_name, @file, params.slice(:user, :comment, :meta, :rev, :keeplink).permit!.to_h)
 
     unless @package_name == '_pattern' || @package_name == '_project'
       # _pattern was not a real package in old times

--- a/src/api/app/controllers/source_package_controller.rb
+++ b/src/api/app/controllers/source_package_controller.rb
@@ -118,7 +118,7 @@ class SourcePackageController < SourceController
 
     Package.verify_file!(@pack, params[:filename], request.raw_post)
 
-    @path += build_query_from_hash(params, %i[user comment rev linkrev keeplink meta])
+    @path += build_query_from_hash(params, %i[user comment rev keeplink meta])
     pass_to_backend(@path)
 
     # update package timestamp and reindex sources
@@ -134,7 +134,7 @@ class SourcePackageController < SourceController
 
     raise DeleteFileNoPermission, 'Insufficient permissions to delete file' unless @allowed
 
-    @path += build_query_from_hash(params, %i[user comment meta rev linkrev keeplink])
+    @path += build_query_from_hash(params, %i[user comment meta rev keeplink])
     Backend::Connection.delete @path
 
     unless @package_name == '_pattern' || @package_name == '_project'

--- a/src/api/app/lib/backend/api/sources/file.rb
+++ b/src/api/app/lib/backend/api/sources/file.rb
@@ -24,8 +24,8 @@ module Backend
         end
 
         # Deletes a package source file
-        def self.delete(project_name, package_name, filename)
-          http_delete(['/source/:project/:package/:filename', project_name, package_name, filename])
+        def self.delete(project_name, package_name, filename, options = {})
+          http_delete(['/source/:project/:package/:filename', project_name, package_name, filename], params: options, accepted: %i[user comment meta rev keeplink])
         end
       end
     end


### PR DESCRIPTION
This is another PR of a series of changes to refactor direct calls to `Backend::Connection` into the `Backend::Api` library.

~Depends on:~
- #18427