### PR TITLE
Add link for missing reportable type `BsRequest` to helper

### DIFF
--- a/src/api/app/helpers/webui/reportables_helper.rb
+++ b/src/api/app/helpers/webui/reportables_helper.rb
@@ -21,6 +21,8 @@ module Webui::ReportablesHelper
       link_to(reportable.name.to_s, Rails.application.routes.url_helpers.project_show_url(reportable, anchor: 'comments-list', only_path: only_path, host: host))
     when 'User'
       link_to(reportable.login.to_s, Rails.application.routes.url_helpers.user_url(reportable, only_path: only_path, host: host))
+    when 'BsRequest'
+      link_to("Request ##{reportable.number}", Rails.application.routes.url_helpers.request_show_url(reportable, only_path: only_path, host: host))
     end
   end
 


### PR DESCRIPTION
The helper misses the link for the reportable type `BsRequest`, so we end up not showing it on the report show view.

**AFTER:**
<img width="1550" height="518" alt="image" src="https://github.com/user-attachments/assets/6f4983fe-e6c5-4f11-aa12-4aaddb539833" />
