### PR TITLE
Make all build status the same width

### DIFF
--- a/src/api/app/views/webui/shared/_build_status_badge.html.haml
+++ b/src/api/app/views/webui/shared/_build_status_badge.html.haml
@@ -1,5 +1,5 @@
 - if url
-  .btn-group-vertical
+  .btn-group-vertical.d-flex
     = link_to(url, class: "btn btn-sm #{build_status_category_color(status)}") do
       %i.fa.me-2{ class: build_status_icon(status), title: status.humanize }
       %span.architecture #{architecture} :


### PR DESCRIPTION
This is how it looked like **before**:
<img width="1479" height="542" alt="Screenshot From 2025-10-28 10-05-18" src="https://github.com/user-attachments/assets/7a6ec405-90b9-40b2-8ff9-839d053978ac" />

This is how it looks like **now**
<img width="1479" height="542" alt="Screenshot From 2025-10-28 10-04-40" src="https://github.com/user-attachments/assets/9e2972d9-865c-40dc-858b-0803cb626141" />

Depends on #18697
