### PR TITLE
Fix NoMethodError in field_with_errors when form elements lack class attribute

### DIFF
--- a/src/api/config/initializers/field_with_errors.rb
+++ b/src/api/config/initializers/field_with_errors.rb
@@ -2,7 +2,13 @@
 # This snippet replaces the wrapping with that class with an injection of .is-invalid class, which is bootstrap compatible.
 ActionView::Base.field_error_proc = proc do |html|
   frag = Nokogiri::HTML5::DocumentFragment.parse(html)
-  klass = frag.children[0].attributes['class']
-  frag.children[0].attributes['class'].value = [klass, 'is-invalid'].join(' ')
+  element = frag.children[0]
+
+  if element.attributes['class']
+    element.attributes['class'].value = [element.attributes['class'], 'is-invalid'].join(' ')
+  else
+    element['class'] = 'is-invalid'
+  end
+
   frag.to_html.html_safe # rubocop:disable Rails/OutputSafety -- The input is code from our views, so it's safe to disable this
 end


### PR DESCRIPTION
Fixes: #18012 

Hey Friends, 

Looking at the logs, the User submits an empty form in which all fields (`title`, `content`, `decision_type`) are empty strings. Validation fails on the `CannedResponsesController#create`. Then Controller renders `:index` (line 27), which re-renders the form with validation errors. Rails wraps error fields, for each field with errors, Rails calls `ActionView::Base.field_error_proc`

The bug occurs on lines 5-6 of `field_with_errors.rb` because it assumes `frag.children[0].attributes['class']` always exists, but some form elements ( like `<label>` tags ) may not have a class attribute, making it `nil`. Then calling `.value = ` on `nil` throws the error.

To fix it, I added a check before modifying the class attribute, so 

- If the element has a `class` attribute → append `is-invalid` to existing classes. 
- Else create the attribute with `is-invalid`.

Before:
<img width="1198" height="317" alt="image" src="https://github.com/user-attachments/assets/fa50695f-f60a-47f8-a2eb-2b4ed1fa50ed" />

After: 
<img width="1206" height="205" alt="image" src="https://github.com/user-attachments/assets/62d9c42c-f178-42ce-8cb1-fddd1beb374e" />

Thanks!


