### PR TITLE
Refactor person register route

### DIFF
--- a/src/api/app/controllers/person_controller.rb
+++ b/src/api/app/controllers/person_controller.rb
@@ -24,11 +24,7 @@ class PersonController < ApplicationController
   end
 
   def command
-    if params[:cmd] == 'register'
-      internal_register
-      return
-    end
-    raise UnknownCommandError, "Allowed command is 'register'"
+    internal_register
   end
 
   def userinfo

--- a/src/api/config/routes/api.rb
+++ b/src/api/config/routes/api.rb
@@ -10,7 +10,7 @@ constraints(RoutesHelper::APIMatcher) do
   resources :announcements, except: %i[edit new]
 
   ### /person
-  post 'person' => 'person#command'
+  post 'person' => 'person#command', constraints: ->(req) { req.params[:cmd] == 'register' }
   get 'person' => 'person#show'
   get 'person/:login/token' => 'person/token#index', constraints: cons
   post 'person/:login/token' => 'person/token#create', constraints: cons


### PR DESCRIPTION
Make use of a parameter constraint in the router instead of checking for the value of the cmd parameter in the controller.

Instead of an "Invalid command" response, throw "Not found".

Related to #18480.