### PR TITLE
Remove call to find project by name

### DIFF
--- a/src/api/app/controllers/source_project_command_controller.rb
+++ b/src/api/app/controllers/source_project_command_controller.rb
@@ -292,9 +292,6 @@ class SourceProjectCommandController < SourceController
   ##
 
   def private_plain_backend_command
-    # is there any value in this call?
-    Project.find_by_name(params[:project])
-
     path = request.path_info
     path += build_query_from_hash(params, %i[cmd user comment days])
     pass_to_backend(path)


### PR DESCRIPTION
It doesn't make a difference to perform the call or not. It is not needed.