### PR TITLE
Fix form jQuery selector to correctly match a form with id suffix

### DIFF
--- a/src/api/app/components/request_decision_component.html.haml
+++ b/src/api/app/components/request_decision_component.html.haml
@@ -82,9 +82,9 @@
   });
 
   // Only require the text if submitting a comment, declining or reopening
-  $('#request_handle_form [name=revoked], #request_handle_form [name=accepted]').on('click', function () {
-    $('#request_handle_form #new_comment_body').removeAttr('required');
+  $('[id^="request_handle_form_"]').find('[name=revoked], [name=accepted]').on('click', function () {
+    $('#new_comment_body').removeAttr('required');
   });
-  $('#request_handle_form [name=new], #request_handle_form [name=declined], #request_handle_form [name=commented]').on('click', function () {
-    $('#request_handle_form #new_comment_body').attr('required', 'required');
+  $('[id^="request_handle_form_"]').find('[name=new], [name=declined], [name=commented]').on('click', function () {
+    $('#new_comment_body').attr('required', 'required');
   });


### PR DESCRIPTION
To give some context, the id sufix was introduced in c4d132295a5a80863b19013fbacd6eb4424f249d.

Fix #18788.