### PR TITLE
[api] Fix usage of scmsync projects via project links

### DIFF
--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -245,7 +245,7 @@ class Package < ApplicationRecord
       package = project.packages.find_by_name(package_name) if package.nil?
     end
 
-    if package.nil? && project.scmsync.present?
+    if package.nil? && project.expand_all_projects.any? { |s| s.try(:scmsync).present? }
       return nil unless opts[:follow_project_scmsync_links]
 
       begin


### PR DESCRIPTION
It is not enough to check only the project itself for scmsync

Fixes: https://github.com/openSUSE/open-build-service/issues/18205
