### PR TITLE
Always start actions with nobody in User.session

### DIFF
--- a/src/api/spec/controllers/concerns/authenticator_spec.rb
+++ b/src/api/spec/controllers/concerns/authenticator_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe ApplicationController do # rubocop:disable RSpec/SpecFilePathForm
   context 'proxy auth' do
     before do
       allow(Configuration).to receive(:proxy_auth_mode_enabled?).and_return(true)
+      User.find_nobody! # avoid user nobody creation during examples
       request.headers['HTTP_X_USERNAME'] = 'hans'
       request.headers['HTTP_X_FIRSTNAME'] = 'Hans'
       request.headers['HTTP_X_LASTNAME'] = 'Sarpei'


### PR DESCRIPTION
We have a couple of controllers that skip the extract_user before action because they authenticate people by other means (token, backend etc.) or do not require authentication for a certain action.

In that case no one ever set User.session which made our logging return users assigned from previous sessions.