### PR TITLE
Allow moderators to create decisions over a report

### DIFF
--- a/src/api/app/components/reports_notice_component.html.haml
+++ b/src/api/app/components/reports_notice_component.html.haml
@@ -2,7 +2,7 @@
 - if by_user?
   %span.text-warning
     You reported this #{reportable_name}.
-- else
+- if !by_user? || @user.moderator?
   %span.text-warning
     This #{reportable_name} has
     = link_to report_amount, '#', class: 'link-warning text-decoration-underline',


### PR DESCRIPTION
Sometimes there aren't enough moderators to allow another moderator to have a look into a report, with this change, we allow the moderator that created the report to create a decision on it.

Replaces #18974 