### PR TITLE
Fix undefined method 'reports' for nil

### DIFF
--- a/src/api/app/models/report.rb
+++ b/src/api/app/models/report.rb
@@ -39,6 +39,8 @@ class Report < ApplicationRecord
   end
 
   def other_reports_from_reportable
+    return [] unless reportable
+
     reportable.reports - [self]
   end
 

--- a/src/api/spec/models/report_spec.rb
+++ b/src/api/spec/models/report_spec.rb
@@ -27,5 +27,16 @@ RSpec.describe Report do
     let!(:another_report) { create(:report, reportable: comment) }
 
     it { expect(report.other_reports_from_reportable).to contain_exactly(another_report) }
+
+    context 'when reportable is nil' do
+      let(:report) { create(:report) }
+
+      before do
+        report.reportable.destroy
+        report.reload
+      end
+
+      it { expect(report.other_reports_from_reportable).to eq([]) }
+    end
   end
 end


### PR DESCRIPTION
Fixes: #19031 

Hey friends, 

The backtrace logs indicate that the error "undefined method 'reports' for nil" is occurring in Report#other_reports_from_reportable. Because the `reportable` could be nil, which in the next line becomes nil.reports -> CRASH. 

We can avoid it by putting a Guard Clause before it, Which safely return an empty array if reportable is "nil". 

I have also added a test in the respective spec file, and below are the logs. 

Before Guard. 

<img width="1194" height="398" alt="image" src="https://github.com/user-attachments/assets/560ad049-b3b1-4fd7-b006-ecd8fd85cd72" />

After Guard.

<img width="1204" height="285" alt="image" src="https://github.com/user-attachments/assets/4b12e412-c908-46ac-a64c-f8242a66dd05" />



Thanks and Happy New Year! 
in adv