### PR TITLE
Omit package name filter for single package build results

### DIFF
--- a/src/api/app/views/webui/request/_build_results_filters.haml
+++ b/src/api/app/views/webui/request/_build_results_filters.haml
@@ -1,9 +1,10 @@
 = form_tag(filter_url, method: :get) do
-  = render partial: 'webui/shared/build_result_filter', locals: { id: 'project-monitor-package-dropdown',
-                                                                  text: 'Package Name',
-                                                                  values: package_names,
-                                                                  value_prefix: 'package_',
-                                                                  checked_values: filters }
+  - if package_names.size > 1
+    = render partial: 'webui/shared/build_result_filter', locals: { id: 'project-monitor-package-dropdown',
+                                                                    text: 'Package Name',
+                                                                    values: package_names,
+                                                                    value_prefix: 'package_',
+                                                                    checked_values: filters }
   = render partial: 'webui/shared/build_result_filter', locals: { id: 'project-monitor-repositories-dropdown',
                                                                   text: 'Repository',
                                                                   values: repository_names,


### PR DESCRIPTION
Previously, the package name filter was shown regardless of how many packages the build results contained.

<img width="767" height="190" alt="Screenshot From 2025-10-23 16-21-39" src="https://github.com/user-attachments/assets/bbd946dd-6fe9-482f-a0a7-6c7d39db1500" />

With this change, the package name filter is only displayed when the build results contain more than one package.

<img width="767" height="190" alt="Screenshot From 2025-10-23 16-21-22" src="https://github.com/user-attachments/assets/18ba6338-cbb7-4f15-b112-c348e906c2f7" />
