### PR TITLE
Remove unreachable code in `BuildController#project_index`

### DIFF
--- a/src/api/app/controllers/build_controller.rb
+++ b/src/api/app/controllers/build_controller.rb
@@ -89,9 +89,6 @@ class BuildController < ApplicationController
         render_error status: 403, errorcode: 'execute_cmd_no_permission',
                      message: "No permission to execute command on project #{params[:project]}"
       end
-    else
-      render_error status: 400, errorcode: 'illegal_request',
-                   message: "Illegal request: #{request.method.to_s.upcase} #{request.path}"
     end
     nil
   end


### PR DESCRIPTION
The endpoint defined in the router only allows the methods GET, POST and PUT.

See: https://github.com/openSUSE/open-build-service/blob/c1dca97bfe9eac4a82b754d91116b3e90bf2a3b5/src/api/config/routes/api.rb#L463