### PR TITLE
Add `obscpio` to the extensions recognized as binary by Marcel

### DIFF
--- a/src/api/config/initializers/marcel.rb
+++ b/src/api/config/initializers/marcel.rb
@@ -8,3 +8,4 @@ Marcel::MimeType.extend "application/x-tarz", parents: "application/x-compress",
 Marcel::MimeType.extend "application/x-lzma-compressed-tar", parents: "application/x-lzma", extensions: %w[tlz]
 Marcel::MimeType.extend "application/zstd", extensions: %w[zst]
 Marcel::MimeType.extend "application/vnd.microsoft.portable-executable", extensions: %w[efi]
+Marcel::MimeType.extend "application/x-cpio", extensions: %w[obscpio]

--- a/src/api/spec/helpers/webui/package_helper_spec.rb
+++ b/src/api/spec/helpers/webui/package_helper_spec.rb
@@ -278,6 +278,7 @@ RSpec.describe Webui::PackageHelper do
     it { expect(binary_file?('hzeml5OTc2e.taz')).to be(true) }
     it { expect(binary_file?('WZ6OTdneXJqa.tlz')).to be(true) }
     it { expect(binary_file?('shim-opensuse.x86.efi')).to be(true) }
+    it { expect(binary_file?('build.specials.obscpio')).to be(true) }
     it { expect(binary_file?('3c0ZWdha.diff')).to be(false) }
     it { expect(binary_file?('GpyNWpoc.txt')).to be(false) }
     it { expect(binary_file?('0ZLREpoCg.csv')).to be(false) }


### PR DESCRIPTION
Prevent the blame icon from appearing on file lines where the file has the .obscpio extension.

Fix #18078.

Follow up to #19108.