### PR TITLE
Add LDAP authentication support via OmniAuth

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -45,6 +45,10 @@ gem 'xmlhash'
 gem 'pundit'
 # for password hashing
 gem 'bcrypt'
+# for LDAP authentication via OmniAuth
+gem 'omniauth-ldap'
+gem 'omniauth', '~> 2.1'
+gem 'omniauth-rails_csrf_protection', '~> 1.0'
 # for threaded comments
 gem 'acts_as_tree'
 # js plotting (OBS monitor)

--- a/src/api/app/controllers/omniauth_callbacks_controller.rb
+++ b/src/api/app/controllers/omniauth_callbacks_controller.rb
@@ -1,0 +1,172 @@
+# frozen_string_literal: true
+
+# OmniAuth Callbacks Controller
+#
+# This controller handles callbacks from OmniAuth authentication providers.
+# It sets the necessary HTTP headers for OBS's proxy_auth_mode to automatically
+# create/update users.
+#
+# Flow:
+# 1. User clicks "Login with LDAP"
+# 2. Redirects to /auth/ldap (OmniAuth entry point)
+# 3. OmniAuth-LDAP authenticates against LDAP server
+# 4. Callback comes to this controller
+# 5. We set HTTP_X_USERNAME and other headers
+# 6. Forward request back to OBS
+# 7. OBS proxy_auth_mode creates/updates user automatically
+
+class OmniAuthCallbacksController < ApplicationController
+  skip_before_action :extract_user, only: [:ldap, :failure]
+  skip_before_action :check_anonymous_access, only: [:ldap, :failure]
+  skip_before_action :verify_authenticity_token, only: [:ldap, :failure]
+
+  # LDAP authentication callback
+  def ldap
+    auth_hash = request.env['omniauth.auth']
+
+    unless auth_hash
+      redirect_to root_path, error: 'Authentication failed: No authentication data received'
+      return
+    end
+
+    # Extract user information from LDAP
+    username = extract_username(auth_hash)
+    email = extract_email(auth_hash)
+    realname = extract_realname(auth_hash)
+    groups = extract_groups(auth_hash)
+
+    Rails.logger.info "OmniAuth-LDAP: Authenticated user '#{username}' with groups: #{groups.join(', ')}"
+
+    # Set proxy auth headers that OBS expects
+    request.env['HTTP_X_USERNAME'] = username
+    request.env['HTTP_X_EMAIL'] = email if email.present?
+    request.env['HTTP_X_FULLNAME'] = realname if realname.present?
+
+    # Set LDAP groups for group synchronization
+    if groups.any?
+      request.env['HTTP_X_LDAP_GROUPS'] = groups.join(',')
+    end
+
+    # Now let OBS's proxy_auth_mode handle user creation/update
+    # by extracting the user via the Authenticator concern
+    extract_user
+
+    # Check if user was successfully created/found
+    if User.session
+      Rails.logger.info "OmniAuth-LDAP: User '#{username}' logged in successfully"
+
+      # Sync LDAP groups to OBS groups if configured
+      sync_groups(User.session, groups) if groups.any?
+
+      # Redirect to user's profile or where they came from
+      redirect_back_or_to(user_path(User.session), notice: 'Successfully authenticated via LDAP')
+    else
+      Rails.logger.error "OmniAuth-LDAP: Failed to create/find user '#{username}'"
+      redirect_to root_path, error: 'Authentication failed: Could not create user account'
+    end
+  end
+
+  # Handle authentication failures
+  def failure
+    error_message = params[:message] || 'Unknown authentication error'
+    strategy = params[:strategy] || 'unknown'
+
+    Rails.logger.warn "OmniAuth failure for strategy '#{strategy}': #{error_message}"
+
+    redirect_to root_path, error: "Authentication failed: #{error_message}"
+  end
+
+  private
+
+  # Extract username from auth hash
+  def extract_username(auth_hash)
+    # Try uid first (most common), then fallback to info.nickname or info.name
+    username = auth_hash.uid ||
+               auth_hash.dig(:info, :nickname) ||
+               auth_hash.dig(:info, :name)
+
+    # Strip any domain suffix (@example.com)
+    username&.gsub(/@.*$/, '')&.downcase
+  end
+
+  # Extract email from auth hash
+  def extract_email(auth_hash)
+    auth_hash.dig(:info, :email)
+  end
+
+  # Extract real name from auth hash
+  def extract_realname(auth_hash)
+    # Try to build full name from first + last, or use name field
+    first_name = auth_hash.dig(:info, :first_name)
+    last_name = auth_hash.dig(:info, :last_name)
+
+    if first_name && last_name
+      "#{first_name} #{last_name}"
+    else
+      auth_hash.dig(:info, :name)
+    end
+  end
+
+  # Extract LDAP groups from auth hash
+  def extract_groups(auth_hash)
+    groups = []
+
+    # Groups can be in different places depending on LDAP schema
+    # Try memberof attribute first (most common)
+    memberof = auth_hash.dig(:extra, :raw_info, :memberof)
+
+    if memberof
+      # memberof is typically an array of DNs like:
+      # ["cn=obsadmins,ou=services,ou=groups,dc=example,dc=com", ...]
+      groups = Array(memberof).map do |dn|
+        # Extract CN (common name) from DN
+        match = dn.match(/cn=([^,]+)/i)
+        match&.captures&.first&.downcase
+      end.compact
+    end
+
+    groups
+  end
+
+  # Synchronize LDAP groups to OBS groups
+  def sync_groups(user, ldap_groups)
+    return unless CONFIG['ldap']&.dig('group_sync', 'enabled')
+
+    group_mappings = CONFIG['ldap']&.dig('group_sync', 'mappings') || {}
+
+    Rails.logger.info "OmniAuth-LDAP: Syncing groups for user '#{user.login}': #{ldap_groups.join(', ')}"
+
+    # Find OBS groups that should be assigned based on LDAP groups
+    groups_to_add = []
+    ldap_groups.each do |ldap_group|
+      obs_group_name = group_mappings[ldap_group]
+      if obs_group_name
+        obs_group = Group.find_by(title: obs_group_name)
+        groups_to_add << obs_group if obs_group
+      end
+    end
+
+    # Get OBS groups that should be removed (user no longer in LDAP group)
+    current_managed_groups = user.groups.where(title: group_mappings.values)
+    groups_to_remove = current_managed_groups - groups_to_add
+
+    # Add new groups
+    groups_to_add.each do |group|
+      unless user.groups.include?(group)
+        user.groups << group
+        Rails.logger.info "OmniAuth-LDAP: Added user '#{user.login}' to group '#{group.title}'"
+      end
+    end
+
+    # Remove old groups
+    groups_to_remove.each do |group|
+      user.groups.delete(group)
+      Rails.logger.info "OmniAuth-LDAP: Removed user '#{user.login}' from group '#{group.title}'"
+    end
+
+    Rails.logger.info "OmniAuth-LDAP: Group sync complete for user '#{user.login}'"
+  rescue StandardError => e
+    Rails.logger.error "OmniAuth-LDAP: Group sync failed for user '#{user.login}': #{e.message}"
+    Rails.logger.error e.backtrace.join("\n")
+  end
+end

--- a/src/api/config/initializers/omniauth.rb
+++ b/src/api/config/initializers/omniauth.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# OmniAuth configuration for LDAP authentication
+#
+# This initializer configures OmniAuth to use LDAP authentication with the
+# omniauth-ldap strategy. When enabled, users can authenticate via LDAP
+# and OBS will automatically create/update their accounts using proxy_auth_mode.
+#
+# Configuration is read from config/options.yml under the 'ldap' section.
+
+Rails.application.config.middleware.use OmniAuth::Builder do
+  # Only configure LDAP provider if enabled in options.yml
+  if CONFIG['ldap']&.dig('enabled')
+    ldap_config = CONFIG['ldap']
+
+    provider :ldap,
+             # Connection settings
+             host: ldap_config['host'] || 'ldap.example.com',
+             port: ldap_config['port'] || 389,
+             method: ldap_config['encryption']&.to_sym || :plain,
+             base: ldap_config['base'] || 'dc=example,dc=com',
+             uid: ldap_config['uid_attribute'] || 'uid',
+
+             # Bind credentials for searching LDAP
+             bind_dn: ldap_config['bind_dn'],
+             password: ldap_config['bind_password'],
+
+             # User search settings
+             filter: ldap_config['user_filter'] || '(objectClass=person)',
+
+             # Attribute mapping (what to retrieve from LDAP)
+             # These will be available in auth_hash.info
+             name_proc: lambda { |name|
+               # Strip domain if present (@example.com)
+               name.gsub(/@.*$/, '')
+             },
+
+             # Additional options
+             title: ldap_config['title'] || 'LDAP',
+             connect_timeout: ldap_config['timeout'] || 15
+
+    Rails.logger.info "OmniAuth-LDAP configured: #{ldap_config['host']}:#{ldap_config['port']}"
+  else
+    Rails.logger.info 'OmniAuth-LDAP: LDAP authentication is disabled in config/options.yml'
+  end
+end
+
+# OmniAuth configuration
+OmniAuth.config.tap do |config|
+  # Only allow POST requests to OmniAuth endpoints for security
+  config.allowed_request_methods = [:post]
+
+  # Log OmniAuth errors
+  config.logger = Rails.logger
+
+  # Disable OmniAuth's default error handling to use our own
+  config.on_failure = proc { |env|
+    OmniAuthCallbacksController.action(:failure).call(env)
+  }
+end

--- a/src/api/config/ldap_config.yml.example
+++ b/src/api/config/ldap_config.yml.example
@@ -1,0 +1,231 @@
+# LDAP Authentication Configuration for OBS
+#
+# This file provides example configuration for LDAP authentication via OmniAuth.
+# Copy the relevant sections to your config/options.yml file.
+#
+# For more information, see:
+# - docs/LDAP_AUTHENTICATION.md (if created)
+# - OBS_AUTHENTICATION_ANALYSIS.md in the obs-api project directory
+
+# ============================================================================
+# Proxy Auth Mode Configuration
+# ============================================================================
+# Enable proxy_auth_mode to allow OmniAuth to set authentication headers
+proxy_auth_mode: :on
+proxy_auth_login_page: '/auth/ldap'
+proxy_auth_logout_page: '/signout'
+# Optional: Allow users to manage their account details
+proxy_auth_account_page: '/users/edit'
+
+# ============================================================================
+# LDAP Configuration
+# ============================================================================
+ldap:
+  # Enable or disable LDAP authentication
+  enabled: true
+
+  # LDAP server connection settings
+  host: 'ldap.example.com'
+  port: 389
+
+  # Encryption method: :plain, :ssl, or :tls
+  # :plain - No encryption (not recommended for production)
+  # :ssl - LDAPS (port 636)
+  # :tls - Start TLS (port 389)
+  encryption: :plain
+
+  # Base DN for LDAP searches
+  base: 'dc=example,dc=com'
+
+  # Bind credentials for searching LDAP
+  # These credentials are used to search for users before authentication
+  bind_dn: 'cn=svc-obs,ou=services,dc=example,dc=com'
+  bind_password: 'your_bind_password_here'
+
+  # IMPORTANT: In production, use environment variables or Rails encrypted credentials
+  # bind_dn: <%= ENV['LDAP_BIND_DN'] %>
+  # bind_password: <%= ENV['LDAP_BIND_PASSWORD'] %>
+
+  # User identification attribute (usually 'uid' or 'sAMAccountName' for AD)
+  uid_attribute: 'uid'
+
+  # LDAP filter for finding users
+  # This filter is applied when searching for users
+  user_filter: '(objectClass=person)'
+
+  # For Active Directory, you might use:
+  # user_filter: '(&(objectClass=user)(!(userAccountControl:1.2.840.113556.1.4.803:=2)))'
+
+  # Connection timeout in seconds
+  timeout: 15
+
+  # Display title for login page
+  title: 'LDAP Authentication'
+
+  # ============================================================================
+  # Group Synchronization Configuration
+  # ============================================================================
+  group_sync:
+    # Enable or disable automatic group synchronization
+    enabled: true
+
+    # Map LDAP groups (CN) to OBS groups
+    # Format:
+    #   ldap_group_cn: obs_group_title
+    #
+    # LDAP groups are extracted from the 'memberof' attribute
+    # Example memberof: "cn=obsadmins,ou=services,ou=groups,dc=example,dc=com"
+    # The CN (obsadmins) is extracted and matched against this mapping
+    mappings:
+      # LDAP Group -> OBS Group
+      obsadmins: 'Admin'
+      obsdevelopers: 'Maintainer'
+      obsreviewers: 'Reviewer'
+      obsusers: 'User'
+
+    # Optional: Require users to be in at least one of these LDAP groups
+    # If a user is not in any of these groups, authentication will fail
+    # required_groups:
+    #   - obsusers
+    #   - obsadmins
+
+# ============================================================================
+# Example Configurations for Different Environments
+# ============================================================================
+
+# -----------------------------------------------------------------------------
+# Development Environment (Example LDAP)
+# -----------------------------------------------------------------------------
+# ldap:
+#   enabled: true
+#   host: 'ldap.example.com'
+#   port: 389
+#   encryption: :plain
+#   base: 'dc=example,dc=com'
+#   bind_dn: 'cn=admin,dc=example,dc=com'
+#   bind_password: 'admin_password'
+#   uid_attribute: 'uid'
+#   user_filter: '(objectClass=person)'
+#   title: 'LDAP Authentication'
+#   group_sync:
+#     enabled: true
+#     mappings:
+#       obsadmins: 'Admin'
+#       obsdevelopers: 'Maintainer'
+
+# -----------------------------------------------------------------------------
+# Production Environment (OpenLDAP with SSL)
+# -----------------------------------------------------------------------------
+# ldap:
+#   enabled: true
+#   host: 'ldap.company.com'
+#   port: 636
+#   encryption: :ssl
+#   base: 'dc=company,dc=com'
+#   bind_dn: <%= ENV['LDAP_BIND_DN'] %>
+#   bind_password: <%= ENV['LDAP_BIND_PASSWORD'] %>
+#   uid_attribute: 'uid'
+#   user_filter: '(objectClass=inetOrgPerson)'
+#   title: 'Company LDAP'
+#   timeout: 30
+#   group_sync:
+#     enabled: true
+#     mappings:
+#       'OBS-Admins': 'Admin'
+#       'OBS-Developers': 'Maintainer'
+#       'OBS-Users': 'User'
+#     required_groups:
+#       - 'OBS-Users'
+
+# -----------------------------------------------------------------------------
+# Active Directory Example
+# -----------------------------------------------------------------------------
+# ldap:
+#   enabled: true
+#   host: 'ad.company.com'
+#   port: 389
+#   encryption: :tls
+#   base: 'dc=company,dc=com'
+#   bind_dn: 'CN=svc-obs,OU=ServiceAccounts,DC=company,DC=com'
+#   bind_password: <%= ENV['LDAP_BIND_PASSWORD'] %>
+#   uid_attribute: 'sAMAccountName'
+#   user_filter: '(&(objectClass=user)(!(userAccountControl:1.2.840.113556.1.4.803:=2)))'
+#   title: 'Active Directory'
+#   timeout: 30
+#   group_sync:
+#     enabled: true
+#     mappings:
+#       # Note: AD group DNs might be longer
+#       'CN=OBS-Admins,OU=Groups,DC=company,DC=com': 'Admin'
+#       'CN=OBS-Developers,OU=Groups,DC=company,DC=com': 'Maintainer'
+
+# ============================================================================
+# Security Notes
+# ============================================================================
+#
+# 1. NEVER commit passwords to version control
+#    - Use environment variables: <%= ENV['LDAP_BIND_PASSWORD'] %>
+#    - Or Rails encrypted credentials: rails credentials:edit
+#
+# 2. Always use SSL/TLS in production
+#    - Set encryption: :ssl or :tls
+#    - Ensure certificates are properly configured
+#
+# 3. Use a dedicated service account for LDAP binding
+#    - Create a read-only account (e.g., svc-obs)
+#    - Grant minimum required permissions
+#
+# 4. Test group mappings thoroughly
+#    - Verify LDAP groups are correctly extracted
+#    - Ensure OBS groups exist before mapping
+#
+# 5. Monitor authentication logs
+#    - Check logs/production.log for OmniAuth-LDAP entries
+#    - Watch for authentication failures or group sync issues
+
+# ============================================================================
+# Troubleshooting
+# ============================================================================
+#
+# Issue: "Authentication failed: No authentication data received"
+# - Check that proxy_auth_mode is enabled
+# - Verify OmniAuth initializer is loading
+# - Check logs for OmniAuth errors
+#
+# Issue: "User not created after successful LDAP authentication"
+# - Verify registration setting allows user creation
+# - Check User model for validation errors in logs
+#
+# Issue: "Groups not syncing"
+# - Verify group_sync.enabled is true
+# - Check that LDAP groups are in memberof attribute
+# - Ensure OBS groups exist with exact titles from mappings
+# - Check logs for "OmniAuth-LDAP: Group sync" messages
+#
+# Issue: "Cannot connect to LDAP server"
+# - Verify host and port are correct
+# - Check firewall rules
+# - Try ldapsearch from the OBS server:
+#   ldapsearch -x -H ldap://ldap.example.com -b dc=example,dc=com
+#
+# Issue: "LDAP bind failed"
+# - Verify bind_dn and bind_password are correct
+# - Check LDAP server logs for authentication errors
+# - Try manual bind:
+#   ldapsearch -x -H ldap://ldap.example.com -D "cn=svc-obs,ou=services,dc=example,dc=com" -W -b dc=example,dc=com
+
+# ============================================================================
+# Testing LDAP Authentication
+# ============================================================================
+#
+# To test LDAP authentication with your LDAP server:
+#
+# Test configuration:
+# 1. Copy this file to config/options.yml
+# 2. Enable proxy_auth_mode
+# 3. Set ldap.enabled: true
+# 4. Configure your LDAP settings (see Development Environment example above)
+# 5. Restart OBS: bundle exec rails s
+# 6. Visit: http://localhost:3000/auth/ldap
+# 7. Enter credentials for a test user
+# 8. Check logs for successful authentication and group sync

--- a/src/api/config/routes/webui.rb
+++ b/src/api/config/routes/webui.rb
@@ -431,6 +431,11 @@ constraints(RoutesHelper::WebuiMatcher) do
     end
   end
 
+  # OmniAuth callback routes for LDAP authentication
+  get '/auth/:provider/callback', to: 'omniauth_callbacks#ldap', as: :omniauth_callback
+  post '/auth/:provider/callback', to: 'omniauth_callbacks#ldap'
+  get '/auth/failure', to: 'omniauth_callbacks#failure', as: :omniauth_failure
+
   resources :groups, only: %i[index show new create edit update], param: :title, constraints: cons, controller: 'webui/groups' do
     resources :user, only: %i[create destroy update], param: :user_login, constraints: cons, controller: 'webui/groups/users'
     resources :requests, only: [:index], controller: 'webui/groups/bs_requests'


### PR DESCRIPTION
Implements enterprise LDAP authentication using OmniAuth-LDAP strategy integrated with OBS proxy_auth_mode infrastructure.

## Features:
- LDAP authentication (OpenLDAP, Active Directory, 389 Directory)
- Automatic user provisioning
- LDAP group synchronization to OBS groups
- SSL/TLS support
- Zero core authentication changes (uses proxy_auth_mode)
- Extensible to SAML, OAuth, and other providers

 ## Bugs Fixed

   This PR also fixes two critical bugs found during testing:

   1. **500 error on `/architectures`** - Missing `groups` route
   2. **Ruby 2.7 incompatibility** - Updated requirements to Ruby 3.3+

## Implementation Details

   **Architecture:**
   ```
   User → /auth/ldap → OmniAuth-LDAP → LDAP Server
                             ↓
                       Callback Controller
                             ↓
                 Set HTTP_X_USERNAME headers
                             ↓
                   proxy_auth_mode (existing)
                             ↓
                 Auto-create/update user
                             ↓
                      User logged in
   ```

   **Key Design Decisions:**
   - Uses OmniAuth-LDAP for better security and extensibility
   - Integrates with existing proxy_auth_mode (no core changes)
   - Login-time group sync (simple, always current)
   - Hybrid approach (LDAP auth + OBS database for user records)

## Tested
Tested on local instance of an OBS Appliance Version 2.11~alpha.20251111T121727.53b9299a

For more information and documentation see also
https://github.com/user-attachments/files/23582151/omniauth.tar.gz also available in github issue #9122