### PR TITLE
Refactor `bs_requests` methods to improve performance

### DIFF
--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -1342,11 +1342,16 @@ class Project < ApplicationRecord
 
   # Returns an ActiveRecord::Relation with all BsRequest that the project is somehow involved in
   def bs_requests
-    BsRequest.left_outer_joins(:bs_request_actions, :reviews)
-             .where(reviews: { project_id: id })
-             .or(BsRequest.left_outer_joins(:bs_request_actions, :reviews).where(bs_request_actions: { source_project_id: id }))
-             .or(BsRequest.left_outer_joins(:bs_request_actions, :reviews).where(bs_request_actions: { target_project_id: id }))
-             .distinct
+    review_ids = Review.where(project_id: id)
+                       .pluck(:bs_request_id)
+
+    action_ids = BsRequestAction.where(target_project_id: id)
+                                .or(BsRequestAction.where(source_project_id: id))
+                                .pluck(:bs_request_id)
+
+    all_ids = (review_ids + action_ids).compact.uniq
+
+    BsRequest.left_outer_joins(:bs_request_actions, :reviews).where(id: all_ids)
   end
 
   private


### PR DESCRIPTION
The previous implementation relied on a single, complex ActiveRecord query using `left_outer_joins` combined with a massive `OR` clause spanning multiple tables (`bs_requests`, `reviews`, `bs_request_actions`).

This approach caused significant performance degradation because:
1. The Cross-Table `OR` conditions prevented the database query planner from effectively using indices.
2. Consequently, the database performed costly full table scans.

This refactor:
1. Executes separate, lightweight queries to `pluck` relevant IDs from `Reviews` and `Actions`. These individual queries can now fully leverage their specific table indices.
2. Merges and deduplicates the resulting integer arrays in Ruby (which is extremely fast for this operation).

### Benchmarks

#### Current query

```
> puts ActiveRecord::Base.uncached { Benchmark.measure { User.find_by(login: 'SOME_USER').bs_requests.count } }
  0.026618   0.004384   0.031002 ( 10.871841)
=> nil
```

#### Improved query

Tested introducing from the console in production a method `bs_requests_fast` in the User model:

``` 
> puts ActiveRecord::Base.uncached { Benchmark.measure { User.find_by(login: 'SOME_USER').bs_requests_fast.count } }
  0.053551   0.007487   0.061038 (  0.096481)
=> nil
```