### PR TITLE
Add missing processing status categories map

### DIFF
--- a/src/api/app/models/buildresult.rb
+++ b/src/api/app/models/buildresult.rb
@@ -46,6 +46,7 @@ class Buildresult
   STATUS_CATEGORIES_MAP = {
     succeeded: STATUS_CATEGORIES[0],
     failed: STATUS_CATEGORIES[1],
+    processing: STATUS_CATEGORIES[2],
     unresolvable: STATUS_CATEGORIES[3],
     broken: STATUS_CATEGORIES[1],
     blocked: STATUS_CATEGORIES[3],


### PR DESCRIPTION
Fix #18821.

### Before

| Light mode | Dark mode |
| --- | --- |
| <img width="191" height="85" alt="Screenshot From 2025-11-19 16-29-05" src="https://github.com/user-attachments/assets/724550d7-42d9-4fe2-92b5-a4a21b72fb29" /> | <img width="191" height="85" alt="Screenshot From 2025-11-19 16-29-00" src="https://github.com/user-attachments/assets/30a02d74-11a3-4bd1-abcf-9d4e807f7615" /> |

### After

| Light mode | Dark mode |
| --- | --- |
| <img width="191" height="215" alt="Screenshot From 2025-11-19 16-26-58" src="https://github.com/user-attachments/assets/c855d4e9-d90c-4a53-85e8-2ca1a5f5399b" /> | <img width="191" height="215" alt="Screenshot From 2025-11-19 16-26-47" src="https://github.com/user-attachments/assets/67d24249-8032-48bc-9fe0-b9b53ef599bf" /> |