### PR TITLE
Validate category in reports

### DIFF
--- a/docs/api/api/report.rng
+++ b/docs/api/api/report.rng
@@ -33,7 +33,13 @@
       </optional>
       <optional>
         <attribute name="category">
-          <data type="string" />
+          <choice>
+            <value>spam</value>
+            <value>scam</value>
+            <value>forbidden_license</value>
+            <value>illegal_content</value>
+            <value>other</value>
+          </choice>
         </attribute>
       </optional>
       <optional>


### PR DESCRIPTION
Otherwise, an invalid category throws an 500.