### PR TITLE
Refactor group command routes

### DIFF
--- a/src/api/app/controllers/group_controller.rb
+++ b/src/api/app/controllers/group_controller.rb
@@ -78,8 +78,6 @@ class GroupController < ApplicationController
       group.remove_user(user, user_session_login: User.session.login)
     when 'set_email'
       group.update!(email: params[:email])
-    else
-      raise UnknownCommandError, 'cmd must be set to add_user or remove_user'
     end
 
     render_ok

--- a/src/api/config/routes/api.rb
+++ b/src/api/config/routes/api.rb
@@ -37,10 +37,12 @@ constraints(RoutesHelper::APIMatcher) do
   ### /group
   controller :group do
     get 'group' => :index
-    get 'group/:title' => :show, constraints: cons
-    delete 'group/:title' => :delete, constraints: cons
-    put 'group/:title' => :update, constraints: cons
-    post 'group/:title' => :command, constraints: cons
+    constraints(cons) do
+      get 'group/:title' => :show
+      delete 'group/:title' => :delete
+      put 'group/:title' => :update
+      post 'group/:title' => :command, constraints: ->(req) { %w[add_user remove_user set_email].include?(req.params[:cmd]) }
+    end
   end
 
   ### /service

--- a/src/api/public/apidocs/paths/group_group_title.yaml
+++ b/src/api/public/apidocs/paths/group_group_title.yaml
@@ -59,15 +59,6 @@ post:
   responses:
     '200':
       $ref: '../components/responses/succeeded.yaml'
-    '400':
-      description: Bad Request.
-      content:
-        application/xml; charset=utf-8:
-          schema:
-            $ref: '../components/schemas/api_response.yaml'
-          example:
-            code: bad_request
-            summary: cmd must be set to add_user or remove_user
     '401':
       $ref: '../components/responses/unauthorized.yaml'
     '404':


### PR DESCRIPTION
Make use of a parameter constraint in the router instead of checking for the value of the `cmd` parameter in the controller.

Instead of an "Invalid command" response, throw "Not found".

Related to #18480.