### PR TITLE
Rename `lock` to `command_lock` in Project model

### DIFF
--- a/src/api/app/controllers/source_project_command_controller.rb
+++ b/src/api/app/controllers/source_project_command_controller.rb
@@ -43,7 +43,7 @@ class SourceProjectCommandController < SourceController
   def project_command_lock
     # comment is optional
 
-    @project.lock(params[:comment])
+    @project.command_lock(params[:comment])
 
     render_ok
   end

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -1149,7 +1149,7 @@ class Project < ApplicationRecord
     packages.dirty_backend_packages.each(&:update_if_dirty)
   end
 
-  def lock(comment = nil)
+  def command_lock(comment = nil)
     transaction do
       f = flags.find_by_flag_and_status('lock', 'disable')
       flags.delete(f) if f

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -586,7 +586,7 @@ class User < ApplicationRecord
     Project.where('name like ?', "#{home_project_name}%").find_each do |prj|
       next if prj.locked?
 
-      prj.lock('User account got locked')
+      prj.command_lock('User account got locked')
     end
   end
 

--- a/src/api/config/brakeman.ignore
+++ b/src/api/config/brakeman.ignore
@@ -435,29 +435,6 @@
     {
       "warning_type": "SQL Injection",
       "warning_code": 0,
-      "fingerprint": "afd4dc0b2b4083a14e5ba67ae832b6197e30102105b020ff976e0cd54ecd25d8",
-      "check_name": "SQL",
-      "message": "Possible SQL injection",
-      "file": "app/controllers/source_project_command_controller.rb",
-      "line": 46,
-      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "Project.get_by_name(params[:project]).lock(params[:comment])",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "SourceProjectCommandController",
-        "method": "project_command_lock"
-      },
-      "user_input": "params[:comment]",
-      "confidence": "High",
-      "cwe_id": [
-        89
-      ],
-      "note": ""
-    },
-    {
-      "warning_type": "SQL Injection",
-      "warning_code": 0,
       "fingerprint": "b1d6007ada268c2f7129e8f9cd72bfcb3b3f69614a2671320c6f3411b86cd284",
       "check_name": "SQL",
       "message": "Possible SQL injection",


### PR DESCRIPTION
The `lock` method name conflicted with ActiveRecord’s `lock` and caused false SQL injection warnings in Brakeman. Renaming it avoids confusion, even if the original warnings were false positives.