### PR TITLE
Add length validation to description field in AttribType model

### DIFF
--- a/src/api/.database_consistency.todo.yml
+++ b/src/api/.database_consistency.todo.yml
@@ -46,9 +46,6 @@ AttribType:
   default_values:
     ForeignKeyCascadeChecker:
       enabled: false
-  description:
-    LengthConstraintChecker:
-      enabled: false
   id:
     PrimaryKeyTypeChecker:
       enabled: false

--- a/src/api/app/models/attrib_type.rb
+++ b/src/api/app/models/attrib_type.rb
@@ -23,6 +23,7 @@ class AttribType < ApplicationRecord
   #### Scopes (first the default_scope macro if is used)
   #### Validations macros
   validates :name, presence: true
+  validates :description, length: { maximum: 255 }
 
   #### Class methods using self. (public and then private)
   def self.find_by_name!(name)


### PR DESCRIPTION
Because otherwise rails will allow descriptions too large to crash against the database.