### PR TITLE
Pin `strscan` bundled gem version to the one used by ruby3.4

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -121,6 +121,7 @@ gem 'rexml'
 gem 'base64', '0.2.0', require: false
 gem 'irb', '1.14.3'
 gem 'stringio', '3.1.2'
+gem 'strscan', '3.1.2'
 
 # OpenStruct implementation (no longer a default gem from ruby > 3.4.0)
 gem 'ostruct'

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -701,6 +701,7 @@ DEPENDENCIES
   sprockets-rails
   stringio (= 3.1.2)
   strong_migrations
+  strscan (= 3.1.2)
   terser
   test-unit
   thinking-sphinx


### PR DESCRIPTION
"strscan" is one of the default/standard gems shipped with ruby. We should pin the version used in the bundle to the one coming from the ruby interpreter currently used in production (ruby 3.4.7) to prevent accidental updates of it (which leads to version mismatch errors, preventing phusion passenger from spawning).