### PR TITLE
Link to release monitoring from upstream version

### DIFF
--- a/src/api/app/datatables/package_datatable.rb
+++ b/src/api/app/datatables/package_datatable.rb
@@ -1,5 +1,7 @@
 # NOTE: Folowing: https://github.com/jbox-web/ajax-datatables-rails#using-view-helpers
 class PackageDatatable < Datatable
+  include Webui::PackageHelper
+
   def_delegator :@view, :link_to
   def_delegator :@view, :package_show_path
   def_delegator :@view, :time_ago_in_words
@@ -71,8 +73,10 @@ class PackageDatatable < Datatable
       upstream = record.latest_upstream_version&.version
       version_string = ''
       version_string += local if local
-      version_string += " (upstream #{upstream})" if upstream && local != upstream
-      version_string
+      version_string += " (#{release_monitoring_package_link(record)})" if upstream && local != upstream
+      # rubocop:disable Rails/OutputSafety
+      version_string.html_safe
+      # rubocop:enable Rails/OutputSafety
     end
   end
 end

--- a/src/api/app/helpers/webui/package_helper.rb
+++ b/src/api/app/helpers/webui/package_helper.rb
@@ -97,4 +97,10 @@ module Webui::PackageHelper
     result -= 1 if state == 'deleted'
     [result, 0].max
   end
+
+  def release_monitoring_package_link(package)
+    text = "upstream #{package.latest_upstream_version.version}"
+    release_monitoring_url = "https://release-monitoring.org/distro/#{package.project.anitya_distribution_name}/search/#{package.name}"
+    link_to(text, release_monitoring_url, target: '_blank', rel: 'noopener')
+  end
 end

--- a/src/api/app/views/webui/package/show.html.haml
+++ b/src/api/app/views/webui/package/show.html.haml
@@ -38,7 +38,7 @@
           - if @package.latest_local_version
             %b= @package.latest_local_version.version
           - if @package.latest_upstream_version && (@package.latest_local_version&.version != @package.latest_upstream_version.version)
-            (upstream #{@package.latest_upstream_version.version})
+            (#{release_monitoring_package_link(@package)})
         .in-place-editing
           = render partial: 'basic_info', locals: { package: @package, project: @project }
       .col-md-4


### PR DESCRIPTION
This PR introduces links to release monitoring from upstream versions

Packages list
<img width="987" height="171" alt="image" src="https://github.com/user-attachments/assets/6a5e2d10-e29e-4290-8c94-63b8607f605c" />

Package show
<img width="546" height="169" alt="image" src="https://github.com/user-attachments/assets/13497570-9893-45cc-893d-d156441ade3a" />
