### PR TITLE
Refactor call to backend with a method from `Backend::Api`

### DIFF
--- a/src/api/app/controllers/source_package_meta_controller.rb
+++ b/src/api/app/controllers/source_package_meta_controller.rb
@@ -30,10 +30,9 @@ class SourcePackageMetaController < SourceController
     end
 
     # Let the backend answer for deleted or remote packages. For specific revisions or the blame view. Or if the meta parameter is used.
-    if params.key?(:deleted) || params.key?(:meta) || params.key?(:rev) || params.key?(:view) || pack.nil?
-      path = request.path_info
-      path += build_query_from_hash(params, %i[deleted meta rev view])
-      pass_to_backend(path)
+    meta_params = params.slice(:deleted, :meta, :rev, :view).permit!.to_h
+    if meta_params.any? || pack.nil?
+      render xml: Backend::Api::Sources::Package.meta(@project_name, @package_name, meta_params)
       return
     end
 

--- a/src/api/app/lib/backend/api/sources/package.rb
+++ b/src/api/app/lib/backend/api/sources/package.rb
@@ -48,7 +48,7 @@ module Backend
         # Returns the meta file from a package
         # @return [String]
         def self.meta(project_name, package_name, options = {})
-          http_get(['/source/:project/:package/_meta', project_name, package_name], params: options.compact, accepted: :deleted)
+          http_get(['/source/:project/:package/_meta', project_name, package_name], params: options.compact, accepted: %i[deleted meta rev view])
         end
 
         # Writes a Package meta


### PR DESCRIPTION
Get rid of the antipattern:
- create `path`
- add `build_query_from_hash` to `path`
- call backend with `pass_to_backend(path)`