### PR TITLE
Enable new request UI for anonymous users

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -301,7 +301,7 @@ class Webui::PackageController < Webui::WebuiController
       [repo_name, valid_xml_id(elide(repo_name, 30))]
     end
 
-    if Flipper.enabled?(:request_show_redesign, User.session)
+    if Flipper.enabled?(:request_show_redesign, User.possibly_nobody)
       filters = params.keys.select { |k| k.start_with?('repo', 'arch') }
       render 'webui/package/beta/rpmlint_result', locals: { index: params[:index], project: @project, package: @package,
                                                             package_name: @package_name,

--- a/src/api/app/models/notification_comment.rb
+++ b/src/api/app/models/notification_comment.rb
@@ -43,7 +43,7 @@ class NotificationComment < Notification
   def link_path
     case event_type
     when 'Event::CommentForRequest'
-      anchor = if Flipper.enabled?(:request_show_redesign, User.session!)
+      anchor = if Flipper.enabled?(:request_show_redesign, User.possibly_nobody)
                  "comment-#{notifiable.id}-bubble"
                else
                  'comments-list'

--- a/src/api/app/services/rpmlint_log_extractor.rb
+++ b/src/api/app/services/rpmlint_log_extractor.rb
@@ -25,7 +25,7 @@ class RpmlintLogExtractor
 
       # Condition: Flipper.enabled?(...   : TODO: Remove this `unless` condition once request_show_redesign is rolled out
       # Condition: e.summary.include?(... : Case of removed project, package, repository or architecture
-      retrieve_rpmlint_log_from_log if Flipper.enabled?(:request_show_redesign, User.session) && e.summary.include?('rpmlint.log: No such file or directory')
+      retrieve_rpmlint_log_from_log if Flipper.enabled?(:request_show_redesign, User.possibly_nobody) && e.summary.include?('rpmlint.log: No such file or directory')
     end
 
     time_delta = (Time.now.to_f - time_start).round(3)

--- a/src/api/app/views/webui/package/_tabs.html.haml
+++ b/src/api/app/views/webui/package/_tabs.html.haml
@@ -7,7 +7,7 @@
     - unless @spider_bot
       -# haml-lint:enable InstanceVariables
       = tab_link('Repositories', repositories_path(project, package), 'scrollable-tab-link')
-      - if Flipper.enabled?(:request_show_redesign, User.session)
+      - if Flipper.enabled?(:request_show_redesign, User.possibly_nobody)
         = tab_link('RPM Lint', rpmlint_result_path(project, package), 'scrollable-tab-link')
       = tab_link('Revisions', package_view_revisions_path(project, package), 'scrollable-tab-link')
       - if Flipper.enabled?(:request_index, User.session)

--- a/src/api/app/views/webui/shared/_buildresult_box.html.haml
+++ b/src/api/app/views/webui/shared/_buildresult_box.html.haml
@@ -24,7 +24,7 @@
           = link_to("#build#{index}", id: "build#{index}-tab", class: 'nav-link active text-nowrap',
             data: { 'bs-toggle': 'tab' }, role: 'tab', aria: { controls: "build#{index}", selected: true }) do
             Build Results
-        - if package && !Flipper.enabled?(:request_show_redesign, User.session)
+        - if package && !Flipper.enabled?(:request_show_redesign, User.possibly_nobody)
           %li.nav-item
             = link_to("#rpm#{index}", id: "rpm#{index}-tab", class: 'nav-link text-nowrap', data: { 'bs-toggle': 'tab' },
               role: 'tab', aria: { controls: "rpm#{index}", selected: false }) do
@@ -42,7 +42,7 @@
               From staging project
               = link_to(project, project_show_path(project))
           .result
-        - if package && !Flipper.enabled?(:request_show_redesign, User.session)
+        - if package && !Flipper.enabled?(:request_show_redesign, User.possibly_nobody)
           .tab-pane.fade{ id: "rpm#{index}", role: 'tabpanel', aria: { labelledby: "rpm#{index}-tab" } }
             .btn.btn-outline-primary.mb-2{ onclick: "updateRpmlintResult('#{index}')", title: 'Refresh Rpmlint Results' }
               Refresh


### PR DESCRIPTION
This PR enables the new request UI for anonymous users by replacing `User.session` with `User.possibly_nobody`