### PR TITLE
Fix route error in changes_diff

### DIFF
--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -340,11 +340,11 @@ class Webui::RequestController < Webui::WebuiController
     sourcediff = @action.webui_sourcediff({ diff_to_superseded: @diff_to_superseded, file: filename, filelimit: 0, tarlimit: 0 }.compact).first
     source_rev = sourcediff.dig('new', 'srcmd5')
     if @action.source_package_object&.file_exists?(filename, { rev: source_rev, expand: 1 }.compact)
-      source_file = project_package_file_path(@action.source_project_object, @action.source_package_object, filename, rev: source_rev, expand: 1)
+      source_file = project_package_file_path(@action.source_project_object || @action.source_project, @action.source_package_object, filename, rev: source_rev, expand: 1)
     end
     target_rev = sourcediff.dig('old', 'srcmd5')
     if @action.target_package_object&.file_exists?(filename, { rev: target_rev, expand: 1 }.compact)
-      target_file = project_package_file_path(@action.target_project_object, @action.target_package_object, filename, rev: target_rev, expand: 1)
+      target_file = project_package_file_path(@action.target_project_object || @action.source_project, @action.target_package_object, filename, rev: target_rev, expand: 1)
     end
     render partial: 'webui/request/changes_diff', formats: [:html],
            locals: { commentable: @action,


### PR DESCRIPTION
Fixes: #19089 

Changed from positional arguments with objects to named arguments with strings  because using the string column `source_project` instead of the `source_project_object` guarantees we always have a value.

This is a similar crash I was getting which was fixed by these changes. 
<img width="1920" height="726" alt="image" src="https://github.com/user-attachments/assets/3a29f6d9-f47c-461a-a579-eeb42363ef82" />




Thanks!