### PR TITLE
style: changed the color of "excluded" to gray color of "disabled"

### DIFF
--- a/src/api/app/assets/stylesheets/webui/build-results.scss
+++ b/src/api/app/assets/stylesheets/webui/build-results.scss
@@ -136,9 +136,7 @@
 }
 
 .build-state-excluded {
-  @extend .text-bg-light;
-  @extend .border;
-  @extend .px-1;
+  color: $gray-600;
 }
 
 .build-state-blocked {


### PR DESCRIPTION
Fixes : #18966 

Changed the style of "excluded" to match the styles of "disabled" in the `build-results.scss` 

before : 

<img width="123" height="129" alt="image" src="https://github.com/user-attachments/assets/425a5d47-20c8-46bc-a504-25f15c0ce7d2" />


after : 
<img width="123" height="129" alt="Screenshot From 2025-12-16 07-03-59" src="https://github.com/user-attachments/assets/895bad33-c1c5-46fc-b2ca-227c965cd1dd" />


Thanks ! 