### PR TITLE
Highlight active filters

### DIFF
--- a/src/api/app/views/webui/shared/_build_result_filter.haml
+++ b/src/api/app/views/webui/shared/_build_result_filter.haml
@@ -1,5 +1,6 @@
+- btn_class = (values.map { "#{value_prefix}#{_1}" } & checked_values).any? ? 'btn-secondary' : 'btn-outline-secondary'
 %span.dropdown{ id: id }
-  %button.btn.btn-outline-secondary.dropdown-toggle{ data: { 'bs-toggle': :dropdown }, type: :button }
+  %button.btn.dropdown-toggle{ class: btn_class, data: { 'bs-toggle': :dropdown }, type: :button }
     %span.caret
     = text
   .dropdown-menu.keep-open.limit-height


### PR DESCRIPTION
Before, filters where never highlighted.

<img width="767" height="181" alt="Screenshot From 2025-10-23 15-50-50" src="https://github.com/user-attachments/assets/ebcfb1e7-8fdd-463c-8e56-1515006316c0" />

After the proposed changes, filters are highlighted when they are active, when they have some values selected.

<img width="767" height="181" alt="Screenshot From 2025-10-23 15-50-31" src="https://github.com/user-attachments/assets/4a3fb096-f474-4e1b-b1c4-79fac0131795" />
