### PR TITLE
Eager load required sources and targets objects

### DIFF
--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -882,12 +882,12 @@ class BsRequest < ApplicationRecord
 
   # Check if 'user' is maintainer in _all_ request sources:
   def source_maintainer?(user)
-    bs_request_actions.all? { |action| action.source_maintainer?(user) }
+    bs_request_actions.includes(:source_project_object, :source_package_object).all? { |action| action.source_maintainer?(user) }
   end
 
   # Check if 'user' is maintainer in _all_ request targets:
   def target_maintainer?(user)
-    bs_request_actions.all? { |action| action.target_maintainer?(user) }
+    bs_request_actions.includes(:target_package_object, :target_project_object).all? { |action| action.target_maintainer?(user) }
   end
 
   def sanitize!


### PR DESCRIPTION
`BsRequest#target_maintainer?` iterates over all bs_request_actions. For each action, it calls `action.target_maintainer?`, which accesses `target_package_object` (and `target_project_object`). The same goes for `source_project_object` and `source_package_object`. These associations are not loaded at the time they are used, so Rails fires a separate query for each action to fetch them.

Go to: https://obs-reviewlab.opensuse.org/ncounter-eager-loading/requests/6 or https://obs-reviewlab.opensuse.org/ncounter-eager-loading/requests/12 and check that `Bullet Warnings` are few and no longer about `bs_request_actions`