### PR TITLE
[backend] support kiwi file name in old and style for static links

### DIFF
--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -1338,11 +1338,16 @@ sub createrepo_staticlinks {
       } elsif (/^(.*)-Build(?:\d\d\d\d+|\d+(?:\.\d+)+)(-Media\d?)\.iso$/s) {
         # product builds
         $link = "$1$2.iso"; # no support for versioned links
-      } elsif (/^(.*\.(?:$binarchs)?)-([^-]+)?(-.*?)?-([^-]+)(\.(raw\.install\.raw\.xz|raw\.xz|raw|tar\.xz|box|json|install\.iso|install\.tar|tbz|tgz|vmx|vmdk|vmdk\.xz|appx|wsl|vhdx|vhdx\.xz|vdi|vdi\.xz|vhdfixed\.xz|iso|phar|qcow2|qcow2\.xz|ova|ova\.xz|cpio\.tar\.bz2))$/s) {
-        # kiwi appliance
+      } elsif (/^(.*\.(?:$binarchs)?)-([0-9][^-]+)?(-.*?)?-([^-]+)(\.(raw\.install\.raw\.xz|raw\.xz|raw|tar\.xz|box|json|install\.iso|install\.tar|tbz|tgz|vmx|vmdk|vmdk\.xz|appx|wsl|vhdx|vhdx\.xz|vdi|vdi\.xz|vhdfixed\.xz|iso|phar|qcow2|qcow2\.xz|ova|ova\.xz|cpio\.tar\.bz2))$/s) {
+        # kiwi appliance old style with name.arch-version-profile-BuildX.Y.suffix
         my $profile = $3 || "";
         $link = "$1$profile$5";
         $link = "$1-$2$profile$5" if $versioned;
+      } elsif (/^(.*\.(?:$binarchs)?)-?(-.*?)?-([^-]+)(\.(raw\.install\.raw\.xz|raw\.xz|raw|tar\.xz|box|json|install\.iso|install\.tar|tbz|tgz|vmx|vmdk|vmdk\.xz|appx|wsl|vhdx|vhdx\.xz|vdi|vdi\.xz|vhdfixed\.xz|iso|phar|qcow2|qcow2\.xz|ova|ova\.xz|cpio\.tar\.bz2))$/s) {
+        # kiwi appliance new style with name.arch-profile-BuildX.Y.suffix
+        my $profile = $2 || "";
+        my $link = "$1$profile$4";
+        $link = "$1-$2$profile$4" if $versioned;
       } elsif (/^(.*?)(?:_(.*?))?(?:_(.*))?\.(manifest|metainfo.xml|efi|vmlinuz|initrd|tar|cpio|img|raw|verity|roothash|roothash\.p7s|usrhash|usrhash\.p7s)(\.(?:gz|bz2|xz|zst|zstd))?$/s) {
         # mkosi appliance, format is 'name_version_architecture.extension' as defined in https://www.freedesktop.org/software/systemd/man/257/systemd.v.html
         # architecture and compression are optional


### PR DESCRIPTION
New style example: Leap-16.0-Minimal-Image.aarch64-kvm-and-xen-Build14.13.qcow2
  Note: 16.0 is part of product name, no version is in the file name

Old style example: opensuse-leap-image.x86_64-1.0.0-lxc-Buildlp151.1.2.tar.xz