### PR TITLE
Clear draft comment after cancel

### DIFF
--- a/src/api/app/assets/javascripts/webui/comment.js
+++ b/src/api/app/assets/javascripts/webui/comment.js
@@ -198,13 +198,43 @@ function draftComments(formId) { // jshint ignore:line
 
 $(document).on('click', '.cancel-comment', function() {
   var formId = $(this).closest('form').attr('id');
-  sessionStorage.removeItem(formId); // clear session
+  clearDraftCommentFromSession(formId);
 });
 
-function clearDraftCommentFromSession(event) { // jshint ignore:line
-  var form = event.target;
-  var formId = form.id;
-  sessionStorage.removeItem(formId);
+// Returns the sessionStorage key or null. Examples of returned values:
+//   - new_comment_diff_0_n1_form
+//   - BsRequestActionSubmit_70_0_1
+//   - null
+function sessionStorageKey(formId) {
+  if (sessionStorage.getItem(formId) !== null) {
+    return formId;
+  }
+
+  let commentForm = document.getElementById(formId);
+  if (!commentForm) return null;
+  var commentableType = commentForm.querySelector('[name="commentable_type"]').value;
+  var commentableId = commentForm.querySelector('[name="commentable_id"]').value;
+  var diffFileIndex;
+  var diffLineNumber;
+  if (commentForm.querySelector('[name="comment[diff_file_index]"]')) {
+    diffFileIndex = commentForm.querySelector('[name="comment[diff_file_index]"]').value;
+  }
+
+  if (commentForm.querySelector('[name="comment[diff_line_number]"]')) {
+    diffLineNumber = commentForm.querySelector('[name="comment[diff_line_number]"]').value;
+  }
+
+  var compositeKey = `${commentableType}_${commentableId}_${diffFileIndex}_${diffLineNumber}`;
+  return sessionStorage.getItem(compositeKey) !== null ? compositeKey : null;
+}
+
+// Removes the sessionStorage key-value pair
+function clearDraftCommentFromSession(formId) {
+  var key = sessionStorageKey(formId);
+
+  if (key !== null && key !== undefined) {
+    sessionStorage.removeItem(key);
+  }
 }
 
 function openInlineCommentFormWithDraftAvailable(commentableType, commentableId) { // jshint ignore:line

--- a/src/api/app/views/webui/comment/_comment_field.html.haml
+++ b/src/api/app/views/webui/comment/_comment_field.html.haml
@@ -1,5 +1,5 @@
 = form_for(comment, method: form_method, remote: true,
-           html: { id: "#{element_suffix}_form", class: "#{form_method}-comment-form", onsubmit: "clearDraftCommentFromSession(event)" },
+           html: { id: "#{element_suffix}_form", class: "#{form_method}-comment-form", onsubmit: "clearDraftCommentFromSession(event.target.id)" },
            data: { turbo_frame: "_top" }) do |f|
   = hidden_field_tag :commentable_type, commentable.class.name, { id: "#{element_suffix}_commentable_type" }
   = hidden_field_tag :commentable_id, commentable.id, { id: "#{element_suffix}_commentable_id" }

--- a/src/api/app/views/webui/request/inline_comment.js.erb
+++ b/src/api/app/views/webui/request/inline_comment.js.erb
@@ -2,5 +2,6 @@ $('#flash').empty();
 $('#comment<%= @line %> .diff-comments').html("<%= escape_javascript(render(partial: 'webui/request/inline_comment', locals: { comment: @comment, commentable: @action, diff_ref: @line, file_index: @file_index, line_number: @line_number, source_rev: @source_rev, target_rev: @target_rev })) %>");
 $("#comment<%= @line %> .diff-comments textarea").focus();
 $("#comment<%= @line %>").on('click', '#new_comment_<%= @line %>_form .cancel-comment', function (e) {
+  clearDraftCommentFromSession('new_comment_<%= @line %>_form');
   $('#comment<%= @line %> .diff-comments').html("<%= escape_javascript(render(partial: 'webui/request/add_inline_comment', locals: { commentable: @action, diff_file_index: @file_index, diff_line_number: @line_number, source_rev: @source_rev, target_rev: @target_rev })) %>");
 });


### PR DESCRIPTION
Fixes: https://github.com/openSUSE/open-build-service/issues/18775

We keep the text of a comment even if the users move through the tabs or refresh the page to allow the users to continue with the comment later on.

However, if the users click on Cancel there is a clear intention to abandon what they where doing so we don't have to keep the comment anymore.

I left some inline clarifications. The main problem is that we searched the sessionStorage key by form id but sometimes the key was something else. 

## Testing Tips

Find a request with changes and type comments and cancel them on the Conversation and on the Changes tab. After refreshing the draft comment will no longer be there.