### PR TITLE
Relax check for invalid external report bug URL

### DIFF
--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -1411,7 +1411,7 @@ class Package < ApplicationRecord
     # detected as Generic protocol and the detection of the fragments is a
     # bit... weird.
     if parsed_report_bug_url.is_a?(URI::Generic)
-      errors.add(:report_bug_url, 'Local urls are not allowed') if parsed_report_bug_url.path&.starts_with?('/')
+      errors.add(:report_bug_url, 'Local urls are not allowed') if parsed_report_bug_url.host.blank? && parsed_report_bug_url.path&.starts_with?('/')
       # urls like localhost:3000 have no path and no host, and the schema is 'localhost'
       errors.add(:report_bug_url, 'Local urls are not allowed') if parsed_report_bug_url.scheme == parsed_instance_url.host
     elsif parsed_report_bug_url == parsed_instance_url

--- a/src/api/spec/models/package_spec.rb
+++ b/src/api/spec/models/package_spec.rb
@@ -817,6 +817,12 @@ RSpec.describe Package, :vcr do
       it { expect(package.errors).to be_empty }
     end
 
+    context 'url is external and has a path' do
+      let(:package) { build(:package, report_bug_url: 'https://example.com/issues') }
+
+      it { expect(package.errors).to be_empty }
+    end
+
     context 'url is relative' do
       let(:package) { build(:package, report_bug_url: '/about') }
 


### PR DESCRIPTION
After these changes, URLs with an external host and also with a path are marked as valid.

Fix #18715.