### PR TITLE
[backend] bs_repserver: set signflavor in copybuild

### DIFF
--- a/src/backend/bs_repserver
+++ b/src/backend/bs_repserver
@@ -2799,6 +2799,7 @@ sub copybuild {
   }
 
   # and emit signals to signer or scheduler
+  $needsign = 0 unless $BSConfig::sign && $cgi->{'resign'};
   my $info = {
     'project' => $projid,
     'repository' => $repoid,
@@ -2807,9 +2808,10 @@ sub copybuild {
     'job' => $job,
     'file' => '_aggregate',	# HACK: makes signer remove old signatures
   };
+  $info->{'signflavor'} = '_unknown' if $needsign && $BSConfig::sign_flavor;
   writexml("$jobsdir/$arch/.$job", "$jobsdir/$arch/$job", $info, $BSXML::buildinfo);
   my $ev = {'type' => 'uploadbuild', 'arch' => $arch, 'job' => $job};
-  if ($BSConfig::sign && $cgi->{'resign'} && $needsign) {
+  if ($needsign) {
     $jobstatus->{'code'} = 'signing';
     writexml("$jobsdir/$arch/.$job:status", "$jobsdir/$arch/$job:status", $jobstatus, $BSXML::jobstatus);
     $arch = 'signer';

--- a/src/backend/bs_signer
+++ b/src/backend/bs_signer
@@ -774,6 +774,17 @@ sub getsignkey {
   return ($algo, $signkey, $pubkey, $cert);
 }
 
+sub getsignflavor {
+  my ($projid, $repoid, $arch) = @_;
+  my $param = {
+    'uri' => "$BSConfig::srcserver/getconfig",
+    'timeout' => 300,
+  };
+  my $config = BSRPC::rpc($param, undef, "project=$projid", "repository=$repoid");
+  my $bconf = Build::read_config($arch, [ split("\n", $config) ]);
+  return $bconf->{'buildflags:signflavor'};
+}
+
 sub setsigntype {
   my ($signargs, $signtype) = @_;
   return unless $BSConfig::sign_type;
@@ -870,6 +881,10 @@ sub signjob {
   }
   if (@signfiles) {
     my $signflavor;
+    if (($info->{'signflavor'} || '') eq '_unknown') {
+      $info->{'signflavor'} = getsignflavor($info->{'project'}, $info->{'repository'}, $info->{'arch'});
+      delete $info->{'signflavor'} unless $info->{'signflavor'};
+    }
     if (($info->{'signflavor'} || '') eq '_buildenv') {
       # take the signflavor from the generated _buildenv file
       my $buildenv = readxml("$jobdir/_buildenv", $BSXML::buildinfo);


### PR DESCRIPTION
We set the signflavor to '_unknown' and let the signer get the correct value.