### PR TITLE
Resolve routing error when creating package with malformed project URL

### DIFF
--- a/src/api/app/views/webui/package/_breadcrumb_items.html.haml
+++ b/src/api/app/views/webui/package/_breadcrumb_items.html.haml
@@ -1,7 +1,7 @@
 = render partial: 'webui/project/breadcrumb_items'
 
 -# The package doesn't exist in the context of package#new, so we don't check other paths below to avoid exceptions
-- if current_page?(new_package_path(@project))
+- if controller_name == 'package' && action_name == 'new'
   %li.breadcrumb-item.active{ 'aria-current' => 'page' }
     Create Package
 - else


### PR DESCRIPTION
Fixes: #18663 

When the URL contains %20, `current_page?` returns false due to URL mismatch.

This PR replaces `current_page?` with a direct `action_name` check. This approach is already used in the same file (L 32) for the `statistics` action. 

To reproduce the Error and Fix. Please visit this URL.

```
http://localhost:3000/package/new/home:Admin%20
```

Before: 
<img width="1919" height="846" alt="image" src="https://github.com/user-attachments/assets/b94bbb2a-5bfb-4a95-8ad6-9d4b36707d8b" />

After: 
<img width="1917" height="771" alt="image" src="https://github.com/user-attachments/assets/fc2868f9-54df-4566-b2d5-e4621f1611a9" />




