### PR TITLE
Handle projects without packages in the Backend

### DIFF
--- a/src/api/app/jobs/fetch_local_package_version_job.rb
+++ b/src/api/app/jobs/fetch_local_package_version_job.rb
@@ -5,9 +5,18 @@ class FetchLocalPackageVersionJob < ApplicationJob
     info = if package_name
              Backend::Api::Sources::Package.files(project_name, package_name, view: :info, parse: 1)
            else
-             Backend::Api::Sources::Project.packages(project_name, view: :info, parse: 1)
+             begin
+               Backend::Api::Sources::Project.packages(project_name, view: :info, parse: 1)
+             rescue Backend::NotFoundError
+               logger.info("FetchLocalPackageVersionJob: #{project_name} has no packages in the Backend")
+               nil
+             end
            end
 
+    create_local_version_from_backend_output(info) if info
+  end
+
+  def create_local_version_from_backend_output(info)
     Nokogiri::XML(info).xpath('//sourceinfo[@package]').each do |sourceinfo|
       next unless (package = Package.find_by_project_and_name(project_name, sourceinfo['package']))
       next unless (version = sourceinfo.at('version')&.content)


### PR DESCRIPTION
The job that creates instances of `PackageVersionLocal` was crashing when the project had no packages in the backed with:

```
     Backend::NotFoundError:                                                                                                                                                                               
       <status code="404">                                                                                                                                                                                 
         <summary>project 'factory' does not exist</summary>                                                                                                                                               
         <details>404 project 'factory' does not exist</details>                                                                                                                                           
       </status
```

That's controlled now. This error was exposed thanks to a factory that couldn't add the `anitya_distribution_name` at the creation time, as the packages weren't in the backend at that point (the factory will be fixed next).