### PR TITLE
Add pagination to binaries list

### DIFF
--- a/src/api/app/controllers/webui/packages/binaries_controller.rb
+++ b/src/api/app/controllers/webui/packages/binaries_controller.rb
@@ -26,25 +26,42 @@ module Webui
       after_action :verify_authorized, only: [:destroy]
 
       def index
+        page_size = params[:page_size].to_i
+        @per_page = [50, 100, 300].include?(page_size) ? page_size : 50
+        @page = (params[:page] || 1).to_i
+
         results_from_backend = Buildresult.find_hashed(project: @project.name, package: @package_name, repository: @repository.name, view: %w[binarylist status])
         raise ActiveRecord::RecordNotFound, 'Not Found' if results_from_backend.empty?
 
-        @buildresults = []
+        # Collect all binaries with their architecture information
+        all_binaries = []
+        @repository_statistics = {}
+        @binaries_by_arch = {}
+
         results_from_backend.elements('result') do |result|
-          build_results_set = { arch: result['arch'], statistics: false, repocode: result['state'], binaries: [] }
+          arch = result['arch']
+          @repository_statistics[arch] = { repocode: result['state'], has_statistics: false }
+          arch_binaries = []
 
           result.get('binarylist').try(:elements, 'binary') do |binary|
             if binary['filename'] == '_statistics'
-              build_results_set[:statistics] = true
+              @repository_statistics[arch][:has_statistics] = true
             else
-              build_results_set[:binaries] << { filename: binary['filename'],
-                                                size: binary['size'],
-                                                links: { details?: QUERYABLE_BUILD_RESULTS.any? { |regex| regex.match?(binary['filename']) },
-                                                         download_url: download_url_for_binary(architecture_name: result['arch'], file_name: binary['filename']) } }
+              binary_hash = {
+                arch: arch,
+                filename: binary['filename'],
+                size: binary['size'].to_i,
+                details?: QUERYABLE_BUILD_RESULTS.any? { |regex| regex.match?(binary['filename']) },
+                download_url: download_url_for_binary(architecture_name: arch, file_name: binary['filename'])
+              }
+              all_binaries << binary_hash
+              arch_binaries << binary_hash
             end
           end
-          @buildresults << build_results_set
+          @binaries_by_arch[arch] = arch_binaries
         end
+
+        @binaries = Kaminari.paginate_array(all_binaries).page(@page).per(@per_page)
       rescue Backend::Error => e
         flash[:error] = e.message
         redirect_back_or_to({ controller: :package, action: :show, project: @project, package: @package })

--- a/src/api/app/views/webui/packages/binaries/_binaries_actions.html.haml
+++ b/src/api/app/views/webui/packages/binaries/_binaries_actions.html.haml
@@ -1,9 +1,9 @@
-- if binary[:links][:download_url]
+- if binary[:download_url]
   %span.d-block.d-xs-block.d-sm-inline.dropdown-item
-    = link_to(binary[:links][:download_url], title: 'Download', class: 'ms-2') do
+    = link_to(binary[:download_url], title: 'Download', class: 'ms-2') do
       %i.fas.fa-download.text-secondary
       Download
-- if binary[:links][:details?]
+- if binary[:details?]
   %span.d-block.d-xs-block.d-sm-inline.dropdown-item
     = link_to(project_package_repository_binary_path(project_name: project, package_name: package_name, repository_name: repository,
       arch: architecture, filename: binary[:filename]), title: 'Information', class: 'ms-2') do

--- a/src/api/app/views/webui/packages/binaries/_trigger_rebuild_wipe_binaries.html.haml
+++ b/src/api/app/views/webui/packages/binaries/_trigger_rebuild_wipe_binaries.html.haml
@@ -1,8 +1,8 @@
+-# haml-lint:disable LineLength
 %li.nav-item
-  = link_to(rebuild_project_package_trigger_path(project_name: project, package_name: package, repository: repository, arch: result[:arch]),
-  title: 'Trigger rebuild', method: :post, class: 'nav-link') do
+  = link_to(rebuild_project_package_trigger_path(project_name: project, package_name: package, repository: repository, arch: result[:arch]), title: 'Trigger rebuild', method: :post, class: 'nav-link') do
     %i.fas.fa-redo
-    Trigger rebuild
+    Trigger
 %li.nav-item
   - unless result[:binaries].empty?
     = link_to('#', title: 'Delete binaries', class: 'nav-link',

--- a/src/api/app/views/webui/packages/binaries/index.html.haml
+++ b/src/api/app/views/webui/packages/binaries/index.html.haml
@@ -7,7 +7,7 @@
     %ul.list-inline
       - if @configuration['download_url']
         = render DownloadRepositoryLinkComponent.new(project: @project, repository: @repository, configuration: @configuration)
-      - if @buildresults.present? && policy(@package).update?
+      - if @binaries.present? && policy(@package).update?
         %li.list-inline-item
           = link_to('#', title: 'Delete all built binaries', data: { 'bs-toggle': 'modal',
                                                                      'bs-target': '#delete-all-binaries-modal' }) do
@@ -24,28 +24,41 @@
                                                          method: :delete,
                                                          options: { modal_title: 'Do you want to remove these binaries?' })
 
-    - @buildresults.each do |result|
-      %h5.bg-body-secondary.p-2.mb-0
-        = repository_status_icon(status: result[:repocode].to_s, html_class: 'fa-xs')
-        = result[:arch]
-      - if result[:binaries].empty?
-        %p.ps-2
-          %i No built binaries
-      - else
-        .table-responsive
-          %table.table.table-hover.table-sm
-            %thead
-            %tbody
-            - result[:binaries].each do |binary|
+    - if @binaries.empty?
+      %p.ps-2
+        %i No built binaries
+    - else
+      .d-flex.justify-content-between.align-items-center.mb-2
+        %p.text-muted.mb-0
+          Showing
+          = @binaries.offset_value + 1
+          - range_end = [@binaries.offset_value + @binaries.size, @binaries.total_count].min
+          = "-#{range_end} of #{@binaries.total_count} binaries"
+        - if @binaries.total_pages > 1
+          = render partial: 'webui/users/notifications/page_size_navigation', locals: { paginated_objects: @binaries }
+
+      = paginate @binaries, views_prefix: 'webui', window: 2
+
+      .table-responsive
+        %table.table.table-hover.table-sm
+          %thead
+            %tr
+              %th Architecture
+              %th Binary (Size)
+              %th.text-end Actions
+          %tbody
+            - @binaries.each do |binary|
               %tr
-                %td.px-2 #{binary[:filename]} (#{number_to_human_size(binary[:size])})
+                %td.px-2
+                  = repository_status_icon(status: @repository_statistics[binary[:arch]][:repocode].to_s, html_class: 'fa-xs')
+                  = binary[:arch]
+                %td.px-2
+                  = binary[:filename]
+                  %span.text-muted
+                    (#{number_to_human_size(binary[:size])})
                 %td.text-nowrap.text-end.px-2
-                  - render_partial = h(render partial: 'binaries_actions', locals: { project: @project,
-                                                                                   package_name: @package_name,
-                                                                                   package: @package,
-                                                                                   binary: binary,
-                                                                                   repository: @repository,
-                                                                                   architecture: result[:arch] })
+                  -# haml-lint:disable LineLength
+                  - render_partial = h(render(partial: 'binaries_actions', locals: { project: @project, package_name: @package_name, package: @package, binary: binary, repository: @repository, architecture: binary[:arch] }))
                   .d-none.d-sm-block
                     = render_partial
                   .d-sm-none
@@ -53,10 +66,16 @@
                       %i.fas.fa-ellipsis-h.text-secondary{ type: 'button', 'data-bs-toggle': 'dropdown' }
                       .dropdown-menu
                         = render_partial
-      %ul.nav
-        - if User.possibly_nobody.can_modify?(@package)
-          = render partial: 'trigger_rebuild_wipe_binaries', locals: { result: result, project: @project,
-                                                            package: @package_name, repository: @repository }
 
-        = render partial: 'show_statistics_job_history_build_reason', locals: { result: result,
-          project: @project, package: @package_name, repository: @repository }
+      = paginate @binaries, views_prefix: 'webui', window: 2
+
+    - @repository_statistics.each do |arch, stats|
+      %ul.nav
+        - if policy(@package).update?
+          = render partial: 'trigger_rebuild_wipe_binaries',
+                   locals: { result: { arch: arch, binaries: @binaries_by_arch[arch] },
+                             project: @project, package: @package_name, repository: @repository }
+
+        = render partial: 'show_statistics_job_history_build_reason',
+                 locals: { result: { arch: arch, statistics: stats[:has_statistics], binaries: @binaries_by_arch[arch] },
+                           project: @project, package: @package_name, repository: @repository }

--- a/src/api/spec/controllers/webui/packages/binaries_controller_spec.rb
+++ b/src/api/spec/controllers/webui/packages/binaries_controller_spec.rb
@@ -34,6 +34,95 @@ RSpec.describe Webui::Packages::BinariesController, :vcr do
 
       it { expect { set_binaries }.to raise_error(ActiveRecord::RecordNotFound) }
     end
+
+    context 'with valid build results' do
+      let(:fake_buildresult) do
+        Xmlhash.parse(
+          "<resultlist state='123'>
+             <result project='#{home_tom.name}' repository='#{repo_for_home_tom.name}' arch='x86_64' state='succeeded'>
+               <binarylist>
+                 <binary filename='test1.rpm' size='1024'/>
+                 <binary filename='test2.rpm' size='2048'/>
+                 <binary filename='_statistics' size='0'/>
+               </binarylist>
+             </result>
+             <result project='#{home_tom.name}' repository='#{repo_for_home_tom.name}' arch='i586' state='building'>
+               <binarylist>
+                 <binary filename='test3.rpm' size='4096'/>
+               </binarylist>
+             </result>
+           </resultlist>"
+        )
+      end
+
+      before do
+        allow(Buildresult).to receive(:find_hashed).and_return(fake_buildresult)
+        allow(Backend::Api::BuildResults::Binaries).to receive(:download_url_for_file).and_return('http://test.host/download')
+      end
+
+      it 'responds with success' do
+        get :index, params: { package_name: toms_package, project_name: home_tom, repository_name: repo_for_home_tom, page: 1, page_size: 2 }
+        expect(response).to have_http_status(:success)
+      end
+
+      it 'assigns paginated @binaries with correct length' do
+        get :index, params: { package_name: toms_package, project_name: home_tom, repository_name: repo_for_home_tom, page: 1, page_size: 2 }
+        expect(assigns(:binaries).length).to eq(2)
+      end
+
+      it 'assigns paginated @binaries with correct total counts' do
+        get :index, params: { package_name: toms_package, project_name: home_tom, repository_name: repo_for_home_tom, page: 1, page_size: 2 }
+        expect(assigns(:binaries).total_count).to eq(3)
+        expect(assigns(:binaries).total_pages).to eq(2)
+      end
+
+      it 'assigns paginated @binaries with correct elements' do
+        get :index, params: { package_name: toms_package, project_name: home_tom, repository_name: repo_for_home_tom, page: 1, page_size: 2 }
+        expect(assigns(:binaries).first[:filename]).to eq('test1.rpm')
+        expect(assigns(:binaries).last[:filename]).to eq('test2.rpm')
+      end
+
+      it 'respects pagination offsets for length' do
+        get :index, params: { package_name: toms_package, project_name: home_tom, repository_name: repo_for_home_tom, page: 2, page_size: 2 }
+        expect(assigns(:binaries).length).to eq(1)
+      end
+
+      it 'respects pagination offsets for elements' do
+        get :index, params: { package_name: toms_package, project_name: home_tom, repository_name: repo_for_home_tom, page: 2, page_size: 2 }
+        expect(assigns(:binaries).first[:filename]).to eq('test3.rpm')
+      end
+
+      it 'validates page_size constraints to 50, 100, 300' do
+        get :index, params: { package_name: toms_package, project_name: home_tom, repository_name: repo_for_home_tom, page_size: 999_999 }
+        # Should fallback to 50 if invalid
+        expect(assigns(:per_page)).to eq(50)
+      end
+
+      it 'assigns @binaries_by_arch correctly with full lengths' do
+        get :index, params: { package_name: toms_package, project_name: home_tom, repository_name: repo_for_home_tom }
+        expect(assigns(:binaries_by_arch)['x86_64'].length).to eq(2)
+        expect(assigns(:binaries_by_arch)['i586'].length).to eq(1)
+      end
+
+      it 'assigns @binaries_by_arch correctly with right elements' do
+        get :index, params: { package_name: toms_package, project_name: home_tom, repository_name: repo_for_home_tom }
+        expect(assigns(:binaries_by_arch)['i586'].first[:filename]).to eq('test3.rpm')
+      end
+
+      it 'assigns @repository_statistics correctly' do
+        get :index, params: { package_name: toms_package, project_name: home_tom, repository_name: repo_for_home_tom }
+
+        expect(assigns(:repository_statistics)['x86_64'][:has_statistics]).to be true
+        expect(assigns(:repository_statistics)['i586'][:has_statistics]).to be false
+      end
+
+      it 'ensures binary size is an integer' do
+        get :index, params: { package_name: toms_package, project_name: home_tom, repository_name: repo_for_home_tom }
+
+        expect(assigns(:binaries).first[:size]).to be_an(Integer)
+        expect(assigns(:binaries).first[:size]).to eq(1024)
+      end
+    end
   end
 
   describe 'GET #show' do


### PR DESCRIPTION
## Description

Adds pagination to the binaries list page to improve performance and user experience when dealing with packages that produce hundreds or thousands of binary files.

## Problem

Some packages have massive binary lists (see issue screenshots) which causes:
- Slow page load times
- Overwhelming, hard-to-navigate interface
- Browser memory issues with large DOM

## Solution

Implemented Kaminari pagination to display binaries in manageable chunks:

### **Controller Changes** (`binaries_controller.rb`):
- Flattened binary data across all architectures into a single collection
- Used `Kaminari.paginate_array()` to paginate the binaries
- Default: 50 binaries per page (configurable)
- Separated repository statistics for architecture-level info

### **View Changes** (`index.html.haml`):
- Added pagination controls at top and bottom
- Added page size selector (50, 100, 300 per page)
- Display "Showing X-Y of Z binaries" count
- Unified table showing Architecture | Binary | Size | Actions
- Repository status icons preserved per architecture

### **Partial Updates** (`_binaries_actions.html.haml`):
- Updated to match new flattened data structure
- Simplified binary hash keys (removed nested `:links`)

## Benefits

✅ **Performance**: Only renders 50 items at a time instead of thousands  
✅ **UX**: Clean, navigable interface with Previous/Next/Page numbers  
✅ **Flexibility**: Users can choose page size (50, 100, 300)  
✅ **Consistency**: Uses same Kaminari pattern as notifications, workflow runs, etc.  
✅ **Maintainability**: Cleaner code structure with separated concerns

## Verification Steps

1. Navigate to a package with many binaries (e.g., large development package)
2. Verify pagination controls appear at top and bottom
3. Click through pages to verify binaries load correctly
4. Change page size using the dropdown
5. Verify repository status icons and download/details links work
6. Test with packages having binaries across multiple architectures

## Files Changed

- `app/controllers/webui/packages/binaries_controller.rb` - Added pagination logic
- `app/views/webui/packages/binaries/index.html.haml` - Redesigned UI with pagination
- `app/views/webui/packages/binaries/_binaries_actions.html.haml` - Updated data structure

## Related Issues

Fixes #18898