### PR TITLE
Don't leak class names into the labels UI

### DIFF
--- a/src/api/app/views/webui/shared/_label_global_form.html.haml
+++ b/src/api/app/views/webui/shared/_label_global_form.html.haml
@@ -2,7 +2,7 @@
   %button.btn.btn-sm.dropdown-toggle.ps-0.border-0{ data: { 'bs-toggle': 'dropdown', 'bs-auto-close': 'outside' }, aria: { expanded: 'false' } }
     %i.fas.fa-tag
     %strong
-      Set Global Labels
+      Set Labels
   .dropdown-menu
     .dropdown-item-text.d-flex.justify-content-end
       %button.btn-close{ type: 'button', 'data-bs-dismiss': 'dropdown', 'aria-label': 'Close' }


### PR DESCRIPTION
This might be a GlobalLabel in the code base but this means nothing to people using the label interface.