### PR TITLE
Fix `event_type` condition in `link_path` method

### DIFF
--- a/src/api/app/models/notification_report.rb
+++ b/src/api/app/models/notification_report.rb
@@ -60,7 +60,7 @@ class NotificationReport < Notification
   def link_path
     if event_type.starts_with?('Event::ReportFor')
       Rails.application.routes.url_helpers.report_path(event_payload['id'])
-    elsif event_type == 'Event::ClearedDecision' || 'Event::FavoredDecision'
+    elsif ['Event::ClearedDecision', 'Event::FavoredDecision'].include?(event_type)
       reportable = notifiable.reports.first.reportable
       link_for_reportables(reportable)
     elsif event_type == 'Event::AppealCreated'


### PR DESCRIPTION
Found while running a rollback in a development environment:

```
frontend@e330348e78d4:/obs/src/api> bin/rails db:rollback:with_data
To use retry middleware with Faraday v2.0+, install `faraday-retry` gem
== Schema =====================================================================
== 20260122085231 AddIndexCreatedAtToBsRequests: reverting ====================
-- remove_index(:bs_requests, :created_at)
   -> 0.0747s
== 20260122085231 AddIndexCreatedAtToBsRequests: reverted (0.0873s) ===========

Annotating models
/obs/src/api/app/models/notification_report.rb:63: warning: string literal in condition
Annotated (1): app/models/bs_request.rb
frontend@e330348e78d4:/obs/src/api>
```