### PR TITLE
Made the event listener more specific in diff comment

### DIFF
--- a/src/api/app/views/webui/request/inline_comment.js.erb
+++ b/src/api/app/views/webui/request/inline_comment.js.erb
@@ -1,6 +1,6 @@
 $('#flash').empty();
 $('#comment<%= @line %> .diff-comments').html("<%= escape_javascript(render(partial: 'webui/request/inline_comment', locals: { comment: @comment, commentable: @action, diff_ref: @line, file_index: @file_index, line_number: @line_number, source_rev: @source_rev, target_rev: @target_rev })) %>");
 $("#comment<%= @line %> .diff-comments textarea").focus();
-$("#comment<%= @line %>").on('click', '.cancel-comment', function (e) {
+$("#comment<%= @line %>").on('click', '#new_comment_<%= @line %>_form .cancel-comment', function (e) {
   $('#comment<%= @line %> .diff-comments').html("<%= escape_javascript(render(partial: 'webui/request/add_inline_comment', locals: { commentable: @action, diff_file_index: @file_index, diff_line_number: @line_number, source_rev: @source_rev, target_rev: @target_rev })) %>");
 });


### PR DESCRIPTION
Fixes : #18736 

Hey friends , 

I have tried to fix the disappearing bug when clicking "EDIT" , because I think the global `comment.js` will close other forms when clicked "EDIT" by programmatic  clicking "Cancel" button. 
I think this is that part in `comment.js`

` // Toggle visibility of reply form of the same comment `
 ` $(document).on('click', '[id*="edit_button_of_"]', function (e) {
    const idNumber = $(e.target).attr('id').split('edit_button_of_')[1];
    $('#reply_form_of_' + idNumber + ' .cancel-comment').click();
  });`
  
  Now the `inline_comment.js.erb` is too broad and will listen to any `.cancel-comment` and will reset the thread . 
  `
$("#comment<%= @line %>").on('click', '.cancel-comment', function (e) {
  `
  So i changed it to me more specific . 
  
 Video : 
  


https://github.com/user-attachments/assets/d8b568b0-03c1-4971-923e-331a334f7879



