### PR TITLE
Refactor backend calls from Package model using Backend::Api methods (II)

### DIFF
--- a/src/api/app/lib/backend/api/build_results/binaries.rb
+++ b/src/api/app/lib/backend/api/build_results/binaries.rb
@@ -58,10 +58,9 @@ module Backend
           Xmlhash.parse(fileinfo) if fileinfo
         end
 
-        def self.builddepinfo(project_name, repository, arch, package_name = nil)
-          params = {}
-          params[:package] = package_name if package_name
-          http_get(['/build/:project/:repository/:arch/_builddepinfo', project_name, repository, arch], params: params)
+        def self.builddepinfo(project_name, repository, arch, package_name = nil, options = {})
+          options[:package] = package_name if package_name
+          http_get(['/build/:project/:repository/:arch/_builddepinfo', project_name, repository, arch], params: options, accepted: %i[package view])
         end
 
         # Returns the build dependency information

--- a/src/api/app/lib/backend/api/sources/file.rb
+++ b/src/api/app/lib/backend/api/sources/file.rb
@@ -7,8 +7,8 @@ module Backend
 
         # Returns the content of the source file
         # @return [String]
-        def self.content(project_name, package_name, file_name)
-          http_get(['/source/:project/:package/:filename', project_name, package_name, file_name])
+        def self.content(project_name, package_name, file_name, options = {})
+          http_get(['/source/:project/:package/:filename', project_name, package_name, file_name], params: options, accepted: %i[deleted expand meta rev view])
         end
 
         # Returns the content of the source file

--- a/src/api/app/lib/backend/api/sources/package.rb
+++ b/src/api/app/lib/backend/api/sources/package.rb
@@ -31,6 +31,12 @@ module Backend
           http_get(['/source/:project/:package', project_name, package_name], params: options, accepted: %i[expand rev view])
         end
 
+        # Returns a file list of the products for a package
+        # @return [String]
+        def self.products(project_name, package_name)
+          http_get(['/source/:project/:package', project_name, package_name], defaults: { view: :products })
+        end
+
         # Returns the revisions (mrev) list for a package
         # @return [String]
         def self.revisions(project_name, package_name, options = {})

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -1308,8 +1308,8 @@ class Package < ApplicationRecord
   end
 
   def self.what_depends_on(project, package, repository, architecture)
-    path = "/build/#{project}/#{repository}/#{architecture}/_builddepinfo?package=#{package}&view=revpkgnames"
-    [Xmlhash.parse(Backend::Connection.get(path).body).try(:[], 'package').try(:[], 'pkgdep')].flatten.compact
+    builddepinfo_xml = Backend::Api::BuildResults::Binaries.builddepinfo(project, repository, architecture, package, { view: :revpkgnames })
+    [Xmlhash.parse(builddepinfo_xml).try(:[], 'package').try(:[], 'pkgdep')].flatten.compact
   rescue Backend::NotFoundError
     []
   end

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -507,7 +507,7 @@ class Package < ApplicationRecord
   end
 
   def source_file(file, opts = {})
-    Backend::Connection.get(source_path(file, opts)).body
+    Backend::Api::Sources::File.content(project.name, name, file, opts)
   end
 
   def dir_hash(opts = {})

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -660,7 +660,7 @@ class Package < ApplicationRecord
 
     Product.transaction do
       begin
-        xml = Xmlhash.parse(Backend::Connection.get(source_path(nil, view: :products)).body)
+        xml = Xmlhash.parse(Backend::Api::Sources::Package.products(project.name, name))
       rescue StandardError
         next
       end


### PR DESCRIPTION
This is another PR of a series of changes to refactor direct calls to `Backend::Connection` into the `Backend::Api` library.

~Depends on:~
- #18433
- #18439