### PR TITLE
[backend] Avoid duplicate updateinfo_id when not defined

### DIFF
--- a/src/api/test/functional/channel_maintenance_test.rb
+++ b/src/api/test/functional/channel_maintenance_test.rb
@@ -536,7 +536,7 @@ class ChannelMaintenanceTests < ActionDispatch::IntegrationTest
     node = Xmlhash.parse(@response.body)
     old_release_date = node['update']['issued']['date']
     assert_equal old_release_date, old_release_date.to_i.to_s
-    assert_xml_tag parent: { tag: 'update', attributes: { from: 'tom', status: 'stable', type: 'recommended', version: '1' } }, tag: 'id', content: "UpdateInfoTag-#{Time.now.utc.year}-My_Maintenance_0"
+    assert_xml_tag parent: { tag: 'update', attributes: { from: 'tom', status: 'stable', type: 'recommended', version: '1' } }, tag: 'id', content: "UpdateInfoTag-#{Time.now.utc.year}-My_Maintenance_0__patchinfo"
 
     # check published search db
     get "/search/published/binary/id?match=project='" + incident_project + "'"

--- a/src/backend/BSSched/BuildJob/Patchinfo.pm
+++ b/src/backend/BSSched/BuildJob/Patchinfo.pm
@@ -676,7 +676,7 @@ sub build {
   $update->{'version'} = $patchinfo->{'version'} || '1';        # bodhi inserts its own version...
   $update->{'id'} = $patchinfo->{'incident'};
   if (!$update->{'id'}) {
-    $update->{'id'} = $projid;
+    $update->{'id'} = "${projid}::$packid";
     $update->{'id'} =~ s/:/_/g;
   }
   if ($target && $target->{'id_template'}) {


### PR DESCRIPTION
We did set the updateinfo id to the project name in case it was not defined elsewhere. This leads to conflicts when multiple patchinfos were inside the project.

We extend it now with the package name to avoid duplicates.

This is an incompatible change, but all production configurations define the patchinfo id. Also it would lead to not usable repository meta data, so it is unlikely a regression.