### PR TITLE
Add PUT endpoint to update comments via API

### DIFF
--- a/src/api/app/controllers/comments_controller.rb
+++ b/src/api/app/controllers/comments_controller.rb
@@ -14,6 +14,13 @@ class CommentsController < ApplicationController
     render_ok
   end
 
+  def update
+    comment = Comment.find(params[:id])
+    authorize comment, :update?
+    comment.update!(body: request.raw_post)
+    render_ok
+  end
+
   def destroy
     comment = Comment.find(params[:id])
     authorize comment, :destroy?

--- a/src/api/config/routes/api.rb
+++ b/src/api/config/routes/api.rb
@@ -384,7 +384,7 @@ defaults format: 'xml' do
     post 'comments/project/:project' => :create, constraints: cons, as: :create_project_comment
     get 'comments/user' => :index, constraints: cons, as: :comments_user
     get 'comment/:id/history' => :history, constraints: cons
-
+    put 'comment/:id' => :update, constraints: cons, as: :comment_update
     delete 'comment/:id' => :destroy, constraints: cons, as: :comment_delete
   end
 end

--- a/src/api/public/apidocs/paths/comment_comment_id.yaml
+++ b/src/api/public/apidocs/paths/comment_comment_id.yaml
@@ -1,3 +1,49 @@
+put:
+  summary: Update a comment
+  description: Update a given comment based on its id. Only the comment author can update their own comment.
+  security:
+    - basic_authentication: []
+  parameters:
+    - in: path
+      name: comment_id
+      schema:
+        type: integer
+      required: true
+      description: Id of the comment.
+      example: 1124
+  requestBody:
+    description: The new comment body text
+    required: true
+    content:
+      text/plain:
+        schema:
+          type: string
+        example: Updated comment text
+  responses:
+    '200':
+      $ref: '../components/responses/succeeded.yaml'
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '403':
+      description: 'Forbidden'
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          example:
+            code: update_comment_not_authorized
+            summary: Sorry, you are not authorized to update this comment
+    '404':
+      description: Not Found
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          example:
+            code: not_found
+            summary: Couldn't find Comment with id '1124'
+  tags:
+    - Comments
 delete:
   summary: Delete a comment
   description: Delete a given comment based on its id.


### PR DESCRIPTION
## Summary
- Add PUT route for comment/:id endpoint
- Add update action in CommentsController
- Uses existing CommentPolicy#update? for authorization
- Update API documentation with PUT endpoint specification

## Test plan
- [ ] Test updating a comment via API: `PUT /comment/:id`
- [ ] Verify only comment author can update their own comment
- [ ] Check 403 response for unauthorized users
- [ ] Verify API documentation is accurate

Fixes #10178