### PR TITLE
Introduce flash messages when creating a comment on a request

### DIFF
--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -213,9 +213,12 @@ class Webui::RequestController < Webui::WebuiController
     changestate = (%w[accepted commented declined revoked new] & params.keys).last
 
     if changestate == 'commented'
-
       build_new_comment(@bs_request, body: params[:reason])
-
+      if @comment.save
+        flash[:success] = 'Comment created successfully.'
+      else
+        flash[:error] = "Failed to create comment: #{@comment.errors.full_messages.to_sentence}."
+      end
     elsif change_state(changestate, params)
       # TODO: Make this work for each submit action individually
 


### PR DESCRIPTION
When creating a coment for a request:

<img width="1030" height="339" alt="Screenshot From 2025-09-23 11-21-06" src="https://github.com/user-attachments/assets/03e7e57b-2d09-4f74-9b3c-34b942f91840" />

... show a flash message for a successful creation of a comment:

<img width="695" height="226" alt="Screenshot From 2025-09-23 11-22-22" src="https://github.com/user-attachments/assets/f0f863b9-dee3-4169-b87d-45e7857d340f" />

... or show a flash message for an unsuccessful creation of a comment:

<img width="695" height="226" alt="Screenshot From 2025-09-23 11-22-08" src="https://github.com/user-attachments/assets/edf3126a-13b1-47dd-b7ff-6ad458859fd5" />
