### PR TITLE
Filter group request count to `new` and `review` states

### DIFF
--- a/src/api/app/views/webui/groups/show.html.haml
+++ b/src/api/app/views/webui/groups/show.html.haml
@@ -14,7 +14,7 @@
           = link_to(group_requests_path(@group, state: %w[new review]), class: 'nav-link', title: 'Requests') do
             Group Requests
             %span.badge.text-bg-primary
-              = @group.requests.count
+              = @group.bs_requests.where(state: %w[new review]).count
       - else
         %li.nav-item
           %a.nav-link.text-nowrap#reviews-in-tab{ aria: { controls: 'reviews-in', selected: 'true' },


### PR DESCRIPTION
Previously, the counter showed all requests regardless of their state. Now, we keep the counter of group requests in sync with the number of requests shown when clicking in the "Group Requests" link.