### PR TITLE
Titleize `Your Profile` menu option

### DIFF
--- a/src/api/app/views/layouts/webui/_top_navigation.html.haml
+++ b/src/api/app/views/layouts/webui/_top_navigation.html.haml
@@ -20,7 +20,7 @@
             %li.dropdown-item
               = link_to(user_path(User.session), id: 'link-to-user-home', class: 'nav-link p-0 w-100') do
                 %i.fas.fa-user.fa-fw.me-2
-                Your profile
+                Your Profile
             %li.dropdown-item
               = link_to(my_requests_path, class: 'nav-link p-0 w-100') do
                 %i.fas.fa-code-pull-request.fa-fw.me-2


### PR DESCRIPTION
 "Your profile" was the only not titleized item in the dropdown menu (it was in footer, Places and breadcrumbs):

<img width="322" height="355" alt="Screenshot 2025-09-12 at 13-12-17 Tasks for Admin - Open Build Service" src="https://github.com/user-attachments/assets/2111dde1-ae2c-4635-a075-66912269b748" />
