### PR TITLE
Simplify RoleMatcher

### DIFF
--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -633,6 +633,7 @@ RSpec/VerifiedDoubles:
     - 'spec/jobs/issue_tracker_update_issues_job_spec.rb'
     - 'spec/lib/authenticator_spec.rb'
     - 'spec/lib/backend/connection_helper_spec.rb'
+    - 'spec/lib/routes_helper/role_matcher_spec.rb'
     - 'spec/mixins/build_log_support_spec.rb'
     - 'spec/mixins/parse_package_diff_spec.rb'
     - 'spec/models/issue_tracker_spec.rb'

--- a/src/api/spec/lib/routes_helper/role_matcher_spec.rb
+++ b/src/api/spec/lib/routes_helper/role_matcher_spec.rb
@@ -2,74 +2,34 @@ RSpec.describe RoutesHelper::RoleMatcher do
   describe '.matches?' do
     subject { described_class.matches?(request) }
 
-    context 'when the request is from a bot' do
-      let(:request) { instance_double(ActionDispatch::Request, bot?: true) }
-
-      it { is_expected.to be(false) }
-    end
-
-    context 'when the request is from a user with a disabled account' do
-      let(:request) { instance_double(ActionDispatch::Request, bot?: false) }
-      let(:user_checker) { instance_double(WebuiControllerService::UserChecker, call: false) }
-
-      before do
-        allow(WebuiControllerService::UserChecker).to receive(:new).and_return(user_checker)
-      end
-
-      it { is_expected.to be(false) }
-    end
+    let(:request) { double(session: { login: user.login }) }
 
     context 'when the request is from an anonymous user' do
-      let(:request) { instance_double(ActionDispatch::Request, bot?: false, session: session) }
-      let(:session) { instance_double(ActionDispatch::Request::Session) }
-      let(:user_checker) { instance_double(WebuiControllerService::UserChecker, call: true) }
-
-      before do
-        allow(WebuiControllerService::UserChecker).to receive(:new).and_return(user_checker)
-        allow(session).to receive(:[]).with(:login).and_return(nil)
-      end
+      let(:request) { double(session: { login: nil }) }
 
       it { is_expected.to be(false) }
     end
 
     context 'when the request is from a user without any role' do
-      let(:request) { instance_double(ActionDispatch::Request, bot?: false, session: session) }
-      let(:session) { instance_double(ActionDispatch::Request::Session) }
-      let(:user_checker) { instance_double(WebuiControllerService::UserChecker, call: true) }
       let(:user) { create(:confirmed_user) }
 
-      before do
-        allow(WebuiControllerService::UserChecker).to receive(:new).and_return(user_checker)
-        allow(session).to receive(:[]).with(:login).and_return(user.login)
-      end
+      it { is_expected.to be(false) }
+    end
+
+    context 'when the request is from a user with an inactive account' do
+      let(:user) { create(:locked_user) }
 
       it { is_expected.to be(false) }
     end
 
     context 'when the request is from a staff user' do
-      let(:request) { instance_double(ActionDispatch::Request, bot?: false, session: session) }
-      let(:session) { instance_double(ActionDispatch::Request::Session) }
-      let(:user_checker) { instance_double(WebuiControllerService::UserChecker, call: true) }
       let(:user) { create(:staff_user) }
-
-      before do
-        allow(WebuiControllerService::UserChecker).to receive(:new).and_return(user_checker)
-        allow(session).to receive(:[]).with(:login).and_return(user.login)
-      end
 
       it { is_expected.to be(true) }
     end
 
     context 'when the request is from an admin user' do
-      let(:request) { instance_double(ActionDispatch::Request, bot?: false, session: session) }
-      let(:session) { instance_double(ActionDispatch::Request::Session) }
-      let(:user_checker) { instance_double(WebuiControllerService::UserChecker, call: true) }
       let(:user) { create(:admin_user) }
-
-      before do
-        allow(WebuiControllerService::UserChecker).to receive(:new).and_return(user_checker)
-        allow(session).to receive(:[]).with(:login).and_return(user.login)
-      end
 
       it { is_expected.to be(true) }
     end


### PR DESCRIPTION
No need for all the things (creating/updating users, tracking sessions etc.) that WebuiControllerService::UserChecker does to decide if we should draw the flipper-ui routes or not.