### PR TITLE
Add cascade deletion on attrib_allowed_values table attrib_type foreign key

### DIFF
--- a/src/api/.database_consistency.todo.yml
+++ b/src/api/.database_consistency.todo.yml
@@ -40,9 +40,6 @@ AttribNamespaceModifiableBy:
     PrimaryKeyTypeChecker:
       enabled: false
 AttribType:
-  allowed_values:
-    ForeignKeyCascadeChecker:
-      enabled: false
   default_values:
     ForeignKeyCascadeChecker:
       enabled: false

--- a/src/api/app/models/attrib_allowed_value.rb
+++ b/src/api/app/models/attrib_allowed_value.rb
@@ -18,5 +18,5 @@ end
 #
 # Foreign Keys
 #
-#  attrib_allowed_values_ibfk_1  (attrib_type_id => attrib_types.id)
+#  attrib_allowed_values_ibfk_1  (attrib_type_id => attrib_types.id) ON DELETE => cascade
 #

--- a/src/api/db/migrate/20251124111003_add_cascade_deletion_on_attrib_allowed_values_table_attrib_type_foreign_key.rb
+++ b/src/api/db/migrate/20251124111003_add_cascade_deletion_on_attrib_allowed_values_table_attrib_type_foreign_key.rb
@@ -1,0 +1,6 @@
+class AddCascadeDeletionOnAttribAllowedValuesTableAttribTypeForeignKey < ActiveRecord::Migration[7.2]
+  def change
+    remove_foreign_key :attrib_allowed_values, :attrib_types
+    add_foreign_key :attrib_allowed_values, :attrib_types, on_delete: :cascade, name: 'attrib_allowed_values_ibfk_1'
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_11_20_113549) do
+ActiveRecord::Schema[7.2].define(version: 2025_11_24_111003) do
   create_table "active_storage_attachments", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -1295,7 +1295,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_11_20_113549) do
   add_foreign_key "assignments", "packages"
   add_foreign_key "assignments", "users", column: "assignee_id"
   add_foreign_key "assignments", "users", column: "assigner_id"
-  add_foreign_key "attrib_allowed_values", "attrib_types", name: "attrib_allowed_values_ibfk_1"
+  add_foreign_key "attrib_allowed_values", "attrib_types", name: "attrib_allowed_values_ibfk_1", on_delete: :cascade
   add_foreign_key "attrib_default_values", "attrib_types", name: "attrib_default_values_ibfk_1"
   add_foreign_key "attrib_issues", "attribs", name: "attrib_issues_ibfk_1"
   add_foreign_key "attrib_issues", "issues", name: "attrib_issues_ibfk_2"


### PR DESCRIPTION
Because the existing foreign key lacks the cascade deletion we may end with stale references on attrib_allowed_values table.
