### PR TITLE
Call the proper backend method to list files of a package

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -427,7 +427,7 @@ class Webui::PackageController < Webui::WebuiController
       @current_rev = @package.rev
       @revision = @current_rev if !@revision && !@srcmd5 # on very first page load only
 
-      files_xml = @package.source_file(nil, { rev: @srcmd5 || @revision, expand: @expand }.compact)
+      files_xml = Backend::Api::Sources::Package.files(@package.project.name, @package.name, { rev: @srcmd5 || @revision, expand: @expand }.compact)
       files_hash = Xmlhash.parse(files_xml)
       @files = files_hash.elements('entry')
       @srcmd5 = files_hash['srcmd5'] unless @revision == @current_rev

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -482,7 +482,7 @@ class Package < ApplicationRecord
     dir_xml = if dir_xml.is_a?(Net::HTTPSuccess)
                 dir_xml.body
               else
-                source_file(nil)
+                Backend::Api::Sources::Package.files(project.name, name)
               end
     private_set_package_kind(Xmlhash.parse(dir_xml))
     update_project_for_product


### PR DESCRIPTION
Instead of calling a file content method with a `nil` file which will perform a file listing, call the file listing method directly.