### PR TITLE
Extend action description for release request actions

### DIFF
--- a/src/api/app/views/webui/request/_action_description.haml
+++ b/src/api/app/views/webui/request/_action_description.haml
@@ -33,7 +33,7 @@
   %i.fas.fa-long-arrow-alt-right.text-info.mx-2
   = project_or_package_link({ project: action.target_project, package: action.target_package, trim_to: nil })
 - when 'release'
-  Release
+  Release (copy sources and binaries)
   = project_or_package_link({ project: action.source_project, package: action.source_package, trim_to: nil })
   %i.fas.fa-long-arrow-alt-right.text-info.mx-2
   = project_or_package_link({ project: action.target_project, package: action.target_package, trim_to: nil })


### PR DESCRIPTION
Mention that binaries and source are copied by the release request action...

<img width="1658" height="447" alt="image" src="https://github.com/user-attachments/assets/25c3374b-2a1d-40f0-9d9f-37c56ec9f847" />

