### PR TITLE
[api] Remove invalid project access check

### DIFF
--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -332,10 +332,7 @@ class Project < ApplicationRecord
           target_project_name = element.value('project')
           if target_project_name != project_name
             begin
-              target_project = Project.get_by_name(target_project_name)
-              # user can access tprj, but backend would refuse to take binaries from there
-              return { error: "The current backend implementation is not using binaries from read access protected projects #{target_project_name}" } if target_project.instance_of?(Project) &&
-                                                                                                                                                         target_project.disabled_for?('access', nil, nil)
+              Project.get_by_name(target_project_name)
             rescue Project::Errors::UnknownObjectError
               return { error: "A project with the name #{target_project_name} does not exist. Please update the repository path elements." }
             end

--- a/src/api/test/functional/read_permission_test.rb
+++ b/src/api/test/functional/read_permission_test.rb
@@ -818,6 +818,11 @@ class ReadPermissionTest < ActionDispatch::IntegrationTest
         params: '<project name="home:tom:ProtectedProject2"> <title/> <description/>  <repository name="HiddenProjectRepo"> <path repository="nada" project="HiddenProject"/> <arch>i586</arch> </repository> </project>'
     assert_response :not_found
 
+    # building against can not work, as we don't see the project
+    put url_for(controller: :source_project_meta, action: :update, project: 'home:tom:ProtectedProject2'),
+        params: '<project name="home:tom:ProtectedProject2"> <title/> <description/> <repository name="HiddenProjectRepo"> <path repository="nada" project="HiddenProject"/> <arch>i586</arch> </repository> </project>'
+    assert_response :not_found
+
     # try to access it with a user permitted for access
     login_adrian
 
@@ -826,23 +831,10 @@ class ReadPermissionTest < ActionDispatch::IntegrationTest
     # STDERR.puts(@response.body)
     assert_response :ok
 
-    put url_for(controller: :source_project_meta, action: :update, project: 'home:adrian:ProtectedProject1'),
-        params: '<project name="home:adrian:ProtectedProject1"> <title/> <description/> <repository name="HiddenProjectRepo"> <path repository="nada" project="HiddenProject"/> <arch>i586</arch> </repository> </project>'
-    assert_response :not_found
-
-    # building against
-    put url_for(controller: :source_project_meta, action: :update, project: 'home:adrian:ProtectedProject2'),
-        params: '<project name="home:adrian:ProtectedProject2"> <title/> <description/> <repository name="HiddenProjectRepo"> <path repository="nada" project="HiddenProject"/> <arch>i586</arch> </repository> </project>'
-    assert_response :not_found
-
     # check if download protected project has to access protected project, which reveals Hidden project existence to others and is and error
     put url_for(controller: :source_project_meta, action: :update, project: 'home:adrian:ProtectedProject2'),
         params: '<project name="home:adrian:ProtectedProject2"> <title/> <description/> <binarydownload><disable/></binarydownload> </project>'
     assert_response :ok
-
-    put url_for(controller: :source_project_meta, action: :update, project: 'home:adrian:ProtectedProject2'),
-        params: '<project name="home:adrian:ProtectedProject2"> <title/> <description/> <repository name="HiddenProjectRepo"> <path repository="nada" project="HiddenProject"/> <arch>i586</arch> </repository> </project>'
-    assert_response :not_found
 
     # check if access protected project has access binarydownload protected project
     prepare_request_with_user('binary_homer', 'buildservice')

--- a/src/api/test/unit/project_test.rb
+++ b/src/api/test/unit/project_test.rb
@@ -696,43 +696,6 @@ class ProjectTest < ActiveSupport::TestCase
     assert_equal({}, actual)
   end
 
-  test 'returns an error if repository access is disabled' do
-    User.session = users(:Iggy)
-    project = projects(:home_Iggy)
-    flag = project.add_flag('access', 'disable')
-    flag.save
-
-    xml = <<~XML
-      <project name='other_project'>
-        <title>Up-to-date project</title>
-        <description>the description</description>
-        <repository><path project='home:Iggy'></path></repository>
-      </project>
-    XML
-
-    expected = { error: 'The current backend implementation is not using binaries from read access protected projects home:Iggy' }
-    actual = Project.validate_repository_xml_attribute(Xmlhash.parse(xml), 'other_project')
-    assert_equal expected, actual
-  end
-
-  test 'returns no error if target project equals project' do
-    User.session = users(:Iggy)
-    project = projects(:home_Iggy)
-    flag = project.add_flag('access', 'disable')
-    flag.save
-
-    xml = <<~XML
-      <project name='home:Iggy'>
-        <title>Up-to-date project</title>
-        <description>the description</description>
-        <repository><path project='home:Iggy'></path></repository>
-      </project>
-    XML
-
-    actual = Project.validate_repository_xml_attribute(Xmlhash.parse(xml), 'home:Iggy')
-    assert_equal({}, actual)
-  end
-
   test 'get_removed_repositories returns all repositories if new_repositories does not contain the old repositories' do
     User.session = users(:Iggy)
     project = projects(:home_Iggy)


### PR DESCRIPTION
This was only true for a short time > 10 years ago. Backend is checking based on user lists instead

Fixes: https://github.com/openSUSE/open-build-service/issues/18540