### PR TITLE
Improve UI clarity for expandable table rows

### DIFF
--- a/src/api/app/assets/stylesheets/webui/datatables.scss
+++ b/src/api/app/assets/stylesheets/webui/datatables.scss
@@ -33,3 +33,41 @@ table.dataTable.table-sm {
   @extend .d-flex;
   @extend .justify-content-center;
 }
+
+// Enhance visibility of expandable rows in responsive DataTables
+// Fix for issue #15610: Make it clear that attributes can be expanded
+#attributes {
+  // Show visual cue that rows are expandable when in collapsed responsive mode
+  &.dtr-inline.collapsed > tbody > tr > td.dtr-control {
+    // Ensure pointer cursor for clickable rows
+    cursor: pointer;
+
+    // Style the expand icon to be more prominent
+    &:before {
+      font-weight: bold;
+      box-shadow: 0 0 0.3em rgba(0, 0, 0, 0.3);
+    }
+
+    // Add hover effect to indicate interactivity
+    &:hover:before {
+      transform: scale(1.1);
+      box-shadow: 0 0 0.4em rgba(0, 0, 0, 0.4);
+    }
+  }
+
+  // Add hover highlight for entire row when expandable
+  &.dtr-inline.collapsed > tbody > tr:hover {
+    background-color: $custom-gray-100;
+
+    td.dtr-control:before {
+      background-color: darken(#0d6efd, 10%);
+    }
+  }
+
+  // Style for expanded rows (parent class is added when row is expanded)
+  &.dtr-inline.collapsed > tbody > tr.parent > td.dtr-control {
+    &:hover:before {
+      background-color: darken(#d33333, 10%);
+    }
+  }
+}

--- a/src/api/app/views/webui/attribute/index.html.haml
+++ b/src/api/app/views/webui/attribute/index.html.haml
@@ -7,6 +7,9 @@
   .card-body
     %h3= @pagetitle
     - if @attributes.present?
+      %p.text-muted.small.d-md-none.mb-2
+        %i.fas.fa-info-circle.me-1
+        Click on a row to expand and see all details
       %table.responsive.table.table-bordered.table-hover.w-100#attributes
         %thead
           %tr

--- a/src/api/spec/features/webui/attributes_spec.rb
+++ b/src/api/spec/features/webui/attributes_spec.rb
@@ -6,6 +6,24 @@ RSpec.describe 'Attributes', :js do
   # AttribTypes are part of the seeds, so we can reuse them
   let!(:attribute_type) { AttribType.find_by(name: 'ImageTemplates') }
 
+  describe 'expandable row hint' do
+    before do
+      User.session = user
+      create(:attrib, project: user.home_project)
+      User.session = nil
+      login user
+      visit index_attribs_path(project: user.home_project_name)
+    end
+
+    it 'shows expand hint on mobile screens' do
+      if mobile?
+        expect(page).to have_content('Click on a row to expand and see all details')
+      else
+        expect(page).to have_no_content('Click on a row to expand and see all details')
+      end
+    end
+  end
+
   describe 'for a project without packages' do
     it 'add attribute with values' do
       login user


### PR DESCRIPTION
## Summary
- Added visual indicators for expandable rows in DataTables
- Enhanced expand/collapse icon with box shadow
- Hover effect with scale transform
- Mobile hint text for touch users

## Test plan
- [ ] Navigate to attributes page with responsive table
- [ ] Verify expand icon is more visible
- [ ] Test hover effect on expand icon
- [ ] Check mobile hint text on smaller screens

Fixes #15610