### PR TITLE
Make the moderator the one who can report requests

### DIFF
--- a/src/api/app/policies/bs_request_policy.rb
+++ b/src/api/app/policies/bs_request_policy.rb
@@ -30,10 +30,6 @@ class BsRequestPolicy < ApplicationPolicy
     author? || record.source_maintainer?(user)
   end
 
-  def report?
-    !author?
-  end
-
   def decline_request?
     return false if BsRequest::FINAL_REQUEST_STATES.include?(record.state)
 

--- a/src/api/app/policies/report_policy.rb
+++ b/src/api/app/policies/report_policy.rb
@@ -25,7 +25,7 @@ class ReportPolicy < ApplicationPolicy
     when 'User'
       !UserPolicy.new(user, record.reportable).update?
     when 'BsRequest'
-      BsRequestPolicy.new(user, record.reportable).report?
+      record.reportable.creator != user.login
     end
   end
   # rubocop:enable Metrics/CyclomaticComplexity


### PR DESCRIPTION
Before, only the creator of the request could report it, because the request policy allowed non-creators to report but we negated it in the reports policy. With this change, if you are a moderator but not the creator, you can report the request.