### PR TITLE
Fix Mysql2::Error duplicate entry  in BranchPackage#create_branch_packages

### DIFF
--- a/src/api/app/models/branch_package.rb
+++ b/src/api/app/models/branch_package.rb
@@ -198,7 +198,15 @@ class BranchPackage
         tpkg.bcntsynctag << ".#{p[:link_target_project].name.tr(':', '_')}" if tpkg.bcntsynctag && @extend_names
         tpkg.releasename = p[:release_name]
       end
-      tpkg.store
+
+      begin
+        tpkg.store
+      rescue ActiveRecord::RecordNotUnique
+        raise DoubleBranchPackageError.new(tprj.name, tpkg.name), "branch target package already exists: #{tprj.name}/#{tpkg.name}" unless params[:force]
+
+        # reload package that already exists if params[:force] is given
+        tpkg = tprj.packages.find_by_name(pack_name)
+      end
 
       if p[:local_link]
         # copy project local linked packages


### PR DESCRIPTION
Fixes #17746

The code checks if a package exists with `find_by_name`, then creates it. If the package is created between the check and the INSERT (by any means), the INSERT fails with a duplicate key error. This PR adds a rescue block to handle this edge case.


Please let me know if it could be better handled ( like using locks ). 

Thanks! 