### PR TITLE
Refactor calls to backend for project commands using `Backend::Api`

### DIFF
--- a/src/api/app/controllers/source_project_command_controller.rb
+++ b/src/api/app/controllers/source_project_command_controller.rb
@@ -61,7 +61,9 @@ class SourceProjectCommandController < SourceController
   # freeze project link, either creating the freeze or updating it
   # POST /source/<project>?cmd=freezelink
   def project_command_freezelink
-    pass_to_backend(request.path_info + build_query_from_hash(params, %i[cmd user comment]))
+    backend_params = { user: User.session.login, comment: params[:comment] }.compact
+
+    render xml: Backend::Api::Sources::Project.freezelink(params[:project], backend_params)
   end
 
   # add channel packages and extend repository list

--- a/src/api/app/lib/backend/api/sources/project.rb
+++ b/src/api/app/lib/backend/api/sources/project.rb
@@ -94,6 +94,11 @@ module Backend
           http_post(['/source/:project', project_name], defaults: { cmd: :extendkey }, params: options, accepted: %i[user comment days])
         end
 
+        # Freeze a project link
+        def self.freezelink(project_name, options = {})
+          http_post(['/source/:project', project_name], defaults: { cmd: :freezelink }, params: options, accepted: %i[user comment requestid])
+        end
+
         # Moves the source project to the target
         # @return [String]
         def self.move(source_project_name, target_project_name)


### PR DESCRIPTION
This time, three methods were created for different project commands in the `Backend::Api` library, based on the parameters accepted by the backend endpoints:
- `?cmd=extendkey`: https://github.com/openSUSE/open-build-service/blob/143172cc9b820b91789be2741dce4e93fcbf34db/src/backend/bs_srcserver#L7926
- `?cmd=createkey`: https://github.com/openSUSE/open-build-service/blob/143172cc9b820b91789be2741dce4e93fcbf34db/src/backend/bs_srcserver#L7925
- `?cmd=freezelink`: https://github.com/openSUSE/open-build-service/blob/143172cc9b820b91789be2741dce4e93fcbf34db/src/backend/bs_srcserver#L7931