### PR TITLE
Refactor worker checkcontraints route

### DIFF
--- a/src/api/app/controllers/worker/command_controller.rb
+++ b/src/api/app/controllers/worker/command_controller.rb
@@ -2,8 +2,6 @@ class Worker::CommandController < ApplicationController
   def run
     params.require(%i[cmd project package repository arch])
 
-    raise UnknownCommandError, "Unknown command '#{params[:cmd]}' for path #{request.path}" unless params[:cmd] == 'checkconstraints'
-
     # read permission checking
     Package.get_by_project_and_name(params[:project], params[:package], { follow_multibuild: true })
 

--- a/src/api/config/routes/api.rb
+++ b/src/api/config/routes/api.rb
@@ -416,21 +416,25 @@ controller 'webui/sitemaps' do
   get 'package/sitemap(/:project_name)' => :packages
 end
 
+### /worker
 scope :worker, as: :worker do
-  resources :status, only: [:index], controller: 'worker/status'
-  resources :capability, only: [:show], param: :worker, controller: 'worker/capability'
-  resources :command, only: [], controller: 'worker/command' do
+  resources :status, only: [:index], controller: 'worker/status'                        # Deprecated: GET  /worker/status
+  resources :capability, only: [:show], param: :worker, controller: 'worker/capability' # Deprecated: GET  /worker/capability/:worker
+  resources :command, only: [], controller: 'worker/command', constraints: cons do      # Deprecated: POST /worker/command/run
     collection do
-      post 'run'
+      post 'run', constraints: ->(req) { req.params[:cmd] == 'checkconstraints' }
     end
   end
 end
 
-### /worker
 get 'worker/_status' => 'worker/status#index', as: :worker_status
 get 'build/_workerstatus' => 'worker/status#index', as: :build_workerstatus # For backward compatibility
 get 'worker/:worker' => 'worker/capability#show'
-post 'worker' => 'worker/command#run'
+controller 'worker/command' do
+  constraints(cons) do
+    post 'worker' => :run, constraints: ->(req) { req.params[:cmd] == 'checkconstraints' }
+  end
+end
 
 ### /build
 get 'build/:project/:repository/:arch/:package/_log' => 'build#logfile', constraints: cons, as: :raw_logfile

--- a/src/api/spec/controllers/worker/command_controller_spec.rb
+++ b/src/api/spec/controllers/worker/command_controller_spec.rb
@@ -41,15 +41,5 @@ RSpec.describe Worker::CommandController do
 
       it { is_expected.to have_http_status(:success) }
     end
-
-    context 'invalid command' do
-      subject! do
-        post :run, params: { cmd: 'foo', project: 'foo',
-                             package: 'bar', repository: 'my-repo',
-                             arch: 'i586', format: :xml }
-      end
-
-      it { is_expected.to have_http_status(:bad_request) }
-    end
   end
 end

--- a/src/api/test/functional/status_controller_test.rb
+++ b/src/api/test/functional/status_controller_test.rb
@@ -8,9 +8,6 @@ class StatusControllerTest < ActionDispatch::IntegrationTest
   end
 
   def test_calculate_workers_by_constraints
-    post '/worker'
-    assert_response :bad_request
-    assert_xml_tag(tag: 'status', attributes: { code: 'missing_parameter' })
     post '/worker?cmd=checkconstraints&project=HiddenProject&package=TestPack&repository=10.2&arch=i586'
     assert_response :not_found
     assert_xml_tag(tag: 'status', attributes: { code: 'unknown_project' })


### PR DESCRIPTION
Make use of a parameter constraint in the router instead of checking for values in the controller.

Remove spec and minitest checking for other worker run command paths. These cases should return 404 not found.