### PR TITLE
Add rich syntax-highlighted diffs in email notifications

### DIFF
--- a/src/api/app/helpers/application_helper.rb
+++ b/src/api/app/helpers/application_helper.rb
@@ -3,4 +3,12 @@ module ApplicationHelper
   def render_diff(content, file_index:)
     sanitize(CodeRay.scan(content, :diff).div(css: :class, line_numbers: :inline, line_number_anchors: "diff_#{file_index}_n"))
   end
+
+  # Render diff with inline CSS for HTML emails (email clients don't support external stylesheets)
+  def render_email_diff(content)
+    return '' if content.blank?
+
+    # Use CodeRay with inline styles for email compatibility
+    sanitize(CodeRay.scan(content, :diff).div(css: :style, line_numbers: false))
+  end
 end

--- a/src/api/app/views/event_mailer/_actions.html.haml
+++ b/src/api/app/views/event_mailer/_actions.html.haml
@@ -1,0 +1,6 @@
+%h4 Actions:
+- event['actions'].each do |a|
+  - if %w(submit maintenance_incident maintenance_release release).include?(a['type'])
+    = render partial: 'event_mailer/submit_action', formats: [:html], locals: { a: a }
+  - else
+    = render partial: "event_mailer/#{a['type']}_action", formats: [:html], locals: { a: a }

--- a/src/api/app/views/event_mailer/_add_role_action.html.haml
+++ b/src/api/app/views/event_mailer/_add_role_action.html.haml
@@ -1,0 +1,6 @@
+%div{ style: 'margin-bottom: 1em; padding: 0.5em; background-color: #f5f5f5; border-left: 3px solid #28a745;' }
+  %strong add_role
+  - if a['group'].blank?
+    #{a['person']} wants to be #{a['role']} in #{project_or_package_text(a['targetproject'], a['targetpackage'])}
+  - else
+    Group #{a['group']} wants to be #{a['role']} in #{project_or_package_text(a['targetproject'], a['targetpackage'])}

--- a/src/api/app/views/event_mailer/_change_devel_action.html.haml
+++ b/src/api/app/views/event_mailer/_change_devel_action.html.haml
@@ -1,0 +1,3 @@
+%div{ style: 'margin-bottom: 1em; padding: 0.5em; background-color: #f5f5f5; border-left: 3px solid #17a2b8;' }
+  %strong change_devel
+  = "#{a['targetproject']}/#{a['targetpackage']} => #{a['sourceproject']}/#{a['sourcepackage']}"

--- a/src/api/app/views/event_mailer/_delete_action.html.haml
+++ b/src/api/app/views/event_mailer/_delete_action.html.haml
@@ -1,0 +1,6 @@
+%div{ style: 'margin-bottom: 1em; padding: 0.5em; background-color: #f5f5f5; border-left: 3px solid #dc3545;' }
+  %strong delete
+  - if a['targetrepository'].present?
+    repository #{a['targetrepository']} in #{a['targetproject']}
+  - else
+    = project_or_package_text(a['targetproject'], a['targetpackage'])

--- a/src/api/app/views/event_mailer/_group_action.html.haml
+++ b/src/api/app/views/event_mailer/_group_action.html.haml
@@ -1,0 +1,2 @@
+%div{ style: 'margin-bottom: 1em; padding: 0.5em; background-color: #f5f5f5; border-left: 3px solid #6c757d;' }
+  = a.inspect

--- a/src/api/app/views/event_mailer/_set_bugowner_action.html.haml
+++ b/src/api/app/views/event_mailer/_set_bugowner_action.html.haml
@@ -1,0 +1,6 @@
+%div{ style: 'margin-bottom: 1em; padding: 0.5em; background-color: #f5f5f5; border-left: 3px solid #ffc107;' }
+  %strong set_bugowner
+  - if a['group'].blank?
+    set the bugowner of #{project_or_package_text(a['targetproject'], a['targetpackage'])} to #{a['person']}
+  - else
+    set the bugowner of #{project_or_package_text(a['targetproject'], a['targetpackage'])} to group #{a['group']}

--- a/src/api/app/views/event_mailer/_submit_action.html.haml
+++ b/src/api/app/views/event_mailer/_submit_action.html.haml
@@ -1,0 +1,7 @@
+%div{ style: 'margin-bottom: 1em; padding: 0.5em; background-color: #f5f5f5; border-left: 3px solid #007bff;' }
+  %strong= a['type']
+  = "#{a['sourceproject']}/#{a['sourcepackage']} => #{a['targetproject']}/#{a['targetpackage']}"
+
+- if a['diff'].present?
+  %div{ style: 'margin-top: 0.5em; font-family: monospace; font-size: 12px; overflow-x: auto;' }
+    = render_email_diff(a['diff'])

--- a/src/api/app/views/event_mailer/request_create.html.haml
+++ b/src/api/app/views/event_mailer/request_create.html.haml
@@ -1,0 +1,29 @@
+%p
+  = link_to 'View Request', url_for(controller: 'webui/request', action: :show, number: event['number'], host: @host, only_path: false)
+
+- if event['description'].present?
+  %h4 Description:
+  %p= event['description']
+
+= render partial: 'event_mailer/actions', formats: [:html], locals: { event: event }
+
+%h4 Command Line Options:
+%p
+  %strong To REVIEW against the previous version:
+  %br/
+  %code osc request show --diff #{event['number']}
+
+%p
+  %strong To ACCEPT the request:
+  %br/
+  %code osc request accept #{event['number']} --message="reviewed ok."
+
+%p
+  %strong To DECLINE the request:
+  %br/
+  %code osc request decline #{event['number']} --message="declined for reason xyz (see ... for background / policy / ...)."
+
+%p
+  %strong To REVOKE the request:
+  %br/
+  %code osc request revoke #{event['number']} --message="retracted because ..., sorry / thx / see better version ..."

--- a/src/api/app/views/event_mailer/request_statechange.html.haml
+++ b/src/api/app/views/event_mailer/request_statechange.html.haml
@@ -1,0 +1,20 @@
+%p
+  = link_to 'View Request', url_for(controller: 'webui/request', action: :show, number: event['number'], host: @host, only_path: false)
+
+%p
+  State of request
+  %strong= event['number']
+  was changed by
+  %strong= event['who']
+  \:
+
+%p{ style: 'padding: 0.5em; background-color: #f8f9fa; border-radius: 4px;' }
+  %span{ style: 'color: #6c757d;' }= event['oldstate']
+  = '→'
+  %span{ style: 'font-weight: bold; color: #007bff;' }= event['state']
+
+- if event['comment'].present?
+  %h4 Comment:
+  %p= event['comment']
+
+= render partial: 'event_mailer/actions', formats: [:html], locals: { event: event }

--- a/src/api/app/views/event_mailer/review_wanted.html.haml
+++ b/src/api/app/views/event_mailer/review_wanted.html.haml
@@ -1,0 +1,26 @@
+- bystring = if event['by_user']
+-   "by user #{event['by_user']}"
+- elsif event['by_group']
+-   "by group #{event['by_group']}"
+- elsif event['by_package']
+-   "by package maintainers of #{event['by_project']}/#{event['by_package']}"
+- else
+-   "by project maintainers of #{event['by_project']}"
+
+%p
+  Request
+  %strong= event['number']
+  (by #{event['author']}) requires a review #{bystring}
+
+%p
+  = link_to 'View Request', url_for(controller: 'webui/request', action: :show, number: event['number'], host: @host, only_path: false)
+
+- if event['comment'].present?
+  %h4
+    Review reason set by #{event['who']}:
+  %p= event['comment']
+
+%h4 Request description:
+%p= event['description']
+
+= render partial: 'event_mailer/actions', formats: [:html], locals: { event: event }


### PR DESCRIPTION
## Summary
- Add render_email_diff helper using CodeRay with inline styles for email compatibility
- Create HTML templates for request_create, request_statechange, review_wanted emails
- Create HTML action partials for submit, delete, add_role, change_devel, set_bugowner, group actions
- Email clients now display syntax-highlighted diffs instead of plain text

## Test plan
- [ ] Trigger a request creation email notification
- [ ] Verify HTML email contains syntax-highlighted diff
- [ ] Test in multiple email clients (Gmail, Outlook, etc.)
- [ ] Verify plain text fallback still works

Fixes #14695