### PR TITLE
Fix encoding issues by replacing `.blank?` with `.empty?`

### DIFF
--- a/src/api/app/helpers/webui/webui_helper.rb
+++ b/src/api/app/helpers/webui/webui_helper.rb
@@ -95,7 +95,7 @@ module Webui::WebuiHelper
   end
 
   def force_utf8_and_transform_nonprintables(text)
-    return '' if text.blank?
+    return '' if text.empty?
 
     text.force_encoding('UTF-8')
     text = 'The file you look at is not valid UTF-8 text. Please convert the file.' unless text.valid_encoding?


### PR DESCRIPTION
closes #18458

`.blank?` can raise an ArgumentError on strings with invalid UTF-8 bytes. We just need to check for the presence of a string, and the validation has already been handled in the code below. 