### PR TITLE
Fix race conditions in ConfigureRepositories by adding locks 

### DIFF
--- a/src/api/app/models/workflow/step/configure_repositories.rb
+++ b/src/api/app/models/workflow/step/configure_repositories.rb
@@ -26,10 +26,12 @@ class Workflow::Step::ConfigureRepositories < Workflow::Step
         repository.path_elements.find_or_create_by(link: target_repository)
       end
 
-      repository.repository_architectures.destroy_all
+      repository.with_lock do
+        repository.repository_architectures.destroy_all
 
-      repository_instructions[:architectures].uniq.each do |architecture_name|
-        repository.architectures << @supported_architectures.select { |architecture| architecture.name == architecture_name }
+        repository_instructions[:architectures].uniq.each do |architecture_name|
+          repository.architectures << @supported_architectures.select { |architecture| architecture.name == architecture_name }
+        end
       end
     end
 


### PR DESCRIPTION
Hey friends , 

I have tried to implement lock condition to avoid racing in `Workflow::Step::ConfigureRepositories#configure_repositories` . I think in the lines 

- L22 `Repository.find_or_create_by(...)`  (race on repository creation)
- L26 `repository.path_elements.find_or_create_by(...)`  (race on path creation)
- L29-33  `destroy_all` followed by insert 


 all can be possible cases of racing . So performing `target_project.with_lock` at the very top could be necessary , 

but let me know if my assertion is wrong . 

Fixes:#18939 
Thanks ! 