### PR TITLE
Replace jshint ignore lines with propper function exports

### DIFF
--- a/src/api/app/assets/javascripts/webui/autocomplete.js
+++ b/src/api/app/assets/javascripts/webui/autocomplete.js
@@ -1,4 +1,6 @@
-function setupAutocomplete(selector) { // jshint ignore:line
+/* exported setupAutocomplete */
+
+function setupAutocomplete(selector) {
   $(selector).autocomplete({
     // Note: 'append' is optional and only needed when there is no element with class ui-front
     appendTo:  $(selector).data('append'),

--- a/src/api/app/assets/javascripts/webui/badge.js
+++ b/src/api/app/assets/javascripts/webui/badge.js
@@ -1,11 +1,14 @@
+/* exported badgeTextCopy */
+/* global BASE_BADGE_URL, BASE_PACKAGE_URL */
+
 // BASE_BADGE_URL and BASE_PACKAGE_URL are set in the view
 function buildBadge() {
-  var badgeImageUrl = new URL(BASE_BADGE_URL); // jshint ignore:line
+  var badgeImageUrl = new URL(BASE_BADGE_URL);
   badgeImageUrl.searchParams.set('type', $('#badge-style-selector').val());
   $('#badge-preview').attr("src", badgeImageUrl);
-  return '[![build result](' + badgeImageUrl + ')](' + BASE_PACKAGE_URL + ')'; // jshint ignore:line
+  return '[![build result](' + badgeImageUrl + ')](' + BASE_PACKAGE_URL + ')';
 }
 
-function badgeTextCopy() { // jshint ignore:line
+function badgeTextCopy() {
   $('#copy-to-clipboard-readonly').val(buildBadge());
 }

--- a/src/api/app/assets/javascripts/webui/banners.js
+++ b/src/api/app/assets/javascripts/webui/banners.js
@@ -1,4 +1,6 @@
-function dismissBanner(bannerId, cookieId) { // jshint ignore:line
+/* exported dismissBanner */
+
+function dismissBanner(bannerId, cookieId) {
   const btn = document.getElementById(bannerId);
   if (btn) {
     btn.addEventListener("click", function () {

--- a/src/api/app/assets/javascripts/webui/buildresult.js
+++ b/src/api/app/assets/javascripts/webui/buildresult.js
@@ -1,8 +1,11 @@
+/* exported updateRpmlintResult, updateBuildResult, updateArchDisplay, toggleBuildInfo */
+/* global initializePopovers */
+
 // TODO: replace with the content of
 // app/assets/javascripts/webui/request_show_redesign/build_results.js
 // after the rollout of 'request_show_redesign'.
 
-function updateRpmlintResult(index) { // jshint ignore:line
+function updateRpmlintResult(index) {
   $('#rpm'+index+'-reload').addClass('fa-spin');
   $.ajax({
     url: '/package/rpmlint_result',
@@ -19,7 +22,7 @@ function updateRpmlintResult(index) { // jshint ignore:line
   });
 }
 
-function updateBuildResult(index) { // jshint ignore:line
+function updateBuildResult(index) {
   var collapsedPackages = [];
   var collapsedRepositories = {};
   $('.result div.collapse:not(.show)').map(function(_index, domElement) {
@@ -49,12 +52,12 @@ function updateBuildResult(index) { // jshint ignore:line
     },
     complete: function() {
       $('#build' + index + '-reload').removeClass('fa-spin');
-      initializePopovers('[data-toggle="popover"]'); // jshint ignore:line
+      initializePopovers('[data-toggle="popover"]');
     }
   });
 }
 
-function updateArchDisplay(index) { // jshint ignore:line
+function updateArchDisplay(index) {
   $('.rpmlint_arch_select_' + index).hide();
   $('select[name="rpmlint_arch_select_' + index + '_' + $('#rpmlint_repo_select_' + index + ' option:selected').attr('value') + '"]').show();
   updateRpmlintDisplay(index);
@@ -75,7 +78,7 @@ function updateRpmlintDisplay(index) {
 }
 
 // TODO: Stop using toggleBuildInfo in favor of the generic toggleCollapsibleTooltip
-function toggleBuildInfo() { // jshint ignore:line
+function toggleBuildInfo() {
   $('.toggle-build-info').on('click', function(){
     var replaceTitle = $(this).attr('title') === 'Click to keep it open' ? 'Click to close it' : 'Click to keep it open';
     var infoContainer = $(this).parents('.toggle-build-info-parent').next();

--- a/src/api/app/assets/javascripts/webui/canned_responses.js
+++ b/src/api/app/assets/javascripts/webui/canned_responses.js
@@ -1,4 +1,6 @@
-function setupCannedResponses() { // jshint ignore:line
+/* exported setupCannedResponses */
+
+function setupCannedResponses() {
   $('[data-canned-controller]').on('click', '[data-canned-response]', function(e) {
     $(e.target).closest('[data-canned-controller]').find('textarea').val(e.target.dataset.cannedResponse);
     // let's make sure this exists first, to avoid errors

--- a/src/api/app/assets/javascripts/webui/collapsible_text.js
+++ b/src/api/app/assets/javascripts/webui/collapsible_text.js
@@ -1,4 +1,6 @@
-function setCollapsible() { // jshint ignore:line
+/* exported setCollapsible */
+
+function setCollapsible() {
   $('.obs-collapsible-textbox').each(function() {
     var container = $(this);
     var textBox = container.find('.obs-collapsible-text');

--- a/src/api/app/assets/javascripts/webui/collapsible_tooltip.js
+++ b/src/api/app/assets/javascripts/webui/collapsible_tooltip.js
@@ -1,4 +1,6 @@
-function toggleCollapsibleTooltip() { // jshint ignore:line
+/* exported toggleCollapsibleTooltip */
+
+function toggleCollapsibleTooltip() {
   $('.collapsible-tooltip').on('click', function(){
     var replaceTitle = $(this).attr('title') === 'Click to keep it open' ? 'Click to close it' : 'Click to keep it open';
     var infoContainer = $(this).parents('.collapsible-tooltip-parent').next();

--- a/src/api/app/assets/javascripts/webui/comment.js
+++ b/src/api/app/assets/javascripts/webui/comment.js
@@ -1,4 +1,4 @@
-function resizeTextarea(textarea) { // jshint ignore:line
+function resizeTextarea(textarea) {
   var heightPerRow = Math.ceil(textarea.clientHeight / textarea.rows);
   var linesOfText = Math.ceil(textarea.scrollHeight / heightPerRow);
   var rowsToIncrease = linesOfText - textarea.rows;

--- a/src/api/app/assets/javascripts/webui/datatables.js
+++ b/src/api/app/assets/javascripts/webui/datatables.js
@@ -1,3 +1,5 @@
+/* exported initializeDataTable, initializeRemoteDatatable */
+
 //= require datatables/jquery.dataTables
 //= require datatables/dataTables.bootstrap5
 //= require datatables/extensions/Responsive/dataTables.responsive
@@ -27,12 +29,12 @@ var DEFAULT_DT_PARAMS = {
   }
 };
 
-function initializeDataTable(cssSelector, params){ // jshint ignore:line
+function initializeDataTable(cssSelector, params){
   var newParams = $.extend({}, DEFAULT_DT_PARAMS, params);
   $(cssSelector).DataTable(newParams);
 }
 
-function initializeRemoteDatatable(cssSelector, params) { // jshint ignore:line
+function initializeRemoteDatatable(cssSelector, params) {
   var defaultRemoteParams = {
     processing: true,
     serverSide: true,

--- a/src/api/app/assets/javascripts/webui/delete_confirmation_dialog.js
+++ b/src/api/app/assets/javascripts/webui/delete_confirmation_dialog.js
@@ -1,4 +1,6 @@
-function collectDeleteConfirmationModalsAndSetValues() { // jshint ignore:line
+/* exported collectDeleteConfirmationModalsAndSetValues */
+
+function collectDeleteConfirmationModalsAndSetValues() {
   $.each(modalIds(), function( _index, modalId ) {
     setValuesOnDeleteConfirmationDialog(modalId);
   });

--- a/src/api/app/assets/javascripts/webui/distributions.js
+++ b/src/api/app/assets/javascripts/webui/distributions.js
@@ -1,4 +1,6 @@
-function toggleDistribution() { // jshint ignore:line
+/* exported toggleDistribution */
+
+function toggleDistribution() {
   $('.distribution-input').on('change', function (){
     var distributionId = $( this ).attr('data-distribution');
     $('#distribution-' + distributionId + '-checkbox').prop( 'disabled', true );

--- a/src/api/app/assets/javascripts/webui/dropdown.js
+++ b/src/api/app/assets/javascripts/webui/dropdown.js
@@ -1,3 +1,6 @@
+/* exported setupDropdownFilters */
+/* global initializePopovers */
+
 $(document).ready(function(){
   // Dismiss dropdowns using a button with `data-bs-dismiss` value
   const dropdownDismissList = document.querySelectorAll('[data-bs-dismiss="dropdown"]');
@@ -11,8 +14,8 @@ $(document).ready(function(){
   });
 });
 
-function setupDropdownFilters() { // jshint ignore:line
-  initializePopovers('[data-bs-toggle="popover"]'); // jshint ignore:line
+function setupDropdownFilters() {
+  initializePopovers('[data-bs-toggle="popover"]');
 
   function setAllRelatedLinks(event) {
     $(this).closest('.dropdown-menu').find('input').prop('checked', event.data.checked);

--- a/src/api/app/assets/javascripts/webui/image_templates.js
+++ b/src/api/app/assets/javascripts/webui/image_templates.js
@@ -1,4 +1,6 @@
-function setupImageTemplates() { // jshint ignore:line
+/* exported setupImageTemplates */
+
+function setupImageTemplates() {
   $(".image_template").on("click", function(){
     $('.image-template-box').removeClass('active');
     $(this).parents('.image-template-box').addClass('active');

--- a/src/api/app/assets/javascripts/webui/in_place_editing.js
+++ b/src/api/app/assets/javascripts/webui/in_place_editing.js
@@ -1,16 +1,18 @@
-function setFormValidation(element, messages) { // jshint ignore:line
+/* exported setFormValidation, resetFormValidation, scrollToInPlace */
+
+function setFormValidation(element, messages) {
   element.addClass('is-invalid');
   element.after("<div class='invalid-feedback'>"+ messages + "</div>");
 }
 
-function resetFormValidation() { // jshint ignore:line
+function resetFormValidation() {
   $('.in-place-editing form .is-invalid').each(function(){
     $(this).toggleClass('is-invalid');
     $(this).siblings('.invalid-feedback').remove();
   });
 }
 
-function scrollToInPlace() { // jshint ignore:line
+function scrollToInPlace() {
   $('html, body').animate({
     scrollTop: $('.in-place-editing').offset().top - 73 // header height + 16px
   }, 500);

--- a/src/api/app/assets/javascripts/webui/kiwi_editor.js
+++ b/src/api/app/assets/javascripts/webui/kiwi_editor.js
@@ -1,10 +1,12 @@
+/* exported initializeTabs, initializeKiwi */
+
 var canSave = false;
 
 function hideOverlay() {
   $('.modal.show').modal('hide');
 }
 
-function saveImage(isOutdatedUrl) { // jshint ignore:line
+function saveImage(isOutdatedUrl) {
   if (canSave) {
     $.ajax({ url: isOutdatedUrl,
       dataType: 'json',
@@ -23,7 +25,7 @@ function enableSave() {
   $('#kiwi-image-update-form-save, #kiwi-image-update-form-revert').removeClass('disabled');
 }
 
-function editRepositoryDialog() { // jshint ignore:line
+function editRepositoryDialog() {
   var fields = $(this).parents('.nested-fields');
   var dialog = fields.find('.modal');
   var sourcePath = fields.find("[id$='source_path']");
@@ -58,7 +60,7 @@ function addRepositoryErrorMessage(sourcePath, field) {
   field.removeClass('d-none');
 }
 
-function closeKiwiDescriptionDialog() { // jshint ignore:line
+function closeKiwiDescriptionDialog() {
   var fields = $(this).parents('.nested-fields');
   var dialog = fields.find('.modal.show');
   var name = dialog.find("[id$='name']");
@@ -90,7 +92,7 @@ function closeKiwiDescriptionDialog() { // jshint ignore:line
   hideOverlay();
 }
 
-function closeKiwiPreferencesDialog() { // jshint ignore:line
+function closeKiwiPreferencesDialog() {
   var fields = $(this).parents('.nested-fields');
   var dialog = fields.find('.modal.show');
 
@@ -120,7 +122,7 @@ function showRemoveAction(fields) {
   fields.find('.kiwi_actions').removeClass('d-none');
 }
 
-function closeKiwiDialog() { // jshint ignore:line
+function closeKiwiDialog() {
   var fields = $(this).parents('.nested-fields'),
       isRepository = fields.parents('#kiwi-repositories-list').length === 1,
       name = fields.find('.kiwi_element_name'),
@@ -180,7 +182,7 @@ function closeKiwiDialog() { // jshint ignore:line
   hideOverlay();
 }
 
-function revertDialog() { // jshint ignore:line
+function revertDialog() {
   var fields = $(this).parents('.nested-fields');
   var dialog = fields.find('.modal');
   dialog.find(".ui-state-error").addClass('d-none');
@@ -215,7 +217,7 @@ function addDefault(dialog) {
   });
 }
 
-function showOnAddition(list, show) { // jshint ignore:line
+function showOnAddition(list, show) {
   list.on('cocoon:after-remove', function() {
     if ($(this).find('.nested-fields:visible').length === 0) {
       show.removeClass('d-none');
@@ -321,7 +323,7 @@ function kiwiRepositoriesSetupAutocomplete(fields) {
   });
 }
 
-function initializeTabs() { // jshint ignore:line
+function initializeTabs() {
   $("#kiwi-details-trigger").click(function() {
     $("#kiwi-preferences").removeClass('d-none');
     $(".detailed-info").removeClass('d-none');
@@ -352,7 +354,7 @@ function cocoonAfterInsert(addedFields) {
   $(addedFields).find('.modal').modal('show');
 }
 
-function initializeKiwi(isOutdatedUrl) { // jshint ignore:line
+function initializeKiwi(isOutdatedUrl) {
   // Save image
   $('#kiwi-image-update-form-save').click(function() { saveImage(isOutdatedUrl); });
   $('#kiwi_image_use_project_repositories').click(function(){

--- a/src/api/app/assets/javascripts/webui/multi_select.js
+++ b/src/api/app/assets/javascripts/webui/multi_select.js
@@ -1,4 +1,6 @@
-function collectMultiSelects() { // jshint ignore:line
+/* exported collectMultiSelects */
+
+function collectMultiSelects() {
   document.querySelectorAll('.form-multi-select').forEach(( multiSelect ) => {
     multiSelect.addEventListener("change", function(e) {
       var multiSelect = e.target.closest(".form-multi-select");

--- a/src/api/app/assets/javascripts/webui/nav_tabs.js
+++ b/src/api/app/assets/javascripts/webui/nav_tabs.js
@@ -1,3 +1,5 @@
+/* global setCollapsible */
+
 var HASH_PREFIX = 'tab-pane-';
 
 $(document).ready(function () {
@@ -23,7 +25,7 @@ $(document).ready(function () {
      * jshint false positive fires an error saying the `setCollapsible` function is not defined
      * actually it is, just in another file (`collapsible_text.js`)
      */
-    setCollapsible(); // jshint ignore:line
+    setCollapsible();
   });
 
   function replaceURLActionHash() {

--- a/src/api/app/assets/javascripts/webui/notification.js
+++ b/src/api/app/assets/javascripts/webui/notification.js
@@ -1,3 +1,5 @@
+/* exported handleNotificationCheckboxSelection */
+
 function setSelectAllCheckbox() {
   $(document).on('change', '#select-all-notifications', function() {
     var checkboxes = $(this).closest('form').find('input[type=checkbox]');
@@ -24,7 +26,7 @@ function setCheckboxCounterAndSubmitButton() {
   }
 }
 
-function handleNotificationCheckboxSelection() { // jshint ignore:line
+function handleNotificationCheckboxSelection() {
   setCheckboxCounterAndSubmitButton();
   setSelectAllCheckbox();
   $(document).on('change', 'input[type="checkbox"]', function() {

--- a/src/api/app/assets/javascripts/webui/package-view_file.js
+++ b/src/api/app/assets/javascripts/webui/package-view_file.js
@@ -1,3 +1,5 @@
+/* exported addChangesEntryTemplate */
+
 var DAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 var MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
 
@@ -6,7 +8,7 @@ var toTwoChars = function(number, leadingChar) {
 };
 
 // The jshint ignore:line is needed to ignore the offense: `'addChangesEntryTemplate' is defined but never used.` This is used in the view directly
-function addChangesEntryTemplate() { // jshint ignore:line
+function addChangesEntryTemplate() {
   var date = new Date(),
       weekDay = DAYS[date.getUTCDay()],
       month = MONTHS[date.getUTCMonth()],

--- a/src/api/app/assets/javascripts/webui/packages.js
+++ b/src/api/app/assets/javascripts/webui/packages.js
@@ -1,3 +1,5 @@
+/* global setupDropdownFilters */
+
 // Remove this after PackageController#rdiff moves to DiffListComponent
 $(function ($) {
   $('body').on('click', '.expand-diffs', function () {
@@ -14,7 +16,7 @@ $(function ($) {
 });
 
 $(document).ready(function() {
-  setupDropdownFilters(); // jshint ignore:line
+  setupDropdownFilters();
   $('.btn-more').click(function() {
     var moreInfo = $('.more_info');
     moreInfo.toggleClass('d-none');

--- a/src/api/app/assets/javascripts/webui/patchinfo.js
+++ b/src/api/app/assets/javascripts/webui/patchinfo.js
@@ -1,4 +1,6 @@
-function setupPatchinfo() { // jshint ignore:line
+/* exported setupPatchinfo */
+
+function setupPatchinfo() {
   addIssuesAjaxBefore();
   addIssuesAjaxSuccess();
   addIssuesAjaxComplete();

--- a/src/api/app/assets/javascripts/webui/plotbusyworkers.js
+++ b/src/api/app/assets/javascripts/webui/plotbusyworkers.js
@@ -1,4 +1,6 @@
-function plotbusyworkers(data) { // jshint ignore:line
+/* exported plotbusyworkers */
+
+function plotbusyworkers(data) {
   $.plot($("#overallgraph"), [
     { data: data, label: "Busy workers", color: 3}
   ],

--- a/src/api/app/assets/javascripts/webui/project.js
+++ b/src/api/app/assets/javascripts/webui/project.js
@@ -1,3 +1,6 @@
+/* global initializeRemoteDatatable */
+/* exported initializeProjectDatatable, initializeProjectDatatableLabelBeta */
+
 function toggleProjectsDatatable() {
   var all = $("#projects-datatable").data("all");
   var $toggleText = $("#toggle-text");
@@ -14,8 +17,8 @@ function toggleProjectsDatatable() {
   $("#projects-datatable").DataTable().draw();
 }
 
-function initializeProjectDatatable() { // jshint ignore:line
-  initializeRemoteDatatable( // jshint ignore:line
+function initializeProjectDatatable() {
+  initializeRemoteDatatable(
     "#projects-datatable",
     {
       "ajax": {
@@ -33,8 +36,8 @@ function initializeProjectDatatable() { // jshint ignore:line
   $(".toggle-projects").click(function() { toggleProjectsDatatable(); });
 }
 
-function initializeProjectDatatableLabelBeta() { // jshint ignore:line
-  initializeRemoteDatatable( // jshint ignore:line
+function initializeProjectDatatableLabelBeta() {
+  initializeRemoteDatatable(
     "#projects-datatable",
     {
       "ajax": {

--- a/src/api/app/assets/javascripts/webui/project_monitor.js
+++ b/src/api/app/assets/javascripts/webui/project_monitor.js
@@ -1,3 +1,6 @@
+/* global initializeDataTable, initializePopovers */
+/* exported setupProjectMonitor */
+
 function setAllLinks(event) {
   $(this).closest('.dropdown-menu').find('input').prop('checked', event.data.checked);
 }
@@ -41,7 +44,7 @@ function initializeMonitorDataTable() {
   var projectName = data.project;
   var scmsync = data.scmsync;
 
-  initializeDataTable('#project-monitor-table', { // jshint ignore:line
+  initializeDataTable('#project-monitor-table', {
     responsive: false,
     scrollX: true,
     fixedColumns: true,
@@ -82,7 +85,7 @@ function initializeMonitorDataTable() {
   });
 }
 
-function setupProjectMonitor() { // jshint ignore:line
+function setupProjectMonitor() {
   initializeMonitorDataTable();
 
   $('#table-spinner').addClass('d-none');
@@ -93,10 +96,10 @@ function setupProjectMonitor() { // jshint ignore:line
   });
 
   $('#project-monitor-table').on('draw.dt', function () {
-    initializePopovers('[data-bs-toggle="popover"]'); // jshint ignore:line
+    initializePopovers('[data-bs-toggle="popover"]');
   });
 
-  initializePopovers('[data-bs-toggle="popover"]'); // jshint ignore:line
+  initializePopovers('[data-bs-toggle="popover"]');
 
   $('.monitor-no-filter-link').on('click', { checked: false }, setAllLinks);
 

--- a/src/api/app/assets/javascripts/webui/report.js
+++ b/src/api/app/assets/javascripts/webui/report.js
@@ -1,4 +1,6 @@
-function collectReportModalsAndSetValues() { // jshint ignore:line
+/* exported collectReportModalsAndSetValues */
+
+function collectReportModalsAndSetValues() {
   $.each(modalIdsForReport(), function( _index, modalId ) {
     setValuesOnReportDialog(modalId);
   });

--- a/src/api/app/assets/javascripts/webui/repositories.js
+++ b/src/api/app/assets/javascripts/webui/repositories.js
@@ -1,4 +1,7 @@
-function setSpinnersForFlags() { // jshint ignore:line
+/* global initializePopovers, bootstrap */
+/* exported setSpinnersForFlags, setupFlagPopup */
+
+function setSpinnersForFlags() {
   $(document).on('click', '.popover_flag_action', function() {
     var flag = $(this).data('flag-id');
     var icon = $('div[id="' + flag + '"] a');
@@ -37,7 +40,7 @@ function prepareFlagPopover(element) {
 }
 
 function initializeFlagPopovers(cssSelector) {
-  initializePopovers(cssSelector, { trigger: 'click', html: true, content: prepareFlagPopover }); // jshint ignore:line
+  initializePopovers(cssSelector, { trigger: 'click', html: true, content: prepareFlagPopover });
 }
 
 function replaceFlagTable(data, flagType) {
@@ -45,7 +48,7 @@ function replaceFlagTable(data, flagType) {
   initializeFlagPopovers('#flag_table_' + flagType + ' .flag-popup');
 }
 
-function setupFlagPopup() { // jshint ignore:line
+function setupFlagPopup() {
   ['build', 'useforbuild', 'debuginfo', 'publish'].forEach(function(flagType) {
     initializeFlagPopovers('#flag_table_' + flagType + ' .flag-popup');
   });

--- a/src/api/app/assets/javascripts/webui/request.js
+++ b/src/api/app/assets/javascripts/webui/request.js
@@ -1,3 +1,5 @@
+/* exported setupSubmitPackagePage, requestAddAutocompleteResponsiveUx, requestAddAutocomplete, reloadRequestAction, loadChanges */
+
 function updateSupersedeAndDevelPackageDisplay() {
   if ($('[id$="target_project"]').length > 0 && $('[id$="target_project"]')[0].value.length > 2) {
     if ($('[id$="target_project"]')[0].value === $('[id$="source_project"]')[0].value) {
@@ -44,7 +46,7 @@ function updateSupersedeAndDevelPackageDisplay() {
   }
 }
 
-function setupSubmitPackagePage(url) { // jshint ignore:line
+function setupSubmitPackagePage(url) {
   $('#devel-project-name').click(function () {
     $('[id$="target_project"]').attr('value', $('#devel-project-name').html());
   });
@@ -76,7 +78,7 @@ function prefillSubmitRequestForm(url) {
   });
 }
 
-function toggleAutocomplete(autocompleteElement) { // jshint ignore:line
+function toggleAutocomplete(autocompleteElement) {
   $('.hideable').addClass('d-none');
   $('.hideable input:not(:visible)').attr('disabled', true);
 
@@ -86,14 +88,14 @@ function toggleAutocomplete(autocompleteElement) { // jshint ignore:line
 }
 
 // TODO: Rename once modals depending on the non-responsive-ux version are all removed
-function requestAddAutocompleteResponsiveUx(autocompleteElement) { // jshint ignore:line
+function requestAddAutocompleteResponsiveUx(autocompleteElement) {
   toggleAutocomplete(autocompleteElement);
 
   $(autocompleteElement).change(function () { toggleAutocomplete(autocompleteElement); });
 }
 
 // TODO: Remove once modals depending on this are all removed
-function requestAddAutocomplete(autocompleteElement) { // jshint ignore:line
+function requestAddAutocomplete(autocompleteElement) {
   $('.modal').on('shown.bs.modal', function() {
     $('.hideable input:not(:visible)').attr('disabled', true);
   });
@@ -151,7 +153,7 @@ $(document).ready(function(){
 });
 
 // TODO: Remove the following method when the request_show_redesign feature is finished
-function reloadRequestAction(index){ // jshint ignore:line
+function reloadRequestAction(index){
   var element = $('.request-tab[data-index=' + index + ']');
   $('.tab-pane.sourcediff.active').html('');
   if(element) {
@@ -185,7 +187,7 @@ function loadDiffs(element){
   });
 }
 
-function loadChanges() { // jshint ignore:line
+function loadChanges() {
   $('.tab-content.sourcediff .loading').removeClass('invisible');
 
   // Take the parameters from the container data

--- a/src/api/app/assets/javascripts/webui/request_show_redesign/add_review.js
+++ b/src/api/app/assets/javascripts/webui/request_show_redesign/add_review.js
@@ -1,4 +1,6 @@
-function handleReviewerCollapsibleForm() { // jshint ignore:line
+/* exported handleReviewerCollapsibleForm */
+
+function handleReviewerCollapsibleForm() {
   $('#add-review-dropdown-component .dropdown-item').on('click', function() {
     var review = $(this);
 

--- a/src/api/app/assets/javascripts/webui/request_show_redesign/build_results.js
+++ b/src/api/app/assets/javascripts/webui/request_show_redesign/build_results.js
@@ -1,5 +1,8 @@
+/* global setupDropdownFilters */
+/* exported updateBuildResultBeta */
+
 // TODO: rename without "Beta" after the rollout of 'request_show_redesign'.
-function updateBuildResultBeta() { // jshint ignore:line
+function updateBuildResultBeta() {
   var buildResultsUrl = $('.build-results-content .result').data('build-results-url');
 
   $('#build-reload').addClass('fa-spin');
@@ -14,7 +17,7 @@ function updateBuildResultBeta() { // jshint ignore:line
     },
     complete: function() {
       $('#build-reload').removeClass('fa-spin');
-      setupDropdownFilters(); // jshint ignore:line
+      setupDropdownFilters();
     }
   });
 }

--- a/src/api/app/assets/javascripts/webui/request_show_redesign/chart_build_results.js
+++ b/src/api/app/assets/javascripts/webui/request_show_redesign/chart_build_results.js
@@ -14,7 +14,7 @@ function updateChartBuildResults() {
   });
 }
 
-function linkBuildSummaryChartToBuildResultsTab() { // jshint ignore:line
+function linkBuildSummaryChartToBuildResultsTab() {
   var buildResultSummaryChart = Chartkick.charts['build-summary-chart'].getChartObject();
 
   // If the mouse hovers a data point, let the cursor tell the user it is clickable

--- a/src/api/app/assets/javascripts/webui/request_show_redesign/rpm_lint_results.js
+++ b/src/api/app/assets/javascripts/webui/request_show_redesign/rpm_lint_results.js
@@ -1,4 +1,6 @@
-function updateRpmLintArchitectures() { // jshint ignore:line
+/* exported updateRpmLintArchitectures */
+
+function updateRpmLintArchitectures() {
   $('.rpmlint_arch_select').hide();
   $('#rpmlint_arch_select_' + $('#rpmlint_repo_select option:selected').attr('value')).show();
   updateRpmLintLog();

--- a/src/api/app/assets/javascripts/webui/staging_workflow.js
+++ b/src/api/app/assets/javascripts/webui/staging_workflow.js
@@ -1,4 +1,6 @@
-function setSpinnersForDeletion() { // jshint ignore:line
+/* exported setSpinnersForDeletion */
+
+function setSpinnersForDeletion() {
   $("#staging-workflow-delete").on('ajax:beforeSend', function(){
     $(this).find('.delete-spinner').removeClass('d-none');
   });

--- a/src/api/app/assets/javascripts/webui/tabs.js
+++ b/src/api/app/assets/javascripts/webui/tabs.js
@@ -1,3 +1,5 @@
+/* exported toggleTabs */
+
 function resizeTabs(trigger, tabListContainer, selector, target) {
   var item;
   while(tabListContainer.hasOverflow() === trigger && (item = tabListContainer.find(selector)).length) {
@@ -27,7 +29,7 @@ function refreshTabs(tabList) {
 
 /* bootstrap's tabs javascript doesn't remove the active class
    when tabs are implemented without the usage of ul and li */
-function toggleTabs(tabLinkContainerId) { // jshint ignore:line
+function toggleTabs(tabLinkContainerId) {
   $('#'+tabLinkContainerId+' a').on('click', function(e) {
     e.preventDefault();
     $(this).tab('show');

--- a/src/api/app/assets/javascripts/webui/user_profile.js
+++ b/src/api/app/assets/javascripts/webui/user_profile.js
@@ -1,4 +1,7 @@
-function moveInvolvementToContainer() { // jshint ignore:line
+/* exported moveInvolvementToContainer */
+/* exported updateCharactersCount */
+
+function moveInvolvementToContainer() {
   var container = $('#involvement-and-activity');
   if ($('#involvement-and-activity > .tab-content:visible').length > 0)
     container = $('.tab-pane#involved-projects-and-packages');
@@ -7,7 +10,7 @@ function moveInvolvementToContainer() { // jshint ignore:line
   $('#involvement').removeClass('d-none');
 }
 
-function updateCharactersCount(e) { // jshint ignore:line
+function updateCharactersCount(e) {
   var maxLength = $(e.target).attr('maxlength');
   var currentLength = $(e.target).val().length;
   var remainingCount = maxLength - currentLength;

--- a/src/api/app/assets/javascripts/webui/users_groups.js
+++ b/src/api/app/assets/javascripts/webui/users_groups.js
@@ -1,5 +1,11 @@
-function initializeUserConfigurationDatatable() { // jshint ignore:line
-  initializeRemoteDatatable( // jshint ignore:line
+/* exported initializeUserConfigurationDatatable */
+/* exported changeUserRole */
+/* exported setDataTableForUsersAndGroups */
+/* exported initializeGroupTokenfield */
+
+/* globals initializeRemoteDatatable */
+function initializeUserConfigurationDatatable() {
+  initializeRemoteDatatable(
     '#user-table',
     {
       pageLength: 50,
@@ -14,7 +20,7 @@ function initializeUserConfigurationDatatable() { // jshint ignore:line
   );
 }
 
-function changeUserRole(obj) { // jshint ignore:line
+function changeUserRole(obj) {
   var type = obj.data("type");
   var role = obj.data("role");
   var spinner = obj.siblings('.fa-spinner');
@@ -50,7 +56,7 @@ function changeUserRole(obj) { // jshint ignore:line
   });
 }
 
-function setDataTableForUsersAndGroups() { // jshint ignore:line
+function setDataTableForUsersAndGroups() {
   $('#user-table').dataTable({
     responsive: true,
     info: false,
@@ -65,7 +71,7 @@ function setDataTableForUsersAndGroups() { // jshint ignore:line
   });
 }
 
-function initializeGroupTokenfield() { // jshint ignore:line
+function initializeGroupTokenfield() {
   var $tokenfield = $('#group-members.tag-input');
 
   $tokenfield.tagsInput({


### PR DESCRIPTION
The jshint ignore silences all the jshint issues, while the exports fixes only the unused function jshint issues.