### PR TITLE
Show selected filters for build results

### DIFF
--- a/src/api/app/components/build_results_monitor_component.html.haml
+++ b/src/api/app/components/build_results_monitor_component.html.haml
@@ -5,7 +5,8 @@
                                                                        architecture_names: architecture_names,
                                                                        status_names: status_names,
                                                                        filter_url: filter_url,
-                                                                       filters: filters }
+                                                                       filters: filters,
+                                                                       selected_filters_text: selected_filters_text }
 .accordion#build-results-monitor
   - if filtered_package_names.count > 1
     - filtered_package_names.each do |package_name|

--- a/src/api/app/components/build_results_monitor_component.rb
+++ b/src/api/app/components/build_results_monitor_component.rb
@@ -1,4 +1,6 @@
 class BuildResultsMonitorComponent < ApplicationComponent
+  FILTERS = { package: 'Package', repo: 'Repository', arch: 'Architecture', status: 'Status' }.freeze
+
   attr_reader :raw_data, :filter_url, :filters
 
   def initialize(raw_data:, filter_url:, filters:)
@@ -93,5 +95,20 @@ class BuildResultsMonitorComponent < ApplicationComponent
     return data if filters.blank?
 
     data.select { |result| filters.include?("#{prefix}#{result[key_name]}") }
+  end
+
+  def selected_filters_text
+    FILTERS.filter_map do |key, label|
+      selected_options = filters_by_type("#{key}_")
+      next if selected_options.empty?
+
+      normalized_label = label.downcase
+      if selected_options.size == 1
+        selected_option = selected_options.first.sub("#{key}_", '')
+        "#{normalized_label}: #{selected_option}"
+      else
+        pluralize(selected_options.size, normalized_label)
+      end
+    end.join(', ')
   end
 end

--- a/src/api/app/views/webui/request/_build_results_filters.haml
+++ b/src/api/app/views/webui/request/_build_results_filters.haml
@@ -24,3 +24,6 @@
     Apply Filter
 
   = render partial: 'webui/shared/build_status_legend_modal', locals: { legend: Buildresult::STATUS_DESCRIPTION }
+
+- if selected_filters_text.present?
+  .mt-3 Selected filters: #{selected_filters_text}


### PR DESCRIPTION
These are a couple of examples after the changes:

<img width="691" height="232" alt="Screenshot From 2025-10-28 17-12-47" src="https://github.com/user-attachments/assets/be30a040-ecdd-4243-914b-19bc5a472a2f" />

<img width="691" height="232" alt="Screenshot From 2025-10-28 17-12-51" src="https://github.com/user-attachments/assets/c8ab1029-1750-4222-a6dc-5a49d62ead08" />
