### PR TITLE
Return unique rows for user or group requests

### DIFF
--- a/src/api/app/models/bs_request/data_table/find_for_user_or_group_query.rb
+++ b/src/api/app/models/bs_request/data_table/find_for_user_or_group_query.rb
@@ -17,6 +17,7 @@ class BsRequest
           .limit(@params[:limit])
           .reorder(@params[:sort])
           .preload(:bs_request_actions)
+          .distinct
       end
 
       def records_total


### PR DESCRIPTION
When joining `bs_requests` and `bs_request_actions` table we need to remove the duplicated rows coming from `bs_requests`, because we're going to get some when having several rows on `bs_request_actions` for the same `bs_request`.

Fix #18509.

## How To Test This

1. Go to https://obs-reviewlab.opensuse.org/danidoni-remove-duplicates-from-incoming-requests-datatable/my/tasks
2. It should not show any duplicates, while on master it shows several duplicates in the "Incoming Requests" tab.