### PR TITLE
Fix BuildResultsMonitorComponent's monitor_page preview

### DIFF
--- a/src/api/spec/components/previews/build_results_monitor_component_preview.rb
+++ b/src/api/spec/components/previews/build_results_monitor_component_preview.rb
@@ -11,7 +11,7 @@ class BuildResultsMonitorComponentPreview < ViewComponent::Preview
   ].freeze
 
   def monitor_page
-    render(BuildResultsMonitorComponent.new(raw_data: FAKE_RAW_DATA, filter_url: '', filters: {}))
+    render(BuildResultsMonitorComponent.new(raw_data: FAKE_RAW_DATA, filter_url: '', filters: []))
   end
 
   def monitor_page_with_filters


### PR DESCRIPTION
It accepts arrays, not hashes

Fixes #18724