### PR TITLE
Make attrib association in AttribValue model required

### DIFF
--- a/src/api/.database_consistency.todo.yml
+++ b/src/api/.database_consistency.todo.yml
@@ -60,9 +60,6 @@ AttribTypeModifiableBy:
     PrimaryKeyTypeChecker:
       enabled: false
 AttribValue:
-  attrib_id:
-    NullConstraintChecker:
-      enabled: false
   id:
     PrimaryKeyTypeChecker:
       enabled: false

--- a/src/api/app/models/attrib_value.rb
+++ b/src/api/app/models/attrib_value.rb
@@ -1,6 +1,6 @@
 class AttribValue < ApplicationRecord
   acts_as_list scope: :attrib
-  belongs_to :attrib, optional: true
+  belongs_to :attrib, optional: false
 
   after_initialize :set_default_value
   before_validation :universal_newlines


### PR DESCRIPTION
Because the attrib_id column in attrib_values table do not allow nulls and we need to sync the model.