### PR TITLE
Get payload through the workflow_run

### DIFF
--- a/src/api/app/jobs/report_to_scm_job.rb
+++ b/src/api/app/jobs/report_to_scm_job.rb
@@ -12,7 +12,7 @@ class ReportToSCMJob < CreateJob
 
     matched_event_subscription(event: event).each do |event_subscription|
       SCMStatusReporter.new(event_payload: event.payload,
-                            event_subscription_payload: event_subscription.payload,
+                            event_subscription_payload: event_subscription.workflow_run&.payload,
                             scm_token: event_subscription.token.scm_token,
                             workflow_run: event_subscription.workflow_run,
                             event_type: event_subscription.eventtype).call

--- a/src/api/app/services/workflows/scm_event_subscription_creator.rb
+++ b/src/api/app/services/workflows/scm_event_subscription_creator.rb
@@ -27,7 +27,7 @@ module Workflows
                                              token: @token,
                                              package: package).tap do |subscription|
           # Set payload and workflow_run regardless of whether the subscription already existed or not
-          subscription.update!(workflow_run: @workflow_run, payload: @workflow_run.payload)
+          subscription.update!(workflow_run: @workflow_run)
         end
       end
     end
@@ -40,7 +40,7 @@ module Workflows
                                            enabled: true,
                                            token: @token,
                                            bs_request: bs_request).tap do |subscription|
-        subscription.update!(workflow_run: @workflow_run, payload: @workflow_run.payload) # The payload is updated regardless of whether the subscription already existed or not.
+        subscription.update!(workflow_run: @workflow_run) # The payload is updated regardless of whether the subscription already existed or not.
       end
     end
   end


### PR DESCRIPTION
Fixes https://github.com/openSUSE/open-build-service/issues/17545
And will restore the report back to this PR https://github.com/openSUSE/open-build-service/pull/19133

Error **Data too long for column 'payload'** is talking about `EventSubscription.payload` [(normal-size text field)](https://github.com/openSUSE/open-build-service/blob/f887a05acded51a019d18f134d35bead25318a98/src/api/db/schema.rb#L502)  which stores the same data we store in `WorkfloRun.request_payload` but [parsed](https://github.com/openSUSE/open-build-service/blob/f887a05acded51a019d18f134d35bead25318a98/src/api/app/models/workflow_run.rb#L101). However, the latter is a [long-size text field](https://github.com/openSUSE/open-build-service/blob/f887a05acded51a019d18f134d35bead25318a98/src/api/db/schema.rb#L1258) because sometimes it's too long.

The EventSubscription we are talking about are those related to SCM/CI wokflows, those with `channel: scm`.

The "quick" solution is changing `EventSubscription.payload` to long size. However, there is no need to store the payload if we can access it because we also store the `workflow_run_id`. 

The next step will be removing the field from the database.