### PR TITLE
Allow some BsRequestActions to scmsync Projects

### DIFF
--- a/src/api/app/models/bs_request_action.rb
+++ b/src/api/app/models/bs_request_action.rb
@@ -946,6 +946,13 @@ class BsRequestAction < ApplicationRecord
     sprj
   end
 
+  def allow_action_to_scmsync?
+    return true unless target_project_object # no object, no scmsync
+    return true if target_project_object.scmsync.present? # no scmsync, no problems
+
+    false if target_package # we allow to change the target project, but not the target package
+  end
+
   def check_action_permission_target!
     return unless target_project
 
@@ -957,7 +964,7 @@ class BsRequestAction < ApplicationRecord
                                      'a submit self is not possible, please use the maintenance workflow instead.'
       end
 
-      if tprj.scmsync.present?
+      unless allow_action_to_scmsync?
         raise RequestRejected,
               "The target project #{target_project} is managed in an external SCM: #{tprj.scmsync}"
       end

--- a/src/api/app/models/bs_request_action_change_devel.rb
+++ b/src/api/app/models/bs_request_action_change_devel.rb
@@ -38,6 +38,10 @@ class BsRequestActionChangeDevel < BsRequestAction
     'Change Devel'
   end
 
+  def allow_action_to_scmsync?
+    false
+  end
+
   #### Alias of methods
 end
 

--- a/src/api/app/models/bs_request_action_maintenance_incident.rb
+++ b/src/api/app/models/bs_request_action_maintenance_incident.rb
@@ -117,6 +117,10 @@ class BsRequestActionMaintenanceIncident < BsRequestAction
 
   private
 
+  def allow_action_to_scmsync?
+    false
+  end
+
   def _merge_pkg_into_maintenance_incident(incident_project)
     # recreate package based on link target and throw everything away, except source changes
     # silently as maintenance teams requests ...

--- a/src/api/app/models/bs_request_action_maintenance_release.rb
+++ b/src/api/app/models/bs_request_action_maintenance_release.rb
@@ -155,6 +155,10 @@ class BsRequestActionMaintenanceRelease < BsRequestAction
 
   private
 
+  def allow_action_to_scmsync?
+    false
+  end
+
   def sanity_check!
     # get sure that the releasetarget definition exists or we release without binaries
     prj = Project.get_by_name(source_project)

--- a/src/api/app/models/bs_request_action_release.rb
+++ b/src/api/app/models/bs_request_action_release.rb
@@ -87,6 +87,10 @@ class BsRequestActionRelease < BsRequestAction
 
   private
 
+  def allow_action_to_scmsync?
+    false
+  end
+
   def sanity_check!
     # get sure that the releasetarget definition exists or we release without binaries
     prj = Project.get_by_name(source_project)

--- a/src/api/app/models/bs_request_action_submit.rb
+++ b/src/api/app/models/bs_request_action_submit.rb
@@ -175,6 +175,12 @@ class BsRequestActionSubmit < BsRequestAction
     backend_package&.[]('linkinfo')&.[]('xsrcmd5') || backend_package&.[]('srcmd5')
   end
 
+  private
+
+  def allow_action_to_scmsync?
+    false
+  end
+
   #### Alias of methods
 end
 


### PR DESCRIPTION
It's okay to request add_role, delete and set_bugowner for scmsync Projects. Why not?

Fixes #18852