### PR TITLE
Set anitya_distribution_name after the project is on backend

### DIFF
--- a/src/api/spec/cassettes/FetchUpstreamPackageVersionJob/_perform/not_providing_a_project_name/creates_a_package_version_upstream_record_for_all_projects_packages_with_the_attribute_assigned.yml
+++ b/src/api/spec/cassettes/FetchUpstreamPackageVersionJob/_perform/not_providing_a_project_name/creates_a_package_version_upstream_record_for_all_projects_packages_with_the_attribute_assigned.yml
@@ -2,12 +2,12 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/factory/_meta?user=user_4
+    uri: http://backend:5352/source/factory/_meta?user=user_1
     body:
       encoding: UTF-8
       string: |
         <project name="factory">
-          <title>I Know Why the Caged Bird Sings</title>
+          <title>The Parliament of Man</title>
           <description/>
         </project>
     headers:
@@ -29,24 +29,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '115'
+      - '105'
     body:
       encoding: UTF-8
       string: |
         <project name="factory">
-          <title>I Know Why the Caged Bird Sings</title>
+          <title>The Parliament of Man</title>
           <description></description>
         </project>
-  recorded_at: Thu, 18 Sep 2025 13:36:59 GMT
+  recorded_at: Fri, 17 Oct 2025 12:02:44 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/factory/hello/_meta?user=user_5
+    uri: http://backend:5352/source/factory/hello/_meta?user=user_2
     body:
       encoding: UTF-8
       string: |
         <package name="hello" project="factory">
-          <title>I Know Why the Caged Bird Sings</title>
-          <description>Dolorem nihil unde non.</description>
+          <title>The Glory and the Dream</title>
+          <description>Rerum maxime nam numquam.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -67,24 +67,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '154'
+      - '148'
     body:
       encoding: UTF-8
       string: |
         <package name="hello" project="factory">
-          <title>I Know Why the Caged Bird Sings</title>
-          <description>Dolorem nihil unde non.</description>
+          <title>The Glory and the Dream</title>
+          <description>Rerum maxime nam numquam.</description>
         </package>
-  recorded_at: Thu, 18 Sep 2025 13:36:59 GMT
+  recorded_at: Fri, 17 Oct 2025 12:02:44 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/factory/hello/_meta?user=user_5
+    uri: http://backend:5352/source/factory/hello/_meta?user=user_2
     body:
       encoding: UTF-8
       string: |
         <package name="hello" project="factory">
-          <title>I Know Why the Caged Bird Sings</title>
-          <description>Dolorem nihil unde non.</description>
+          <title>The Glory and the Dream</title>
+          <description>Rerum maxime nam numquam.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -105,15 +105,70 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '154'
+      - '148'
     body:
       encoding: UTF-8
       string: |
         <package name="hello" project="factory">
-          <title>I Know Why the Caged Bird Sings</title>
-          <description>Dolorem nihil unde non.</description>
+          <title>The Glory and the Dream</title>
+          <description>Rerum maxime nam numquam.</description>
         </package>
-  recorded_at: Thu, 18 Sep 2025 13:36:59 GMT
+  recorded_at: Fri, 17 Oct 2025 12:02:44 GMT
+- request:
+    method: get
+    uri: https://release-monitoring.org/api/v2/packages/?distribution=openSUSE&name=hello
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - release-monitoring.org
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 17 Oct 2025 12:02:45 GMT
+      Server:
+      - Apache/2.4.64 (Fedora Linux) mod_wsgi/5.0.2 Python/3.13
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Apptime:
+      - D=35077
+      Content-Length:
+      - '213'
+      Content-Type:
+      - application/json
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Cookie
+      X-Content-Type-Options:
+      - nosniff
+      X-Fedora-Proxyserver:
+      - proxy01.rdu3.fedoraproject.org
+      X-Fedora-Requestid:
+      - aPIwZQp_No5UrzLp_FJAsQAAJEE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Set-Cookie:
+      - c7f2af7958ac7bdd3fe2e687de986bfb=ae99571a12133b6a37ba8d349566aad0; path=/;
+        HttpOnly; Secure; SameSite=None
+    body:
+      encoding: UTF-8
+      string: '{"items":[{"distribution":"openSUSE","ecosystem":"https://www.gnu.org/software/hello/","name":"hello","project":"hello","stable_version":"2.12.2","version":"2.12.2"}],"items_per_page":25,"page":1,"total_items":1}
+
+'
+  recorded_at: Fri, 17 Oct 2025 12:02:45 GMT
 - request:
     method: get
     uri: http://backend:5352/source/factory?parse=1&view=info
@@ -148,112 +203,15 @@ http_interactions:
             <error>no source uploaded</error>
           </sourceinfo>
         </sourceinfolist>
-  recorded_at: Thu, 18 Sep 2025 13:36:59 GMT
-- request:
-    method: get
-    uri: https://release-monitoring.org/api/v2/packages/?distribution=openSUSE&name=hello
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Host:
-      - release-monitoring.org
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 18 Sep 2025 13:36:59 GMT
-      Server:
-      - Apache/2.4.64 (Fedora Linux) mod_wsgi/5.0.2 Python/3.13
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Content-Length:
-      - '213'
-      Vary:
-      - Cookie
-      Content-Type:
-      - application/json
-      Set-Cookie:
-      - c7f2af7958ac7bdd3fe2e687de986bfb=5a4aec613afb900faa188f3e7b71c7fb; path=/;
-        HttpOnly; Secure; SameSite=None
-      Apptime:
-      - D=53474
-      X-Fedora-Proxyserver:
-      - proxy10.rdu3.fedoraproject.org
-      X-Fedora-Requestid:
-      - aMwK-21WmLuE8NdhR5-aiwAADMU
-    body:
-      encoding: UTF-8
-      string: '{"items":[{"distribution":"openSUSE","ecosystem":"https://www.gnu.org/software/hello/","name":"hello","project":"hello","stable_version":"2.12.2","version":"2.12.2"}],"items_per_page":25,"page":1,"total_items":1}
-
-'
-  recorded_at: Thu, 18 Sep 2025 13:36:59 GMT
+  recorded_at: Fri, 17 Oct 2025 12:02:45 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/factory/_project/_attribute?meta=1
-    body:
-      encoding: UTF-8
-      string: |
-        <attributes>
-          <attribute name="AnityaDistribution" namespace="OBS">
-            <value>openSUSE</value>
-          </attribute>
-        </attributes>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '170'
-    body:
-      encoding: UTF-8
-      string: |
-        <revision rev="10">
-          <srcmd5>0285fe3935ecfd045f458061b532823d</srcmd5>
-          <time>1758202619</time>
-          <user>unknown</user>
-          <comment></comment>
-          <requestid/>
-        </revision>
-  recorded_at: Thu, 18 Sep 2025 13:36:59 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/games/_meta?user=user_7
+    uri: http://backend:5352/source/games/_meta?user=user_3
     body:
       encoding: UTF-8
       string: |
         <project name="games">
-          <title>No Longer at Ease</title>
+          <title>The Stars' Tennis Balls</title>
           <description/>
         </project>
     headers:
@@ -275,24 +233,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '99'
+      - '105'
     body:
       encoding: UTF-8
       string: |
         <project name="games">
-          <title>No Longer at Ease</title>
+          <title>The Stars' Tennis Balls</title>
           <description></description>
         </project>
-  recorded_at: Thu, 18 Sep 2025 13:36:59 GMT
+  recorded_at: Fri, 17 Oct 2025 12:02:45 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/games/0ad/_meta?user=user_8
+    uri: http://backend:5352/source/games/0ad/_meta?user=user_4
     body:
       encoding: UTF-8
       string: |
         <package name="0ad" project="games">
-          <title>Antic Hay</title>
-          <description>Non ab velit ea.</description>
+          <title>Dying of the Light</title>
+          <description>Consectetur et et laboriosam.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -313,24 +271,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '121'
+      - '143'
     body:
       encoding: UTF-8
       string: |
         <package name="0ad" project="games">
-          <title>Antic Hay</title>
-          <description>Non ab velit ea.</description>
+          <title>Dying of the Light</title>
+          <description>Consectetur et et laboriosam.</description>
         </package>
-  recorded_at: Thu, 18 Sep 2025 13:36:59 GMT
+  recorded_at: Fri, 17 Oct 2025 12:02:45 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/games/0ad/_meta?user=user_8
+    uri: http://backend:5352/source/games/0ad/_meta?user=user_4
     body:
       encoding: UTF-8
       string: |
         <package name="0ad" project="games">
-          <title>Antic Hay</title>
-          <description>Non ab velit ea.</description>
+          <title>Dying of the Light</title>
+          <description>Consectetur et et laboriosam.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -351,15 +309,70 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '121'
+      - '143'
     body:
       encoding: UTF-8
       string: |
         <package name="0ad" project="games">
-          <title>Antic Hay</title>
-          <description>Non ab velit ea.</description>
+          <title>Dying of the Light</title>
+          <description>Consectetur et et laboriosam.</description>
         </package>
-  recorded_at: Thu, 18 Sep 2025 13:36:59 GMT
+  recorded_at: Fri, 17 Oct 2025 12:02:45 GMT
+- request:
+    method: get
+    uri: https://release-monitoring.org/api/v2/packages/?distribution=openSUSE&name=0ad
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - release-monitoring.org
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 17 Oct 2025 12:02:46 GMT
+      Server:
+      - Apache/2.4.64 (Fedora Linux) mod_wsgi/5.0.2 Python/3.13
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Apptime:
+      - D=36319
+      Content-Length:
+      - '194'
+      Content-Type:
+      - application/json
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Cookie
+      X-Content-Type-Options:
+      - nosniff
+      X-Fedora-Proxyserver:
+      - proxy10.rdu3.fedoraproject.org
+      X-Fedora-Requestid:
+      - aPIwZko-ukFLQtvV00rRHgAAFEw
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Set-Cookie:
+      - c7f2af7958ac7bdd3fe2e687de986bfb=ae99571a12133b6a37ba8d349566aad0; path=/;
+        HttpOnly; Secure; SameSite=None
+    body:
+      encoding: UTF-8
+      string: '{"items":[{"distribution":"openSUSE","ecosystem":"https://play0ad.com/","name":"0ad","project":"0ad","stable_version":"0.27.1","version":"0.27.1"}],"items_per_page":25,"page":1,"total_items":1}
+
+'
+  recorded_at: Fri, 17 Oct 2025 12:02:46 GMT
 - request:
     method: get
     uri: http://backend:5352/source/games?parse=1&view=info
@@ -394,104 +407,7 @@ http_interactions:
             <error>no source uploaded</error>
           </sourceinfo>
         </sourceinfolist>
-  recorded_at: Thu, 18 Sep 2025 13:36:59 GMT
-- request:
-    method: get
-    uri: https://release-monitoring.org/api/v2/packages/?distribution=openSUSE&name=0ad
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Host:
-      - release-monitoring.org
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 18 Sep 2025 13:37:00 GMT
-      Server:
-      - Apache/2.4.64 (Fedora Linux) mod_wsgi/5.0.2 Python/3.13
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Content-Length:
-      - '194'
-      Vary:
-      - Cookie
-      Content-Type:
-      - application/json
-      Set-Cookie:
-      - c7f2af7958ac7bdd3fe2e687de986bfb=5a4aec613afb900faa188f3e7b71c7fb; path=/;
-        HttpOnly; Secure; SameSite=None
-      Apptime:
-      - D=33800
-      X-Fedora-Proxyserver:
-      - proxy01.rdu3.fedoraproject.org
-      X-Fedora-Requestid:
-      - aMwK_HeXpLJnUFftEYgaFgAACkI
-    body:
-      encoding: UTF-8
-      string: '{"items":[{"distribution":"openSUSE","ecosystem":"https://play0ad.com/","name":"0ad","project":"0ad","stable_version":"0.27.1","version":"0.27.1"}],"items_per_page":25,"page":1,"total_items":1}
-
-'
-  recorded_at: Thu, 18 Sep 2025 13:37:00 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/games/_project/_attribute?meta=1
-    body:
-      encoding: UTF-8
-      string: |
-        <attributes>
-          <attribute name="AnityaDistribution" namespace="OBS">
-            <value>openSUSE</value>
-          </attribute>
-        </attributes>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '169'
-    body:
-      encoding: UTF-8
-      string: |
-        <revision rev="6">
-          <srcmd5>51358cee48b1f75379ced3459b66fb3c</srcmd5>
-          <time>1758202620</time>
-          <user>unknown</user>
-          <comment></comment>
-          <requestid/>
-        </revision>
-  recorded_at: Thu, 18 Sep 2025 13:37:00 GMT
+  recorded_at: Fri, 17 Oct 2025 12:02:46 GMT
 - request:
     method: get
     uri: https://release-monitoring.org/api/v2/packages/?distribution=openSUSE&name=hello
@@ -513,40 +429,40 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 18 Sep 2025 13:37:00 GMT
+      - Fri, 17 Oct 2025 12:02:46 GMT
       Server:
       - Apache/2.4.64 (Fedora Linux) mod_wsgi/5.0.2 Python/3.13
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
+      Apptime:
+      - D=36051
+      Content-Length:
+      - '213'
+      Content-Type:
+      - application/json
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Cookie
+      X-Content-Type-Options:
+      - nosniff
+      X-Fedora-Proxyserver:
+      - proxy01.rdu3.fedoraproject.org
+      X-Fedora-Requestid:
+      - aPIwZvgt0QzpJwFWUyYu3gAAJQE
       X-Frame-Options:
       - SAMEORIGIN
       X-Xss-Protection:
       - 1; mode=block
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Content-Length:
-      - '213'
-      Vary:
-      - Cookie
-      Content-Type:
-      - application/json
       Set-Cookie:
-      - c7f2af7958ac7bdd3fe2e687de986bfb=5a4aec613afb900faa188f3e7b71c7fb; path=/;
+      - c7f2af7958ac7bdd3fe2e687de986bfb=ae99571a12133b6a37ba8d349566aad0; path=/;
         HttpOnly; Secure; SameSite=None
-      Apptime:
-      - D=36293
-      X-Fedora-Proxyserver:
-      - proxy10.rdu3.fedoraproject.org
-      X-Fedora-Requestid:
-      - aMwK_M-EJ_VeLqXDo8FvnwAACFI
     body:
       encoding: UTF-8
       string: '{"items":[{"distribution":"openSUSE","ecosystem":"https://www.gnu.org/software/hello/","name":"hello","project":"hello","stable_version":"2.12.2","version":"2.12.2"}],"items_per_page":25,"page":1,"total_items":1}
 
 '
-  recorded_at: Thu, 18 Sep 2025 13:37:00 GMT
+  recorded_at: Fri, 17 Oct 2025 12:02:47 GMT
 - request:
     method: get
     uri: https://release-monitoring.org/api/v2/packages/?distribution=openSUSE&name=0ad
@@ -568,38 +484,38 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 18 Sep 2025 13:37:01 GMT
+      - Fri, 17 Oct 2025 12:02:47 GMT
       Server:
       - Apache/2.4.64 (Fedora Linux) mod_wsgi/5.0.2 Python/3.13
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
+      Apptime:
+      - D=36239
+      Content-Length:
+      - '194'
+      Content-Type:
+      - application/json
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Cookie
+      X-Content-Type-Options:
+      - nosniff
+      X-Fedora-Proxyserver:
+      - proxy10.rdu3.fedoraproject.org
+      X-Fedora-Requestid:
+      - aPIwZ3ojdlHykwNGjZ9HQgAAGlE
       X-Frame-Options:
       - SAMEORIGIN
       X-Xss-Protection:
       - 1; mode=block
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Content-Length:
-      - '194'
-      Vary:
-      - Cookie
-      Content-Type:
-      - application/json
       Set-Cookie:
-      - c7f2af7958ac7bdd3fe2e687de986bfb=5a4aec613afb900faa188f3e7b71c7fb; path=/;
+      - c7f2af7958ac7bdd3fe2e687de986bfb=ae99571a12133b6a37ba8d349566aad0; path=/;
         HttpOnly; Secure; SameSite=None
-      Apptime:
-      - D=50808
-      X-Fedora-Proxyserver:
-      - proxy01.rdu3.fedoraproject.org
-      X-Fedora-Requestid:
-      - aMwK_dCBa67rSA9wFAvlRAAACZQ
     body:
       encoding: UTF-8
       string: '{"items":[{"distribution":"openSUSE","ecosystem":"https://play0ad.com/","name":"0ad","project":"0ad","stable_version":"0.27.1","version":"0.27.1"}],"items_per_page":25,"page":1,"total_items":1}
 
 '
-  recorded_at: Thu, 18 Sep 2025 13:37:01 GMT
+  recorded_at: Fri, 17 Oct 2025 12:02:47 GMT
 recorded_with: VCR 6.3.1

--- a/src/api/spec/cassettes/FetchUpstreamPackageVersionJob/_perform/providing_a_project_name/creates_a_package_version_upstream_record_for_the_projects_packages.yml
+++ b/src/api/spec/cassettes/FetchUpstreamPackageVersionJob/_perform/providing_a_project_name/creates_a_package_version_upstream_record_for_the_projects_packages.yml
@@ -2,12 +2,12 @@
 http_interactions:
 - request:
     method: put
-    uri: http://backend:5352/source/factory/_meta?user=user_1
+    uri: http://backend:5352/source/factory/_meta?user=user_5
     body:
       encoding: UTF-8
       string: |
         <project name="factory">
-          <title>Time of our Darkness</title>
+          <title>The Curious Incident of the Dog in the Night-Time</title>
           <description/>
         </project>
     headers:
@@ -29,24 +29,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '104'
+      - '133'
     body:
       encoding: UTF-8
       string: |
         <project name="factory">
-          <title>Time of our Darkness</title>
+          <title>The Curious Incident of the Dog in the Night-Time</title>
           <description></description>
         </project>
-  recorded_at: Thu, 18 Sep 2025 13:36:57 GMT
+  recorded_at: Fri, 17 Oct 2025 12:02:47 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/factory/hello/_meta?user=user_2
+    uri: http://backend:5352/source/factory/hello/_meta?user=user_6
     body:
       encoding: UTF-8
       string: |
         <package name="hello" project="factory">
-          <title>The Wings of the Dove</title>
-          <description>Et consequatur ipsam molestias.</description>
+          <title>O Pioneers!</title>
+          <description>Quasi harum et natus.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -67,24 +67,24 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '152'
+      - '132'
     body:
       encoding: UTF-8
       string: |
         <package name="hello" project="factory">
-          <title>The Wings of the Dove</title>
-          <description>Et consequatur ipsam molestias.</description>
+          <title>O Pioneers!</title>
+          <description>Quasi harum et natus.</description>
         </package>
-  recorded_at: Thu, 18 Sep 2025 13:36:57 GMT
+  recorded_at: Fri, 17 Oct 2025 12:02:48 GMT
 - request:
     method: put
-    uri: http://backend:5352/source/factory/hello/_meta?user=user_2
+    uri: http://backend:5352/source/factory/hello/_meta?user=user_6
     body:
       encoding: UTF-8
       string: |
         <package name="hello" project="factory">
-          <title>The Wings of the Dove</title>
-          <description>Et consequatur ipsam molestias.</description>
+          <title>O Pioneers!</title>
+          <description>Quasi harum et natus.</description>
         </package>
     headers:
       Accept-Encoding:
@@ -105,15 +105,70 @@ http_interactions:
       Connection:
       - close
       Content-Length:
-      - '152'
+      - '132'
     body:
       encoding: UTF-8
       string: |
         <package name="hello" project="factory">
-          <title>The Wings of the Dove</title>
-          <description>Et consequatur ipsam molestias.</description>
+          <title>O Pioneers!</title>
+          <description>Quasi harum et natus.</description>
         </package>
-  recorded_at: Thu, 18 Sep 2025 13:36:57 GMT
+  recorded_at: Fri, 17 Oct 2025 12:02:48 GMT
+- request:
+    method: get
+    uri: https://release-monitoring.org/api/v2/packages/?distribution=openSUSE&name=hello
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - release-monitoring.org
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 17 Oct 2025 12:02:48 GMT
+      Server:
+      - Apache/2.4.64 (Fedora Linux) mod_wsgi/5.0.2 Python/3.13
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Apptime:
+      - D=45157
+      Content-Length:
+      - '213'
+      Content-Type:
+      - application/json
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Cookie
+      X-Content-Type-Options:
+      - nosniff
+      X-Fedora-Proxyserver:
+      - proxy01.rdu3.fedoraproject.org
+      X-Fedora-Requestid:
+      - aPIwaHP-hoboXyWcgQX95AAAJ4Q
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Set-Cookie:
+      - c7f2af7958ac7bdd3fe2e687de986bfb=ae99571a12133b6a37ba8d349566aad0; path=/;
+        HttpOnly; Secure; SameSite=None
+    body:
+      encoding: UTF-8
+      string: '{"items":[{"distribution":"openSUSE","ecosystem":"https://www.gnu.org/software/hello/","name":"hello","project":"hello","stable_version":"2.12.2","version":"2.12.2"}],"items_per_page":25,"page":1,"total_items":1}
+
+'
+  recorded_at: Fri, 17 Oct 2025 12:02:48 GMT
 - request:
     method: get
     uri: http://backend:5352/source/factory?parse=1&view=info
@@ -148,7 +203,7 @@ http_interactions:
             <error>no source uploaded</error>
           </sourceinfo>
         </sourceinfolist>
-  recorded_at: Thu, 18 Sep 2025 13:36:58 GMT
+  recorded_at: Fri, 17 Oct 2025 12:02:48 GMT
 - request:
     method: get
     uri: https://release-monitoring.org/api/v2/packages/?distribution=openSUSE&name=hello
@@ -170,135 +225,38 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 18 Sep 2025 13:36:58 GMT
+      - Fri, 17 Oct 2025 12:02:49 GMT
       Server:
       - Apache/2.4.64 (Fedora Linux) mod_wsgi/5.0.2 Python/3.13
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
+      Apptime:
+      - D=37902
+      Content-Length:
+      - '213'
+      Content-Type:
+      - application/json
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Cookie
+      X-Content-Type-Options:
+      - nosniff
+      X-Fedora-Proxyserver:
+      - proxy10.rdu3.fedoraproject.org
+      X-Fedora-Requestid:
+      - aPIwaRxQjG281gYelNNDmQAAItY
       X-Frame-Options:
       - SAMEORIGIN
       X-Xss-Protection:
       - 1; mode=block
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Content-Length:
-      - '213'
-      Vary:
-      - Cookie
-      Content-Type:
-      - application/json
       Set-Cookie:
-      - c7f2af7958ac7bdd3fe2e687de986bfb=5a4aec613afb900faa188f3e7b71c7fb; path=/;
+      - c7f2af7958ac7bdd3fe2e687de986bfb=ae99571a12133b6a37ba8d349566aad0; path=/;
         HttpOnly; Secure; SameSite=None
-      Apptime:
-      - D=37222
-      X-Fedora-Proxyserver:
-      - proxy10.rdu3.fedoraproject.org
-      X-Fedora-Requestid:
-      - aMwK-kesGKgIq1Fy8itibAAAD80
     body:
       encoding: UTF-8
       string: '{"items":[{"distribution":"openSUSE","ecosystem":"https://www.gnu.org/software/hello/","name":"hello","project":"hello","stable_version":"2.12.2","version":"2.12.2"}],"items_per_page":25,"page":1,"total_items":1}
 
 '
-  recorded_at: Thu, 18 Sep 2025 13:36:58 GMT
-- request:
-    method: put
-    uri: http://backend:5352/source/factory/_project/_attribute?meta=1
-    body:
-      encoding: UTF-8
-      string: |
-        <attributes>
-          <attribute name="AnityaDistribution" namespace="OBS">
-            <value>openSUSE</value>
-          </attribute>
-        </attributes>
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - text/xml
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Length:
-      - '169'
-    body:
-      encoding: UTF-8
-      string: |
-        <revision rev="8">
-          <srcmd5>b01a5cc278ea8e418a8b9d0c75c05ed0</srcmd5>
-          <time>1758202618</time>
-          <user>unknown</user>
-          <comment></comment>
-          <requestid/>
-        </revision>
-  recorded_at: Thu, 18 Sep 2025 13:36:58 GMT
-- request:
-    method: get
-    uri: https://release-monitoring.org/api/v2/packages/?distribution=openSUSE&name=hello
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-      Host:
-      - release-monitoring.org
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 18 Sep 2025 13:36:58 GMT
-      Server:
-      - Apache/2.4.64 (Fedora Linux) mod_wsgi/5.0.2 Python/3.13
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Content-Length:
-      - '213'
-      Vary:
-      - Cookie
-      Content-Type:
-      - application/json
-      Set-Cookie:
-      - c7f2af7958ac7bdd3fe2e687de986bfb=5a4aec613afb900faa188f3e7b71c7fb; path=/;
-        HttpOnly; Secure; SameSite=None
-      Apptime:
-      - D=34116
-      X-Fedora-Proxyserver:
-      - proxy10.rdu3.fedoraproject.org
-      X-Fedora-Requestid:
-      - aMwK-mNv7Qb7j_0Tdl-WgwAACgc
-    body:
-      encoding: UTF-8
-      string: '{"items":[{"distribution":"openSUSE","ecosystem":"https://www.gnu.org/software/hello/","name":"hello","project":"hello","stable_version":"2.12.2","version":"2.12.2"}],"items_per_page":25,"page":1,"total_items":1}
-
-'
-  recorded_at: Thu, 18 Sep 2025 13:36:58 GMT
+  recorded_at: Fri, 17 Oct 2025 12:02:49 GMT
 recorded_with: VCR 6.3.1

--- a/src/api/spec/jobs/fetch_upstream_package_version_job_spec.rb
+++ b/src/api/spec/jobs/fetch_upstream_package_version_job_spec.rb
@@ -1,7 +1,12 @@
 RSpec.describe FetchUpstreamPackageVersionJob, :vcr do
   describe '#perform' do
-    let!(:project) { create(:project_with_package, name: 'factory', package_name: 'hello', anitya_distribution_name: 'openSUSE') }
+    let!(:project) { create(:project_with_package, name: 'factory', package_name: 'hello') }
     let(:package) { project.packages.first }
+
+    before do
+      # The project should exist in the Backend before we set anitya_distribution_name (what triggers the fetching jobs)
+      project.update(anitya_distribution_name: 'openSUSE')
+    end
 
     context 'providing a project name' do
       before do
@@ -15,10 +20,12 @@ RSpec.describe FetchUpstreamPackageVersionJob, :vcr do
     end
 
     context 'not providing a project name' do
-      let!(:another_project) { create(:project_with_package, name: 'games', package_name: '0ad', anitya_distribution_name: 'openSUSE') }
+      let!(:another_project) { create(:project_with_package, name: 'games', package_name: '0ad') }
       let(:another_package) { another_project.packages.first }
 
       before do
+        # The project should exist in the Backend before we set anitya_distribution_name (what triggers the fetching jobs)
+        another_project.update(anitya_distribution_name: 'openSUSE')
         described_class.perform_now
       end
 


### PR DESCRIPTION
The existing cassettes hid an error in the specs, which appeared when we moved from having an attribute regarding to anytia to having a column in the project table.

After saving a project with a new value on `anitya_distribution_name`, the job to fetch local versions is triggered.
The local version is fetched from Backend, so the project should be stored on backend before setting the value.

Right now, the project controller is in charge of calling `project.store`
https://github.com/openSUSE/open-build-service/blob/bd17f64e3fca9de625d699cdbf14b7915cac5a4d/src/api/app/controllers/webui/project_controller.rb#L98

But `Project#store` calls `save!` (which triggers the `FetchLocalPackageVersionJob`) and after that it calls `write_to_backend`. That's the reason why we have to set the `anitya_distribution_name` later.