### PR TITLE
Update models annotations

### DIFF
--- a/src/api/app/models/bs_request_action_add_role.rb
+++ b/src/api/app/models/bs_request_action_add_role.rb
@@ -79,7 +79,7 @@ end
 #  target_project        :string(255)      indexed
 #  target_releaseproject :string(255)
 #  target_repository     :string(255)
-#  type                  :string(255)
+#  type                  :string(255)      indexed
 #  updatelink            :boolean          default(FALSE)
 #  created_at            :datetime
 #  bs_request_id         :integer          indexed, indexed => [target_package_id], indexed => [target_project_id]
@@ -101,6 +101,7 @@ end
 #  index_bs_request_actions_on_target_package_id                    (target_package_id)
 #  index_bs_request_actions_on_target_project                       (target_project)
 #  index_bs_request_actions_on_target_project_id                    (target_project_id)
+#  index_bs_request_actions_on_type                                 (type)
 #
 # Foreign Keys
 #

--- a/src/api/app/models/bs_request_action_change_devel.rb
+++ b/src/api/app/models/bs_request_action_change_devel.rb
@@ -58,7 +58,7 @@ end
 #  target_project        :string(255)      indexed
 #  target_releaseproject :string(255)
 #  target_repository     :string(255)
-#  type                  :string(255)
+#  type                  :string(255)      indexed
 #  updatelink            :boolean          default(FALSE)
 #  created_at            :datetime
 #  bs_request_id         :integer          indexed, indexed => [target_package_id], indexed => [target_project_id]
@@ -80,6 +80,7 @@ end
 #  index_bs_request_actions_on_target_package_id                    (target_package_id)
 #  index_bs_request_actions_on_target_project                       (target_project)
 #  index_bs_request_actions_on_target_project_id                    (target_project_id)
+#  index_bs_request_actions_on_type                                 (type)
 #
 # Foreign Keys
 #

--- a/src/api/app/models/bs_request_action_delete.rb
+++ b/src/api/app/models/bs_request_action_delete.rb
@@ -114,7 +114,7 @@ end
 #  target_project        :string(255)      indexed
 #  target_releaseproject :string(255)
 #  target_repository     :string(255)
-#  type                  :string(255)
+#  type                  :string(255)      indexed
 #  updatelink            :boolean          default(FALSE)
 #  created_at            :datetime
 #  bs_request_id         :integer          indexed, indexed => [target_package_id], indexed => [target_project_id]
@@ -136,6 +136,7 @@ end
 #  index_bs_request_actions_on_target_package_id                    (target_package_id)
 #  index_bs_request_actions_on_target_project                       (target_project)
 #  index_bs_request_actions_on_target_project_id                    (target_project_id)
+#  index_bs_request_actions_on_type                                 (type)
 #
 # Foreign Keys
 #

--- a/src/api/app/models/bs_request_action_maintenance_incident.rb
+++ b/src/api/app/models/bs_request_action_maintenance_incident.rb
@@ -234,7 +234,7 @@ end
 #  target_project        :string(255)      indexed
 #  target_releaseproject :string(255)
 #  target_repository     :string(255)
-#  type                  :string(255)
+#  type                  :string(255)      indexed
 #  updatelink            :boolean          default(FALSE)
 #  created_at            :datetime
 #  bs_request_id         :integer          indexed, indexed => [target_package_id], indexed => [target_project_id]
@@ -256,6 +256,7 @@ end
 #  index_bs_request_actions_on_target_package_id                    (target_package_id)
 #  index_bs_request_actions_on_target_project                       (target_project)
 #  index_bs_request_actions_on_target_project_id                    (target_project_id)
+#  index_bs_request_actions_on_type                                 (type)
 #
 # Foreign Keys
 #

--- a/src/api/app/models/bs_request_action_maintenance_release.rb
+++ b/src/api/app/models/bs_request_action_maintenance_release.rb
@@ -204,7 +204,7 @@ end
 #  target_project        :string(255)      indexed
 #  target_releaseproject :string(255)
 #  target_repository     :string(255)
-#  type                  :string(255)
+#  type                  :string(255)      indexed
 #  updatelink            :boolean          default(FALSE)
 #  created_at            :datetime
 #  bs_request_id         :integer          indexed, indexed => [target_package_id], indexed => [target_project_id]
@@ -226,6 +226,7 @@ end
 #  index_bs_request_actions_on_target_package_id                    (target_package_id)
 #  index_bs_request_actions_on_target_project                       (target_project)
 #  index_bs_request_actions_on_target_project_id                    (target_project_id)
+#  index_bs_request_actions_on_type                                 (type)
 #
 # Foreign Keys
 #

--- a/src/api/app/models/bs_request_action_release.rb
+++ b/src/api/app/models/bs_request_action_release.rb
@@ -130,7 +130,7 @@ end
 #  target_project        :string(255)      indexed
 #  target_releaseproject :string(255)
 #  target_repository     :string(255)
-#  type                  :string(255)
+#  type                  :string(255)      indexed
 #  updatelink            :boolean          default(FALSE)
 #  created_at            :datetime
 #  bs_request_id         :integer          indexed, indexed => [target_package_id], indexed => [target_project_id]
@@ -152,6 +152,7 @@ end
 #  index_bs_request_actions_on_target_package_id                    (target_package_id)
 #  index_bs_request_actions_on_target_project                       (target_project)
 #  index_bs_request_actions_on_target_project_id                    (target_project_id)
+#  index_bs_request_actions_on_type                                 (type)
 #
 # Foreign Keys
 #

--- a/src/api/app/models/bs_request_action_set_bugowner.rb
+++ b/src/api/app/models/bs_request_action_set_bugowner.rb
@@ -72,7 +72,7 @@ end
 #  target_project        :string(255)      indexed
 #  target_releaseproject :string(255)
 #  target_repository     :string(255)
-#  type                  :string(255)
+#  type                  :string(255)      indexed
 #  updatelink            :boolean          default(FALSE)
 #  created_at            :datetime
 #  bs_request_id         :integer          indexed, indexed => [target_package_id], indexed => [target_project_id]
@@ -94,6 +94,7 @@ end
 #  index_bs_request_actions_on_target_package_id                    (target_package_id)
 #  index_bs_request_actions_on_target_project                       (target_project)
 #  index_bs_request_actions_on_target_project_id                    (target_project_id)
+#  index_bs_request_actions_on_type                                 (type)
 #
 # Foreign Keys
 #

--- a/src/api/app/models/bs_request_action_submit.rb
+++ b/src/api/app/models/bs_request_action_submit.rb
@@ -193,7 +193,7 @@ end
 #  target_project        :string(255)      indexed
 #  target_releaseproject :string(255)
 #  target_repository     :string(255)
-#  type                  :string(255)
+#  type                  :string(255)      indexed
 #  updatelink            :boolean          default(FALSE)
 #  created_at            :datetime
 #  bs_request_id         :integer          indexed, indexed => [target_package_id], indexed => [target_project_id]
@@ -215,6 +215,7 @@ end
 #  index_bs_request_actions_on_target_package_id                    (target_package_id)
 #  index_bs_request_actions_on_target_project                       (target_project)
 #  index_bs_request_actions_on_target_project_id                    (target_project_id)
+#  index_bs_request_actions_on_type                                 (type)
 #
 # Foreign Keys
 #

--- a/src/api/app/models/token/rebuild.rb
+++ b/src/api/app/models/token/rebuild.rb
@@ -26,7 +26,7 @@ end
 #  description                 :string(64)       default("")
 #  enabled                     :boolean          default(TRUE), not null, indexed
 #  scm_token                   :string(255)      indexed
-#  string                      :string(255)      indexed
+#  string                      :string(255)      uniquely indexed
 #  triggered_at                :datetime
 #  type                        :string(255)
 #  workflow_configuration_path :string(255)      default(".obs/workflows.yml")

--- a/src/api/app/models/token/release.rb
+++ b/src/api/app/models/token/release.rb
@@ -66,7 +66,7 @@ end
 #  description                 :string(64)       default("")
 #  enabled                     :boolean          default(TRUE), not null, indexed
 #  scm_token                   :string(255)      indexed
-#  string                      :string(255)      indexed
+#  string                      :string(255)      uniquely indexed
 #  triggered_at                :datetime
 #  type                        :string(255)
 #  workflow_configuration_path :string(255)      default(".obs/workflows.yml")

--- a/src/api/app/models/token/service.rb
+++ b/src/api/app/models/token/service.rb
@@ -19,7 +19,7 @@ end
 #  description                 :string(64)       default("")
 #  enabled                     :boolean          default(TRUE), not null, indexed
 #  scm_token                   :string(255)      indexed
-#  string                      :string(255)      indexed
+#  string                      :string(255)      uniquely indexed
 #  triggered_at                :datetime
 #  type                        :string(255)
 #  workflow_configuration_path :string(255)      default(".obs/workflows.yml")

--- a/src/api/app/models/token/workflow.rb
+++ b/src/api/app/models/token/workflow.rb
@@ -89,7 +89,7 @@ end
 #  description                 :string(64)       default("")
 #  enabled                     :boolean          default(TRUE), not null, indexed
 #  scm_token                   :string(255)      indexed
-#  string                      :string(255)      indexed
+#  string                      :string(255)      uniquely indexed
 #  triggered_at                :datetime
 #  type                        :string(255)
 #  workflow_configuration_path :string(255)      default(".obs/workflows.yml")


### PR DESCRIPTION
These missing annotiations should have been included in previous migrations.

Found after resetting the database and running all migrations in a development environment with:

```shell
rake dev:test_data:create; rake db:migrate:with_data
```