### PR TITLE
Add `GET /build/<project>/_result?lastsuccess=1` endpoint to API docs

### DIFF
--- a/src/api/public/apidocs/OBS-v2.10.50.yaml
+++ b/src/api/public/apidocs/OBS-v2.10.50.yaml
@@ -127,6 +127,8 @@ paths:
     $ref: 'paths/build_project_name.yaml'
   /build/{project_name}/_result:
     $ref: 'paths/build_project_name_result.yaml'
+  /build/{project_name}/_result?lastsuccess=1:
+    $ref: 'paths/build_project_name_result_lastsuccess.yaml'
   /build/{project_name}/{repository_name}:
     $ref: 'paths/build_project_name_repository_name.yaml'
   /build/{project_name}/{repository_name}/_buildconfig:

--- a/src/api/public/apidocs/components/schemas/lastsuccess.yaml
+++ b/src/api/public/apidocs/components/schemas/lastsuccess.yaml
@@ -1,0 +1,26 @@
+type: object
+properties:
+  repository:
+    type: array
+    items:
+      type: object
+      properties:
+        name:
+          type: string
+          xml:
+            attribute: true
+        arch:
+          type: array
+          items:
+            type: object
+            properties:
+              arch:
+                type: string
+                xml:
+                  attribute: true
+              result:
+                type: string
+                xml:
+                  attribute: true
+xml:
+  name: status

--- a/src/api/public/apidocs/paths/build_project_name_result.yaml
+++ b/src/api/public/apidocs/paths/build_project_name_result.yaml
@@ -1,6 +1,10 @@
 get:
   summary: Get the build results for packages, architectures and repositories of the specified project.
-  description: Get the build results for packages, architectures and repositories of the specified project.
+  description: |
+    Get the build results for packages, architectures and repositories of the specified project.
+
+    Since the schema of the output of this endpoint depends on the value of the `lastsuccess` parameter,
+    the case where `lastsuccess` is set to `1` is documented under this [other endpoint](#/Build/get_build__project_name___result_lastsuccess_1).
   security:
     - basic_authentication: []
   parameters:
@@ -68,6 +72,15 @@ get:
         - 1
       default: 0
       example: 1
+    - in: query
+      name: lastsuccess
+      schema:
+        type: string
+      description: |
+        Set to `1` to show the last build results.
+
+        Since the schema of the output of this endpoint depends on the value of the `lastsuccess` parameter,
+        the case where `lastsuccess` is set to `1` is documented under this [other endpoint](#/Build/get_build__project_name___result_lastsuccess_1).
   responses:
     '200':
       $ref: '../components/responses/resultlist.yaml'

--- a/src/api/public/apidocs/paths/build_project_name_result_lastsuccess.yaml
+++ b/src/api/public/apidocs/paths/build_project_name_result_lastsuccess.yaml
@@ -1,0 +1,80 @@
+get:
+  summary: Get the last build results of a package of a project.
+  description: |
+    Get the last build results of a package of a project.
+
+    Since the schema of the output of this endpoint depends on the value of the `lastsuccess` parameter,
+    the case where `lastsuccess` is not set to `1` is documented under this [other endpoint](#/Build/get_build__project_name___result).
+  security:
+    - basic_authentication: []
+  parameters:
+    - $ref: '../components/parameters/project_name.yaml'
+    - in: query
+      name: lastsuccess
+      schema:
+        type: string
+      description: |
+        Set to `1` to show the last build results.
+
+        Since the schema of the output of this endpoint depends on the value of the `lastsuccess` parameter,
+        the case where `lastsuccess` is not set to `1` is documented under this [other endpoint](#/Build/get_build__project_name___result).
+      example: 1
+    - in: query
+      required: true
+      name: package
+      schema:
+        type: string
+      description: Name of the package. Limit results to the specified package.
+      example: 'obs-server'
+    - in: query
+      required: true
+      name: pathproject
+      schema:
+        type: string
+      description: Name of the project. Limit results to the specified project path.
+      example: 'home:Admin'
+  responses:
+    '200':
+      description: OK
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/lastsuccess.yaml'
+          example:
+            repository:
+              - name: openSUSE_Factory
+                arch:
+                  - arch: x86_64
+                    result: failed
+                  - arch: i586
+                    result: unknown
+              - name: containment
+                arch:
+                  - arch: x86_64
+                    result: disabled
+                  - arch: i586
+                    result: disabled
+              - name: '16.0'
+                arch:
+                  - arch: x86_64
+                    result: failed
+                  - arch: i586
+                    result: failed
+    '400':
+      description: Bad Request.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          examples:
+            pathproject Not Provided:
+              description: Not passing a value to `pathproject`.
+              value:
+                code: missing_parameter
+                summary: "param is missing or the value is empty: pathproject"
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '404':
+      $ref: '../components/responses/unknown_project.yaml'
+  tags:
+    - Build


### PR DESCRIPTION
Fix #18103.

## For reviewers

Use the review-app browsing [this link](https://obs-reviewlab.opensuse.org/eduardoj-fixissue_18103/apidocs/index#/Build/get_build__project_name___result_lastsuccess_1).