### PR TITLE
Show label filter section only to beta users

### DIFF
--- a/src/api/app/views/webui/project/_project_packages.html.haml
+++ b/src/api/app/views/webui/project/_project_packages.html.haml
@@ -60,6 +60,6 @@
     initializeRemoteDatatable('#packages-table', {
         "columns": package_datatable_columns
       });
-  - if Flipper.enabled?(:package_version_tracking, User.session)
+  - if Flipper.enabled?(:labels, User.session)
     :plain
       labelFiltering();


### PR DESCRIPTION
We only show the labels column etc. to user under the labels beta program. We should do the same for the filter section since it is tied to it.

<img width="1087" height="268" alt="image" src="https://github.com/user-attachments/assets/12857944-7d9f-436c-b766-e3f0903dce17" />
