### PR TITLE
Initialize hash variables resulting from parsing XML content with Xmlhash

### DIFF
--- a/src/api/app/jobs/old/consistency_check_job.rb
+++ b/src/api/app/jobs/old/consistency_check_job.rb
@@ -93,8 +93,8 @@ module Old
         return ''
       end
 
-      backend_hash = Xmlhash.parse(backend_meta)
-      api_hash = Xmlhash.parse(api_meta)
+      backend_hash = Xmlhash.parse(backend_meta) || {}
+      api_hash = Xmlhash.parse(api_meta) || {}
       # ignore description and title
       backend_hash['title'] = api_hash['title'] = nil
       backend_hash['description'] = api_hash['description'] = nil


### PR DESCRIPTION
Make sure these hash variables are not `nil`.

Fix #18341.