### PR TITLE
Make it easier to tell failed and unresolvable build status apart

### DIFF
--- a/src/api/app/models/buildresult.rb
+++ b/src/api/app/models/buildresult.rb
@@ -46,7 +46,7 @@ class Buildresult
   STATUS_CATEGORIES_MAP = {
     succeeded: STATUS_CATEGORIES[0],
     failed: STATUS_CATEGORIES[1],
-    unresolvable: STATUS_CATEGORIES[1],
+    unresolvable: STATUS_CATEGORIES[3],
     broken: STATUS_CATEGORIES[1],
     blocked: STATUS_CATEGORIES[3],
     scheduled: STATUS_CATEGORIES[2],


### PR DESCRIPTION
Previously, failed and unresolvable build statuses were draw both in red. Now this PR renders unresolvable build status in orange to make it easier to tell apart from the failed build status.

Depends on #18723

This is how it looked like **before**
<img width="1477" height="357" alt="Screenshot From 2025-10-28 15-45-50" src="https://github.com/user-attachments/assets/9bc76441-a30d-4bf4-84f8-0191c76b60e1" />

This is how it looks like **now**
<img width="1477" height="357" alt="Screenshot From 2025-10-28 15-42-58" src="https://github.com/user-attachments/assets/e043d854-1899-42ac-8757-c7a911a8268c" />
