### PR TITLE
Add presence validation to AttribValue position

### DIFF
--- a/src/api/.database_consistency.todo.yml
+++ b/src/api/.database_consistency.todo.yml
@@ -63,9 +63,6 @@ AttribValue:
   id:
     PrimaryKeyTypeChecker:
       enabled: false
-  position:
-    NullConstraintChecker:
-      enabled: false
   value:
     LengthConstraintChecker:
       enabled: false

--- a/src/api/app/controllers/source_attribute_controller.rb
+++ b/src/api/app/controllers/source_attribute_controller.rb
@@ -61,8 +61,8 @@ class SourceAttributeController < SourceController
       attrib_type = AttribType.find_by_namespace_and_name!(attr.value('namespace'), attr.value('name'))
       attrib = Attrib.new(attrib_type: attrib_type)
 
-      attr.elements('value') do |value|
-        attrib.values.new(value: value)
+      attr.elements('value').zip(attr.elements('position')).each do |(value, position)|
+        attrib.values.new(value: value, position: position)
       end
 
       attrib.container = @attribute_container

--- a/src/api/app/models/attrib_value.rb
+++ b/src/api/app/models/attrib_value.rb
@@ -2,6 +2,8 @@ class AttribValue < ApplicationRecord
   acts_as_list scope: :attrib
   belongs_to :attrib, optional: false
 
+  validates :position, presence: true
+
   after_initialize :set_default_value
   before_validation :universal_newlines
 

--- a/src/api/spec/controllers/source_attribute_controller_spec.rb
+++ b/src/api/spec/controllers/source_attribute_controller_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe SourceAttributeController, :vcr do
       <<~XMLATTRIB
         <attributes>
           <attribute namespace='#{update_project_attrib.namespace}' name='#{update_project_attrib.name}'>
+            <position>1</position>
             <value>1111112</value>
           </attribute>
         </attributes>

--- a/src/api/test/functional/request_controller_test.rb
+++ b/src/api/test/functional/request_controller_test.rb
@@ -3737,6 +3737,7 @@ class RequestControllerTest < ActionDispatch::IntegrationTest
     login_king
     post '/source/BaseDistro2.0/_attribute', params: "<attributes><attribute namespace='OBS' name='IncidentPriority' >
               <value>100</value>
+              <position>1</position>
             </attribute></attributes>"
     assert_response :success
     get '/search/request', params: { match: "target/@project = 'home:Iggy'" }
@@ -3749,6 +3750,7 @@ class RequestControllerTest < ActionDispatch::IntegrationTest
     # make the low and important request equal high prio
     post '/source/BaseDistro/_attribute', params: "<attributes><attribute namespace='OBS' name='IncidentPriority' >
               <value>100</value>
+              <position>1</position>
             </attribute></attributes>"
     assert_response :success
     get '/search/request', params: { match: "target/@project = 'home:Iggy'" }
@@ -3763,6 +3765,7 @@ class RequestControllerTest < ActionDispatch::IntegrationTest
     # make the low most important
     post '/source/BaseDistro/_attribute', params: "<attributes><attribute namespace='OBS' name='IncidentPriority' >
               <value>101</value>
+              <position>1</position>
             </attribute></attributes>"
     assert_response :success
     get '/search/request', params: { match: "target/@project = 'home:Iggy'" }


### PR DESCRIPTION
The position column is required in the database, but the model was missing the validation. This commit adds the validation to the model so the constraint is in sync.