### PR TITLE
Make sure that the correct latest version is retrieved

### DIFF
--- a/src/api/app/datatables/package_datatable.rb
+++ b/src/api/app/datatables/package_datatable.rb
@@ -24,7 +24,7 @@ class PackageDatatable < Datatable
 
   # rubocop:disable Naming/AccessorMethodName
   def get_raw_records
-    @project.packages.includes(:package_kinds, :latest_local_version, :latest_upstream_version).left_joins(labels: [:label_template]).references(:labels, :label_template)
+    @project.packages.includes(:package_kinds).left_joins(:latest_local_version, :latest_upstream_version, labels: [:label_template]).references(:labels, :label_template)
   end
   # rubocop:enable Naming/AccessorMethodName
 

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -64,8 +64,8 @@ class Package < ApplicationRecord
   has_many :reports, as: :reportable, dependent: :nullify
   has_many :labels, as: :labelable
   has_many :package_versions, dependent: :destroy
-  has_one :latest_local_version, -> { order(created_at: :desc) }, class_name: 'PackageVersionLocal'
-  has_one :latest_upstream_version, -> { order(created_at: :desc) }, class_name: 'PackageVersionUpstream'
+  has_one :latest_local_version, -> { order(updated_at: :desc) }, class_name: 'PackageVersionLocal'
+  has_one :latest_upstream_version, -> { order(updated_at: :desc) }, class_name: 'PackageVersionUpstream'
 
   has_one :assignment, dependent: :destroy
   has_one :assignee, through: :assignment


### PR DESCRIPTION
Using includes resulted in some issues:
<img width="689" height="244" alt="Screenshot From 2025-09-25 13-22-27" src="https://github.com/user-attachments/assets/050450b1-2956-4192-8a6c-f0cfe8c0a096" />
<img width="985" height="114" alt="Screenshot From 2025-09-25 13-22-09" src="https://github.com/user-attachments/assets/df7120b0-bb38-4949-af1f-28adbf5ab260" />
This seems to be fixed by using left_joins instead.