### PR TITLE
Don't accept MACRO version

### DIFF
--- a/src/api/app/models/package_version_local.rb
+++ b/src/api/app/models/package_version_local.rb
@@ -15,6 +15,7 @@ class PackageVersionLocal < PackageVersion
   #### Scopes (first the default_scope macro if is used)
 
   #### Validations macros
+  validates :version, comparison: { other_than: 'MACRO' }
 
   #### Class methods using self. (public and then private)
 


### PR DESCRIPTION
This is a result of the backend not being able to tell the version of a package because of a macro