### PR TITLE
Fix flickering spec on labels controller

### DIFF
--- a/src/api/spec/controllers/webui/labels_controller_spec.rb
+++ b/src/api/spec/controllers/webui/labels_controller_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe Webui::LabelsController do
   let(:tom) { create(:confirmed_user, :with_home, login: 'tom') }
   let(:home_tom) { tom.home_project }
   let(:toms_package) { create(:package, name: 'my_package', project: home_tom) }
-  let!(:label_one) { create(:label_template, project: home_tom) }
-  let!(:label_two) { create(:label_template, project: home_tom) }
-  let!(:label_three) { create(:label_template, project: home_tom) }
+  let!(:label_one) { create(:label_template, project: home_tom, name: 'Label One') }
+  let!(:label_two) { create(:label_template, project: home_tom, name: 'Label Two') }
+  let!(:label_three) { create(:label_template, project: home_tom, name: 'Label Three') }
 
   before do
     Flipper.enable(:labels)


### PR DESCRIPTION
Set explicit names for all labels used in the spec. This avoids returning unintended results when searching for labels that match a given pattern.

Happened last time [here](https://app.circleci.com/pipelines/github/openSUSE/open-build-service/28189/workflows/fd5e32e9-505c-4edb-8602-32bd09794d40/jobs/264194).

Failing spec message:

```
  1) Webui::LabelsController GET autocomplete returns list with more than one matching result
     Failure/Error: expect(response.parsed_body).to eq(%w[Test Coolest])
     
       expected: ["Test", "Coolest"]
            got: ["Est", "Test", "Coolest"]
     
       (compared using ==)
     # ./spec/controllers/webui/labels_controller_spec.rb:53:in 'block (3 levels) in <top (required)>'
```