### PR TITLE
Add uniqueness validation to AttribTypeModifiableBy

### DIFF
--- a/src/api/.database_consistency.todo.yml
+++ b/src/api/.database_consistency.todo.yml
@@ -59,9 +59,6 @@ AttribTypeModifiableBy:
   attrib_type:
     ForeignKeyChecker:
       enabled: false
-  attrib_type_user_role_all_index:
-    UniqueIndexChecker:
-      enabled: false
   id:
     PrimaryKeyTypeChecker:
       enabled: false

--- a/src/api/app/models/attrib_type_modifiable_by.rb
+++ b/src/api/app/models/attrib_type_modifiable_by.rb
@@ -3,6 +3,8 @@ class AttribTypeModifiableBy < ApplicationRecord
   belongs_to :user, optional: true
   belongs_to :group, optional: true
   belongs_to :role, optional: true
+
+  validates :attrib_type, uniqueness: { scope: %i[user group role] }
 end
 
 # == Schema Information


### PR DESCRIPTION
The attrib_type_user_role_all_index is unique in the database, but the model was missing a uniqueness validator. This commit syncs both worlds.