### PR TITLE
Include the associated tables to allow sorting

### DIFF
--- a/src/api/app/models/bs_request/data_table/find_for_user_or_group_query.rb
+++ b/src/api/app/models/bs_request/data_table/find_for_user_or_group_query.rb
@@ -12,6 +12,7 @@ class BsRequest
       def requests
         @requests ||=
           requests_query(@params[:search])
+          .joins(:bs_request_actions)
           .offset(@params[:offset])
           .limit(@params[:limit])
           .reorder(@params[:sort])


### PR DESCRIPTION
When accessing your tasks outside of the beta program, we use Datatables to render incoming, outgoing requests and reviews. 
We were not joining the `bs_request_actions` table, and we need it to sort by source project.
Fixes #18500 and #18499