### PR TITLE
Do not render build results chart if there are too many bs_request_actions

### DIFF
--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -363,6 +363,9 @@ class Webui::RequestController < Webui::WebuiController
   end
 
   def chart_build_results
+    # a bs_request with a lot of bs_request_actions can cause performance issues on the backend, we need to skip those
+    return if @actions.count > 300
+
     important_repoarch = RepositoryArchitecture.joins(:repository, :architecture).where(repository: Repository.where(project: @actions.pluck(:source_project_id)),
                                                                                         important: true).pluck([
                                                                                                                  'repositories.name', 'architectures.name'

--- a/src/api/app/views/webui/request/beta_show.html.haml
+++ b/src/api/app/views/webui/request/beta_show.html.haml
@@ -103,11 +103,13 @@
                     will be
                     %strong auto-accepted
                     = render TimeComponent.new(time: @bs_request.accept_at)
-
-              .chart_build_results_wrapper{ data: { url: request_chart_build_results_path } }
-              :javascript
-                updateChartBuildResults();
-                setInterval(updateChartBuildResults, 60000);
+              // rendering the chart for a bs_request with a lot of bs_request_actions can cause performance issues on the backend,
+              // we need to skip those
+              - unless @actions.count > 300
+                .chart_build_results_wrapper{ data: { url: request_chart_build_results_path } }
+                :javascript
+                  updateChartBuildResults();
+                  setInterval(updateChartBuildResults, 60000);
 
               - if policy(@bs_request).handle_request? && @bs_request.can_be_reopened?
                 = render partial: 'accordion_reviews', locals: { accepted_reviews: @request_reviews.accepted,


### PR DESCRIPTION
The query produced by this can be too expensive when there are too many
`bs_request_actions` involved. This causes performance issues on the
backend, since passenger instances pile up with those calls waiting to be
processed. As a quick fix, skip rendering of this for now if there are
more than 300 `bs_request_actions`.