### PR TITLE
Consider multibuild flavor of package when deleting binaries

### DIFF
--- a/src/api/app/views/webui/packages/binaries/index.html.haml
+++ b/src/api/app/views/webui/packages/binaries/index.html.haml
@@ -18,7 +18,7 @@
                                                          options: { modal_title: 'Delete all built binaries?',
                                                                     confirmation_text: 'Please confirm deletion of all built binaries',
                                                                     action: project_package_repository_binaries_path(project_name: @project,
-                                                                                                                     package_name: @package,
+                                                                                                                     package_name: @package_name,
                                                                                                                      repository_name: @repository) })
           = render DeleteConfirmationDialogComponent.new(modal_id: 'delete-binaries-modal',
                                                          method: :delete,


### PR DESCRIPTION
Deleting the binaries through the webui doesn't work for the binaries of a package with a multibuild flavor, since the package name without the flavor is passed to the controller and the backend call in the end.

We have to pass the `@package_name` variable which includes the flavor over the `@package` object which does not.

How to reproduce this:

1. Create a package with a multibuild flavor
2. Let the binaries built
3. Go to the binaries path for one of the flavors (e.g "projects/test/packages/hello:bar/repositories/openSUSE_Tumbleweed/binaries")
4. Click the "Delete all built binaries" link and confirm the deletion modal
5. See how it deletes the binaries for the package without the multibuild flavor and redirecting you to the page of those.
6. Go back to the binaries of the package including the multibuild flavor name and see them still appearing.

<img width="1180" height="682" alt="image" src="https://github.com/user-attachments/assets/7458a388-7a83-4e44-bdeb-ad920a5441bf" />
