### PR TITLE
Check if the foreign key exists before removing

### DIFF
--- a/src/api/db/migrate/20251120113549_change_attrib_namespace_modifiable_bies_foreign_key_on_attrib_namespace_to_on_delete_cascade.rb
+++ b/src/api/db/migrate/20251120113549_change_attrib_namespace_modifiable_bies_foreign_key_on_attrib_namespace_to_on_delete_cascade.rb
@@ -1,6 +1,6 @@
 class ChangeAttribNamespaceModifiableBiesForeignKeyOnAttribNamespaceToOnDeleteCascade < ActiveRecord::Migration[7.2]
   def change
-    remove_foreign_key :attrib_namespace_modifiable_bies, :attrib_namespaces
+    remove_foreign_key :attrib_namespace_modifiable_bies, :attrib_namespaces, if_exists: true
     add_foreign_key :attrib_namespace_modifiable_bies, :attrib_namespaces, name: 'attrib_namespace_modifiable_bies_ibfk_1', on_delete: :cascade
   end
 end


### PR DESCRIPTION
```
"ArgumentError: Table 'attrib_namespace_modifiable_bies' has no foreign key for attrib_namespaces (ArgumentError)", "",
"            raise(ArgumentError, \"Table '#{from_table}' has no foreign key for #{to_table || options}\")", "    

```