### PR TITLE
Fix autocomplete filters showing empty values

### DIFF
--- a/src/api/app/controllers/concerns/webui/requests_filter.rb
+++ b/src/api/app/controllers/concerns/webui/requests_filter.rb
@@ -41,42 +41,42 @@ module Webui::RequestsFilter
   def filter_creators
     return if params[:creators]&.compact_blank.blank?
 
-    @selected_filter['creators'] = params[:creators]
+    @selected_filter['creators'] = params[:creators].compact_blank
     @bs_requests = @bs_requests.where(creator: @selected_filter['creators'])
   end
 
   def filter_priorities
     return if params[:priorities]&.compact_blank.blank?
 
-    @selected_filter['priorities'] = params[:priorities]
+    @selected_filter['priorities'] = params[:priorities].compact_blank
     @bs_requests = @bs_requests.where(priority: @selected_filter['priorities'])
   end
 
   def filter_staging_projects
     return if params[:staging_projects]&.compact_blank.blank?
 
-    @selected_filter['staging_projects'] = params[:staging_projects]
+    @selected_filter['staging_projects'] = params[:staging_projects].compact_blank
     @bs_requests = @bs_requests.where(staging_project: Project.find_by(name: @selected_filter['staging_projects']))
   end
 
   def filter_reviewers
     return if params[:reviewers]&.compact_blank.blank?
 
-    @selected_filter['reviewers'] = params[:reviewers]
+    @selected_filter['reviewers'] = params[:reviewers].compact_blank
     @bs_requests = @bs_requests.where(reviews: { by_user: @selected_filter['reviewers'] }).or(@bs_requests.where(reviews: { by_group: @selected_filter['reviewers'] }))
   end
 
   def filter_project_names
     return if params[:project_names]&.compact_blank.blank?
 
-    @selected_filter['project_names'] = params[:project_names]
+    @selected_filter['project_names'] = params[:project_names].compact_blank
     @bs_requests = @bs_requests.where(bs_request_actions: { source_project: @selected_filter['project_names'] }).or(@bs_requests.where(bs_request_actions: { target_project: @selected_filter['project_names'] }))
   end
 
   def filter_package_names
     return if params[:package_names]&.compact_blank.blank?
 
-    @selected_filter['package_names'] = params[:package_names]
+    @selected_filter['package_names'] = params[:package_names].compact_blank
     @bs_requests = @bs_requests.where(bs_request_actions: { source_package: @selected_filter['package_names'] }).or(@bs_requests.where(bs_request_actions: { target_package: @selected_filter['package_names'] }))
   end
 


### PR DESCRIPTION
## Description

This PR fixes a bug where autocomplete filters (Projects, Packages, Creators, Reviewers, Staging Projects, and Priorities) were showing empty checkboxes after clicking the magnifier button to submit a search.

## Problem

When using autocomplete filters on the requests page:
1. User types a value in an autocomplete field (e.g., Project name)
2. User clicks the magnifier (🔍) button to submit
3. Filter dropdown shows the selected value
4. User clicks magnifier again (with or without typing a new value)
5. **Bug**: Empty checkboxes appear in the filter dropdown

This happened because when the form was submitted, empty string values were being added to the params array and stored in `@selected_filter` without being cleaned up.

## Solution

Modified `Webui::RequestsFilter` concern to use `.compact_blank` when assigning filter parameters to `@selected_filter`, ensuring empty strings are removed before rendering checkboxes in the view.

**Changed methods:**
- `filter_creators`
- `filter_priorities`
- `filter_staging_projects`
- `filter_reviewers`
- `filter_project_names`
- `filter_package_names`

This brings all filter methods in line with the `filter_labels` method, which was already correctly using `compact_blank`.

## Testing

Added comprehensive tests in `spec/controllers/webui/users/bs_requests_controller_spec.rb` to verify:
- Empty strings in filter parameters are properly removed
- Valid filter values continue to work correctly
- `@selected_filter` hash doesn't contain empty strings
- All 6 affected filters behave consistently

## Verification Steps

1. Navigate to a requests page with filters (e.g., `/my/requests`)
2. Open the "Projects" filter dropdown
3. Type a project name in the search box
4. Click the magnifier (🔍) button
5. Open the Projects filter dropdown again
6. Click the magnifier button again (with empty search or new value)
7. Open the Projects filter dropdown
8. **Expected**: Only valid project names appear as checkboxes (no empty checkboxes)
9. Repeat for Packages, Creators, Reviewers, Staging Projects, and Priorities filters

## Files Changed

- `app/controllers/concerns/webui/requests_filter.rb` - Added `.compact_blank` to 6 filter methods
- `spec/controllers/webui/users/bs_requests_controller_spec.rb` - Added tests for empty value handling

## Related Issues

Fixes #18826