### PR TITLE
Remove label filter for workflows workaround

### DIFF
--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -17,9 +17,6 @@ testbuild:
               - x86_64
   filters:
     event: pull_request
-    label:
-      only:
-        - NON_EXISTING_LABEL # Workaround for preventing workflows from running on labeled/unlabeled events
 
 rebuild:
   steps:


### PR DESCRIPTION
There is a typo: `label` should have been `labels`.

Anyway, this solution will not work: all `pull_request` events will be ignored.

Reverts #19142.