### PR TITLE
Move WebuiMatcher/APIMatcher constraints into routes.rb

### DIFF
--- a/src/api/app/lib/routes_helper/api_matcher.rb
+++ b/src/api/app/lib/routes_helper/api_matcher.rb
@@ -3,11 +3,12 @@ module RoutesHelper
   class APIMatcher
     def self.matches?(request)
       format = request.format.to_sym || :xml
-      format == :xml || format == :json || public_or_about_path?(request)
+      format == :xml || format == :json || formatless_path?(request)
     end
 
-    def self.public_or_about_path?(request)
-      request.fullpath.start_with?('/public', '/about')
+    # We serve those routes to all requested formats...
+    def self.formatless_path?(request)
+      request.fullpath.start_with?('/public', '/about', '/build')
     end
   end
 end

--- a/src/api/app/lib/routes_helper/webui_matcher.rb
+++ b/src/api/app/lib/routes_helper/webui_matcher.rb
@@ -6,9 +6,14 @@ module RoutesHelper
     end
 
     def self.matches?(request)
-      request.format.to_sym != :xml
+      request.format.to_sym != :xml || formatless_path?(request)
     rescue ArgumentError => e
       raise InvalidRequestFormat, e.to_s
+    end
+
+    # We serve those routes to all requested formats...
+    def self.formatless_path?(request)
+      request.fullpath.start_with?('/sitemaps', '/project/sitemap', '/package/sitemap')
     end
   end
 end

--- a/src/api/config/routes.rb
+++ b/src/api/config/routes.rb
@@ -1,4 +1,8 @@
 OBSApi::Application.routes.draw do
-  draw :webui
-  draw :api
+  constraints(RoutesHelper::WebuiMatcher) do
+    draw :webui
+  end
+  constraints(RoutesHelper::APIMatcher) do
+    draw :api
+  end
 end

--- a/src/api/config/routes/api.rb
+++ b/src/api/config/routes/api.rb
@@ -1,216 +1,213 @@
 cons = RoutesHelper::RoutesConstraints::CONS
 
-constraints(RoutesHelper::APIMatcher) do
-  get '/', to: redirect('/about')
+get '/', to: redirect('/about')
 
-  resources :about, only: :index
+resources :about, only: :index
 
-  resource :configuration, only: %i[show update]
+resource :configuration, only: %i[show update]
 
-  resources :announcements, except: %i[edit new]
+resources :announcements, except: %i[edit new]
 
-  ### /person
-  post 'person' => 'person#command', constraints: ->(req) { req.params[:cmd] == 'register' }
-  get 'person' => 'person#show'
-  get 'person/:login/token' => 'person/token#index', constraints: cons
-  post 'person/:login/token' => 'person/token#create', constraints: cons
-  delete 'person/:login/token/:id' => 'person/token#delete', constraints: cons
-  put 'person/:login/token/:id' => 'person/token#update', constraints: cons
+### /person
+post 'person' => 'person#command', constraints: ->(req) { req.params[:cmd] == 'register' }
+get 'person' => 'person#show'
+get 'person/:login/token' => 'person/token#index', constraints: cons
+post 'person/:login/token' => 'person/token#create', constraints: cons
+delete 'person/:login/token/:id' => 'person/token#delete', constraints: cons
+put 'person/:login/token/:id' => 'person/token#update', constraints: cons
 
-  # FIXME3.0: this is no clean namespace, a person "register" or "changepasswd" could exist ...
-  #           remove these for OBS 3.0
-  match 'person/register' => 'person#register', via: %i[post put] # use /person?cmd=register POST instead
-  match 'person/changepasswd' => 'person#change_my_password', via: %i[post put] # use /person/:login?cmd=changepassword POST instead
-  get 'person/:login/group' => 'person#grouplist', constraints: cons # Use /group?person=:login GET instead
+# FIXME3.0: this is no clean namespace, a person "register" or "changepasswd" could exist ...
+#           remove these for OBS 3.0
+match 'person/register' => 'person#register', via: %i[post put] # use /person?cmd=register POST instead
+match 'person/changepasswd' => 'person#change_my_password', via: %i[post put] # use /person/:login?cmd=changepassword POST instead
+get 'person/:login/group' => 'person#grouplist', constraints: cons # Use /group?person=:login GET instead
 
-  ### notifications
-  get '/my/notifications' => 'person/notifications#index'
-  put '/my/notifications/:id' => 'person/notifications#update'
+### notifications
+get '/my/notifications' => 'person/notifications#index'
+put '/my/notifications/:id' => 'person/notifications#update'
 
-  # /FIXME3.0
-  get 'person/:login' => 'person#userinfo', constraints: cons
-  put 'person/:login' => 'person#put_userinfo', constraints: cons
-  post 'person/:login' => 'person#post_userinfo', constraints: cons
-  get 'person/:login/watchlist' => 'person#watchlist', constraints: cons
-  put 'person/:login/watchlist' => 'person#put_watchlist', constraints: cons
+# /FIXME3.0
+get 'person/:login' => 'person#userinfo', constraints: cons
+put 'person/:login' => 'person#put_userinfo', constraints: cons
+post 'person/:login' => 'person#post_userinfo', constraints: cons
+get 'person/:login/watchlist' => 'person#watchlist', constraints: cons
+put 'person/:login/watchlist' => 'person#put_watchlist', constraints: cons
 
-  ### /group
-  controller :group do
-    get 'group' => :index
-    constraints(cons) do
-      get 'group/:title' => :show
-      delete 'group/:title' => :delete
-      put 'group/:title' => :update
-      post 'group/:title' => :command, constraints: ->(req) { %w[add_user remove_user set_email].include?(req.params[:cmd]) }
-    end
+### /group
+controller :group do
+  get 'group' => :index
+  constraints(cons) do
+    get 'group/:title' => :show
+    delete 'group/:title' => :delete
+    put 'group/:title' => :update
+    post 'group/:title' => :command, constraints: ->(req) { %w[add_user remove_user set_email].include?(req.params[:cmd]) }
   end
-
-  ### /service
-  get 'service' => 'service#index'
-
-  ### /source
-  controller :attribute_namespace do
-    get 'attribute' => :index
-    get 'attribute/:namespace' => :index
-    # FIXME3.0: drop the POST and DELETE here
-    get 'attribute/:namespace/_meta' => :show
-    delete 'attribute/:namespace/_meta' => :delete
-    delete 'attribute/:namespace' => :delete
-    match 'attribute/:namespace/_meta' => :update, via: %i[post put]
-  end
-
-  controller :attribute do
-    get 'attribute/:namespace/:name/_meta' => :show
-    delete 'attribute/:namespace/:name/_meta' => :delete
-    delete 'attribute/:namespace/:name' => :delete
-    match 'attribute/:namespace/:name/_meta' => :update, via: %i[post put]
-  end
-
-  ### /architecture
-  resources :architectures, only: %i[index show update] # create,delete currently disabled
-
-  ### /trigger
-  post 'trigger' => 'trigger#create'
-  post 'trigger/webhook' => 'trigger#create'
-  post 'trigger/rebuild' => 'trigger#rebuild'
-  post 'trigger/release' => 'trigger#release'
-  post 'trigger/runservice' => 'trigger#runservice'
-  post 'trigger/workflow' => 'trigger_workflow#create'
-
-  ### /issue_trackers
-  resources :issue_trackers, only: %i[index show create update destroy], param: :name do
-    resources :issues, only: [:show]
-  end
-
-  ### /statistics
-  # Routes for statistics
-  # ---------------------
-  controller :statistics do
-    # Timestamps
-    #
-    get 'statistics/added_timestamp/:project(/:package)' => :added_timestamp, constraints: cons
-    get 'statistics/updated_timestamp/:project(/:package)' => :updated_timestamp, constraints: cons
-
-    # Activity
-    #
-    get 'statistics/activity/:project(/:package)' => :activity, constraints: cons
-
-    get 'statistics' => :index
-    get 'statistics/most_active_projects' => :most_active_projects
-    get 'statistics/most_active_packages' => :most_active_packages
-    get 'statistics/latest_added' => :latest_added
-    get 'statistics/latest_updated' => :latest_updated
-    get 'statistics/global_counters' => :global_counters
-
-    get 'statistics/active_request_creators/:project' => :active_request_creators, constraints: cons
-    get 'statistics/maintenance_statistics/:project' => 'statistics/maintenance_statistics#index', constraints: cons,
-        as: 'maintenance_statistics'
-    get 'public/statistics/maintenance_statistics/:project' => 'statistics/maintenance_statistics#index', constraints: cons
-  end
-
-  ### /status_message
-  resources :status_messages, only: %i[show index update create destroy], path: 'status/messages'
-
-  resources :status_project, only: [:show], param: :project, path: 'status/project'
-
-  get 'status_message' => 'status_messages#index'
-  get 'status/workerstatus' => 'worker/status#index'
-
-  ### /search
-
-  controller :search do
-    match 'search/published/binary/id' => :pass_to_backend, via: %i[get post]
-    match 'search/published/repoinfo/id' => :pass_to_backend, via: %i[get post]
-    match 'search/published/pattern/id' => :pass_to_backend, via: %i[get post]
-    match 'search/channel/binary/id' => :channel_binary_id, via: %i[get post]
-    match 'search/channel/binary' => :channel_binary, via: %i[get post]
-    match 'search/channel' => :channel, via: %i[get post]
-    match 'search/released/binary/id' => :released_binary_id, via: %i[get post]
-    match 'search/released/binary' => :released_binary, via: %i[get post]
-    match 'search/project/id' => :project_id, via: %i[get post]
-    match 'search/package/id' => :package_id, via: %i[get post]
-    match 'search/project_id' => :project_id_deprecated, via: %i[get post] # FIXME3.0: to be removed
-    match 'search/package_id' => :package_id_deprecated, via: %i[get post] # FIXME3.0: to be removed
-    match 'search/project' => :project, via: %i[get post]
-    match 'search/package' => :package, via: %i[get post]
-    match 'search/person' => :person, via: %i[get post]
-    match 'search/owner' => :owner, via: %i[get post]
-    match 'search/missing_owner' => :missing_owner, via: %i[get post]
-    match 'search/request' => :bs_request, via: %i[get post]
-    match 'search/request/id' => :bs_request_id, via: %i[get post]
-    match 'search' => :pass_to_backend, via: %i[get post]
-
-    match 'search/repository/id' => :repository_id, via: %i[get post]
-    match 'search/issue' => :issue, via: %i[get post]
-  end
-
-  ### /request
-
-  resources :request, only: %i[index show update destroy] do
-    collection do
-      post :create, constraints: ->(req) { req.params[:cmd] == 'create' }
-    end
-  end
-
-  post 'request/:id' => 'request#request_command', constraints: cons
-  controller :request do
-    constraints(cons) do
-      post 'request/:id' => :request_command_diff, constraints: ->(req) { req.params[:cmd] == 'diff' }
-      post 'request/:id' => :request_command, constraints: lambda { |req|
-        %w[addreview approve assignreview cancelapproval changereviewstate changestate setacceptat setincident setpriority].include?(req.params[:cmd])
-      }
-    end
-  end
-
-  ### /lastevents
-
-  get '/lastevents' => 'source#lastevents_public'
-  match 'public/lastevents' => 'source#lastevents_public', via: %i[get post]
-  post '/lastevents' => 'source#lastevents'
-
-  ### /distributions
-
-  resources :distributions, except: %i[new edit] do
-    collection do
-      get 'include_remotes'
-      put 'bulk_replace' => :bulk_replace
-      # This GET routes gives us a poor mans osc interface for bulk replacing...
-      # Like: osc api -e /distributions/bulk_replace
-      get 'bulk_replace' => :index
-      # This PUT route is for backward compatiblity, it was traditionally
-      # used for bulk replacing distributions.
-      put '' => :bulk_replace
-    end
-  end
-
-  ### /public
-  controller :public do
-    get 'public', to: redirect('/public/about')
-    get 'public/about' => 'about#index'
-    get 'public/configuration' => :configuration_show
-    get 'public/configuration.xml' => :configuration_show
-    get 'public/request/:number' => :show_request, constraints: cons
-    get 'public/source/:project' => :project_index, constraints: cons
-    get 'public/source/:project/_meta' => :project_meta, constraints: cons
-    get 'public/source/:project/_config' => :project_file, constraints: cons
-    get 'public/source/:project/_keyinfo' => :project_file, constraints: cons
-    get 'public/source/:project/_pubkey' => :project_file, constraints: cons
-    get 'public/source/:project/:package' => :package_index, constraints: cons
-    get 'public/source/:project/:package/_meta' => :package_meta, constraints: cons
-    get 'public/source/:project/:package/:filename' => :source_file, constraints: cons
-    get 'public/distributions' => :distributions
-    get 'public/binary_packages/:project/:package' => :binary_packages, constraints: cons
-    get 'public/build/:project(/:repository(/:arch(/:package(/:filename))))' => 'public#build', constraints: cons, as: :public_build
-    get 'public/image_templates' => :image_templates, constraints: cons
-    get 'public/package_templates' => :package_templates, constraints: cons
-  end
-
-  resources :image_templates, constraints: cons, only: [:index], controller: 'webui/image_templates'
-
-  ### /reports
-
-  resources :reports, only: %i[index show create update destroy], constraints: cons
 end
+
+### /service
+get 'service' => 'service#index'
+
+### /source
+controller :attribute_namespace do
+  get 'attribute' => :index
+  get 'attribute/:namespace' => :index
+  # FIXME3.0: drop the POST and DELETE here
+  get 'attribute/:namespace/_meta' => :show
+  delete 'attribute/:namespace/_meta' => :delete
+  delete 'attribute/:namespace' => :delete
+  match 'attribute/:namespace/_meta' => :update, via: %i[post put]
+end
+
+controller :attribute do
+  get 'attribute/:namespace/:name/_meta' => :show
+  delete 'attribute/:namespace/:name/_meta' => :delete
+  delete 'attribute/:namespace/:name' => :delete
+  match 'attribute/:namespace/:name/_meta' => :update, via: %i[post put]
+end
+
+### /architecture
+resources :architectures, only: %i[index show update] # create,delete currently disabled
+
+### /trigger
+post 'trigger' => 'trigger#create'
+post 'trigger/webhook' => 'trigger#create'
+post 'trigger/rebuild' => 'trigger#rebuild'
+post 'trigger/release' => 'trigger#release'
+post 'trigger/runservice' => 'trigger#runservice'
+post 'trigger/workflow' => 'trigger_workflow#create'
+
+### /issue_trackers
+resources :issue_trackers, only: %i[index show create update destroy], param: :name do
+  resources :issues, only: [:show]
+end
+
+### /statistics
+# Routes for statistics
+# ---------------------
+controller :statistics do
+  # Timestamps
+  #
+  get 'statistics/added_timestamp/:project(/:package)' => :added_timestamp, constraints: cons
+  get 'statistics/updated_timestamp/:project(/:package)' => :updated_timestamp, constraints: cons
+
+  # Activity
+  #
+  get 'statistics/activity/:project(/:package)' => :activity, constraints: cons
+
+  get 'statistics' => :index
+  get 'statistics/most_active_projects' => :most_active_projects
+  get 'statistics/most_active_packages' => :most_active_packages
+  get 'statistics/latest_added' => :latest_added
+  get 'statistics/latest_updated' => :latest_updated
+  get 'statistics/global_counters' => :global_counters
+
+  get 'statistics/active_request_creators/:project' => :active_request_creators, constraints: cons
+  get 'statistics/maintenance_statistics/:project' => 'statistics/maintenance_statistics#index', constraints: cons,
+      as: 'maintenance_statistics'
+  get 'public/statistics/maintenance_statistics/:project' => 'statistics/maintenance_statistics#index', constraints: cons
+end
+
+### /status_message
+resources :status_messages, only: %i[show index update create destroy], path: 'status/messages'
+
+resources :status_project, only: [:show], param: :project, path: 'status/project'
+
+get 'status_message' => 'status_messages#index'
+get 'status/workerstatus' => 'worker/status#index'
+
+### /search
+
+controller :search do
+  match 'search/published/binary/id' => :pass_to_backend, via: %i[get post]
+  match 'search/published/repoinfo/id' => :pass_to_backend, via: %i[get post]
+  match 'search/published/pattern/id' => :pass_to_backend, via: %i[get post]
+  match 'search/channel/binary/id' => :channel_binary_id, via: %i[get post]
+  match 'search/channel/binary' => :channel_binary, via: %i[get post]
+  match 'search/channel' => :channel, via: %i[get post]
+  match 'search/released/binary/id' => :released_binary_id, via: %i[get post]
+  match 'search/released/binary' => :released_binary, via: %i[get post]
+  match 'search/project/id' => :project_id, via: %i[get post]
+  match 'search/package/id' => :package_id, via: %i[get post]
+  match 'search/project_id' => :project_id_deprecated, via: %i[get post] # FIXME3.0: to be removed
+  match 'search/package_id' => :package_id_deprecated, via: %i[get post] # FIXME3.0: to be removed
+  match 'search/project' => :project, via: %i[get post]
+  match 'search/package' => :package, via: %i[get post]
+  match 'search/person' => :person, via: %i[get post]
+  match 'search/owner' => :owner, via: %i[get post]
+  match 'search/missing_owner' => :missing_owner, via: %i[get post]
+  match 'search/request' => :bs_request, via: %i[get post]
+  match 'search/request/id' => :bs_request_id, via: %i[get post]
+  match 'search' => :pass_to_backend, via: %i[get post]
+
+  match 'search/repository/id' => :repository_id, via: %i[get post]
+  match 'search/issue' => :issue, via: %i[get post]
+end
+
+### /request
+
+resources :request, only: %i[index show update destroy] do
+  collection do
+    post :create, constraints: ->(req) { req.params[:cmd] == 'create' }
+  end
+end
+
+post 'request/:id' => 'request#request_command', constraints: cons
+controller :request do
+  constraints(cons) do
+    post 'request/:id' => :request_command_diff, constraints: ->(req) { req.params[:cmd] == 'diff' }
+    post 'request/:id' => :request_command, constraints: lambda { |req|
+      %w[addreview approve assignreview cancelapproval changereviewstate changestate setacceptat setincident setpriority].include?(req.params[:cmd])
+    }
+  end
+end
+
+### /lastevents
+
+get '/lastevents' => 'source#lastevents_public'
+match 'public/lastevents' => 'source#lastevents_public', via: %i[get post]
+post '/lastevents' => 'source#lastevents'
+
+### /distributions
+
+resources :distributions, except: %i[new edit] do
+  collection do
+    get 'include_remotes'
+    put 'bulk_replace' => :bulk_replace
+    # This GET routes gives us a poor mans osc interface for bulk replacing...
+    # Like: osc api -e /distributions/bulk_replace
+    get 'bulk_replace' => :index
+    # This PUT route is for backward compatiblity, it was traditionally
+    # used for bulk replacing distributions.
+    put '' => :bulk_replace
+  end
+end
+
+### /public
+controller :public do
+  get 'public', to: redirect('/public/about')
+  get 'public/about' => 'about#index'
+  get 'public/configuration' => :configuration_show
+  get 'public/configuration.xml' => :configuration_show
+  get 'public/request/:number' => :show_request, constraints: cons
+  get 'public/source/:project' => :project_index, constraints: cons
+  get 'public/source/:project/_meta' => :project_meta, constraints: cons
+  get 'public/source/:project/_config' => :project_file, constraints: cons
+  get 'public/source/:project/_keyinfo' => :project_file, constraints: cons
+  get 'public/source/:project/_pubkey' => :project_file, constraints: cons
+  get 'public/source/:project/:package' => :package_index, constraints: cons
+  get 'public/source/:project/:package/_meta' => :package_meta, constraints: cons
+  get 'public/source/:project/:package/:filename' => :source_file, constraints: cons
+  get 'public/distributions' => :distributions
+  get 'public/binary_packages/:project/:package' => :binary_packages, constraints: cons
+  get 'public/build/:project(/:repository(/:arch(/:package(/:filename))))' => 'public#build', constraints: cons, as: :public_build
+  get 'public/image_templates' => :image_templates, constraints: cons
+  get 'public/package_templates' => :package_templates, constraints: cons
+end
+
+resources :image_templates, constraints: cons, only: [:index], controller: 'webui/image_templates'
+
+### /reports
+resources :reports, only: %i[index show create update destroy], constraints: cons
 
 # StagingWorkflow API
 resources :staging, only: [], param: 'workflow_project', module: 'staging', constraints: cons do

--- a/src/api/config/routes/api.rb
+++ b/src/api/config/routes/api.rb
@@ -419,13 +419,6 @@ scope :label_templates do
   end
 end
 
-# spiders request this, not browsers
-controller 'webui/sitemaps' do
-  get 'sitemaps' => :index
-  get 'project/sitemap' => :projects
-  get 'package/sitemap(/:project_name)' => :packages
-end
-
 ### /worker
 scope :worker, as: :worker do
   resources :status, only: [:index], controller: 'worker/status'                        # Deprecated: GET  /worker/status

--- a/src/api/config/routes/webui.rb
+++ b/src/api/config/routes/webui.rb
@@ -1,466 +1,464 @@
 cons = RoutesHelper::RoutesConstraints::CONS
 
-constraints(RoutesHelper::WebuiMatcher) do
-  root 'webui/main#index'
+root 'webui/main#index'
 
-  constraints(RoutesHelper::RoleMatcher) do
-    mount Flipper::UI.app(Flipper) => '/flipper'
+constraints(RoutesHelper::RoleMatcher) do
+  mount Flipper::UI.app(Flipper) => '/flipper'
+end
+
+resources :news_items, only: %i[index new create edit update destroy], controller: 'webui/status_messages' do
+  collection do
+    post 'preview'
   end
+end
 
-  resources :news_items, only: %i[index new create edit update destroy], controller: 'webui/status_messages' do
-    collection do
-      post 'preview'
-    end
+controller 'webui/feeds' do
+  get 'main/news' => :news, constraints: ->(req) { req.format == :rss }, as: :news_feed
+  get 'main/latest_updates' => :latest_updates, constraints: ->(req) { req.format == :rss }, as: :latest_updates_feed
+  get 'project/latest_commits/:project' => :commits, defaults: { format: 'atom' }, constraints: cons, as: 'commits_feed'
+  get 'user/feed/:secret' => :notifications, defaults: { format: 'rss' }, as: :user_rss_notifications
+end
+
+resources :attribs, constraints: cons, only: %i[create update destroy], controller: 'webui/attribute' do
+  collection do
+    get ':project(/:package)/new' => :new, constraints: cons, as: 'new'
+    get ':project(/:package)/:attribute/edit' => :edit, constraints: cons, as: 'edit'
+    get ':project(/:package)' => :index, constraints: cons, as: 'index', defaults: { format: 'html' }
   end
+end
 
-  controller 'webui/feeds' do
-    get 'main/news' => :news, constraints: ->(req) { req.format == :rss }, as: :news_feed
-    get 'main/latest_updates' => :latest_updates, constraints: ->(req) { req.format == :rss }, as: :latest_updates_feed
-    get 'project/latest_commits/:project' => :commits, defaults: { format: 'atom' }, constraints: cons, as: 'commits_feed'
-    get 'user/feed/:secret' => :notifications, defaults: { format: 'rss' }, as: :user_rss_notifications
+resources :image_templates, constraints: cons, only: [:index], controller: 'webui/image_templates'
+
+resources :download_repositories, constraints: cons, only: %i[create update destroy], controller: 'webui/download_on_demand'
+
+controller 'webui/configuration' do
+  get 'configuration' => :index
+  patch 'configuration' => :update
+end
+resources :interconnects, only: %i[new create], controller: 'webui/interconnects'
+
+controller 'webui/subscriptions' do
+  get 'notifications' => :index
+  put 'notifications' => :update
+end
+
+controller 'webui/architectures' do
+  patch 'architectures/bulk_update_availability' => :bulk_update_availability, as: :bulk_update_availability
+end
+
+resources :architectures, only: %i[index update], controller: 'webui/architectures'
+
+resources :label_templates, controller: 'webui/label_templates', constraints: cons
+
+controller 'webui/monitor' do
+  get 'monitor/' => :index
+  get 'monitor/old' => :old
+  get 'monitor/update_building' => :update_building
+  get 'monitor/events' => :events, as: :monitor_events
+end
+
+resources :package, only: [:index], controller: 'webui/package', constraints: cons
+
+controller 'webui/packages/build_log' do
+  get 'package/live_build_log/:project/:package/:repository/:arch' => :live_build_log, constraints: cons, as: 'package_live_build_log'
+  defaults format: 'js' do
+    get 'package/update_build_log/:project/:package/:repository/:arch' => :update_build_log, constraints: cons, as: 'package_update_build_log'
   end
+end
 
-  resources :attribs, constraints: cons, only: %i[create update destroy], controller: 'webui/attribute' do
-    collection do
-      get ':project(/:package)/new' => :new, constraints: cons, as: 'new'
-      get ':project(/:package)/:attribute/edit' => :edit, constraints: cons, as: 'edit'
-      get ':project(/:package)' => :index, constraints: cons, as: 'index', defaults: { format: 'html' }
-    end
+controller 'webui/package' do
+  defaults format: 'js' do
+    get 'package/edit/:project/:package' => :edit, constraints: cons, as: 'edit_package'
+    patch 'package/update' => :update, constraints: cons
+    get 'package/autocomplete' => :autocomplete
   end
+end
 
-  resources :image_templates, constraints: cons, only: [:index], controller: 'webui/image_templates'
-
-  resources :download_repositories, constraints: cons, only: %i[create update destroy], controller: 'webui/download_on_demand'
-
-  controller 'webui/configuration' do
-    get 'configuration' => :index
-    patch 'configuration' => :update
-  end
-  resources :interconnects, only: %i[new create], controller: 'webui/interconnects'
-
-  controller 'webui/subscriptions' do
-    get 'notifications' => :index
-    put 'notifications' => :update
-  end
-
-  controller 'webui/architectures' do
-    patch 'architectures/bulk_update_availability' => :bulk_update_availability, as: :bulk_update_availability
-  end
-
-  resources :architectures, only: %i[index update], controller: 'webui/architectures'
-
-  resources :label_templates, controller: 'webui/label_templates', constraints: cons
-
-  controller 'webui/monitor' do
-    get 'monitor/' => :index
-    get 'monitor/old' => :old
-    get 'monitor/update_building' => :update_building
-    get 'monitor/events' => :events, as: :monitor_events
-  end
-
-  resources :package, only: [:index], controller: 'webui/package', constraints: cons
-
-  controller 'webui/packages/build_log' do
-    get 'package/live_build_log/:project/:package/:repository/:arch' => :live_build_log, constraints: cons, as: 'package_live_build_log'
-    defaults format: 'js' do
-      get 'package/update_build_log/:project/:package/:repository/:arch' => :update_build_log, constraints: cons, as: 'package_update_build_log'
-    end
-  end
-
+defaults format: 'html' do
   controller 'webui/package' do
-    defaults format: 'js' do
-      get 'package/edit/:project/:package' => :edit, constraints: cons, as: 'edit_package'
-      patch 'package/update' => :update, constraints: cons
-      get 'package/autocomplete' => :autocomplete
-    end
-  end
-
-  defaults format: 'html' do
-    controller 'webui/package' do
-      get 'package/show/:project/:package' => :show, as: 'package_show', constraints: cons
-      get 'package/branch_diff_info/:project/:package' => :branch_diff_info, as: 'package_branch_diff_info', constraints: cons
-      # For backward compatibility
-      get 'package/binary/:project/:package/:repository/:arch/:filename', to: redirect('/projects/%{project}/packages/%{package}/repositories/%{repository}/%{arch}/%{filename}'),
-                                                                          constraints: cons
-      # For backward compatibility
-      get 'package/binaries/:project/:package/:repository', to: redirect('/projects/%{project}/packages/%{package}/repositories/%{repository}'), constraints: cons
-      get 'package/users/:project/:package' => :users, as: 'package_users', constraints: cons
-      get 'package/requests/:project/:package' => :requests, as: 'package_requests', constraints: cons
-      get 'package/statistics/:project/:package/:repository/:arch' => :statistics, as: 'package_statistics', constraints: cons
-      get 'package/revisions/:project/:package' => :revisions, constraints: cons, as: 'package_view_revisions'
-      get 'package/rdiff/:project/:package' => :rdiff, constraints: cons, as: 'package_rdiff'
-      post 'package/create/:project' => :create, constraints: cons, as: 'packages'
-      get 'package/new/:project' => :new, constraints: cons, as: 'new_package'
-      post 'package/remove/:project/:package' => :remove, constraints: cons
-      # For backward compatibility
-      get 'package/view_file/:project/:package/:filename', to: redirect('/projects/%{project}/packages/%{package}/files/%{filename}'), constraints: cons
-      get 'package/devel_project/:project/:package' => :devel_project, constraints: cons, as: 'package_devel_project'
-      get 'package/buildresult' => :buildresult, constraints: cons, as: 'package_buildresult'
-      get 'package/rpmlint_result(/:project)(/:package)' => :rpmlint_result, constraints: cons, as: 'rpmlint_result'
-      get 'package/rpmlint_log(/:project)(/:package)' => :rpmlint_log, constraints: cons
-      get 'package/rpmlint_summary(/:project)(/:package)' => :rpmlint_summary, constraints: cons, as: 'rpmlint_summary'
-      # For backward compatibility
-      get 'package/meta/:project/:package', to: redirect('/projects/%{project}/packages/%{package}/meta'), constraints: cons
-      # For backward compatibility
-      get 'package/attributes/:project/:package', to: redirect('/attribs/%{project}/%{package}'), constraints: cons
-      # For backward compatibility
-      get 'package/repositories/:project/:package', to: redirect('/repositories/%{project}/%{package}'), constraints: cons
-      # For backward compatibility
-      get 'package/files/:project/:package' => :show, constraints: cons
-    end
-  end
-
-  controller 'webui/package' do
-    post 'package/save_person/:project/:package' => :save_person, constraints: cons, as: 'package_save_person'
-    post 'package/save_group/:project/:package' => :save_group, constraints: cons, as: 'package_save_group'
-    post 'package/remove_role/:project/:package' => :remove_role, constraints: cons, as: 'package_remove_role'
-    post 'package/preview_description' => :preview_description, constraints: cons
-    get 'projects/:project/packages/:package/template_data' => :template_data, constraints: cons, as: 'package_template_data'
-  end
-
-  resources :packages, only: [], param: :name do
-    resource :job_history, controller: 'webui/packages/job_history', only: [] do
-      get '/:project/:repository/:arch' => :index, as: :index, constraints: cons
-    end
-
-    resource :build_reason, controller: 'webui/packages/build_reason', only: [] do
-      get '/:project/:repository/:arch' => :index, as: :index, constraints: cons
-    end
-
-    resource :branches, controller: 'webui/packages/branches', only: [] do
-      get '/:project', action: :new, as: :new, constraints: cons
-    end
-  end
-
-  resource :packages, only: [] do
-    resources :branches, controller: 'webui/packages/branches', only: [:create], constraints: cons do
-      get '/:project', action: :into, on: :new, as: :project, constraints: cons
-    end
-  end
-
-  resource :patchinfo, except: [:show], controller: 'webui/patchinfo' do
-    get 'new_tracker' => :new_tracker
-    post 'update_issues/:project/:package' => :update_issues, as: :update_issues
-    get 'show/:project/:package' => :show, as: :show, constraints: cons
-  end
-
-  controller 'webui/repositories' do
-    get 'repositories/:project(/:package)' => :index, constraints: cons, as: 'repositories', defaults: { format: 'html' }
-    get 'project/repositories/:project' => :index, constraints: cons, as: 'project_repositories'
-    get 'project/add_repository_from_default_list/:project', to: redirect('/projects/%{project}/distributions/new'), constraints: cons
-    post 'project/save_repository' => :create
-    post 'project/update_target/:project' => :update, constraints: cons
-    post 'project/mark_important/:project' => :mark_important, constraints: cons
-    get 'project/repository_state/:project/:repository' => :state, constraints: cons, as: 'project_repository_state'
-    post 'project/remove_target' => :destroy, as: 'destroy_repository'
-    post 'project/create_dod_repository' => :create_dod_repository, as: 'create_dod_repository'
-    post 'project/create_image_repository' => :create_image_repository
-
-    # Flags
-    post 'flag/:project(/:package)' => :change_flag, constraints: cons, as: 'change_repository_flag'
-  end
-
-  controller 'webui/kiwi/images' do
-    get 'package/:package_id/kiwi_images/import_from_package' => :import_from_package, as: 'import_kiwi_image'
-  end
-
-  resources :kiwi_images, only: %i[show edit update], controller: 'webui/kiwi/images' do
-    member do
-      get 'build_result' => :build_result, constraints: cons
-      get 'autocomplete_binaries' => :autocomplete_binaries, as: :autocomplete_binaries
-    end
-  end
-
-  controller 'webui/project' do
-    get 'project/' => :index, as: 'projects'
-    get 'project/list_public' => :index, as: 'project_list_public'
-    get 'project/list_all' => :index, show_all: true, as: 'project_list_all'
-    get 'project/list' => :index, as: 'project_list'
-    get 'project/autocomplete_projects' => :autocomplete_projects, as: 'autocomplete_projects'
-    get 'project/autocomplete_staging_projects' => :autocomplete_staging_projects, as: 'autocomplete_staging_projects'
-    get 'project/autocomplete_incidents' => :autocomplete_incidents, as: 'autocomplete_incidents'
-    get 'project/autocomplete_packages' => :autocomplete_packages, as: 'autocomplete_packages'
-    get 'project/autocomplete_repositories' => :autocomplete_repositories, as: 'autocomplete_repositories'
-    get 'project/users/:project' => :users, constraints: cons, as: 'project_users'
-    get 'project/subprojects/:project' => :subprojects, constraints: cons, as: 'project_subprojects'
-    get 'project/attributes/:project', to: redirect('/attribs/%{project}'), constraints: cons
-    get 'project/release_request/(:project)' => :release_request, constraints: cons, as: :project_release_request
-    post 'project/new_release_request/(:project)' => :new_release_request, constraints: cons, as: :project_new_release_request
-    get 'project/show/:project' => :show, constraints: cons, as: 'project_show'
-    get 'project/buildresult' => :buildresult, constraints: cons, as: 'project_buildresult'
-    get 'project/new' => :new, as: 'new_project'
-    get 'project/edit/:project' => :edit, constraints: cons, as: 'edit_project'
-    post 'project/create' => :create, constraints: cons, as: 'projects_create'
-    post 'project/restore' => :restore, constraints: cons, as: 'projects_restore'
-    patch 'project/update' => :update, constraints: cons
-    delete 'project/destroy' => :destroy
-    get 'project/requests/:project' => :requests, constraints: cons, as: 'project_requests'
-    post 'project/remove_target_request' => :remove_target_request, as: 'project_remove_target_request'
-    post 'project/remove_path_from_target' => :remove_path_from_target, as: 'remove_repository_path'
-    post 'project/move_path/:project' => :move_path, as: 'move_repository_path'
-    post 'project/save_person/:project' => :save_person, constraints: cons, as: 'project_save_person'
-    post 'project/save_group/:project' => :save_group, constraints: cons, as: 'project_save_group'
-    post 'project/remove_role/:project' => :remove_role, constraints: cons, as: 'project_remove_role'
-    get 'project/monitor/:project' => :monitor, constraints: cons, as: 'project_monitor'
+    get 'package/show/:project/:package' => :show, as: 'package_show', constraints: cons
+    get 'package/branch_diff_info/:project/:package' => :branch_diff_info, as: 'package_branch_diff_info', constraints: cons
     # For backward compatibility
-    get 'project/monitor', to: redirect { |_path_parameters, request|
-      url_string = request.query_parameters.except(:project).to_param
-      url_string = '?' << url_string unless url_string.empty?
-      "/project/monitor/#{request.query_parameters[:project]}#{url_string}"
-    }, constraints: ->(request) { request.query_parameters['project'].present? }
-    get 'project/clear_failed_comment/:project' => :clear_failed_comment, constraints: cons, as: :clear_failed_comment
-    get 'project/edit_comment_form/:project' => :edit_comment_form, constraints: cons, as: :edit_comment_form
-    post 'project/edit_comment/:project' => :edit_comment, constraints: cons
-    post 'project/unlock' => :unlock
-    post 'project/preview_description' => :preview_description
+    get 'package/binary/:project/:package/:repository/:arch/:filename', to: redirect('/projects/%{project}/packages/%{package}/repositories/%{repository}/%{arch}/%{filename}'),
+                                                                        constraints: cons
+    # For backward compatibility
+    get 'package/binaries/:project/:package/:repository', to: redirect('/projects/%{project}/packages/%{package}/repositories/%{repository}'), constraints: cons
+    get 'package/users/:project/:package' => :users, as: 'package_users', constraints: cons
+    get 'package/requests/:project/:package' => :requests, as: 'package_requests', constraints: cons
+    get 'package/statistics/:project/:package/:repository/:arch' => :statistics, as: 'package_statistics', constraints: cons
+    get 'package/revisions/:project/:package' => :revisions, constraints: cons, as: 'package_view_revisions'
+    get 'package/rdiff/:project/:package' => :rdiff, constraints: cons, as: 'package_rdiff'
+    post 'package/create/:project' => :create, constraints: cons, as: 'packages'
+    get 'package/new/:project' => :new, constraints: cons, as: 'new_package'
+    post 'package/remove/:project/:package' => :remove, constraints: cons
+    # For backward compatibility
+    get 'package/view_file/:project/:package/:filename', to: redirect('/projects/%{project}/packages/%{package}/files/%{filename}'), constraints: cons
+    get 'package/devel_project/:project/:package' => :devel_project, constraints: cons, as: 'package_devel_project'
+    get 'package/buildresult' => :buildresult, constraints: cons, as: 'package_buildresult'
+    get 'package/rpmlint_result(/:project)(/:package)' => :rpmlint_result, constraints: cons, as: 'rpmlint_result'
+    get 'package/rpmlint_log(/:project)(/:package)' => :rpmlint_log, constraints: cons
+    get 'package/rpmlint_summary(/:project)(/:package)' => :rpmlint_summary, constraints: cons, as: 'rpmlint_summary'
+    # For backward compatibility
+    get 'package/meta/:project/:package', to: redirect('/projects/%{project}/packages/%{package}/meta'), constraints: cons
+    # For backward compatibility
+    get 'package/attributes/:project/:package', to: redirect('/attribs/%{project}/%{package}'), constraints: cons
+    # For backward compatibility
+    get 'package/repositories/:project/:package', to: redirect('/repositories/%{project}/%{package}'), constraints: cons
+    # For backward compatibility
+    get 'package/files/:project/:package' => :show, constraints: cons
+  end
+end
+
+controller 'webui/package' do
+  post 'package/save_person/:project/:package' => :save_person, constraints: cons, as: 'package_save_person'
+  post 'package/save_group/:project/:package' => :save_group, constraints: cons, as: 'package_save_group'
+  post 'package/remove_role/:project/:package' => :remove_role, constraints: cons, as: 'package_remove_role'
+  post 'package/preview_description' => :preview_description, constraints: cons
+  get 'projects/:project/packages/:package/template_data' => :template_data, constraints: cons, as: 'package_template_data'
+end
+
+resources :packages, only: [], param: :name do
+  resource :job_history, controller: 'webui/packages/job_history', only: [] do
+    get '/:project/:repository/:arch' => :index, as: :index, constraints: cons
   end
 
+  resource :build_reason, controller: 'webui/packages/build_reason', only: [] do
+    get '/:project/:repository/:arch' => :index, as: :index, constraints: cons
+  end
+
+  resource :branches, controller: 'webui/packages/branches', only: [] do
+    get '/:project', action: :new, as: :new, constraints: cons
+  end
+end
+
+resource :packages, only: [] do
+  resources :branches, controller: 'webui/packages/branches', only: [:create], constraints: cons do
+    get '/:project', action: :into, on: :new, as: :project, constraints: cons
+  end
+end
+
+resource :patchinfo, except: [:show], controller: 'webui/patchinfo' do
+  get 'new_tracker' => :new_tracker
+  post 'update_issues/:project/:package' => :update_issues, as: :update_issues
+  get 'show/:project/:package' => :show, as: :show, constraints: cons
+end
+
+controller 'webui/repositories' do
+  get 'repositories/:project(/:package)' => :index, constraints: cons, as: 'repositories', defaults: { format: 'html' }
+  get 'project/repositories/:project' => :index, constraints: cons, as: 'project_repositories'
+  get 'project/add_repository_from_default_list/:project', to: redirect('/projects/%{project}/distributions/new'), constraints: cons
+  post 'project/save_repository' => :create
+  post 'project/update_target/:project' => :update, constraints: cons
+  post 'project/mark_important/:project' => :mark_important, constraints: cons
+  get 'project/repository_state/:project/:repository' => :state, constraints: cons, as: 'project_repository_state'
+  post 'project/remove_target' => :destroy, as: 'destroy_repository'
+  post 'project/create_dod_repository' => :create_dod_repository, as: 'create_dod_repository'
+  post 'project/create_image_repository' => :create_image_repository
+
+  # Flags
+  post 'flag/:project(/:package)' => :change_flag, constraints: cons, as: 'change_repository_flag'
+end
+
+controller 'webui/kiwi/images' do
+  get 'package/:package_id/kiwi_images/import_from_package' => :import_from_package, as: 'import_kiwi_image'
+end
+
+resources :kiwi_images, only: %i[show edit update], controller: 'webui/kiwi/images' do
+  member do
+    get 'build_result' => :build_result, constraints: cons
+    get 'autocomplete_binaries' => :autocomplete_binaries, as: :autocomplete_binaries
+  end
+end
+
+controller 'webui/project' do
+  get 'project/' => :index, as: 'projects'
+  get 'project/list_public' => :index, as: 'project_list_public'
+  get 'project/list_all' => :index, show_all: true, as: 'project_list_all'
+  get 'project/list' => :index, as: 'project_list'
+  get 'project/autocomplete_projects' => :autocomplete_projects, as: 'autocomplete_projects'
+  get 'project/autocomplete_staging_projects' => :autocomplete_staging_projects, as: 'autocomplete_staging_projects'
+  get 'project/autocomplete_incidents' => :autocomplete_incidents, as: 'autocomplete_incidents'
+  get 'project/autocomplete_packages' => :autocomplete_packages, as: 'autocomplete_packages'
+  get 'project/autocomplete_repositories' => :autocomplete_repositories, as: 'autocomplete_repositories'
+  get 'project/users/:project' => :users, constraints: cons, as: 'project_users'
+  get 'project/subprojects/:project' => :subprojects, constraints: cons, as: 'project_subprojects'
+  get 'project/attributes/:project', to: redirect('/attribs/%{project}'), constraints: cons
+  get 'project/release_request/(:project)' => :release_request, constraints: cons, as: :project_release_request
+  post 'project/new_release_request/(:project)' => :new_release_request, constraints: cons, as: :project_new_release_request
+  get 'project/show/:project' => :show, constraints: cons, as: 'project_show'
+  get 'project/buildresult' => :buildresult, constraints: cons, as: 'project_buildresult'
+  get 'project/new' => :new, as: 'new_project'
+  get 'project/edit/:project' => :edit, constraints: cons, as: 'edit_project'
+  post 'project/create' => :create, constraints: cons, as: 'projects_create'
+  post 'project/restore' => :restore, constraints: cons, as: 'projects_restore'
+  patch 'project/update' => :update, constraints: cons
+  delete 'project/destroy' => :destroy
+  get 'project/requests/:project' => :requests, constraints: cons, as: 'project_requests'
+  post 'project/remove_target_request' => :remove_target_request, as: 'project_remove_target_request'
+  post 'project/remove_path_from_target' => :remove_path_from_target, as: 'remove_repository_path'
+  post 'project/move_path/:project' => :move_path, as: 'move_repository_path'
+  post 'project/save_person/:project' => :save_person, constraints: cons, as: 'project_save_person'
+  post 'project/save_group/:project' => :save_group, constraints: cons, as: 'project_save_group'
+  post 'project/remove_role/:project' => :remove_role, constraints: cons, as: 'project_remove_role'
+  get 'project/monitor/:project' => :monitor, constraints: cons, as: 'project_monitor'
   # For backward compatibility
-  controller 'webui/projects/meta' do
-    get 'project/meta/:project', to: redirect('/projects/%{project}/meta')
-  end
-  controller 'webui/projects/pulse' do
-    get 'project/pulse/:project', to: redirect('/projects/%{project}/pulse')
-  end
-  controller 'webui/projects/rebuild_times' do
-    get 'project/rebuild_time/:project/:repository/:arch', to: redirect('/projects/rebuild_time/%{project}/%{repository}/%{arch}')
-    get 'project/rebuild_time_png/:project/:key', to: redirect('/projects/rebuild_time_png/%{project}/%{key}')
-  end
-  controller 'webui/projects/maintenance_incidents' do
-    get 'project/maintenance_incidents/:project', to: redirect('/projects/%{project}/maintenance_incidents')
-  end
-  controller 'webui/projects/project_configuration' do
-    get 'project/prjconf/:project', to: redirect('/projects/%{project}/prjconf')
-  end
-  controller 'webui/projects/signing_keys' do
-    get 'project/keys_and_certificates/:project', to: redirect('/projects/%{project}/signing_keys')
-    get 'projects/:project/public_key', to: redirect('/projects/%{project}/signing_keys')
-    get 'projects/:project/ssl_certificate', to: redirect('/projects/%{project}/signing_keys')
-  end
-  # \For backward compatibility
+  get 'project/monitor', to: redirect { |_path_parameters, request|
+    url_string = request.query_parameters.except(:project).to_param
+    url_string = '?' << url_string unless url_string.empty?
+    "/project/monitor/#{request.query_parameters[:project]}#{url_string}"
+  }, constraints: ->(request) { request.query_parameters['project'].present? }
+  get 'project/clear_failed_comment/:project' => :clear_failed_comment, constraints: cons, as: :clear_failed_comment
+  get 'project/edit_comment_form/:project' => :edit_comment_form, constraints: cons, as: :edit_comment_form
+  post 'project/edit_comment/:project' => :edit_comment, constraints: cons
+  post 'project/unlock' => :unlock
+  post 'project/preview_description' => :preview_description
+end
 
-  resources :projects, only: [], param: :name do
-    resources :maintained_projects, controller: 'webui/projects/maintained_projects',
-                                    param: :maintained_project, only: %i[index destroy create], constraints: cons
-    resource :status, controller: 'webui/projects/status', only: [:show], constraints: cons
-    resource :signing_keys, controller: 'webui/projects/signing_keys', only: [:show], constraints: cons do
-      get 'download'
-    end
-    resource :pulse, controller: 'webui/projects/pulse', only: [:show], constraints: cons
-    resource :meta, controller: 'webui/projects/meta', only: %i[show update], constraints: cons
-    resource :prjconf, controller: 'webui/projects/project_configuration', only: %i[show update], as: :config, constraints: cons
-    resource :rebuild_time, controller: 'webui/projects/rebuild_times', only: [:show], constraints: cons do
-      get 'rebuild_time_png'
-    end
-    resources :maintenance_incidents, controller: 'webui/projects/maintenance_incidents', only: %i[index create], constraints: cons
-    resources :maintenance_incident_requests, controller: 'webui/projects/maintenance_incident_requests', only: %i[new create], constraints: cons
-    resources :packages, only: [], param: :name do
-      resources :role_additions, controller: 'webui/requests/role_additions', only: %i[new create], constraints: cons
-      resources :deletions, controller: 'webui/requests/deletions', only: %i[new create], constraints: cons
-      resources :devel_project_changes, controller: 'webui/requests/devel_project_changes', only: %i[new create], constraints: cons
-      resources :submissions, controller: 'webui/requests/submissions', only: %i[new create], constraints: cons
-      resources :files, controller: 'webui/packages/files', only: %i[new create show update destroy], constraints: cons, param: :filename, format: false, defaults: { format: 'html' } do
-        get :blame
-      end
-      put 'toggle_watched_item', controller: 'webui/watched_items', constraints: cons
-      resource :badge, controller: 'webui/packages/badge', only: [:show], constraints: cons.merge(format: :svg)
-      resources :repositories, only: [], param: :name do
-        resources :architectures, only: [], param: :name do
-          resource :rpmlint, controller: 'webui/packages/rpmlint', only: [:show], constraints: cons
-        end
-        resources :binaries, controller: 'webui/packages/binaries', only: [:index], constraints: cons
-        # Binaries with the exact same name can exist in multiple architectures, so we have to use arch param here additionally
-        resources :binaries, controller: 'webui/packages/binaries', only: [:show], constraints: cons, param: :filename, path: 'binaries/:arch/' do
-          get :dependency
-          get :filelist
-        end
-        # We wipe all binaries at once, so this is resource instead of resources
-        resource :binaries, controller: 'webui/packages/binaries', only: [:destroy], constraints: cons
-      end
-      resource :meta, controller: 'webui/packages/meta', only: %i[show update], constraints: cons
-      resource :trigger, controller: 'webui/packages/trigger', only: [], constraints: cons do
-        defaults format: 'js' do
-          member do
-            post 'rebuild' => :rebuild
-            post 'abort_build' => :abort_build
-            post 'services' => :services
-          end
-        end
-      end
-      resources :assignments, only: %i[create destroy], controller: 'webui/packages/assignments'
-    end
+# For backward compatibility
+controller 'webui/projects/meta' do
+  get 'project/meta/:project', to: redirect('/projects/%{project}/meta')
+end
+controller 'webui/projects/pulse' do
+  get 'project/pulse/:project', to: redirect('/projects/%{project}/pulse')
+end
+controller 'webui/projects/rebuild_times' do
+  get 'project/rebuild_time/:project/:repository/:arch', to: redirect('/projects/rebuild_time/%{project}/%{repository}/%{arch}')
+  get 'project/rebuild_time_png/:project/:key', to: redirect('/projects/rebuild_time_png/%{project}/%{key}')
+end
+controller 'webui/projects/maintenance_incidents' do
+  get 'project/maintenance_incidents/:project', to: redirect('/projects/%{project}/maintenance_incidents')
+end
+controller 'webui/projects/project_configuration' do
+  get 'project/prjconf/:project', to: redirect('/projects/%{project}/prjconf')
+end
+controller 'webui/projects/signing_keys' do
+  get 'project/keys_and_certificates/:project', to: redirect('/projects/%{project}/signing_keys')
+  get 'projects/:project/public_key', to: redirect('/projects/%{project}/signing_keys')
+  get 'projects/:project/ssl_certificate', to: redirect('/projects/%{project}/signing_keys')
+end
+# \For backward compatibility
 
+resources :projects, only: [], param: :name do
+  resources :maintained_projects, controller: 'webui/projects/maintained_projects',
+                                  param: :maintained_project, only: %i[index destroy create], constraints: cons
+  resource :status, controller: 'webui/projects/status', only: [:show], constraints: cons
+  resource :signing_keys, controller: 'webui/projects/signing_keys', only: [:show], constraints: cons do
+    get 'download'
+  end
+  resource :pulse, controller: 'webui/projects/pulse', only: [:show], constraints: cons
+  resource :meta, controller: 'webui/projects/meta', only: %i[show update], constraints: cons
+  resource :prjconf, controller: 'webui/projects/project_configuration', only: %i[show update], as: :config, constraints: cons
+  resource :rebuild_time, controller: 'webui/projects/rebuild_times', only: [:show], constraints: cons do
+    get 'rebuild_time_png'
+  end
+  resources :maintenance_incidents, controller: 'webui/projects/maintenance_incidents', only: %i[index create], constraints: cons
+  resources :maintenance_incident_requests, controller: 'webui/projects/maintenance_incident_requests', only: %i[new create], constraints: cons
+  resources :packages, only: [], param: :name do
     resources :role_additions, controller: 'webui/requests/role_additions', only: %i[new create], constraints: cons
     resources :deletions, controller: 'webui/requests/deletions', only: %i[new create], constraints: cons
-    resources :distributions, only: [:new], controller: 'webui/distributions', constraints: cons do
-      collection do
-        post :toggle
-      end
+    resources :devel_project_changes, controller: 'webui/requests/devel_project_changes', only: %i[new create], constraints: cons
+    resources :submissions, controller: 'webui/requests/submissions', only: %i[new create], constraints: cons
+    resources :files, controller: 'webui/packages/files', only: %i[new create show update destroy], constraints: cons, param: :filename, format: false, defaults: { format: 'html' } do
+      get :blame
     end
     put 'toggle_watched_item', controller: 'webui/watched_items', constraints: cons
-    resource :label_globals, controller: 'webui/projects/label_globals', only: %i[update], constraints: cons
-    resources :label_templates, controller: 'webui/projects/label_templates', constraints: cons do
-      collection do
-        get :copy
-        post :clone
-        get :preview
+    resource :badge, controller: 'webui/packages/badge', only: [:show], constraints: cons.merge(format: :svg)
+    resources :repositories, only: [], param: :name do
+      resources :architectures, only: [], param: :name do
+        resource :rpmlint, controller: 'webui/packages/rpmlint', only: [:show], constraints: cons
+      end
+      resources :binaries, controller: 'webui/packages/binaries', only: [:index], constraints: cons
+      # Binaries with the exact same name can exist in multiple architectures, so we have to use arch param here additionally
+      resources :binaries, controller: 'webui/packages/binaries', only: [:show], constraints: cons, param: :filename, path: 'binaries/:arch/' do
+        get :dependency
+        get :filelist
+      end
+      # We wipe all binaries at once, so this is resource instead of resources
+      resource :binaries, controller: 'webui/packages/binaries', only: [:destroy], constraints: cons
+    end
+    resource :meta, controller: 'webui/packages/meta', only: %i[show update], constraints: cons
+    resource :trigger, controller: 'webui/packages/trigger', only: [], constraints: cons do
+      defaults format: 'js' do
+        member do
+          post 'rebuild' => :rebuild
+          post 'abort_build' => :abort_build
+          post 'services' => :services
+        end
       end
     end
+    resources :assignments, only: %i[create destroy], controller: 'webui/packages/assignments'
   end
 
-  get 'request/show/:number/build_results', to: redirect('/requests/%{number}/build_results'), constraints: cons
-  get 'request/show/:number/(request_action/:request_action_id)/build_results', to: redirect('/requests/%{number}/actions/%{request_action_id}/build_results'), constraints: cons
-  get 'request/show/:number/changes', to: redirect('/requests/%{number}/changes'), constraints: cons
-  get 'request/show/:number/(request_action/:request_action_id)/changes', to: redirect('/requests/%{number}/actions/%{request_action_id}/changes'), constraints: cons
-  get 'request/show/:number/mentioned_issues', to: redirect('/requests/%{number}/mentioned_issues'), constraints: cons
-  get 'request/show/:number/(request_action/:request_action_id)/mentioned_issues', to: redirect('/requests/%{number}/actions/%{request_action_id}/mentioned_issues'), constraints: cons
-
-  controller 'webui/request' do
-    post 'request/add_reviewer' => :add_reviewer
-    post 'request/modify_review' => :modify_review
-    get 'request/show/:number/(request_action/:request_action_id)' => :show, as: 'request_show', constraints: cons
-    # TODO: Simplify this with `resources` instead after rolling out `:request_show_redesign` feature
-    get 'requests/:number/(actions/:request_action_id)' => :beta_show, as: 'request_beta_show', constraints: cons
-    get 'requests/:number/(actions/:request_action_id)/build_results' => :build_results, as: 'request_build_results', constraints: cons
-    get 'requests/:number/(actions/:request_action_id)/changes' => :changes, as: 'request_changes', constraints: cons
-    # Note: `format: false` is used because file names can range from a simple `string` to more complex paths like `vendor.tar.gz/cel.dev/expr/CONTRIBUTING.md`.
-    # We can't apply the filename constraint, it prevents the use of `/` in file names.
-    get 'requests/:number/actions/:request_action_id/changes/*filename' => :changes_diff, as: 'request_changes_diff', format: false, constraints: cons.except(:filename)
-    get 'requests/:number/(actions/:request_action_id)/mentioned_issues' => :mentioned_issues, as: 'request_mentioned_issues', constraints: cons
-    post 'request/sourcediff' => :sourcediff
-    post 'request/changerequest' => :changerequest
-    get 'request/diff/:number' => :diff
-    get 'request/list_small' => :list_small, as: 'request_list_small'
-    post 'request/set_bugowner_request' => :set_bugowner_request
-    get 'request/:number/request_action/:id' => :request_action, as: 'request_action'
-    get 'request/:number/request_action/:request_action_id/changes' => :request_action_changes, as: 'request_action_changes'
-    get 'request/:number/request_action/:request_action_id/details' => :request_action_details, as: 'request_action_details'
-    get 'request/:number/request_action/:request_action_id/inline_comment' => :inline_comment, constraints: cons, as: 'request_inline_comment'
-    get 'request/:number/chart_build_results' => :chart_build_results, as: 'request_chart_build_results', constraints: cons
-    get 'request/:number/complete_build_results' => :complete_build_results, as: 'request_complete_build_results', constraints: cons
-    get 'autocomplete_reviewers' => :autocomplete_reviewers, as: 'autocomplete_reviewers'
-  end
-
-  resources :requests, only: [], param: :number, controller: 'webui/request' do
-    member do
-      put :toggle_watched_item, controller: 'webui/watched_items'
-      put :toggle, controller: 'webui/action_seen_by_users'
-    end
-  end
-
-  get 'projects/:project/requests' => 'webui/projects/bs_requests#index', constraints: cons, as: 'projects_requests'
-  get 'projects/:project/packages/:package/requests' => 'webui/packages/bs_requests#index', constraints: cons, as: 'packages_requests'
-  get 'notification/autocomplete_projects' => 'webui/users/notifications#autocomplete_projects', as: 'notification_autocomplete_projects'
-
-  controller 'webui/search' do
-    get 'search' => :index
-    get 'search/owner' => :owner
-    get 'search/issue' => :issue
-  end
-
-  resources :users, controller: 'webui/users', param: :login, constraints: cons do
+  resources :role_additions, controller: 'webui/requests/role_additions', only: %i[new create], constraints: cons
+  resources :deletions, controller: 'webui/requests/deletions', only: %i[new create], constraints: cons
+  resources :distributions, only: [:new], controller: 'webui/distributions', constraints: cons do
     collection do
-      get 'autocomplete'
-      get 'tokens'
-    end
-    member do
-      put 'censor'
-      post 'change_password'
-      post 'rss_secret'
-      get 'edit_account'
-      post 'update_color_theme'
-    end
-    resource :block, only: %i[create destroy], controller: 'webui/users/block', constraints: cons
-  end
-
-  scope :my do
-    resources :tasks, only: [:index], controller: 'webui/users/tasks', as: :my_tasks
-    resources :requests, only: [:index], controller: 'webui/users/bs_requests', as: :my_requests
-
-    resources :notifications, only: [:index], controller: 'webui/users/notifications', as: :my_notifications do
-      collection do
-        # We allow updating multiple notifications in a single HTTP request
-        put :update
-        get :count_for_notification_types
-        get :count_for_event_types
-        get :count_for_notification_kinds
-        get :count_for_unread
-      end
-    end
-
-    resources :beta_features, only: [:index], controller: 'webui/users/beta_features', as: :my_beta_features
-    resource :beta_feature, only: [:update], controller: 'webui/users/beta_features', as: :my_beta_feature
-
-    resource :notification, only: [:update], controller: 'webui/users/notifications', as: :my_notification
-
-    resources :subscriptions, only: [:index], controller: 'webui/users/subscriptions', as: :my_subscriptions do
-      collection do
-        put 'update', as: :update
-      end
-    end
-
-    resources :patchinfos, only: [:index], controller: 'webui/users/patchinfos', as: :my_patchinfos
-
-    post 'news_items/:id' => :acknowledge, controller: 'webui/status_messages', as: :acknowledge_news_item
-
-    resources :tokens, controller: 'webui/users/tokens' do
-      resources :workflow_runs, only: %i[index show], controller: 'webui/workflow_runs'
-      resources :users, only: %i[index create destroy], controller: 'webui/users/tokens/users', constraints: cons
-      resources :groups, only: %i[create destroy], controller: 'webui/users/tokens/groups', constraints: cons
-    end
-
-    resources :canned_responses, controller: 'webui/users/canned_responses', only: %i[index create edit update destroy], constraints: cons
-  end
-
-  get 'home', to: 'webui/webui#home', as: :home
-  get 'signup', to: 'webui/users#new', as: :signup
-
-  # TODO
-  # keep those routes reachable, but remove them later as
-  # nobody access it anymore
-  # Legacy routes start
-  namespace :user do
-    get '/signup', to: redirect('/signup')
-    get '/register_user', to: redirect('/signup')
-    get '/show/:user', to: redirect('/users/%{user}'), constraints: cons
-    get '/autocomplete', to: redirect('/users/autocomplete')
-    get '/tokens', to: redirect('/users/tokens')
-  end
-  # Legacy routes end
-
-  constraints(RoutesHelper::SessionAuthMatcher) do
-    resource :session, only: %i[new create], controller: 'webui/session' do
-      collection do
-        get :reset
-      end
+      post :toggle
     end
   end
-
-  resources :groups, only: %i[index show new create edit update], param: :title, constraints: cons, controller: 'webui/groups' do
-    resources :user, only: %i[create destroy update], param: :user_login, constraints: cons, controller: 'webui/groups/users'
-    resources :requests, only: [:index], controller: 'webui/groups/bs_requests'
-
+  put 'toggle_watched_item', controller: 'webui/watched_items', constraints: cons
+  resource :label_globals, controller: 'webui/projects/label_globals', only: %i[update], constraints: cons
+  resources :label_templates, controller: 'webui/projects/label_templates', constraints: cons do
     collection do
-      get :autocomplete
+      get :copy
+      post :clone
+      get :preview
     end
   end
-
-  resources :comments, constraints: cons, only: %i[create destroy update], controller: 'webui/comments' do
-    member do
-      post 'moderate'
-    end
-
-    defaults format: 'js' do
-      get 'history/:version_id' => :history, as: :history
-    end
-
-    collection do
-      post 'preview'
-    end
-  end
-
-  resources :reports, only: %i[create show], controller: 'webui/reports'
 end
+
+get 'request/show/:number/build_results', to: redirect('/requests/%{number}/build_results'), constraints: cons
+get 'request/show/:number/(request_action/:request_action_id)/build_results', to: redirect('/requests/%{number}/actions/%{request_action_id}/build_results'), constraints: cons
+get 'request/show/:number/changes', to: redirect('/requests/%{number}/changes'), constraints: cons
+get 'request/show/:number/(request_action/:request_action_id)/changes', to: redirect('/requests/%{number}/actions/%{request_action_id}/changes'), constraints: cons
+get 'request/show/:number/mentioned_issues', to: redirect('/requests/%{number}/mentioned_issues'), constraints: cons
+get 'request/show/:number/(request_action/:request_action_id)/mentioned_issues', to: redirect('/requests/%{number}/actions/%{request_action_id}/mentioned_issues'), constraints: cons
+
+controller 'webui/request' do
+  post 'request/add_reviewer' => :add_reviewer
+  post 'request/modify_review' => :modify_review
+  get 'request/show/:number/(request_action/:request_action_id)' => :show, as: 'request_show', constraints: cons
+  # TODO: Simplify this with `resources` instead after rolling out `:request_show_redesign` feature
+  get 'requests/:number/(actions/:request_action_id)' => :beta_show, as: 'request_beta_show', constraints: cons
+  get 'requests/:number/(actions/:request_action_id)/build_results' => :build_results, as: 'request_build_results', constraints: cons
+  get 'requests/:number/(actions/:request_action_id)/changes' => :changes, as: 'request_changes', constraints: cons
+  # Note: `format: false` is used because file names can range from a simple `string` to more complex paths like `vendor.tar.gz/cel.dev/expr/CONTRIBUTING.md`.
+  # We can't apply the filename constraint, it prevents the use of `/` in file names.
+  get 'requests/:number/actions/:request_action_id/changes/*filename' => :changes_diff, as: 'request_changes_diff', format: false, constraints: cons.except(:filename)
+  get 'requests/:number/(actions/:request_action_id)/mentioned_issues' => :mentioned_issues, as: 'request_mentioned_issues', constraints: cons
+  post 'request/sourcediff' => :sourcediff
+  post 'request/changerequest' => :changerequest
+  get 'request/diff/:number' => :diff
+  get 'request/list_small' => :list_small, as: 'request_list_small'
+  post 'request/set_bugowner_request' => :set_bugowner_request
+  get 'request/:number/request_action/:id' => :request_action, as: 'request_action'
+  get 'request/:number/request_action/:request_action_id/changes' => :request_action_changes, as: 'request_action_changes'
+  get 'request/:number/request_action/:request_action_id/details' => :request_action_details, as: 'request_action_details'
+  get 'request/:number/request_action/:request_action_id/inline_comment' => :inline_comment, constraints: cons, as: 'request_inline_comment'
+  get 'request/:number/chart_build_results' => :chart_build_results, as: 'request_chart_build_results', constraints: cons
+  get 'request/:number/complete_build_results' => :complete_build_results, as: 'request_complete_build_results', constraints: cons
+  get 'autocomplete_reviewers' => :autocomplete_reviewers, as: 'autocomplete_reviewers'
+end
+
+resources :requests, only: [], param: :number, controller: 'webui/request' do
+  member do
+    put :toggle_watched_item, controller: 'webui/watched_items'
+    put :toggle, controller: 'webui/action_seen_by_users'
+  end
+end
+
+get 'projects/:project/requests' => 'webui/projects/bs_requests#index', constraints: cons, as: 'projects_requests'
+get 'projects/:project/packages/:package/requests' => 'webui/packages/bs_requests#index', constraints: cons, as: 'packages_requests'
+get 'notification/autocomplete_projects' => 'webui/users/notifications#autocomplete_projects', as: 'notification_autocomplete_projects'
+
+controller 'webui/search' do
+  get 'search' => :index
+  get 'search/owner' => :owner
+  get 'search/issue' => :issue
+end
+
+resources :users, controller: 'webui/users', param: :login, constraints: cons do
+  collection do
+    get 'autocomplete'
+    get 'tokens'
+  end
+  member do
+    put 'censor'
+    post 'change_password'
+    post 'rss_secret'
+    get 'edit_account'
+    post 'update_color_theme'
+  end
+  resource :block, only: %i[create destroy], controller: 'webui/users/block', constraints: cons
+end
+
+scope :my do
+  resources :tasks, only: [:index], controller: 'webui/users/tasks', as: :my_tasks
+  resources :requests, only: [:index], controller: 'webui/users/bs_requests', as: :my_requests
+
+  resources :notifications, only: [:index], controller: 'webui/users/notifications', as: :my_notifications do
+    collection do
+      # We allow updating multiple notifications in a single HTTP request
+      put :update
+      get :count_for_notification_types
+      get :count_for_event_types
+      get :count_for_notification_kinds
+      get :count_for_unread
+    end
+  end
+
+  resources :beta_features, only: [:index], controller: 'webui/users/beta_features', as: :my_beta_features
+  resource :beta_feature, only: [:update], controller: 'webui/users/beta_features', as: :my_beta_feature
+
+  resource :notification, only: [:update], controller: 'webui/users/notifications', as: :my_notification
+
+  resources :subscriptions, only: [:index], controller: 'webui/users/subscriptions', as: :my_subscriptions do
+    collection do
+      put 'update', as: :update
+    end
+  end
+
+  resources :patchinfos, only: [:index], controller: 'webui/users/patchinfos', as: :my_patchinfos
+
+  post 'news_items/:id' => :acknowledge, controller: 'webui/status_messages', as: :acknowledge_news_item
+
+  resources :tokens, controller: 'webui/users/tokens' do
+    resources :workflow_runs, only: %i[index show], controller: 'webui/workflow_runs'
+    resources :users, only: %i[index create destroy], controller: 'webui/users/tokens/users', constraints: cons
+    resources :groups, only: %i[create destroy], controller: 'webui/users/tokens/groups', constraints: cons
+  end
+
+  resources :canned_responses, controller: 'webui/users/canned_responses', only: %i[index create edit update destroy], constraints: cons
+end
+
+get 'home', to: 'webui/webui#home', as: :home
+get 'signup', to: 'webui/users#new', as: :signup
+
+# TODO
+# keep those routes reachable, but remove them later as
+# nobody access it anymore
+# Legacy routes start
+namespace :user do
+  get '/signup', to: redirect('/signup')
+  get '/register_user', to: redirect('/signup')
+  get '/show/:user', to: redirect('/users/%{user}'), constraints: cons
+  get '/autocomplete', to: redirect('/users/autocomplete')
+  get '/tokens', to: redirect('/users/tokens')
+end
+# Legacy routes end
+
+constraints(RoutesHelper::SessionAuthMatcher) do
+  resource :session, only: %i[new create], controller: 'webui/session' do
+    collection do
+      get :reset
+    end
+  end
+end
+
+resources :groups, only: %i[index show new create edit update], param: :title, constraints: cons, controller: 'webui/groups' do
+  resources :user, only: %i[create destroy update], param: :user_login, constraints: cons, controller: 'webui/groups/users'
+  resources :requests, only: [:index], controller: 'webui/groups/bs_requests'
+
+  collection do
+    get :autocomplete
+  end
+end
+
+resources :comments, constraints: cons, only: %i[create destroy update], controller: 'webui/comments' do
+  member do
+    post 'moderate'
+  end
+
+  defaults format: 'js' do
+    get 'history/:version_id' => :history, as: :history
+  end
+
+  collection do
+    post 'preview'
+  end
+end
+
+resources :reports, only: %i[create show], controller: 'webui/reports'
 
 resources :staging_workflows, except: :index, controller: 'webui/staging/workflows', param: :workflow_project, constraints: cons do
   member do

--- a/src/api/config/routes/webui.rb
+++ b/src/api/config/routes/webui.rb
@@ -494,3 +494,9 @@ resource :labels, controller: 'webui/labels', only: %i[update], constraints: con
 end
 
 resources :global_feature_toggles, only: [:index], controller: 'webui/global_feature_toggles'
+
+controller 'webui/sitemaps' do
+  get 'sitemaps' => :index
+  get 'project/sitemap' => :projects
+  get 'package/sitemap(/:project_name)' => :packages
+end


### PR DESCRIPTION
They are easy to miss inside the large webui/api route files as you can see by the amount of routes outside those constraints...

Best reviewed by hiding whitespace. This came up in https://github.com/openSUSE/open-build-service/pull/18989/changes/477e01543c69ccdb888f74fef0a78254693be7cc 