### PR TITLE
Revert foreignkey related commits

### DIFF
--- a/src/api/.database_consistency.todo.yml
+++ b/src/api/.database_consistency.todo.yml
@@ -29,6 +29,9 @@ AttribIssue:
     UniqueIndexChecker:
       enabled: false
 AttribNamespace:
+  attrib_namespace_modifiable_bies:
+    ForeignKeyCascadeChecker:
+      enabled: false
   id:
     PrimaryKeyTypeChecker:
       enabled: false

--- a/src/api/app/models/attrib_namespace_modifiable_by.rb
+++ b/src/api/app/models/attrib_namespace_modifiable_by.rb
@@ -21,7 +21,7 @@ end
 #
 # Foreign Keys
 #
-#  attrib_namespace_modifiable_bies_ibfk_1  (attrib_namespace_id => attrib_namespaces.id) ON DELETE => cascade
+#  attrib_namespace_modifiable_bies_ibfk_1  (attrib_namespace_id => attrib_namespaces.id)
 #  attrib_namespace_modifiable_bies_ibfk_4  (user_id => users.id)
 #  attrib_namespace_modifiable_bies_ibfk_5  (group_id => groups.id)
 #

--- a/src/api/db/migrate/20251120113549_change_attrib_namespace_modifiable_bies_foreign_key_on_attrib_namespace_to_on_delete_cascade.rb
+++ b/src/api/db/migrate/20251120113549_change_attrib_namespace_modifiable_bies_foreign_key_on_attrib_namespace_to_on_delete_cascade.rb
@@ -1,6 +1,0 @@
-class ChangeAttribNamespaceModifiableBiesForeignKeyOnAttribNamespaceToOnDeleteCascade < ActiveRecord::Migration[7.2]
-  def change
-    remove_foreign_key :attrib_namespace_modifiable_bies, :attrib_namespaces
-    add_foreign_key :attrib_namespace_modifiable_bies, :attrib_namespaces, name: 'attrib_namespace_modifiable_bies_ibfk_1', on_delete: :cascade
-  end
-end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_11_20_113549) do
+ActiveRecord::Schema[7.2].define(version: 2025_11_19_144352) do
   create_table "active_storage_attachments", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -1299,7 +1299,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_11_20_113549) do
   add_foreign_key "attrib_default_values", "attrib_types", name: "attrib_default_values_ibfk_1"
   add_foreign_key "attrib_issues", "attribs", name: "attrib_issues_ibfk_1"
   add_foreign_key "attrib_issues", "issues", name: "attrib_issues_ibfk_2"
-  add_foreign_key "attrib_namespace_modifiable_bies", "attrib_namespaces", name: "attrib_namespace_modifiable_bies_ibfk_1", on_delete: :cascade
+  add_foreign_key "attrib_namespace_modifiable_bies", "attrib_namespaces", name: "attrib_namespace_modifiable_bies_ibfk_1"
   add_foreign_key "attrib_namespace_modifiable_bies", "groups", name: "attrib_namespace_modifiable_bies_ibfk_5"
   add_foreign_key "attrib_namespace_modifiable_bies", "users", name: "attrib_namespace_modifiable_bies_ibfk_4"
   add_foreign_key "attrib_type_modifiable_bies", "groups", name: "attrib_type_modifiable_bies_ibfk_2"


### PR DESCRIPTION
The original issue in the remove_* part failed because didn't find the kwy, so we added `, if_exists: true` clause.
However, the add_* part also fails with:
```
 Caused by:
    Mysql2::Error: Can't create table `frontend`.`attrib_namespace_modifiable_bies` (errno: 121 "Duplicate key on write or update") (Mysql2::Error)
```
We better revert those changes to have no blockers until we solve the issue.