### PR TITLE
Always display the changed filename in a diff subject

### DIFF
--- a/src/api/app/components/diff_subject_component.rb
+++ b/src/api/app/components/diff_subject_component.rb
@@ -17,9 +17,10 @@ class DiffSubjectComponent < ApplicationComponent
   end
 
   def changed_filename
-    return @old_filename if @state == 'deleted'
-    return "#{@old_filename} -> #{@new_filename}" if @state == 'renamed'
+    return @new_filename unless @old_filename
+    return @old_filename unless @new_filename
+    return @new_filename if @old_filename == @new_filename
 
-    @new_filename
+    "#{@old_filename} -> #{@new_filename}"
   end
 end


### PR DESCRIPTION
Ensures that any time a file was renamed, that information is displayed to the user
<img width="1483" height="380" alt="Screenshot From 2025-10-23 13-09-14" src="https://github.com/user-attachments/assets/dfbf0937-8d6f-4f1b-b220-8331203187be" />

Fixes #18579
