### PR TITLE
Fix turbo frame id for package multibuild flavors

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -304,6 +304,7 @@ class Webui::PackageController < Webui::WebuiController
     if Flipper.enabled?(:request_show_redesign, User.session)
       filters = params.keys.select { |k| k.start_with?('repo', 'arch') }
       render 'webui/package/beta/rpmlint_result', locals: { index: params[:index], project: @project, package: @package,
+                                                            package_name: @package_name,
                                                             repository: repository, architecture: architecture,
                                                             repository_list: repo_list.map(&:first), arch_list: repo_arch_hash.values.flatten.uniq, filters: filters }
     else

--- a/src/api/app/views/webui/package/beta/rpmlint_result.html.haml
+++ b/src/api/app/views/webui/package/beta/rpmlint_result.html.haml
@@ -18,6 +18,5 @@
                                                                         checked_values: filters }
         %button.btn.btn-primary#filter-button{ type: :submit }
           Apply Filter
-
-    = turbo_frame_tag "#{project.name}_#{package}_rpmlint", loading: 'lazy',
+    = turbo_frame_tag "#{project.name}_#{package_name}_rpmlint", loading: 'lazy',
                       src: rpmlint_summary_path(project_name: project.name, package_name: package.name, filters: filters)


### PR DESCRIPTION
Right now one of the turbo frames adds the multibuild flavor to the html id, the other one not. This leads to turbo not being able to locate the frame and rendering the partial outside of the frame.
The `package_name` variable used on one of the frames contains the multibuild flavor. Lets use the variable on both so they match in the case of a package with multibuild flavors.

Fixes #18487