### PR TITLE
Do not allow nulls in column issue_list in attrib_types table

### DIFF
--- a/src/api/.database_consistency.todo.yml
+++ b/src/api/.database_consistency.todo.yml
@@ -49,9 +49,6 @@ AttribType:
   id:
     PrimaryKeyTypeChecker:
       enabled: false
-  issue_list:
-    ThreeStateBooleanChecker:
-      enabled: false
   name:
     LengthConstraintChecker:
       enabled: false

--- a/src/api/app/models/attrib_type.rb
+++ b/src/api/app/models/attrib_type.rb
@@ -152,7 +152,7 @@ end
 #
 #  id                  :integer          not null, primary key
 #  description         :string(255)
-#  issue_list          :boolean          default(FALSE)
+#  issue_list          :boolean          default(FALSE), not null
 #  name                :string(255)      not null, uniquely indexed => [attrib_namespace_id], indexed
 #  type                :string(255)
 #  value_count         :integer

--- a/src/api/db/data/20251125120337_backfill_issue_list_in_attrib_types.rb
+++ b/src/api/db/data/20251125120337_backfill_issue_list_in_attrib_types.rb
@@ -1,0 +1,13 @@
+class BackfillIssueListInAttribTypes < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def up
+    AttribType.unscoped.in_batches do |relation|
+      relation.where(issue_list: nil).update_all(issue_list: false) # rubocop:disable Rails/SkipsModelValidations
+    end
+  end
+
+  def down
+    # Irreversible
+  end
+end

--- a/src/api/db/data_schema.rb
+++ b/src/api/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20251008130411)
+DataMigrate::Data.define(version: 2025_11_25_120337)

--- a/src/api/db/migrate/20251125121822_change_issue_list_to_not_null_in_attrib_types.rb
+++ b/src/api/db/migrate/20251125121822_change_issue_list_to_not_null_in_attrib_types.rb
@@ -1,0 +1,9 @@
+class ChangeIssueListToNotNullInAttribTypes < ActiveRecord::Migration[7.2]
+  def up
+    change_column_null :attrib_types, :issue_list, false
+  end
+
+  def down
+    change_column_null :attrib_types, :issue_list, true
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_11_19_144352) do
+ActiveRecord::Schema[7.2].define(version: 2025_11_25_121822) do
   create_table "active_storage_attachments", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -122,7 +122,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_11_19_144352) do
     t.string "type"
     t.integer "value_count"
     t.integer "attrib_namespace_id", null: false
-    t.boolean "issue_list", default: false
+    t.boolean "issue_list", default: false, null: false
     t.index ["attrib_namespace_id", "name"], name: "index_attrib_types_on_attrib_namespace_id_and_name", unique: true
     t.index ["name"], name: "index_attrib_types_on_name"
   end


### PR DESCRIPTION
This migration changes the issue_list column in the attrib_types table to not allow null values.
It also backfills existing null values as `false`.