### PR TITLE
Fix manual service error 18932

### DIFF
--- a/src/api/spec/factories/packages.rb
+++ b/src/api/spec/factories/packages.rb
@@ -184,6 +184,15 @@ FactoryBot.define do
       end
     end
 
+    factory :package_with_manual_service do
+      after(:create) do |package|
+        if CONFIG['global_write_through']
+          Backend::Connection.put(Addressable::URI.escape("/source/#{package.project.name}/#{package.name}/_service"),
+                                  File.read('spec/fixtures/files/manual_service.xml'))
+        end
+      end
+    end
+
     factory :package_with_broken_service do
       after(:create) do |package|
         if CONFIG['global_write_through']

--- a/src/api/spec/fixtures/files/manual_service.xml
+++ b/src/api/spec/fixtures/files/manual_service.xml
@@ -1,0 +1,6 @@
+<services>
+  <service name="obs_scm" mode="manual">
+    <param name="url">git://github.com/coolo/obs-build.git</param>
+    <param name="scm">git</param>
+  </service>
+</services>

--- a/src/backend/BSSrcServer/Service.pm
+++ b/src/backend/BSSrcServer/Service.pm
@@ -116,6 +116,33 @@ sub genservicemark {
   return $smd5;
 }
 
+sub get_service_modes {
+  my ($projid, $packid, $files) = @_;
+  
+  my %modes;
+  my $collect_modes = sub {
+    my ($services) = @_;
+    for my $se (@{$services->{'service'}||[]}) {
+        if ($se->{'mode'}) {
+            $modes{$se->{'mode'}} = 1;
+        } else {
+            $modes{'active'} = 1;
+        }
+    }
+  };
+
+  my $projectservices = getprojectservices($projid, $packid, undef, $files);
+  $collect_modes->($projectservices);
+
+  if ($files->{'_service'}) {
+    my $packagerev = {'project' => $projid, 'package' => $packid};
+    my $services = BSRevision::revreadxml($packagerev, '_service', $files->{'_service'}, $BSXML::services, 1) || {};
+    $collect_modes->($services);
+  }
+  
+  return \%modes;
+}
+
 #
 # Send a notification of the service run result
 #

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -464,6 +464,9 @@ sub triggerservicerun {
       $cgi->{'servicemark'} = $servicemark;
       $rev = addrev_runservice($cgi, $projid, $packid, $files);
     } else {
+      my $modes = BSSrcServer::Service::get_service_modes($projid, $packid, $files);
+      die("404 services are in manual mode!\n") if $modes->{'manual'};
+      die("404 services are disabled!\n") if $modes->{'disabled'};
       die("404 no source service defined!\n");
     }
   }


### PR DESCRIPTION
Description
This PR fixes a bug where triggering services in `manual` or `disabled` mode resulted in a generic "no source service defined!" error.

Problem
When configuring a service (e.g., [obs_scm](cci:1://file:///Users/geetanshgoyal/opensource/open-build-service/src/backend/BSSrcServer/Service.pm:295:0-306:1)) in `manual` mode and using the "Trigger Services" UI button, OBS returns an unclear error message:
`Error while triggering services for home:user/package: no source service defined!`

This is confusing because the service is defined, just configured not to run automatically. The user expects to be informed that the service is in manual mode rather than being told it doesn't exist.

Solution
Modified [src/backend/BSSrcServer/Service.pm](cci:7://file:///Users/geetanshgoyal/opensource/open-build-service/src/backend/BSSrcServer/Service.pm:0:0-0:0) to include a helper function [get_service_modes](cci:1://file:///Users/geetanshgoyal/opensource/open-build-service/src/backend/BSSrcServer/Service.pm:118:0-143:1) that inspects the mode of defined services.
Updated [src/backend/bs_srcserver](cci:7://file:///Users/geetanshgoyal/opensource/open-build-service/src/backend/bs_srcserver:0:0-0:0) to use this helper. Instead of defaulting to the generic error, it now checks if services exist in `manual` or `disabled` modes and raises specific exceptions:
- "services are in manual mode!"
- "services are disabled!"

Testing
Added a new test fixture and factory `package_with_manual_service`.
Added a specific test case in [src/api/spec/controllers/webui/packages/trigger_controller_spec.rb](cci:7://file:///Users/geetanshgoyal/opensource/open-build-service/src/api/spec/controllers/webui/packages/trigger_controller_spec.rb:0:0-0:0) to verify that triggering a manual service returns the correct error message:
`Error while triggering services for my_project/manual_service_package: services are in manual mode!`

Verification Steps
1. Create a new package with a `_service` file configured in manual mode:
   ```xml
   <services>
     <service name="obs_scm" mode="manual">
       <param name="url">git://github.com/coolo/obs-build.git</param>
       <param name="scm">git</param>
     </service>
   </services>
   
2. Attempt to trigger the services via the API or WebUI (e.g., clicking "Trigger Services").
3.Verify that the error message returned is: `Error while triggering services for [project]/[package]: services are in manual mode!`

### Files Changed

```
src/backend/BSSrcServer/Service.pm
 - Added 
get_service_modes
 helper
src/backend/bs_srcserver
 - Updated error handling logic
src/api/spec/fixtures/files/manual_service.xml
 - Added manual service fixture
src/api/spec/factories/packages.rb
 - Added package_with_manual_service factory
src/api/spec/controllers/webui/packages/trigger_controller_spec.rb
 - Added test case
```
Fixes #18932