### PR TITLE
Add length validation to name attribute in AttribNamespace model

### DIFF
--- a/src/api/.database_consistency.todo.yml
+++ b/src/api/.database_consistency.todo.yml
@@ -35,9 +35,6 @@ AttribNamespace:
   id:
     PrimaryKeyTypeChecker:
       enabled: false
-  name:
-    LengthConstraintChecker:
-      enabled: false
 AttribNamespaceModifiableBy:
   attrib_namespace_user_role_all_index:
     UniqueIndexChecker:

--- a/src/api/app/models/attrib_namespace.rb
+++ b/src/api/app/models/attrib_namespace.rb
@@ -11,7 +11,7 @@ class AttribNamespace < ApplicationRecord
   #### Callbacks macros: before_save, after_save, etc.
   #### Scopes (first the default_scope macro if is used)
   #### Validations macros
-  validates :name, presence: true
+  validates :name, presence: true, length: { maximum: 255 }
   validates_associated :attrib_types
 
   #### Class methods using self. (public and then private)


### PR DESCRIPTION
The database field has an implicit length restriction, but it's not explicitly set by the model. With the validation we fix that.