### PR TITLE
Fix duplicate ID selector in user involvement section

### DIFF
--- a/src/api/app/assets/stylesheets/webui/collapsible-text.scss
+++ b/src/api/app/assets/stylesheets/webui/collapsible-text.scss
@@ -49,7 +49,7 @@
   @include collapsible($maxHeight: 4.5em);
 }
 
-#involvement-description {
+.involvement-description {
   @include collapsible($maxHeight: 2.75em, $maxWidth: none);
   .obs-collapsible-textbox {  @extend .pe-0; }
 }

--- a/src/api/app/views/webui/user/_involvement.html.haml
+++ b/src/api/app/views/webui/user/_involvement.html.haml
@@ -82,7 +82,7 @@
                   %span.badge.text-bg-info= role.title.capitalize
             .row.mt-1
               .col
-                #involvement-description= render partial: 'webui/shared/collapsible_text', locals: { text: involved_item.description }
+                .involvement-description= render partial: 'webui/shared/collapsible_text', locals: { text: involved_item.description }
 
       = paginate involved_items, window: 2, views_prefix: 'webui'
 - content_for :ready_function do

--- a/src/api/spec/features/webui/users/user_home_page_spec.rb
+++ b/src/api/spec/features/webui/users/user_home_page_spec.rb
@@ -8,6 +8,40 @@ RSpec.describe "User's home project creation", :js do
            email: 'jim.knopf@puppenkiste.com')
   end
 
+  describe 'involved projects/packages section' do
+    let!(:project1) { create(:project, name: 'TestProject1', description: 'First project long description - ' * 50) }
+    let!(:project2) { create(:project, name: 'TestProject2', description: 'Second project long description - ' * 50) }
+    let!(:relationship1) { create(:relationship_project_user, project: project1, user: user) }
+    let!(:relationship2) { create(:relationship_project_user, project: project2, user: user) }
+
+    before do
+      visit user_path(user)
+      find('[data-bs-target="#tab-pane-involvement"]').click if has_css?('[data-bs-target="#tab-pane-involvement"]')
+    end
+
+    it 'shows expandable description with Show more/less for all involved items' do
+      involvement_descriptions = all('.involvement-description')
+      expect(involvement_descriptions.count).to be >= 2
+
+      # Verify both items have the Show more/less functionality (not just the first one)
+      involvement_descriptions.each do |description|
+        within(description) do
+          expect(page).to have_css('.show-content.more')
+        end
+      end
+    end
+
+    it 'expands and collapses description text' do
+      within(first('.involvement-description')) do
+        find('.show-content').click
+        expect(page).to have_css('.obs-collapsible-text.expanded')
+        expect(page).to have_css('.show-content.less')
+        find('.show-content').click
+        expect(page).to have_no_css('.obs-collapsible-text.expanded')
+      end
+    end
+  end
+
   describe 'as an anonymous user' do
     before do
       visit user_path(user)


### PR DESCRIPTION
## Summary
- Changed `#involvement-description` ID selector to `.involvement-description` class selector
- Fixes show more/less functionality working only for the first involvement card
- ID selectors in loops create duplicate IDs which is invalid HTML and causes JavaScript to only target the first element

## Test plan
- [ ] Navigate to a user profile with multiple involvement cards
- [ ] Verify show more/less works on all cards, not just the first one
- [ ] Run the existing RSpec tests

Fixes #13373