### PR TITLE
Bring back history colors, change review added icon to eye

### DIFF
--- a/src/api/app/components/bs_request_history_element_component.rb
+++ b/src/api/app/components/bs_request_history_element_component.rb
@@ -17,11 +17,11 @@ class BsRequestHistoryElementComponent < ApplicationComponent
   def icon
     case @element.type.demodulize
     when 'ReviewAccepted', 'RequestAccepted'
-      tag.i(nil, class: 'fas fa-lg fa-check')
+      tag.i(nil, class: 'fas fa-lg fa-check text-success')
     when 'ReviewDeclined', 'RequestDeclined'
-      tag.i(nil, class: 'fas fa-lg fa-times')
+      tag.i(nil, class: 'fas fa-lg fa-times text-danger')
     when 'RequestReviewAdded'
-      tag.i(nil, class: 'fas fa-sm fa-circle')
+      tag.i(nil, class: 'fas fa-sm fa-eye')
     else
       tag.i(nil, class: 'fas fa-lg fa-code-commit')
     end

--- a/src/api/spec/components/bs_request_history_element_component_spec.rb
+++ b/src/api/spec/components/bs_request_history_element_component_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe BsRequestHistoryElementComponent, type: :component do
       let(:element) { create(:history_element_request_review_added_with_review, user: user) }
 
       it 'displays the right icon' do
-        expect(rendered_content).to have_css('i.fa-circle')
+        expect(rendered_content).to have_css('i.fa-eye')
       end
 
       it 'describes the element action' do
@@ -106,7 +106,7 @@ RSpec.describe BsRequestHistoryElementComponent, type: :component do
       let(:element) { create(:history_element_request_review_added_without_review, user: user, description_extension: nil) }
 
       it 'displays the right icon' do
-        expect(rendered_content).to have_css('i.fa-circle')
+        expect(rendered_content).to have_css('i.fa-eye')
       end
 
       it 'describes the element action' do


### PR DESCRIPTION
In #18564 we remove the color from the history. But the colors for accept/decline help to parse the request history. Only the icon then we review added was confusing as it was *always* a yellow circle no matter the current state of the review.

## Before

<img width="1558" height="666" alt="Screenshot 2025-09-24 at 18-46-25 Request 18 Submit home Admin_package_1757077936_1 - Open Build Service" src="https://github.com/user-attachments/assets/ca03f29f-44c4-4394-a23a-eef576e5bcd4" />

## After

<img width="993" height="520" alt="Screenshot From 2025-10-08 17-32-37" src="https://github.com/user-attachments/assets/f3c856ee-ae99-4cfc-9f69-adcac3e1fcdc" />
