### PR TITLE
Fix delete confirmation modal initialization across views

### DIFF
--- a/src/api/app/assets/javascripts/webui/delete_confirmation_dialog.js
+++ b/src/api/app/assets/javascripts/webui/delete_confirmation_dialog.js
@@ -1,42 +1,27 @@
-/* exported collectDeleteConfirmationModalsAndSetValues */
+document.addEventListener("turbo:load", function () {
+  $(document).on('show.bs.modal', '.modal[id^="delete"]', function (event) {
+    const link = $(event.relatedTarget);
+    const modal = $(this);
 
-function collectDeleteConfirmationModalsAndSetValues() {
-  $.each(modalIds(), function( _index, modalId ) {
-    setValuesOnDeleteConfirmationDialog(modalId);
-  });
-}
-
-function modalIds() {
-  var targets = $('a[data-bs-toggle="modal"][data-bs-target^="#delete"]').toArray().map(
-    function(e) { return $(e).data('bs-target');
-  });
-
-  return $.unique(targets);
-}
-
-function setValuesOnDeleteConfirmationDialog(modalId) {
-  $(modalId).on('show.bs.modal', function (event) {
-    var link = $(event.relatedTarget);
-    var modal = $(this);
-
-    if (typeof(link.data('modal-title')) !== 'undefined') {
+    if (link.data('modal-title') !== undefined) {
       modal.find('.modal-title').text(link.data('modal-title'));
     }
 
-    if (typeof(link.data('confirmation-text')) !== 'undefined') {
+    if (link.data('confirmation-text') !== undefined) {
       modal.find('.confirmation-text').text(link.data('confirmation-text'));
     }
 
-    if (typeof(link.data('action')) !== 'undefined') {
+    if (link.data('action') !== undefined) {
       modal.find('form').attr('action', link.data('action'));
     }
 
-    if (typeof(link.data('method')) !== 'undefined') {
-      modal.find('form').attr('action', link.data('method'));
+    if (link.data('method') !== undefined) {
+      modal.find('form').attr('method', link.data('method'));
     }
 
-    if (typeof(link.data('remote')) !== 'undefined') {
-      modal.find('form').attr('action', link.data('remote'));
+    if (link.data('remote') !== undefined) {
+      modal.find('form').data('remote', link.data('remote'));
     }
   });
-}
+});
+

--- a/src/api/app/components/delete_confirmation_dialog_component.html.haml
+++ b/src/api/app/components/delete_confirmation_dialog_component.html.haml
@@ -12,8 +12,3 @@
             %a.btn.btn-sm.btn-outline-secondary.px-4{ data: { 'bs-dismiss': 'modal' } }
               Cancel
             = submit_tag('Remove', class: 'btn btn-sm btn-danger px-4')
-
-:javascript
-  $(document).ready(function() {
-    collectDeleteConfirmationModalsAndSetValues();
-  });

--- a/src/api/app/views/webui/comment/beta/_comments_thread.html.haml
+++ b/src/api/app/views/webui/comment/beta/_comments_thread.html.haml
@@ -1,4 +1,1 @@
 = render(BsRequestCommentComponent.new(comment: comment.root, level: 1, commentable: commentable, diff: defined?(diff) ? diff : nil ))
-
-:javascript
-  collectDeleteConfirmationModalsAndSetValues();

--- a/src/api/app/views/webui/watched_items/toggle_watched_item.js.erb
+++ b/src/api/app/views/webui/watched_items/toggle_watched_item.js.erb
@@ -3,4 +3,3 @@ $('#flash').html("<%= escape_javascript(render(partial: 'layouts/webui/flash'))%
 $('.watchlist-collapse').html("<%= escape_javascript(render WatchlistComponent.new(user: User.session, bs_request: @bs_request, package: @package, project: @project, current_object: @current_object, bs_requests: @watched_requests, packages: @watched_packages, projects: @watched_projects)) %>");
 $('#watchlist-icon-wrapper').html("<%= escape_javascript(render WatchlistIconComponent.new(user: User.session, bs_request: @bs_request, package: @package, project: @project, current_object: @current_object)) %>");
 
-collectDeleteConfirmationModalsAndSetValues();


### PR DESCRIPTION
This PR fixes an issue where diff comments could not be deleted due to inconsistent initialization of the delete confirmation modal across views.