### PR TITLE
Adapt the text of the beta feature `label`

### DIFF
--- a/src/api/config/initializers/flipper.rb
+++ b/src/api/config/initializers/flipper.rb
@@ -5,7 +5,7 @@ ENABLED_FEATURE_TOGGLES = [
   { name: :request_show_redesign, description: 'Redesign of the request pages to improve the collaboration workflow' },
   { name: :content_moderation, description: 'Reporting inappropriate content' },
   { name: :foster_collaboration, description: 'Features improving the collaboration opportunities between users of the build service.' },
-  { name: :labels, description: 'Allow to apply labels to packages, submit requests and projects to improve collaboration between build service users.' },
+  { name: :labels, description: 'Allow to apply labels to packages, requests and projects to improve collaboration between build service users.' },
   { name: :request_index, description: 'Redesign of listing requests' },
   { name: :canned_responses, description: 'Create messages using templates' },
   { name: :package_version_tracking, description: 'Track the local and upstream versions of your packages' }


### PR DESCRIPTION
<img width="1237" height="111" alt="Screenshot 2025-11-06 at 16-55-00 Manage Beta Features - Open Build Service" src="https://github.com/user-attachments/assets/43a66d81-45b8-4ab1-bccc-6e92bbf8510e" />


So far, we can add labels to other kind of requests like delete and incident, apart from submit.

I know we are close to rollout, but it's never too late to avoid confusion.
