### PR TITLE
Rescue `ArgumentError` exceptions in search API endpoints

### DIFF
--- a/src/api/app/controllers/search_controller.rb
+++ b/src/api/app/controllers/search_controller.rb
@@ -284,9 +284,11 @@ class SearchController < ApplicationController
 
   def find_items(what, predicate)
     XpathEngine.new.find("/#{what}[#{predicate}]")
-  rescue XpathEngine::IllegalXpathError => e
-    raise IllegalXpathError, "Error found searching elements '#{what}' with xpath predicate: '#{predicate}'.\n\n" \
-                             "Detailed error message from parser: #{e.message}"
+  rescue ArgumentError, XpathEngine::IllegalXpathError => e
+    message = "Error found searching elements '#{what}' with xpath predicate: '#{predicate}'."
+    message += "\n\nDetailed error message from parser: #{e.message}" unless e.is_a?(ArgumentError)
+
+    raise IllegalXpathError, message
   end
 
   def search_results_exceed_configured_limit?(matches)

--- a/src/api/spec/controllers/search_controller_spec.rb
+++ b/src/api/spec/controllers/search_controller_spec.rb
@@ -123,6 +123,17 @@ RSpec.describe SearchController, :vcr do
         expect(Nokogiri::XML(response.body).xpath('//status/summary').inner_text).to match(%r{Error found searching elements 'request' with xpath predicate: '/e\\u0000'.})
       end
     end
+
+    describe 'wrong number of arguments' do
+      it 'shows an error', :aggregate_failures do
+        get :project, params: { match: 'starts-with(openSUSE:Backports)' }, format: :xml
+
+        expect(response).to have_http_status(:bad_request)
+        expect(Nokogiri::XML(response.body).xpath('//status').attribute('code').value).to eq('illegal_xpath_error')
+        expect(Nokogiri::XML(response.body).xpath('//status/summary').inner_text)
+          .to match(/Error found searching elements 'project' with xpath predicate: 'starts-with\(openSUSE:Backports\)'./)
+      end
+    end
   end
 
   describe 'search limited to 2 results', vcr: false do


### PR DESCRIPTION
Do not include detailed parser messages when the raised error is an `ArgumentError`. Keep showing detailed error information for all other previously handled exceptions.

Fix #18652.