### PR TITLE
Convert popover to dropdown

### DIFF
--- a/src/api/app/views/webui/packages/binaries/_binaries_actions.html.haml
+++ b/src/api/app/views/webui/packages/binaries/_binaries_actions.html.haml
@@ -1,9 +1,11 @@
 - if binary[:links][:download_url]
-  = link_to(binary[:links][:download_url], title: 'Download', class: 'ms-2') do
-    %i.fas.fa-download.text-secondary
-    Download
+  %span.d-block.d-xs-block.d-sm-inline.dropdown-item
+    = link_to(binary[:links][:download_url], title: 'Download', class: 'ms-2') do
+      %i.fas.fa-download.text-secondary
+      Download
 - if binary[:links][:details?]
-  = link_to(project_package_repository_binary_path(project_name: project, package_name: package_name, repository_name: repository,
-    arch: architecture, filename: binary[:filename]), title: 'Information', class: 'ms-2') do
-    %i.fas.fa-info-circle
-    Details
+  %span.d-block.d-xs-block.d-sm-inline.dropdown-item
+    = link_to(project_package_repository_binary_path(project_name: project, package_name: package_name, repository_name: repository,
+      arch: architecture, filename: binary[:filename]), title: 'Information', class: 'ms-2') do
+      %i.fas.fa-info-circle
+      Details

--- a/src/api/app/views/webui/packages/binaries/index.html.haml
+++ b/src/api/app/views/webui/packages/binaries/index.html.haml
@@ -49,7 +49,10 @@
                   .d-none.d-sm-block
                     = render_partial
                   .d-sm-none
-                    %i.fas.fa-ellipsis-h.text-secondary{ data: { 'bs-toggle': 'popover', 'bs-html': 'true', 'bs-content': "#{render_partial}" } }
+                    .dropdown
+                      %i.fas.fa-ellipsis-h.text-secondary{ type: 'button', 'data-bs-toggle': 'dropdown' }
+                      .dropdown-menu
+                        = render_partial
       %ul.nav
         - if User.possibly_nobody.can_modify?(@package)
           = render partial: 'trigger_rebuild_wipe_binaries', locals: { result: result, project: @project,


### PR DESCRIPTION
Popover can be flickering on mouse over and disappear as soon as the pointer moves. Dropdown is more reliable especially if useful in mobile small screen where the user clicks ellipsis to open the multi option choices and click on one of them afterwards.

UI remains the same, it's just the internal behavior that is more stable and reliable.

<img width="537" height="600" alt="image" src="https://github.com/user-attachments/assets/67f8a464-2dc0-483e-915f-6320bfa526f6" />
