### PR TITLE
Add end-of-life date field for distributions

### DIFF
--- a/src/api/app/models/distribution.rb
+++ b/src/api/app/models/distribution.rb
@@ -7,6 +7,12 @@ class Distribution < ApplicationRecord
   scope :local, -> { where(remote: false) }
   scope :remote, -> { where(remote: true) }
   scope :for_project, ->(project_name) { where('project like ?', "#{project_name}:%") }
+  scope :not_eol, -> { where(eol: nil).or(where(eol: Date.current..)) }
+  scope :eol, -> { where(eol: ...Date.current) }
+
+  def eol?
+    eol.present? && eol < Date.current
+  end
 
   def self.new_from_xmlhash(xmlhash)
     return new unless xmlhash.is_a?(Xmlhash::XMLHash)

--- a/src/api/app/views/distributions/_distribution.xml.builder
+++ b/src/api/app/views/distributions/_distribution.xml.builder
@@ -4,6 +4,7 @@ builder.distribution(vendor: distribution.vendor, version: distribution.version,
   builder.reponame(distribution.reponame)
   builder.repository(distribution.repository)
   builder.link(distribution.link)
+  builder.eol(distribution.eol) if distribution.eol.present?
   distribution.icons.each do |icon|
     attr = { url: icon.url }
     attr[:width] = icon.width if icon.width.present?

--- a/src/api/app/views/webui/distributions/_variant.html.haml
+++ b/src/api/app/views/webui/distributions/_variant.html.haml
@@ -6,6 +6,11 @@
   = hidden_field_tag 'distribution', variant.id
   %label.form-check-label{ for: "distribution-#{variant.id}-checkbox" }
     = variant.name
+    - if variant.eol?
+      %span.badge.text-bg-secondary.ms-1{ title: "End of life: #{variant.eol}" } EOL
+    - elsif variant.eol.present?
+      %span.badge.text-bg-info.ms-1{ title: "End of life: #{variant.eol}" }
+        EOL: #{variant.eol.strftime('%b %Y')}
   %i.fa.fa-spinner.fa-spin.d-none{ id: "distribution-#{variant.id}-spinner" }
   %i.fa.fa-check.text-success.d-none{ id: "distribution-#{variant.id}-success" }
   %i.fa.fa-times.text-danger.d-none{ id: "distribution-#{variant.id}-fail" }

--- a/src/api/db/migrate/20251231120000_add_eol_to_distributions.rb
+++ b/src/api/db/migrate/20251231120000_add_eol_to_distributions.rb
@@ -1,0 +1,5 @@
+class AddEolToDistributions < ActiveRecord::Migration[7.0]
+  def change
+    add_column :distributions, :eol, :date
+  end
+end

--- a/src/api/public/apidocs/components/schemas/distribution.yaml
+++ b/src/api/public/apidocs/components/schemas/distribution.yaml
@@ -30,6 +30,11 @@ properties:
   link:
     type: string
     example: 'http://www.opensuse.org/'
+  eol:
+    type: string
+    format: date
+    example: '2025-12-31'
+    description: End of life date for the distribution
   architecture:
     type: array
     example:


### PR DESCRIPTION
## Summary
- Add eol column to distributions table via migration
- Add not_eol and eol scopes for filtering distributions
- Add eol? helper method to check EOL status
- Display EOL badge in distributions view
- Update API documentation with eol field

## Test plan
- [ ] Run migration: `rails db:migrate`
- [ ] Create a distribution with EOL date via API
- [ ] Verify EOL badge displays for expired distributions
- [ ] Test not_eol and eol scopes work correctly

Fixes #12288