### PR TITLE
Remove bigdecimal from Gemfile

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -75,8 +75,6 @@ gem 'deep_cloneable'
 gem 'ajax-datatables-rails'
 # Add syntax highlight in ruby
 gem 'coderay'
-# required by rails
-gem 'bigdecimal'
 # Catch unsafe migrations in development
 gem 'strong_migrations'
 # for some rails console fancy


### PR DESCRIPTION
BigDecimal is part of Ruby's standard library and is automatically loaded in Ruby 3.1+.

The explicit gem dependency is no longer required.

Seen while reviewing #19034.