### PR TITLE
Set the `updated_at` field to the time of the last sync

### DIFF
--- a/src/api/app/jobs/fetch_local_package_version_job.rb
+++ b/src/api/app/jobs/fetch_local_package_version_job.rb
@@ -12,7 +12,7 @@ class FetchLocalPackageVersionJob < ApplicationJob
       next unless (package = Package.find_by_project_and_name(project_name, sourceinfo['package']))
       next unless (version = sourceinfo.at('version')&.content)
 
-      PackageVersionLocal.find_or_create_by(version: version, package: package)
+      PackageVersionLocal.find_or_create_by(version: version, package: package).touch # rubocop:disable Rails/SkipsModelValidations
     end
   end
 end

--- a/src/api/app/jobs/fetch_upstream_package_version_job.rb
+++ b/src/api/app/jobs/fetch_upstream_package_version_job.rb
@@ -43,7 +43,7 @@ class FetchUpstreamPackageVersionJob < ApplicationJob
     return if upstream_version.blank?
 
     package_ids.each do |package_id|
-      PackageVersionUpstream.find_or_create_by(version: upstream_version, package_id: package_id)
+      PackageVersionUpstream.find_or_create_by(version: upstream_version, package_id: package_id).touch # rubocop:disable Rails/SkipsModelValidations
     end
   end
 


### PR DESCRIPTION
Before, fetching a version (local or upstream) of a package, we didn't modify the record if the version of  a package was found. Now, the `updated_at` field is updated.

### For reviewers

Use your development environment and check the value of the `updated_at` field of the records of the `package_versions` table.