### PR TITLE
Refactor request command routes

### DIFF
--- a/src/api/config/routes/api.rb
+++ b/src/api/config/routes/api.rb
@@ -153,6 +153,14 @@ constraints(RoutesHelper::APIMatcher) do
   end
 
   post 'request/:id' => 'request#request_command', constraints: cons
+  controller :request do
+    constraints(cons) do
+      post 'request/:id' => :request_command_diff, constraints: ->(req) { req.params[:cmd] == 'diff' }
+      post 'request/:id' => :request_command, constraints: lambda { |req|
+        %w[addreview approve assignreview cancelapproval changereviewstate changestate setacceptat setincident setpriority].include?(req.params[:cmd])
+      }
+    end
+  end
 
   ### /lastevents
 


### PR DESCRIPTION
Make use of a parameter constraint in the router instead of checking for the value of the cmd parameter in the controller.

Instead of an "Invalid command" response, throw "Not found".

Related to #18479.