### PR TITLE
Skip anonymous check for un-authenticated routes

### DIFF
--- a/src/api/app/controllers/about_controller.rb
+++ b/src/api/app/controllers/about_controller.rb
@@ -1,8 +1,7 @@
 class AboutController < ApplicationController
   validate_action index: { method: :get, response: :about }
-  skip_before_action :extract_user
-  skip_before_action :check_anonymous_access
-  skip_before_action :require_login
+  # We always allow access to this action...
+  skip_before_action :extract_user, :require_login, :check_anonymous_access
   before_action :set_response_format_to_xml
 
   def index

--- a/src/api/app/controllers/build_controller.rb
+++ b/src/api/app/controllers/build_controller.rb
@@ -1,7 +1,6 @@
 class BuildController < ApplicationController
-  skip_before_action :extract_user, only: [:scmresult]
-  skip_before_action :require_login, only: [:scmresult]
-
+  # Authentication happens via HTTP_X_SCM_BRIDGE_COOKIE, so no login is required
+  skip_before_action :extract_user, :require_login, :check_anonymous_access, only: [:scmresult]
   before_action :require_scmsync_host_check, only: [:scmresult]
 
   def index

--- a/src/api/app/controllers/person_controller.rb
+++ b/src/api/app/controllers/person_controller.rb
@@ -5,10 +5,8 @@ class PersonController < ApplicationController
   validate_action register: { method: :put, response: :status }
   validate_action register: { method: :post, response: :status }
 
-  skip_before_action :extract_user, only: %i[command register]
-  skip_before_action :check_anonymous_access, only: %i[command register]
-  skip_before_action :require_login, only: %i[command register]
-
+  # We are signing up people, can't require them to login
+  skip_before_action :extract_user, :require_login, :check_anonymous_access, only: %i[command register]
   before_action :set_user, only: %i[post_userinfo change_my_password watchlist put_watchlist]
   before_action :user_permission_check, only: [:post_userinfo]
   before_action :require_admin, only: [:post_userinfo], if: -> { %w[delete lock].include?(params[:cmd]) }

--- a/src/api/app/controllers/source_command_controller.rb
+++ b/src/api/app/controllers/source_command_controller.rb
@@ -1,7 +1,6 @@
 class SourceCommandController < SourceController
-  skip_before_action :extract_user, only: %i[global_command_orderkiwirepos global_command_triggerscmsync]
-  skip_before_action :require_login, only: %i[global_command_orderkiwirepos global_command_triggerscmsync]
-
+  # Authentication happens via HTTP_X_SCM_BRIDGE_COOKIE, so no login is required
+  skip_before_action :extract_user, :require_login, :check_anonymous_access, only: %i[global_command_orderkiwirepos global_command_triggerscmsync]
   before_action :require_scmsync_host_check, only: :global_command_triggerscmsync
 
   # POST /source?cmd=createmaintenanceincident

--- a/src/api/app/controllers/source_controller.rb
+++ b/src/api/app/controllers/source_controller.rb
@@ -4,8 +4,8 @@ class SourceController < ApplicationController
   include MaintenanceHelper
   include Source::Errors
 
-  skip_before_action :extract_user, only: :lastevents_public
-  skip_before_action :require_login, only: :lastevents_public
+  # We always allow access to this action...
+  skip_before_action :extract_user, :require_login, :check_anonymous_access, only: :lastevents_public
 
   # POST, GET /public/lastevents
   # GET /lastevents

--- a/src/api/app/controllers/statistics/maintenance_statistics_controller.rb
+++ b/src/api/app/controllers/statistics/maintenance_statistics_controller.rb
@@ -1,6 +1,7 @@
 module Statistics
   class MaintenanceStatisticsController < ApplicationController
-    skip_before_action :extract_user, :require_login
+    # We always allow access to this action...
+    skip_before_action :extract_user, :require_login, :check_anonymous_access
 
     def index
       @project = Project.get_by_name(params[:project])

--- a/src/api/app/controllers/trigger_controller.rb
+++ b/src/api/app/controllers/trigger_controller.rb
@@ -2,10 +2,8 @@ class TriggerController < ApplicationController
   include Triggerable
   include Trigger::Errors
 
-  # Authentication happens with tokens, so extracting the user is not required
-  skip_before_action :extract_user
-  # Authentication happens with tokens, so no login is required
-  skip_before_action :require_login
+  # Authentication happens via tokens, so no login is required
+  skip_before_action :extract_user, :require_login, :check_anonymous_access
   # SCMs like GitLab/GitHub send data as parameters which are not strings (e.g.: GitHub - PR number is a integer, GitLab - project is a hash)
   # Other SCMs might also do this, so we're not validating parameters.
   skip_before_action :validate_params

--- a/src/api/app/controllers/trigger_workflow_controller.rb
+++ b/src/api/app/controllers/trigger_workflow_controller.rb
@@ -2,10 +2,8 @@ class TriggerWorkflowController < ApplicationController
   include ScmWebhookHeadersDataExtractor
   include Trigger::Errors
 
-  # Authentication happens with tokens, so extracting the user is not required
-  skip_before_action :extract_user
-  # Authentication happens with tokens, so no login is required
-  skip_before_action :require_login
+  # Authentication happens via tokens, so no login is required
+  skip_before_action :extract_user, :require_login, :check_anonymous_access
   # SCMs like GitLab/GitHub send data as parameters which are not strings (e.g.: GitHub - PR number is a integer, GitLab - project is a hash)
   # Other SCMs might also do this, so we're not validating parameters.
   skip_before_action :validate_params

--- a/src/api/app/controllers/webui/session_controller.rb
+++ b/src/api/app/controllers/webui/session_controller.rb
@@ -1,6 +1,6 @@
 class Webui::SessionController < Webui::WebuiController
-  skip_before_action :extract_user
-  skip_before_action :check_anonymous_access
+  # We are signing up people, can't require them to login
+  skip_before_action :extract_user, :check_anonymous_access
 
   def create
     user = User.find_with_credentials(params.fetch(:username, ''), params.fetch(:password, ''))


### PR DESCRIPTION
There are routes we allow access to without authentication.
Before https://github.com/openSUSE/open-build-service/commit/5216fffed9e74adc6576de1790e1eb59e837be13 the
`check_anonymous_access` filter checked previously assigned sessions.
Afterward it started to check the `_nobody_` User and started to complain.
We need to skip this check for the routes we allow access to without
authentication.