### PR TITLE
Do not render build results tab if there are too many bs_request_actions

### DIFF
--- a/src/api/app/views/webui/request/build_results.html.haml
+++ b/src/api/app/views/webui/request/build_results.html.haml
@@ -13,7 +13,7 @@
         locals: { bs_request: @bs_request, action: @action, issues: @issues,
                   actions_count: @actions.count, active_tab: @active_tab }
     .container.p-4
-      - if @buildable
+      - if @buildable && @actions.count <= 300
         .build-results-content
           -# For a request staged in a staging project, we display the Build Results / RPM Lint from the staging project instead
           - if @staging_project.present?
@@ -29,4 +29,8 @@
       - else
         .build-results-content
           .result
-            %i No build results available
+            %i
+              - if @actions.count > 300
+                Too many actions to render build results
+              - else
+                No build results available


### PR DESCRIPTION
Follow up to #18746.

For requests reaching a limit of too many request actions, we will show the following message:

<img width="647" height="155" alt="Screenshot From 2025-10-31 16-20-17" src="https://github.com/user-attachments/assets/417f4ae9-96a0-48eb-b1a0-cce79426c231" />
