### PR TITLE
Fix CVE issue link

### DIFF
--- a/src/api/app/helpers/webui/patchinfo_helper.rb
+++ b/src/api/app/helpers/webui/patchinfo_helper.rb
@@ -9,8 +9,17 @@ module Webui::PatchinfoHelper
   end
 
   def patchinfo_issue_link(tracker, number, url)
-    link_text = tracker == 'cve' ? "#{tracker.upcase}-#{number}" : "#{tracker}##{number}"
-    link_to(link_text, url, target: :_blank, rel: 'noopener')
+    link_text = "#{tracker}##{number}"
+    link_url = url
+
+    # TODO: unify the treatment of CVE issues all over the code
+    if tracker == 'cve'
+      issue_tracker = IssueTracker.find_by(kind: 'cve')
+      link_text = "#{tracker.upcase}-#{number}"
+      link_url = issue_tracker.show_url.gsub('@@@', "CVE-#{number}")
+    end
+
+    link_to(link_text, link_url, target: :_blank, rel: 'noopener')
   end
 
   private

--- a/src/api/app/models/issue.rb
+++ b/src/api/app/models/issue.rb
@@ -83,6 +83,8 @@ class Issue < ApplicationRecord
 
   def url
     return issue_tracker.show_url_for(label) if issue_tracker.kind == 'github'
+    # TODO: unify the treatment of CVE issues all over the code
+    return issue_tracker.show_url.gsub('@@@', "CVE-#{name}") if (issue_tracker.kind == 'cve') && !name.match?(/^(CVE|cve)/)
 
     issue_tracker.show_url.gsub('@@@', name)
   end


### PR DESCRIPTION
Fixes #18454

We have a bit mess in the management of the CVE issues. There is [a plan](https://trello.com/c/ZSBz3xA7/263-cve-issue-name-format) to unify the code with other types of issues.
But meanwhile, let's fix the links to point to the right URL from both Mentioned Issues and Patchinfo.