### PR TITLE
Fix typo return -> raise

### DIFF
--- a/src/api/app/controllers/webui/distributions_controller.rb
+++ b/src/api/app/controllers/webui/distributions_controller.rb
@@ -41,6 +41,8 @@ class Webui::DistributionsController < Webui::WebuiController
     else
       flash.now[:error] = "Can't add repository: #{repository.errors.full_messages.to_sentence}"
     end
+  rescue ActiveRecord::RecordNotFound
+    flash.now[:error] = "Repository #{@distribution.repository} was not found"
   end
 
   def destroy_repository

--- a/src/api/app/models/repository.rb
+++ b/src/api/app/models/repository.rb
@@ -78,7 +78,7 @@ class Repository < ApplicationRecord
 
   def self.find_by_project_and_name!(project, repo)
     result = find_by_project_and_name(project, repo)
-    return ActiveRecord::RecordNotFound if result.blank?
+    raise ActiveRecord::RecordNotFound if result.blank?
 
     result
   end


### PR DESCRIPTION
This PR fixes the typo in `Repository.find_by_project_and_name`, 

Fixes: #19151 