### PR TITLE
Fix Flags validation crash when flags key is missing or nil

### DIFF
--- a/src/api/app/models/workflow/step/set_flags.rb
+++ b/src/api/app/models/workflow/step/set_flags.rb
@@ -50,6 +50,7 @@ class Workflow::Step::SetFlags < Workflow::Step
   end
 
   def validate_flags
+    return if flags.blank?
     return if flags.all? { |flag| (REQUIRED_FLAG_KEYS - flag.keys).empty? }
 
     required_flag_keys_sentence ||= REQUIRED_FLAG_KEYS.map { |key| "'#{key}'" }.to_sentence

--- a/src/api/spec/models/workflow/step/set_flags_step_spec.rb
+++ b/src/api/spec/models/workflow/step/set_flags_step_spec.rb
@@ -196,6 +196,28 @@ RSpec.describe Workflow::Step::SetFlags do
     let(:hook_event) { 'Push Hook' }
     let(:scm_vendor) { 'gitlab' }
 
+    context 'when flags key is missing' do
+      let(:step_instructions) do
+        {}
+      end
+
+      it 'gives an error for missing flags key' do
+        expect(subject).not_to be_valid
+        expect(subject.errors.full_messages.to_sentence).to include("The 'flags' key is missing")
+      end
+    end
+
+    context 'when flags is nil' do
+      let(:step_instructions) do
+        { flags: nil }
+      end
+
+      it 'gives an error for nil flags' do
+        expect(subject).not_to be_valid
+        expect(subject.errors.full_messages.to_sentence).to include("The 'flags' key must provide a value")
+      end
+    end
+
     context 'when a flag is missing a key' do
       let(:step_instructions) do
         {


### PR DESCRIPTION
Fixes: #19069 

Hey friends, 

The error `undefined method 'all?' for nil` is caused when flags is `nil` and `flags.all?` is called. This happens because Rails validations don't short-circuit. The parent class` Workflow::Step` has a validation that checks for required keys and adds an error when flags is missing. However, Rails runs all validations regardless of whether previous ones have added errors. So validate_flags still executes and crashes.

To fix this, I added a guard clause to return early if flags is blank.

Before: 
<img width="1073" height="245" alt="image" src="https://github.com/user-attachments/assets/174a6fa8-e1fb-4dd3-b814-bcf15f83971c" />

After: 
<img width="1073" height="203" alt="image" src="https://github.com/user-attachments/assets/dc2813e6-20b4-4e1a-af84-1a2c22f0217d" />

