### PR TITLE
Update view component's default layout config setting

### DIFF
--- a/src/api/config/application.rb
+++ b/src/api/config/application.rb
@@ -147,7 +147,7 @@ module OBSApi
     # Previews are served at http://HOST:PORT/rails/view_components (this is the default value)
     # config.view_component.preview_route = "/rails/view_components"
     # Set the default layout for previews (app/views/layouts/NAME.html.haml)
-    config.view_component.default_preview_layout = 'view_component_previews'
+    config.view_component.previews.default_layout = 'view_component_previews'
     # Below the preview, display a syntax highlighted source code example of the usage of the view component
     config.view_component.show_previews_source = true
 


### PR DESCRIPTION
Fixes #18719

As explained in the changelog[1]:

	Move previews-related configuration (enabled, route, paths, default_layout, controller) to under previews namespace.

This is how it looked like **before**
<img width="711" height="285" alt="Screenshot From 2025-11-04 09-58-09" src="https://github.com/user-attachments/assets/af82a8ea-60b7-4d94-8d26-998449dac690" />

This is how it looks like **now**
<img width="711" height="285" alt="Screenshot From 2025-11-04 09-57-41" src="https://github.com/user-attachments/assets/c60a8992-be88-4bde-b31d-0b4c4bc3c33e" />


[1] https://github.com/ViewComponent/view_component/releases/tag/v4.0.0