### PR TITLE
Fix wrong class name in attrib model for fetch_upstream_package_version_job

### DIFF
--- a/src/api/app/models/attrib.rb
+++ b/src/api/app/models/attrib.rb
@@ -203,7 +203,7 @@ class Attrib < ApplicationRecord
   end
 
   def fetch_local_package_version
-    FetchLocalPackageVersionForProjectJob.perform_later(project.name, package_name: package&.name)
+    FetchLocalPackageVersionJob.perform_later(project.name, package_name: package&.name)
   end
 end
 


### PR DESCRIPTION
The used class name for the job is wrong.