### PR TITLE
Validate AnityaDistribution attribute only for projects

### DIFF
--- a/src/api/app/models/attrib.rb
+++ b/src/api/app/models/attrib.rb
@@ -30,7 +30,8 @@ class Attrib < ApplicationRecord
   validate :validate_value_count,
            :validate_embargo_date_value,
            :validate_issues,
-           :validate_allowed_values_for_attrib_type
+           :validate_allowed_values_for_attrib_type,
+           :validate_attrib_type_for_project_attribute
 
   after_save :populate_to_sphinx
   after_save :fetch_local_package_version, if: -> { attrib_type == AttribType.find_by_name('OBS:AnityaDistribution') }
@@ -187,6 +188,14 @@ class Attrib < ApplicationRecord
     return if value.blank?
 
     parse_value(value) && check_timezone_identifier(value)
+  end
+
+  def validate_attrib_type_for_project_attribute
+    return unless attrib_type && namespace == 'OBS' && name == 'AnityaDistribution'
+
+    return unless package_id
+
+    errors.add(:attrib_type, "#{namespace}:#{name} can't be set on packages")
   end
 
   def write_container_attributes

--- a/src/api/spec/models/attrib_spec.rb
+++ b/src/api/spec/models/attrib_spec.rb
@@ -158,5 +158,15 @@ RSpec.describe Attrib do
 
       it { expect(subject.errors.full_messages).to contain_exactly('Values has 0 values, but only 1 are allowed') }
     end
+
+    describe '#validate_attrib_type_for_project_attribute' do
+      subject { build(:attrib, package_id: package.id, attrib_type: attrib_type) }
+
+      let(:attrib_type) { AttribType.find_by_namespace_and_name('OBS', 'AnityaDistribution') }
+
+      it {
+        expect(subject.errors.full_messages).to include("Attrib type OBS:AnityaDistribution can't be set on packages")
+      }
+    end
   end
 end


### PR DESCRIPTION
After [this discussion](https://github.com/openSUSE/open-build-service/pull/18518#discussion_r2355290690) we concluded that the AnityaDistribution attribute can only be assigned to a project, not a package. So far we are going to limit is with a validation.


<img width="1331" height="385" alt="Screenshot 2025-09-18 at 13-56-52 Add Attribute - Open Build Service" src="https://github.com/user-attachments/assets/a2dc5f95-afe3-4451-a16d-8e7241061014" />
