### PR TITLE
Validate length of `scm_token` field for Workflow tokens

### DIFF
--- a/src/api/app/models/token.rb
+++ b/src/api/app/models/token.rb
@@ -15,6 +15,7 @@ class Token < ApplicationRecord
   validates :enabled, inclusion: { in: [true, false], message: "must be 'true' or 'false'." }
   validates :string, uniqueness: { case_sensitive: false }
   validates :scm_token, absence: true, if: -> { type != 'Token::Workflow' }
+  validates :scm_token, length: { maximum: 255 }, if: -> { type == 'Token::Workflow' }
 
   validate :workflow_configuration_url_valid_and_accessible
 


### PR DESCRIPTION
Fix #18712.

Instead of erroring, show a message like this one:

<img width="775" height="424" alt="Screenshot From 2026-01-16 14-50-56" src="https://github.com/user-attachments/assets/f6a40246-363a-43b0-a113-24e6cdb53ec4" />
