### PR TITLE
Display labels on the notifications page

### DIFF
--- a/src/api/app/models/notification.rb
+++ b/src/api/app/models/notification.rb
@@ -84,6 +84,10 @@ class Notification < ApplicationRecord
     User.find_by(login: event_payload['accused']) || User.find_by(login: event_payload['user_login'])
   end
 
+  def labelable?
+    notifiable_type.in?(%w[BsRequest Package])
+  end
+
   private
 
   def track_notification_creation

--- a/src/api/app/views/webui/users/notifications/_notification.html.haml
+++ b/src/api/app/views/webui/users/notifications/_notification.html.haml
@@ -55,3 +55,7 @@
       .row.d-none.d-md-block.ps-4
         .col
           %p.mt-3.mb-0= render_without_markdown(truncate_to_first_new_line(notification.excerpt))
+      - if Flipper.enabled?(:labels, User.session) && notification.labelable? && notification.notifiable.labels
+        .row.d-none.d-md-block.mt-3.ps-4
+          .col
+            = render partial: 'webui/shared/label', collection: notification.notifiable.labels, as: :label


### PR DESCRIPTION
Before we introduce the filter by label on the notifications page, we need to display the labels next to each notification.

Only in notifications whose notifiable is labelable: a Request or a Package (_Roles Granted, Roles Revoked, Build Failures_).

<img width="1698" height="1015" alt="Screenshot From 2025-11-10 23-23-21" src="https://github.com/user-attachments/assets/061a0eae-37ff-4c14-b687-56734e45f019" />

## Testing Tips

- Go to the notifications page after running test_data
- Go to the package related to a Build Failure notification and add some labels (after adding label_templates to its project)
- Go to the request related to one of the Request notifications and add some labels (after adding label_templates to its project)
- Go back to the notifications page and see the labels there