### PR TITLE
Support importing preinstallimage as container image

### DIFF
--- a/dist/obsworker
+++ b/dist/obsworker
@@ -76,6 +76,9 @@ fi
 if [ -n "$OBS_WORKER_USE_MKFS_COPYIN" ]; then
     OBS_WORKER_USE_MKFS_COPYIN="--vm-use-mkfs-copyin"
 fi
+if [ -n "$OBS_WORKER_USE_CONTAINER_PREINSTALLIMAGE" ]; then
+    OBS_WORKER_USE_CONTAINER_PREINSTALLIMAGE="--vm-use-container-preinstallimage"
+fi
 
 if [ -n "$OBS_WORKER_SECURITY_LEVEL" ]; then
     OBS_WORKER_HOSTLABELS="OBS_WORKER_SECURITY_LEVEL_${OBS_WORKER_SECURITY_LEVEL} $OBS_WORKER_HOSTLABELS"
@@ -486,8 +489,8 @@ case "$1" in
             echo "screen -t $WORKERID nice -n $OBS_NICE ./bs_worker --hardstatus $vmopt $port $proto --root $R" \
                 "--statedir $workerdir/$I --id $WORKERID $REPO_PARAM $HUGETLBFS $HOSTLABELS" \
                 "$HOSTOWNER $OBS_JOBS $OBS_THREADS $OBS_TEST $OBS_WORKER_OPT $TMPFS $DEVICE $SWAP $MEMORY" \
-                "$OBS_CLEANUP_CHROOT $OBS_WIPE_AFTER_BUILD $OBS_WORKER_USE_MKFS_COPYIN $ARCH $EMULATOR" \
-                >> $screenrc
+                "$OBS_CLEANUP_CHROOT $OBS_WIPE_AFTER_BUILD $OBS_WORKER_USE_MKFS_COPYIN $OBS_WORKER_USE_CONTAINER_PREINSTALLIMAGE" \
+                "$ARCH $EMULATOR" >> $screenrc
             mkdir -p $workerdir/$I
         done
         detachflag=

--- a/dist/obsworker
+++ b/dist/obsworker
@@ -378,6 +378,8 @@ case "$1" in
         elif [ "--emulator" == "$vmopt" ]; then echo "System emulated virtual machine"
         elif [ "--vm-type qemu" == "$vmopt" ]; then echo "System emulated virtual machine via QEMU"
         elif [ "--lxc" == "$vmopt" ]; then echo "LXC container"
+        elif [ "--podman" == "$vmopt" ]; then echo "Podman container"
+        elif [ "--docker" == "$vmopt" ]; then echo "Docker container"
         elif [ "openstack" == "$OBS_VM_TYPE" ]; then echo "OpenStack virtual machine"
         else  echo "chroot"
         fi

--- a/dist/sysconfig.obs-server
+++ b/dist/sysconfig.obs-server
@@ -298,6 +298,16 @@ OBS_VM_DISK_AUTOSETUP_MOUNT_OPTIONS=""
 OBS_WORKER_USE_MKFS_COPYIN=""
 
 ## Path:        Applications/OBS
+## Description: Enable using preinstallimage as container base image during build
+## Type:        ("yes" | "")
+## Default:     ""
+## Config:      OBS
+#
+# This is only possible for docker and podman containers
+#
+OBS_WORKER_USE_CONTAINER_PREINSTALLIMAGE=""
+
+## Path:        Applications/OBS
 ## Description: Enable build in memory
 ## Type:        ("yes" | "")
 ## Default:     ""

--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -206,7 +206,7 @@ sub cleanup_job {
   }
 
   # if this is a chroot like case, get rid of it after the build
-  if ((!$vm || $vm eq 'lxc' || $vm eq 'docker' || $vm eq 'nspwan') && $cleanup_chroot && -d $buildroot) {
+  if ((!$vm || $vm eq 'lxc' || $vm eq 'docker' || $vm eq 'nspwan' || $vm eq 'podman') && $cleanup_chroot && -d $buildroot) {
       print "Removing buildroot $buildroot...";
       eval {
         rm_rf($buildroot);
@@ -229,7 +229,7 @@ sub kill_job {
     push @args, '--vm-worker-nr', $vm_worker_instance if $vm_worker_instance;
   } else {
     push @args, '--root', $buildroot;
-    push @args, '--vm-type', $vm if $vm eq 'lxc' || $vm eq 'docker';
+    push @args, '--vm-type', $vm if $vm eq 'lxc' || $vm eq 'docker' || $vm eq 'podman';
   }
   if (system("$statedir/build/build", @args, "--kill")) {
     return 0;
@@ -307,7 +307,7 @@ Usage: $0 [OPTION] --root <directory> --statedir <directory>
        --hostlabel : define a host label for build constraints, can be used multiple times
 
        --vm-type   : set virtualisation mode to use (kvm, xen, qemu:\$HOSTARCH, zvm, emulator:\$HOSTARCH)
-                     Also possible are lxc or docker, but these are less secure and are not using
+                     Also possible are lxc or docker or podman, but these are less secure and are not using
                      the specified kernel for the build target.
 
        --vm-kernel : set kernel to use (xen/kvm)
@@ -482,7 +482,7 @@ while (@ARGV) {
     $testmode = 1;
     next;
   }
-  if ($ARGV[0] =~ /^--(kvm|xen|lxc|emulator|zvm|docker|pvm|openstack)$/) {
+  if ($ARGV[0] =~ /^--(kvm|xen|lxc|emulator|zvm|docker|pvm|openstack|docker|podman)$/) {
     $vm = $1;
     shift @ARGV;
     next;
@@ -4121,7 +4121,7 @@ sub dobuild {
     push @args, "--vm-worker", $vm_worker_name;
     push @args, "--vm-kernel", $vm_kernel;
     push @args, "--openstack-flavor", "$openstack_flavor";
-  } elsif ($vm eq 'lxc' || $vm eq 'docker') {
+  } elsif ($vm eq 'lxc' || $vm eq 'docker' || $vm eq 'podman') {
     push @args, '--root', $buildroot;
     push @args, '--vm-type', $vm;
     push @args, '--memory', $vm_memory if $vm_memory;

--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -2458,7 +2458,8 @@ sub getpreinstallimage {
   $imagesource =~ s/\/[^\/]*$//;	# strip arch
   $imagesource .= "/$imageinfo->{'package'}" if $imageinfo->{'package'};
   $imagesource .= " [$imageinfo->{'hdrmd5'}]";
-  return $imagefile, \%imagebins, $imagesource, \%metas, \%imageorigins;
+  my $imageinfofile = -e "$dir/preinstallimage.info" ? 'preinstallimage.info' : undef;
+  return $imagefile, \%imagebins, $imagesource, \%metas, \%imageorigins, $imageinfofile;
 }
 
 sub getbinaries_buildenv {
@@ -2878,12 +2879,13 @@ sub getbinaries {
   # get a preinstall image if available
   my ($imagefile, $imagebins);
   if (@todo && $preinstallimagedata && $Build::Features::preinstallimage) {
-    my ($imagesource, $imagemetas, $imageorigins);
-    ($imagefile, $imagebins, $imagesource, $imagemetas, $imageorigins) = getpreinstallimage($buildinfo, $dir, \@todo, \%bvls);
+    my ($imagesource, $imagemetas, $imageorigins, $imageinfofile);
+    ($imagefile, $imagebins, $imagesource, $imagemetas, $imageorigins, $imageinfofile) = getpreinstallimage($buildinfo, $dir, \@todo, \%bvls);
     if ($imagefile && $imagebins && $imagemetas) {
       $preinstallimagedata->{'imagename'} = $imagefile;
       $preinstallimagedata->{'imagebins'} = $imagebins;
       $preinstallimagedata->{'imagesource'} = $imagesource;
+      $preinstallimagedata->{'imageinfofile'} = $imageinfofile if $imageinfofile;
       $meta{$_} = 1 for keys %$imagemetas;
       if ($outbdep) {
 	# record preinstallimage data
@@ -4060,6 +4062,7 @@ sub dobuild {
   }
   push @rpmlist, "preinstallimage: $pkgdir/$preinstallimagedata->{'imagename'}" if $preinstallimagedata->{'imagename'};
   push @rpmlist, "preinstallimagesource: $preinstallimagedata->{'imagesource'}" if $preinstallimagedata->{'imagesource'};
+  push @rpmlist, "preinstallimageinfo: $pkgdir/$preinstallimagedata->{'imageinfofile'}" if $preinstallimagedata->{'imageinfofile'};
   push @rpmlist, "localkiwi $localkiwi/localkiwi.rpm" if $localkiwi && -e "$localkiwi/localkiwi.rpm";
   push @rpmlist, "preinstall: ".join(' ', map {$_->{'name'}} grep {$_->{'preinstall'}} @bdep);
   push @rpmlist, "vminstall: ".join(' ', map {$_->{'name'}} grep {$_->{'vminstall'}} @bdep);

--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -80,6 +80,7 @@ my $vm_initrd;
 my $vm_memory;
 my $vm_custom_option;
 my $vm_use_mkfs_copyin;
+my $use_container_preinstallimage;
 my $vm_enable_console;
 my $vm_worker_name;
 my $vm_worker_instance;
@@ -336,6 +337,8 @@ Usage: $0 [OPTION] --root <directory> --statedir <directory>
 
        --vm-network: enable network (kvm)
 
+       --vm-use-container-preinstallimage: use preinstallimage as container base image (docker|podman)
+
        --emulator-script <script>
                    : Define the emulator script 
 
@@ -545,6 +548,11 @@ while (@ARGV) {
   if ($ARGV[0] eq '--vm-use-mkfs-copyin') {
     shift @ARGV;
     $vm_use_mkfs_copyin = 1;
+    next;
+  }
+  if ($ARGV[0] eq '--vm-use-container-preinstallimage') {
+    shift @ARGV;
+    $use_container_preinstallimage = 1;
     next;
   }
   if ($ARGV[0] eq '--vmdisk-rootsize') {
@@ -4125,6 +4133,7 @@ sub dobuild {
     push @args, '--root', $buildroot;
     push @args, '--vm-type', $vm;
     push @args, '--memory', $vm_memory if $vm_memory;
+    push @args, '--vm-use-container-preinstallimage' if ($vm eq 'docker' || $vm eq 'podman') && $use_container_preinstallimage;
   } else {
     print "VM-TYPE $vm not detected" if $vm;
     push @args, '--root', $buildroot;


### PR DESCRIPTION
Hi,

This PR is trying to download preinstallimage.info when preinstallimage.tar.gz is downloaded and pass it in the package list and allow docker and podman to use preinstallimage as container base image at build time to avoid the extra time that it takes to untar the preinstallimage and install the included packages in build environment.

This change is for my masters thesis. Sorry about not sending an email before starting the process.
I've tried to keep the approach as non invasive as possible. The previous solution still works and if preinstallimage is not found the traditional solution is used even if the option to use preinstallimage as base image for container is enabled.
The last commit should be dropped before merge since it's only for testing purpose. 

The combination of this PR and the https://github.com/openSUSE/obs-build/pull/1105 should allow obs to import preinstallimage a container image for docker and podman if the option is enabled.

I've tested it in local obs setup and in local build with `osc build` for both podman and docker.

The change for osc to support preinstallimage.info is at https://github.com/openSUSE/osc/commit/57bdcf2ef3e8b9bfbc108bac6899325f82b4400a.

For verifying the change in obs please `OBS_VM_TYPE="podman"` or `OBS_VM_TYPE="docker"` and `OBS_WORKER_USE_CONTAINER_PREINSTALLIMAGE="yes"` in buildhost.config or sysconfig.obs-server.

For verifying the change in osc build please run osc build with `--build-opt="--vm-use-container-preinstallimage"` and --vm-type of docker or podman.

I checked build timestamps for checking how much the build time is reduces. It of course depends on how big the preinstallimage is. I tested a preinstallimage with a sample specfile that was not doing any significant build.

When the option was disabled the build time was 13 seconds for docker and 96 seconds for podman. After using the option for the first time that image is being imported in the container images in the worker host it took 72s for docker and 45s for podman. In second build where the image was already imported it took 7s for docker and 8s for podman. This option would make sense for cases were the preinstallimage and it's dependencies are not changing frequently but there are frequent builds using that preinstallimage.

You can see the preinstallimage and spec file that I tested in couple of lines. Please let me know if there is anything I need to do or if you have any questions.

preinstallimage:
```
Name: heavy-base
BuildRequires: bash
BuildRequire: gcc-c++
BuildRequires:  cmake
BuildRequires:  make
BuildRequires:  pkg-config
BuildRequires:  libboost_headers-devel
BuildRequires:  libboost_system-devel
BuildRequires:  libqt5-qtbase-devel
BuildRequires:  libqt5-qttools-devel
BuildRequires:  opencv-devel
BuildRequires:  ffmpeg-4-libavcodec-devel
BuildRequires:  gstreamer-devel
BuildRequires:  gstreamer-plugins-base-devel
BuildRequires:  gtk3-devel
BuildRequires:  libxml2-devel
BuildRequires:  libxslt-devel
BuildRequires:  libopenssl-devel
BuildRequires:  libcurl-devel
BuildRequires:  sqlite3-devel
BuildRequires:  postgresql-devel
BuildRequires:  libmysqlclient-devel
BuildRequires:  python3-devel
BuildRequires:  python3-numpy-devel
BuildRequires:  python3-scipy
BuildRequires:  nodejs-common
BuildRequires:  rust
BuildRequires:  cargo
BuildRequires:  go
BuildRequires:  java-11-openjdk-devel
BuildRequires:  maven
BuildRequires:  gradle
BuildRequires:  texlive-latex-bin
BuildRequires:  ImageMagick-devel
BuildRequires:  libreoffice-sdk
#!BuildIgnore: brp-trim-desktopfiles
```

spec file:
```
Name:           heavy-build-test
Version:        1.0
Release:        1
Summary:        Test package with heavy BuildRequires
License:        MIT
URL:            https://example.com
Source0:        %{name}-%{version}.tar.gz

# Heavy BuildRequires that will stress the preinstallimage
BuildRequires:  gcc-c++
BuildRequires:  cmake
BuildRequires:  make
BuildRequires:  pkg-config
BuildRequires:  libboost_headers-devel
BuildRequires:  libboost_system-devel
BuildRequires:  libqt5-qtbase-devel
BuildRequires:  libqt5-qttools-devel
BuildRequires:  opencv-devel
BuildRequires:  ffmpeg-4-libavcodec-devel
BuildRequires:  gstreamer-devel
BuildRequires:  gstreamer-plugins-base-devel
BuildRequires:  gtk3-devel
BuildRequires:  libxml2-devel
BuildRequires:  libxslt-devel
BuildRequires:  libopenssl-devel
BuildRequires:  libcurl-devel
BuildRequires:  sqlite3-devel
BuildRequires:  postgresql-devel
BuildRequires:  libmysqlclient-devel
BuildRequires:  python3-devel
BuildRequires:  python3-numpy-devel
BuildRequires:  python3-scipy
BuildRequires:  nodejs-common
BuildRequires:  rust
BuildRequires:  cargo
BuildRequires:  go
BuildRequires:  java-11-openjdk-devel
BuildRequires:  maven
BuildRequires:  gradle
BuildRequires:  texlive-latex-bin
BuildRequires:  ImageMagick-devel
BuildRequires:  libreoffice-sdk

%description
A test package designed to have many heavy BuildRequires dependencies
to benchmark preinstallimage performance improvements in OBS.

%prep
%setup -q

%build
# Simple build that uses some of the dependencies
echo "Testing heavy dependencies build..."
gcc --version
cmake --version
python3 --version
java -version
go version
rustc --version
node --version

# Create a simple test program
cat > test.cpp << 'EOF'
#include <iostream>
#include <boost/version.hpp>
int main() {
    std::cout << "Boost version: " << BOOST_VERSION << std::endl;
    return 0;
}
EOF

g++ -o test test.cpp -lboost_system

%install
mkdir -p %{buildroot}%{_bindir}
install -m 755 test %{buildroot}%{_bindir}/heavy-build-test

%files
%{_bindir}/heavy-build-test

%changelog
* Sun Sep 01 2024 Test User <test@example.com> - 1.0-1
- Initial package for testing heavy BuildRequires
```