### PR TITLE
Make the request build status architectures table sticky

### DIFF
--- a/src/api/app/assets/stylesheets/webui/build-results.scss
+++ b/src/api/app/assets/stylesheets/webui/build-results.scss
@@ -196,6 +196,11 @@
   }
 }
 
+.build-result-header {
+  top: 50px;
+  background-color: var(--bs-body-bg);
+}
+
 .build-result-table {
   .build-result-legend {
     display: none;
@@ -226,7 +231,6 @@
   @include media-breakpoint-up(xl) {
     display: grid;
     grid-template-columns: 1fr repeat(20, auto);
-    overflow-x: scroll;
 
     .build-result-architectures, .build-result-row, .build-result-legend {
       display: contents;
@@ -235,6 +239,8 @@
     .build-result-name {
       grid-column-start: 1;
       padding: 0.25rem 1rem;
+      top: 100px;
+      background-color: var(--bs-body-bg);
     }
 
     .build-result-architecture {
@@ -242,11 +248,19 @@
       text-align: end;
       .architecture { display: none }
       &:last-of-type { padding-right: 1rem }
+      top: 100px;
+      background-color: var(--bs-body-bg);
     }
 
-    .build-result-row {
-      .build-result-name, .build-result-architecture {
-        border-top: var(--bs-border-width) solid var(--bs-border-color);
+    .build-result-row:not(:last-of-type) {
+      .build-result-name {
+        border-bottom: var(--bs-border-width) solid var(--bs-border-color);
+        top: 100px;
+      }
+
+      .build-result-architecture {
+        border-bottom: var(--bs-border-width) solid var(--bs-border-color);
+        top: 100px;
       }
     }
   }

--- a/src/api/app/components/build_results_monitor_component.html.haml
+++ b/src/api/app/components/build_results_monitor_component.html.haml
@@ -56,7 +56,7 @@
   - elsif filtered_package_names.count == 1
     - package_name = filtered_package_names.first
     .accordion-item
-      .p-3.w-100.d-flex.flex-wrap.justify-content-between
+      .p-3.w-100.d-flex.flex-wrap.justify-content-between.sticky-top.build-result-header
         %span.text-break.me-2
           = package_name
         %span.text-end
@@ -65,9 +65,9 @@
       .accordion-collapse.my-3{ id: "collapse-#{package_name.gsub(':', '_')}", class: show }
         .build-result-table
           .build-result-legend
-            .build-result-name
+            .build-result-name.sticky-top.border-bottom
             - filtered_architecture_names.each do |architecture_name|
-              .build-result-architecture.mb-1
+              .build-result-architecture.sticky-top.border-bottom
                 %b= architecture_name
           - filtered_repository_names.each do |repository_name|
             .build-result-row


### PR DESCRIPTION
Depends on #18689 

<img width="1485" height="503" alt="Screenshot From 2025-10-24 16-13-03" src="https://github.com/user-attachments/assets/51115cfc-6809-4242-80de-29bfdb79758f" />
