### PR TITLE
Make AttribNamespace name field required

### DIFF
--- a/src/api/.database_consistency.todo.yml
+++ b/src/api/.database_consistency.todo.yml
@@ -36,8 +36,6 @@ AttribNamespace:
     PrimaryKeyTypeChecker:
       enabled: false
   name:
-    ColumnPresenceChecker:
-      enabled: false
     LengthConstraintChecker:
       enabled: false
 AttribNamespaceModifiableBy:

--- a/src/api/app/models/attrib_namespace.rb
+++ b/src/api/app/models/attrib_namespace.rb
@@ -50,7 +50,7 @@ end
 # Table name: attrib_namespaces
 #
 #  id   :integer          not null, primary key
-#  name :string(255)      indexed
+#  name :string(255)      not null, indexed
 #
 # Indexes
 #

--- a/src/api/db/migrate/20251119144352_make_attrib_namespace_name_required.rb
+++ b/src/api/db/migrate/20251119144352_make_attrib_namespace_name_required.rb
@@ -1,0 +1,5 @@
+class MakeAttribNamespaceNameRequired < ActiveRecord::Migration[7.2]
+  def change
+    change_column_null :attrib_namespaces, :name, false
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_10_29_093527) do
+ActiveRecord::Schema[7.2].define(version: 2025_11_19_144352) do
   create_table "active_storage_attachments", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -101,7 +101,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_093527) do
   end
 
   create_table "attrib_namespaces", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
-    t.string "name"
+    t.string "name", null: false
     t.index ["name"], name: "index_attrib_namespaces_on_name"
   end
 


### PR DESCRIPTION
The AttribNamespace model declares the name field as presence required, but the database schema allows null values.

This PR makes the database field NOT NULL to be in sync with the model.