### PR TITLE
Refactor request create route

### DIFF
--- a/src/api/app/controllers/request_controller.rb
+++ b/src/api/app/controllers/request_controller.rb
@@ -61,8 +61,6 @@ class RequestController < ApplicationController
 
   # POST /request?cmd=create
   def create
-    raise UnknownCommandError, "Unknown command '#{params[:cmd]}' for path #{request.path}" unless params[:cmd] == 'create'
-
     BsRequest.transaction do
       @req = BsRequest.new_from_xml(request.raw_post.to_s)
       authorize @req, :create?

--- a/src/api/config/routes/api.rb
+++ b/src/api/config/routes/api.rb
@@ -144,7 +144,11 @@ constraints(RoutesHelper::APIMatcher) do
 
   ### /request
 
-  resources :request, only: %i[index show create update destroy]
+  resources :request, only: %i[index show update destroy] do
+    collection do
+      post :create, constraints: ->(req) { req.params[:cmd] == 'create' }
+    end
+  end
 
   post 'request/:id' => 'request#request_command', constraints: cons
 

--- a/src/api/test/functional/request_controller_test.rb
+++ b/src/api/test/functional/request_controller_test.rb
@@ -51,21 +51,6 @@ class RequestControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  def test_invalid_command
-    post '/request?cmd=INVALID'
-    assert_response :unauthorized
-    login_king
-    post '/request?cmd=INVALID', params: '<request>
-                                            <action type="submit">
-                                              <source project="project1" package="package1" />
-                                              <target project="project2" package="package2" />
-                                            </action>
-                                            <description>Description</description>
-                                          </request>'
-    assert_response :bad_request
-    assert_xml_tag(tag: 'status', attributes: { code: 'unknown_command' })
-  end
-
   def test_get_requests_collection
     login_king
     get '/request', params: { view: 'collection', reviewstates: 'accepted' }


### PR DESCRIPTION
Make use of a parameter constraint in the router instead of checking for the value of the `cmd` parameter in the controller.

Follow-up to #18449.