### PR TITLE
Fix wrong label colors

### DIFF
--- a/src/api/app/views/webui/request/_request_header.html.haml
+++ b/src/api/app/views/webui/request/_request_header.html.haml
@@ -76,6 +76,6 @@
     = render partial: 'webui/request/request_header_actions_list', locals: { bs_request: bs_request }
   - if Flipper.enabled?(:labels, User.session)
     .mt-4
-      = render partial: 'webui/shared/label', collection: bs_request.labels, as: :label
+      = render partial: 'webui/shared/label', collection: bs_request.labels.map(&:label_template), as: :label
       - if can_apply_labels?(bs_request: bs_request, user: User.session)
         = render partial: 'webui/shared/label_form', locals: { labelable: bs_request, project: project_for_labels(bs_request)}

--- a/src/api/app/views/webui/shared/_label_global_list.html.haml
+++ b/src/api/app/views/webui/shared/_label_global_list.html.haml
@@ -1,4 +1,4 @@
 - if Flipper.enabled?(:labels, User.session)
-  = render partial: 'webui/shared/label', collection: project.label_globals, as: :label, locals: { global_label: true }
+  = render partial: 'webui/shared/label', collection: project.label_globals.map(&:label_template), as: :label, locals: { global_label: true }
   - if policy(project).update?
     = render partial: 'webui/shared/label_global_form', locals: { project: }

--- a/src/api/app/views/webui/shared/_label_list.html.haml
+++ b/src/api/app/views/webui/shared/_label_list.html.haml
@@ -1,4 +1,4 @@
 - if Flipper.enabled?(:labels, User.session)
-  = render partial: 'webui/shared/label', collection: LabelTemplate.where(id: labelable.labels.pluck(:label_template_id)), as: :label
+  = render partial: 'webui/shared/label', collection: labelable.labels.map(&:label_template), as: :label
   - if policy(labelable).update_labels?
     = render partial: 'webui/shared/label_form', locals: { labelable:, project: }


### PR DESCRIPTION
In some of the pages where we assign the labels, the colors of the label was off.

### Before
On projects:
<img width="494" height="640" alt="Screenshot From 2025-11-12 17-23-55" src="https://github.com/user-attachments/assets/ccf44d3e-36a3-4733-86c7-0bed31d770ff" />


On requests:
<img width="494" height="640" alt="Screenshot From 2025-11-12 17-16-23" src="https://github.com/user-attachments/assets/6088f890-754f-4d5b-8478-758e488b11bf" />

### Now

On projects:
<img width="494" height="640" alt="Screenshot From 2025-11-12 17-25-02" src="https://github.com/user-attachments/assets/6b53278c-381a-4f8d-862a-1b2501b1e161" />

On requests:
<img width="494" height="686" alt="Screenshot From 2025-11-12 17-29-50" src="https://github.com/user-attachments/assets/54c0af3c-2f6a-4473-be41-e113a8370d08" />
