### PR TITLE
Display more information about the upstream version

### DIFF
--- a/src/api/app/datatables/package_datatable.rb
+++ b/src/api/app/datatables/package_datatable.rb
@@ -71,12 +71,14 @@ class PackageDatatable < Datatable
     tag.span do
       local = record.latest_local_version&.version
       upstream = record.latest_upstream_version&.version
-      version_string = ''
-      version_string += local if local
-      version_string += " (#{release_monitoring_package_link(record)})" if upstream && local != upstream
-      # rubocop:disable Rails/OutputSafety
-      version_string.html_safe
-      # rubocop:enable Rails/OutputSafety
+      tag.span(local) +
+        if upstream && local != upstream
+          " (#{release_monitoring_package_link(record, "#{upstream} available")})"
+        elsif upstream && local == upstream
+          " (#{release_monitoring_package_link(record, 'up to date')})"
+        else
+          " (#{release_monitoring_search_link(record, 'no upstream')})"
+        end
     end
   end
 end

--- a/src/api/app/helpers/webui/package_helper.rb
+++ b/src/api/app/helpers/webui/package_helper.rb
@@ -98,9 +98,13 @@ module Webui::PackageHelper
     [result, 0].max
   end
 
-  def release_monitoring_package_link(package)
-    text = "upstream #{package.latest_upstream_version.version}"
+  def release_monitoring_package_link(package, text)
     release_monitoring_url = "https://release-monitoring.org/distro/#{package.project.anitya_distribution_name}/search/#{package.name}"
+    link_to(text, release_monitoring_url, target: '_blank', rel: 'noopener')
+  end
+
+  def release_monitoring_search_link(package, text)
+    release_monitoring_url = "https://release-monitoring.org/projects/search/?pattern=#{package.name}"
     link_to(text, release_monitoring_url, target: '_blank', rel: 'noopener')
   end
 end

--- a/src/api/app/views/webui/package/show.html.haml
+++ b/src/api/app/views/webui/package/show.html.haml
@@ -38,7 +38,11 @@
           - if @package.latest_local_version
             %b= @package.latest_local_version.version
           - if @package.latest_upstream_version && (@package.latest_local_version&.version != @package.latest_upstream_version.version)
-            (#{release_monitoring_package_link(@package)})
+            (#{release_monitoring_package_link(@package, "#{@package.latest_upstream_version.version} available")})
+          - elsif @package.latest_upstream_version && (@package.latest_local_version&.version == @package.latest_upstream_version.version)
+            (#{release_monitoring_package_link(@package, 'up to date')})
+          - else
+            (#{release_monitoring_search_link(@package, 'no upstream')})
         .in-place-editing
           = render partial: 'basic_info', locals: { package: @package, project: @project }
       .col-md-4


### PR DESCRIPTION
Display additionally if the package is up to date, or if there is no upstream available
<img width="974" height="70" alt="Screenshot From 2025-10-16 13-12-48" src="https://github.com/user-attachments/assets/880eac1d-9696-4682-9921-5d1d11d26c5e" />
<img width="542" height="271" alt="Screenshot From 2025-10-16 13-14-35" src="https://github.com/user-attachments/assets/77dd3759-76bb-45dc-aacf-b493d6cd72b5" />
