### PR TITLE
Enhance the hint about requests search box

### DIFF
--- a/src/api/app/views/webui/shared/bs_requests/_filter_help_search_box.html.haml
+++ b/src/api/app/views/webui/shared/bs_requests/_filter_help_search_box.html.haml
@@ -1,5 +1,5 @@
 :ruby
-  info_text = "<p>Filter the requests by some text of the request content.</p>
+  info_text = "<p>Filter the requests by some text of the request content (<i>description, comments, review reasons, etc</i>).</p>
                <p>Sphinx extended query syntax allowed:
                  <ul>
                    <li> OR: `some | text`</li>


### PR DESCRIPTION
Explain what _request content_ means under the hood when using the request index search box functionality.

<img width="1549" height="527" alt="image" src="https://github.com/user-attachments/assets/aa87e1d7-c44c-4fd9-94e4-574dfb88e09a" />
