### PR TITLE
Update list of crawler user agents

### DIFF
--- a/src/api/config/crawler-user-agents.json
+++ b/src/api/config/crawler-user-agents.json
@@ -3873,6 +3873,23 @@
     "url": "https://developer.amazon.com/support/amazonbot"
   },
   {
+    "pattern": "AmazonProductDiscovery",
+    "addition_date": "2025/12/22",
+    "instances": [
+      "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/110.0.0.0 Safari/537.36 (compatible; AmazonProductDiscovery/1.0; https://vendorcentral.amazon.com/support/amazonproductbot)",
+      "Mozilla/5.0 (X11; Linux x86_64; rv:38.0) Gecko/20100101 Firefox/38.0 (compatible; AmazonProductDiscovery/1.0; https://vendorcentral.amazon.com/support/amazonproductbot)"
+    ],
+    "url": "https://vendorcentral.amazon.com/support/amazonproductbot"
+  },
+  {
+    "pattern": "AmazonSellerInitiatedListing",
+    "addition_date": "2025/12/22",
+    "instances": [
+      "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 (compatible; AmazonSellerInitiatedListing/1.0; https://vendorcentral.amazon.com/support/amazonproductbot)"
+    ],
+    "url": "https://vendorcentral.amazon.com/support/amazonproductbot"
+  },
+  {
     "pattern": "SerendeputyBot",
     "addition_date": "2020/03/02",
     "instances": [
@@ -5173,5 +5190,11 @@
     "instances": [
       "Mozilla/5.0 AppleWebKit/537.36 Chrome/139.0.7258.127 Safari/537.36 Google-Ads-Conversions"
     ]
+  },
+  {
+    "pattern": "ObservePoint",
+    "addition_date": "2025/12/23",
+    "url": "https://help.observepoint.com/en/articles/9101465-allow-exclude-observepoint-traffic#h_2a8176c9b9",
+    "instances": []
   }
 ]


### PR DESCRIPTION
The list was updated using `rake voight_kampff:import_user_agents`.

This is a recurring task. Last time we did it in #18514.