### PR TITLE
Fix comment box not showing on declined requests

### DIFF
--- a/src/api/app/views/webui/request/beta_show.html.haml
+++ b/src/api/app/views/webui/request/beta_show.html.haml
@@ -77,7 +77,7 @@
                                                                 history_elements: @history_elements,
                                                                 request_reviews_for_non_staging_projects: @request_reviews)
 
-              - if !policy(@bs_request).revoke_request? && !policy(@bs_request).reopen_request? && !policy(@bs_request).accept_request?
+              - unless policy(@bs_request).handle_request?
                 .comment_new
                   = render partial: 'webui/comment/new', locals: { commentable: @bs_request }
               %hr

--- a/src/api/spec/features/webui/requests_spec.rb
+++ b/src/api/spec/features/webui/requests_spec.rb
@@ -35,6 +35,35 @@ RSpec.describe 'Requests', :js, :vcr do
       expect(page).to have_no_text(comment1.body)
     end
 
+    context 'for declined requests' do
+      let(:declined_request) { create(:declined_bs_request, target_project: target_project, creator: submitter) }
+
+      it 'shows the comment box for logged in users' do
+        login receiver
+        visit request_show_path(declined_request)
+        expect(page).to have_css('.comment_new')
+        expect(page).to have_css('form.post-comment-form')
+      end
+    end
+
+    context 'for accepted requests' do
+      let(:accepted_request) { create(:bs_request_with_submit_action, state: :accepted, target_project: target_project, creator: submitter) }
+
+      it 'shows the comment box for logged in users' do
+        login receiver
+        visit request_show_path(accepted_request)
+        expect(page).to have_css('.comment_new')
+      end
+    end
+
+    context 'for new requests' do
+      it 'shows the comment box for logged in users' do
+        login receiver
+        visit request_show_path(bs_request)
+        expect(page).to have_css('.comment_new')
+      end
+    end
+
     describe 'request description field' do
       it 'superseded requests' do
         visit request_show_path(bs_request)


### PR DESCRIPTION
What does this PR do?
This PR fixes the comment box not being displayed on declined request pages.

Fixes #19174

Root Cause
In beta_show.html.haml the comment box was conditionally hidden when users had action permissions (revoke/reopen/accept):
```
- if !policy(@bs_request).revoke_request? && !policy(@bs_request).reopen_request? && !policy(@bs_request).accept_request?
  .comment_new
    = render partial: 'webui/comment/new', locals: { commentable: @bs_request }
```
The reopen_request? policy returns true for all declined requests (regardless of user), which caused the comment box to be hidden for everyone on declined request pages.

What was changed

- Removed the flawed condition that hid the comment box based on action permissions
- CommentPolicy#create? already handles proper authorization for who can post comments, so this view-level check was redundant and broken
- Added test coverage for comment box visibility on declined requests

How to verify

1. Visit a declined request page (e.g., /requests/<declined_request_number>)
2. Log in as any user
3. Verify the comment box is now visible
