### PR TITLE
Skip forgery protection for the pulse page

### DIFF
--- a/src/api/app/controllers/webui/projects/pulse_controller.rb
+++ b/src/api/app/controllers/webui/projects/pulse_controller.rb
@@ -5,6 +5,8 @@ module Webui
       before_action :set_project
       before_action :set_range
 
+      skip_forgery_protection only: :show
+
       def show
         respond_to do |format|
           format.js do


### PR DESCRIPTION
We're using a form to change the period over which the pulse page computes its values, that triggers a CSRF warning

Fixes #17818