### PR TITLE
Use stable version instead of latest version

### DIFF
--- a/src/api/app/jobs/fetch_upstream_package_version_job.rb
+++ b/src/api/app/jobs/fetch_upstream_package_version_job.rb
@@ -64,6 +64,6 @@ class FetchUpstreamPackageVersionJob < ApplicationJob
   def extract_version(response)
     return if response.nil?
 
-    response.dig('items', 0, 'version')
+    response.dig('items', 0, 'stable_version')
   end
 end


### PR DESCRIPTION
This way we avoid pre-release versions