### PR TITLE
Fix: Keep 'unresolvable' pop-up visible after interaction by adding p…

### DIFF
--- a/src/api/app/assets/javascripts/webui/project_monitor.js
+++ b/src/api/app/assets/javascripts/webui/project_monitor.js
@@ -108,17 +108,19 @@ function setupPersistentPopovers() {
     e.stopPropagation();
   });
 
-  // Close popovers when clicking outside
-  $(document).on('click', function () {
-    $('.popover').each(function () {
-      var trigger = $('[aria-describedby="' + this.id + '"]')[0];
-      if (trigger) {
-        bootstrap.Popover.getInstance(trigger)?.hide();
-      }
+    // Close popovers when clicking outside
+    $(document).on('click', function () {
+      $('.popover').each(function () {
+        var trigger = $('[aria-describedby="' + this.id + '"]')[0];
+        if (trigger) {
+          var instance = bootstrap.Popover.getInstance(trigger);
+          if (instance) {
+            instance.hide();
+          }
+        }
+      });
     });
-  });
-}
-
+  }
 function setupProjectMonitor() {
   initializeMonitorDataTable();
 


### PR DESCRIPTION
Scope: webui/project_monitor.js
Change: restrict popover initialization to monitor-table entries and switch the trigger to click.
Impact: the “unresolvable” status popover on the project monitor stays open when clicked so text inside remains selectable, restoring parity with the package detail page.

Fixes #18324