### PR TITLE
Optimize search query performance using a lazy query approach

### DIFF
--- a/src/api/lib/xpath_engine.rb
+++ b/src/api/lib/xpath_engine.rb
@@ -364,7 +364,7 @@ class XpathEngine
                                               conditions: cond_ary }.inspect}")
     relation = relation.joins(@joins.flatten.uniq.join(' ')).where(cond_ary).order(order)
     # .distinct is critical for perfomance here...
-    relation.distinct.pluck(:id)
+    relation.distinct
   end
 
   def parse_predicate(root, stack)


### PR DESCRIPTION

Proposal to optimize the expensive search query issue #10777 . 

Previously, `XpathEngine` executed the search query immediately by calling `.pluck(:id)`, which loaded all matching record IDs into memory as an Array. For broad searches (ex 300,000+ matches), this could cause memory spikes and blocked the worker, even if the user only requested the first 10 results. 

Changing `XpathEngine` to return an `ActiveRecord::Relation` instead of an Array. This allows the `SearchController` to apply pagination (LIMIT and OFFSET) directly to the SQL query before execution . 

Also using  `.count` to avoid unnecessary loading of queries by `.size`. 

So at the end we are trading 1 massive, memory-intensive query for 2 small, efficient queries.

Before:

Query1 : Load everything from the db at once . 

After:
 
Query1 : Count the total matching result and give only the number . 
Query2 : Fetch only the results the end user can see at the moment . 