### PR TITLE
Add unique index validation on AttribNamespaceModifiableBy model

### DIFF
--- a/src/api/.database_consistency.todo.yml
+++ b/src/api/.database_consistency.todo.yml
@@ -33,9 +33,6 @@ AttribNamespace:
     PrimaryKeyTypeChecker:
       enabled: false
 AttribNamespaceModifiableBy:
-  attrib_namespace_user_role_all_index:
-    UniqueIndexChecker:
-      enabled: false
   id:
     PrimaryKeyTypeChecker:
       enabled: false

--- a/src/api/app/models/attrib_namespace_modifiable_by.rb
+++ b/src/api/app/models/attrib_namespace_modifiable_by.rb
@@ -2,6 +2,8 @@ class AttribNamespaceModifiableBy < ApplicationRecord
   belongs_to :attrib_namespace
   belongs_to :user, optional: true
   belongs_to :group, optional: true
+
+  validates :attrib_namespace, uniqueness: { scope: %i[user group] }
 end
 
 # == Schema Information


### PR DESCRIPTION
There is a composite unique index on attrib_namespace_modifiable_bies table, around attrib_namespace_id, user_id and group_id.

The appropriate model validation was needed in order to have the index visible by Rails.