### PR TITLE
Prevent crash on blame of non-UTF-8 files

### DIFF
--- a/src/api/app/controllers/webui/packages/files_controller.rb
+++ b/src/api/app/controllers/webui/packages/files_controller.rb
@@ -133,6 +133,10 @@ module Webui
         @blame_info = blame_parsed.slice_when { |a, b| a['revision'] != b['revision'] }.to_a
         @rev = params[:rev] || revision_numbers.max
         @expand = params[:expand]
+      rescue ArgumentError
+        flash[:error] = "Unable to display blame for file '#{@filename}' because it contains invalid UTF-8 characters."
+
+        redirect_to package_show_path(project: @project, package: @package)
       end
 
       private


### PR DESCRIPTION
Rescue `ArgumentError` when parsing files with invalid byte sequences to prevent the application from crashing.

Instead of throwing a 500 error, we now catch the exception and display a user-friendly message.

After the changes of this PR, a message like this is shown:

<img width="773" height="121" alt="Screenshot From 2026-01-14 14-55-44" src="https://github.com/user-attachments/assets/8dcc8b25-a863-48a3-9ab7-616bc050a20e" />

Fix #18930.