### PR TITLE
Hint about request search box syntax

### DIFF
--- a/src/api/app/views/webui/shared/bs_requests/_filter_help_search_box.html.haml
+++ b/src/api/app/views/webui/shared/bs_requests/_filter_help_search_box.html.haml
@@ -1,0 +1,12 @@
+:ruby
+  info_text = "<p>Filter the requests by some text of the request content.</p>
+               <p>Sphinx extended query syntax allowed:
+                 <ul>
+                   <li> OR: `some | text`</li>
+                   <li> NOT: `-text` or `!text`</li>
+                   <li> phrase search: 'some text'</li>
+                 </ul>
+              </p>"
+
+
+= render partial: 'webui/shared/info_popover', locals: { position: 'bottom', text: info_text }

--- a/src/api/app/views/webui/shared/bs_requests/_form.html.haml
+++ b/src/api/app/views/webui/shared/bs_requests/_form.html.haml
@@ -19,10 +19,15 @@
             .card-body.row
               .col
               .col-lg
-                = render partial: 'webui/shared/search_box', locals: { html_id: 'search',
-                                                                       value: selected_filter[:search],
-                                                                       required: false,
-                                                                       button: { type: 'submit' } }
+                .d-flex.align-items-center
+                  .me-2
+                    = render partial: 'webui/shared/bs_requests/filter_help_search_box'
+                  .w-100
+                    = render partial: 'webui/shared/search_box', locals: { html_id: 'search',
+                                                                          value: selected_filter[:search],
+                                                                          required: false,
+                                                                          button: { type: 'submit' },
+                                                                          placeholder: 'Search' }
           .text-center.mb-3
             - if bs_requests.total_count == 0
               %p There are no requests available


### PR DESCRIPTION
The hint reports about the most interesting/common ones, and the only ones that can be used in our interface. There are more for sure, but they are relevant as long as the user can target the `field name`, which we don't expose and it's not labeled to be exposed at all.

It could be a plus to add the official Sphinx link, but the issue here is that if we want to have a clickable link we cannot use the popover because it disappear as soon as the mouse moves out of the icon. And we cannot use the tooltip because it cannot contain other syntax than simple string text. So we would have to write a tailored component for that, which would be completely fine, but it is not worth the effort.

## Before

<img width="1549" height="527" alt="Screenshot from 2026-01-22 16-44-40" src="https://github.com/user-attachments/assets/bdbe06cc-a874-4f39-8cb6-c52e5a895147" />

## After
<img width="1549" height="527" alt="Screenshot from 2026-01-23 09-23-32" src="https://github.com/user-attachments/assets/aa0f6d2e-8266-425b-816a-0d06642ab535" />

