### PR TITLE
Moved the state check inside lock_with block

### DIFF
--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -845,16 +845,16 @@ class BsRequest < ApplicationRecord
   end
 
   def auto_accept
-    # do not run for processed requests. Ignoring review on purpose since this
-    # must also work when people do not react anymore
-    return unless %i[new review].include?(state)
-
-    # use approve mechanic in case you want to wait for reviews
-    return if approver && state == :review
-
-    return unless accept_at || approver
-
     with_lock do
+      # do not run for processed requests. Ignoring review on purpose since this
+      # must also work when people do not react anymore
+      return unless %i[new review].include?(state)
+
+      # use approve mechanic in case you want to wait for reviews
+      return if approver && state == :review
+
+      return unless accept_at || approver
+
       if accept_at
         auto_accept_user = User.find_by!(login: creator)
       elsif approver


### PR DESCRIPTION
hey friends, 

By looking at the logs ,I think `BsRequestAutoAcceptJob` call `auto_accept`  which checks if the state is "**new/review**" but that is outside the lock so by the time it reaches `change_state` , another process can change state to **:accepted** . After which call `change_state` -> `permission_check_change_state!` -> `cmd_changestate_permissions` -> `throw(change state from an accepted state is not allowed)` . 

we can move the check statement inside the lock to avoid racing .

before logs : 
```
open-build-service-frontend-run-fec2812a22be  | created Request #32 with state: new
open-build-service-frontend-run-fec2812a22be  | running auto_accept.. 
open-build-service-frontend-run-fec2812a22be  | changing state to 'accepted' in db directly to simulate race condition
open-build-service-frontend-run-fec2812a22be  | state changed completed.
open-build-service-frontend-run-fec2812a22be  | original state in object is still: :new
open-build-service-frontend-run-fec2812a22be  | changing state to 'accepted' in db directly to simulate race condition
open-build-service-frontend-run-fec2812a22be  | state changed completed.
open-build-service-frontend-run-fec2812a22be  | original state in object is still: :accepted
open-build-service-frontend-run-fec2812a22be  | changing state to 'accepted' in db directly to simulate race condition
open-build-service-frontend-run-fec2812a22be  | state changed completed.
open-build-service-frontend-run-fec2812a22be  | original state in object is still: :accepted
open-build-service-frontend-run-fec2812a22be  | message: change state from an accepted state is not allowed. 
```

After logs : 

```
open-build-service-frontend-run-f1b4c06a7ec8  | created Request #33 with state: new
open-build-service-frontend-run-f1b4c06a7ec8  | running auto_accept.. 
open-build-service-frontend-run-f1b4c06a7ec8  | changing state to 'accepted' in db directly to simulate race condition
open-build-service-frontend-run-f1b4c06a7ec8  | state changed completed.
open-build-service-frontend-run-f1b4c06a7ec8  | original state in object is still: :new
open-build-service-frontend-run-f1b4c06a7ec8  | auto_accept finished without error
```

Fixes : #14689
Hope this helps. Thanks!