### PR TITLE
Explicitly disable RuboCop RSpec/BeforeAfterAll offenses

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -32,16 +32,6 @@ Metrics/MethodLength:
     - 'dist/obs_mirror_project'
     - 'dist/openQA_mail_notification.rb'
 
-# Offense count: 6
-RSpec/BeforeAfterAll:
-  Exclude:
-    - '**/spec/spec_helper.rb'
-    - '**/spec/rails_helper.rb'
-    - '**/spec/support/**/*.rb'
-    - 'dist/t/spec/features/0020_interconnect_spec.rb'
-    - 'dist/t/spec/features/0030_project_spec.rb'
-    - 'dist/t/spec/features/0040_package_spec.rb'
-
 # Offense count: 8
 # Configuration parameters: Max, CountAsOne.
 RSpec/ExampleLength:

--- a/dist/t/spec/features/0020_interconnect_spec.rb
+++ b/dist/t/spec/features/0020_interconnect_spec.rb
@@ -1,11 +1,12 @@
 require 'spec_helper'
 
 RSpec.describe 'Interconnect', type: :feature do
-  before(:context) do
+  # We consciously want the state of a finished spec to be preserved for the next one
+  before(:context) do # rubocop:disable RSpec/BeforeAfterAll
     login
   end
 
-  after(:context) do
+  after(:context) do # rubocop:disable RSpec/BeforeAfterAll
     logout
   end
 

--- a/dist/t/spec/features/0030_project_spec.rb
+++ b/dist/t/spec/features/0030_project_spec.rb
@@ -1,11 +1,12 @@
 require 'spec_helper'
 
 RSpec.describe 'Project', type: :feature do
-  before(:context) do
+  # We consciously want the state of a finished spec to be preserved for the next one
+  before(:context) do # rubocop:disable RSpec/BeforeAfterAll
     login
   end
 
-  after(:context) do
+  after(:context) do # rubocop:disable RSpec/BeforeAfterAll
     logout
   end
 

--- a/dist/t/spec/features/0040_package_spec.rb
+++ b/dist/t/spec/features/0040_package_spec.rb
@@ -1,11 +1,12 @@
 require 'spec_helper'
 
 RSpec.describe 'Package', type: :feature do
-  before(:context) do
+  # We consciously want the state of a finished spec to be preserved for the next one
+  before(:context) do # rubocop:disable RSpec/BeforeAfterAll
     login
   end
 
-  after(:context) do
+  after(:context) do # rubocop:disable RSpec/BeforeAfterAll
     logout
   end
 


### PR DESCRIPTION
In this particular case, mock tests, we consciously want the state of a finished spec to be preserved for the next one.

See: https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecbeforeafterall