### PR TITLE
Display hint when there are no source changes for a request action

### DIFF
--- a/src/api/app/components/sourcediff_component.html.haml
+++ b/src/api/app/components/sourcediff_component.html.haml
@@ -22,6 +22,8 @@
                 Expand all
               %button.btn.btn-outline-secondary.collapse-diffs{ data: { object: @action.source_package } }
                 Collapse all
+          - else
+            %p No source changes.
 
         - if sourcediff[:error]
           %p


### PR DESCRIPTION
Just rendering an empty changes tab/page might let to assumption that something went wrong while rendering the diff. Showing a hint explicitly (it used to be like that in the past) makes it clear that there a no source changes done in the request action.

<img width="1659" height="506" alt="image" src="https://github.com/user-attachments/assets/ee8e9307-d563-44ff-befb-bb054d294623" />
