### PR TITLE
Fix setting anonymous for InfluxDB data

### DIFF
--- a/src/api/app/controllers/application_controller.rb
+++ b/src/api/app/controllers/application_controller.rb
@@ -248,7 +248,7 @@ class ApplicationController < ActionController::Base
   def set_influxdb_data
     InfluxDB::Rails.current.tags = {
       beta: User.possibly_nobody.in_beta?,
-      anonymous: !User.session,
+      anonymous: User.possibly_nobody.nobody?,
       spider: check_spider,
       interconnect: false,
       interface: :api


### PR DESCRIPTION
Return `anonymous` as `true` not only when the user session is empty, but also when the user session is nobody.

Seen after working on #18520.