### PR TITLE
Prevent introducing and rendering invalid characters in comments

### DIFF
--- a/src/api/app/components/comment_component.rb
+++ b/src/api/app/components/comment_component.rb
@@ -24,7 +24,7 @@ class CommentComponent < ApplicationComponent
   def body
     return inline_comment_body if comment.commentable.is_a?(BsRequestAction) && comment.diff_file_index
 
-    comment.body.delete("\u0000")
+    comment.body.delete("\u0000\u000E-\u001F")
   end
 
   private

--- a/src/api/app/models/comment.rb
+++ b/src/api/app/models/comment.rb
@@ -9,8 +9,8 @@ class Comment < ApplicationRecord
   validates :body, presence: true
   # FIXME: this probably should be MEDIUMTEXT(16MB) instead of text (64KB)
   validates :body, length: { maximum: 65_535 }
-  validates :body, format: { with: /\A[^\u0000]*\Z/,
-                             message: 'must not contain null characters' }
+  validates :body, format: { with: /\A[^\u0000\u000E-\u001F]*\Z/,
+                             message: 'must not contain null or invalid characters' }
   validates :source_rev, length: { maximum: 32 }
   validates :target_rev, length: { maximum: 32 }
 

--- a/src/api/spec/models/comment_spec.rb
+++ b/src/api/spec/models/comment_spec.rb
@@ -44,8 +44,8 @@ RSpec.describe Comment do
   describe 'validations' do
     it { is_expected.to validate_presence_of(:body) }
 
-    it 'null character' do
-      comment_package.body = "\u0000"
+    it 'null or invalid characters' do
+      comment_package.body = "\u0000\u000F\u001B"
       expect(comment_package).not_to be_valid
     end
 


### PR DESCRIPTION
Fix #16302 and fix #17257.

There was a first attempt to fix these issues in #16304.