### PR TITLE
Hide the “set-label” button when no label is present

### DIFF
--- a/src/api/app/views/webui/request/_request_header.html.haml
+++ b/src/api/app/views/webui/request/_request_header.html.haml
@@ -77,5 +77,6 @@
   - if Flipper.enabled?(:labels, User.session)
     .mt-4
       = render partial: 'webui/shared/label', collection: bs_request.labels.map(&:label_template), as: :label
-      - if can_apply_labels?(bs_request: bs_request, user: User.session)
-        = render partial: 'webui/shared/label_form', locals: { labelable: bs_request, project: project_for_labels(bs_request)}
+      - project = project_for_labels(bs_request)
+      - if can_apply_labels?(bs_request: bs_request, user: User.session) && project.label_templates.present?
+        = render partial: 'webui/shared/label_form', locals: { labelable: bs_request, project: project}


### PR DESCRIPTION
Fixes #18825 

Hey Friends , 

I have tried to hide the "Set Labels" button by adding a check to ensure the project actually has label templates available.

Previously, the button appeared as long as the user had permission but now I fetch the project first `project = project_for_labels(...)` and only show the button if `project.label_templates.present?` is true. This will ensure the button only appears when there are actually labels to set.

BEFORE : 
<img width="908" height="401" alt="image" src="https://github.com/user-attachments/assets/47168d02-dc75-4a06-9469-1a0d64a400f4" />

AFTER : 
<img width="908" height="387" alt="image" src="https://github.com/user-attachments/assets/e050ccd9-ab66-4070-b592-c5bc70ba90f7" />
