### PR TITLE
Changed the style and position of the maintenance incident request 

### DIFF
--- a/src/api/app/views/webui/request/_request_header.html.haml
+++ b/src/api/app/views/webui/request/_request_header.html.haml
@@ -8,6 +8,9 @@
     %small
       = render BsRequestPriorityBadgeComponent.new(priority: bs_request.priority, css_class: 'ms-2', overview: true)
       = render badge_state
+      -# Maintenance Incident Request
+      - if bs_request.maintenance_incident_request?
+        %span.badge.bg-maintenance.text-light.ms-2 Maintenance Incident
       %span.ms-2
         = render ReportsNoticeComponent.new(reportable: bs_request, user: User.session)
 
@@ -59,11 +62,6 @@
         %mark.text-dark.alert-warning.ps-2.pe-2.text-nowrap{ title: bs_request.accept_at }
           auto accepted
           = render TimeComponent.new(time: bs_request.accept_at)
-    -# Maintenance Incident Request
-    - if bs_request.maintenance_incident_request?
-      %li
-        This is a
-        %mark.text-light.bg-maintenance.text-nowrap.text Maintenance Incident
     -# Maintenance Release Request
     - if bs_request.maintenance_release_request?
       %li

--- a/src/api/spec/features/beta/webui/maintenance_workflow_spec.rb
+++ b/src/api/spec/features/beta/webui/maintenance_workflow_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe 'MaintenanceWorkflow', :js, :vcr do
     end
 
     it 'displays information on type of request' do
-      expect(page).to have_text('This is a Maintenance Incident')
+      expect(page).to have_text('Maintenance Incident')
     end
 
     context 'when accepting request' do
@@ -82,7 +82,7 @@ RSpec.describe 'MaintenanceWorkflow', :js, :vcr do
     end
 
     it 'displays information on type of request' do
-      expect(page).to have_text('This is a Maintenance Incident')
+      expect(page).to have_text('Maintenance Incident')
     end
 
     it 'has patchinfo submission' do


### PR DESCRIPTION
Hey Friends , 

I have redesign  the Maintenance Label by changing its position and the style so that it can match the adjacent components . 

Here is a screenshot of how it looks:

Before : 

<img width="719" height="301" alt="image" src="https://github.com/user-attachments/assets/1aa3bd31-3f90-4d66-a303-f84b3d7fb1e1" />


After : 

<img width="719" height="285" alt="Screenshot From 2025-11-14 18-44-37" src="https://github.com/user-attachments/assets/a2e778c7-d232-44d9-bc55-aa0c27463eec" />


Some additional changes - 
- I have updated the test in `maintenance_incident.rb` to expect the new text `Maintenance Incident` instead of the old text `This is a Maintenance Incident`, aligning it with the recent changes I made in `_request_header.html.haml`.

Fixes #18683


