### PR TITLE
[api] Fix usage of scmsync projects via project links

### DIFF
--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -246,7 +246,7 @@ class Package < ApplicationRecord
       package = project.packages.find_by_name(package_name) if package.nil?
     end
 
-    if package.nil? && project.scmsync.present?
+    if package.nil? && project.expand_all_projects.any? { |s| s.try(:scmsync).present? }
       return nil unless opts[:follow_project_scmsync_links]
 
       begin


### PR DESCRIPTION
It is not enough to check only the project itself for scmsync otherwise permissions are checked on package A and execution is done on package B.

Broke with 02afcf6faa2 for scmsync which made this a special thing for scmsync, but it needs to work anyway in general as it does for remote packages. It means we would also need to duplicate all permission testing now.

Fixes #18205
Related to #18522