### PR TITLE
Drop setting explicitly the nobody user in public controllers

### DIFF
--- a/src/api/app/controllers/public_controller.rb
+++ b/src/api/app/controllers/public_controller.rb
@@ -7,7 +7,6 @@ class PublicController < ApplicationController
   skip_before_action :require_login
   before_action :set_response_format_to_xml
   before_action :set_influxdb_data_interconnect
-  before_action :set_anonymous_user
 
   # GET /public/build/:project/:repository/:arch/:package
   def build
@@ -209,10 +208,6 @@ class PublicController < ApplicationController
     InfluxDB::Rails.current.tags = {
       interconnect: true
     }
-  end
-
-  def set_anonymous_user
-    User.session = User.find_nobody!
   end
 
   # removes /private prefix from path


### PR DESCRIPTION
It is simply not needed.