### PR TITLE
Use require_login in check_anonymous_access

### DIFF
--- a/src/api/app/controllers/concerns/authenticator.rb
+++ b/src/api/app/controllers/concerns/authenticator.rb
@@ -55,16 +55,8 @@ module Authenticator
 
   def check_anonymous_access
     return if ::Configuration.anonymous
-    return if User.session
 
-    respond_to do |format|
-      format.html do
-        redirect_to root_path, error: 'Authentication Required'
-      end
-      format.xml do
-        render_error status: 401, errorcode: 'authentication_required', message: 'Authentication Required'
-      end
-    end
+    require_login
   end
 
   def track_user_login


### PR DESCRIPTION
Both ApplicationController and Webui::WebuiController do the right thing in that before filter in case we require people to authenticate. No need to re-invent it here...

Fixes #18533