### PR TITLE
Applied color style to build status legend model 

### DIFF
--- a/src/api/app/assets/stylesheets/webui/build-results.scss
+++ b/src/api/app/assets/stylesheets/webui/build-results.scss
@@ -117,6 +117,11 @@
   @extend .px-1;
 }
 
+.build-state-dispatching {
+  @extend .text-bg-info;
+  @extend .px-1;
+}
+
 .build-state-signing, .build-state-finished {
   @extend .text-bg-warning;
   @extend .px-1;
@@ -130,10 +135,21 @@
   color: $gray-600;
 }
 
+.build-state-excluded {
+  @extend .text-bg-light;
+  @extend .border;
+  @extend .px-1;
+}
+
 .build-state-blocked {
   @extend .text-white;
   @extend .px-1;
   background-color: $gray-600;
+}
+
+.build-state-locked {
+  @extend .text-bg-warning;
+  @extend .px-1;
 }
 
 .build-state-scheduled-warning {

--- a/src/api/app/views/webui/shared/_build_status_legend_modal.html.haml
+++ b/src/api/app/views/webui/shared/_build_status_legend_modal.html.haml
@@ -11,7 +11,7 @@
       .modal-body
         - legend.each do |status, description|
           %p
-            %strong
+            %strong{ class: "build-state-#{status}" }
               #{status}:
             = description
       .modal-footer


### PR DESCRIPTION
Fixes #8187 

Hey Friends , 

I have made some changes in the `_build_status_legend_modal.html.haml` by adding color coded badges to  match the visual appearance with the monitor table .

some additional changes afterwards  
- added missing styles for ( locked , excluded  and dispatching ) into the `build-results.scss` .


Here is a screenshot of how it looks:

Before 
<img width="798" height="851" alt="image" src="https://github.com/user-attachments/assets/9d3fd3f8-88f1-43ce-a00b-2ae30bf08dfc" />


After 
<img width="798" height="873" alt="image" src="https://github.com/user-attachments/assets/8c5528d9-4812-4aa7-9983-f14ebc27635f" />






