### PR TITLE
Add icons to build result status display

### DIFF
--- a/src/api/app/components/buildresult_status_link_component.html.haml
+++ b/src/api/app/components/buildresult_status_link_component.html.haml
@@ -1,5 +1,9 @@
 - if show_link?
-  = link_to(@build_status, package_live_build_log_path(project: @project_name, package: @package_name, repository: @repository_name,
-                                                       arch: @architecture_name), rel: 'nofollow', class: css_class)
+  = link_to(package_live_build_log_path(project: @project_name, package: @package_name, repository: @repository_name,
+                                        arch: @architecture_name), rel: 'nofollow', class: css_class, title: @build_status.to_s.humanize) do
+    %i.fa{ class: status_icon_class }
+    %span.visually-hidden= @build_status
 - else
-  %span{ id: span_id, class: "#{css_class} toggle-build-info", title: 'Click to keep it open' }= @build_status
+  %span{ id: span_id, class: "#{css_class} toggle-build-info", title: @build_status.to_s.humanize }
+    %i.fa{ class: status_icon_class }
+    %span.visually-hidden= @build_status

--- a/src/api/app/components/buildresult_status_link_component.rb
+++ b/src/api/app/components/buildresult_status_link_component.rb
@@ -1,4 +1,6 @@
 class BuildresultStatusLinkComponent < ApplicationComponent
+  include Webui::BuildresultHelper
+
   def initialize(repository_name:, architecture_name:, project_name:, package_name:, build_status:, build_details:)
     super()
 
@@ -23,5 +25,9 @@ class BuildresultStatusLinkComponent < ApplicationComponent
 
   def span_id
     "id-#{@package_name}_#{@repository_name}_#{@architecture_name}"
+  end
+
+  def status_icon_class
+    build_status_icon(@build_status) || 'fa-question'
   end
 end

--- a/src/api/app/views/webui/project/_buildstatus.html.haml
+++ b/src/api/app/views/webui/project/_buildstatus.html.haml
@@ -52,13 +52,14 @@
                 - build_result.summary.each do |status_count|
                   .toggle-build-info-parent.text-nowrap
                     %i.fa.fa-question-circle.text-info.px-2.ps-lg-1.toggle-build-info{ title: 'Click to keep it open' }
-                    = link_to("#{status_count.code}: #{status_count.count}",
-                      { action: :monitor,
+                    = link_to({ action: :monitor,
                         "#{valid_xml_id("repo_#{repository}")}": 1,
                         "arch_#{build_result.architecture}": 1,
                         project: params[:project],
                         "#{status_count.code}": 1,
-                        defaults: 0 }, rel: 'nofollow', class: "nowrap build-state-#{status_count.code}")
+                        defaults: 0 }, rel: 'nofollow', class: "nowrap build-state-#{status_count.code}", title: status_count.code.to_s.humanize) do
+                      %i.fa{ class: build_status_icon(status_count.code) }
+                      %span.ms-1= status_count.count
                   .build-info.p2.mb-2.mt-1.me-sm-3.collapsed
                     .triangle.left
                     .build-info-content


### PR DESCRIPTION
## Summary
- Replace text-based status indicators with icons in build results
- Uses existing STATUS_ICON mapping for consistent iconography
- Adds tooltip with status name for accessibility
- Shows count alongside icon for multiple results

## Test plan
- [ ] Navigate to project build results page
- [ ] Verify icons display correctly for each status
- [ ] Check tooltip shows status name on hover
- [ ] Verify count displays next to icons

Fixes #10790