### PR TITLE
[api] fork: don't enforce add_repositories always.

### DIFF
--- a/src/api/app/models/branch_package.rb
+++ b/src/api/app/models/branch_package.rb
@@ -147,15 +147,19 @@ class BranchPackage
     end
 
     # add repositories
-    opts = {}
-    opts[:rebuild] = @rebuild_policy if @rebuild_policy
-    opts[:block]   = @block_policy   if @block_policy
-    source_project = Project.get_by_name(params[:project])
-    project.branch_to_repositories_from(source_project, package, opts)
-    project.sync_repository_pathes
-    project.scmsync = @scmsync if params[:package] == '_project'
-    project.store
+    if @add_repositories
+      opts = {}
+      opts[:rebuild] = @rebuild_policy if @rebuild_policy
+      opts[:block]   = @block_policy   if @block_policy
+      source_project = Project.get_by_name(params[:project])
+      project.branch_to_repositories_from(source_project, package, opts)
+      project.sync_repository_pathes
+      project.store
+    end
+
     if params[:package] == '_project'
+      project.scmsync = @scmsync
+      project.store
       return { targetproject: project.name,
                sourceproject: params[:project] }
     end


### PR DESCRIPTION
Do it only when a new project meta got created by the command by default.