### PR TITLE
Improve performance of BinariesController#show using lazy loading

### DIFF
--- a/src/api/app/controllers/webui/packages/binaries_controller.rb
+++ b/src/api/app/controllers/webui/packages/binaries_controller.rb
@@ -16,10 +16,10 @@ module Webui
       before_action :set_package
       before_action :set_multibuild_flavor
       before_action :set_repository
-      before_action :set_architecture, only: %i[show dependency filelist]
+      before_action :set_architecture, only: %i[show dependency filelist dependencies]
       before_action :set_dependant_project, only: :dependency
       before_action :set_dependant_repository, only: :dependency
-      before_action :set_filename, only: %i[show dependency filelist]
+      before_action :set_filename, only: %i[show dependency filelist dependencies]
 
       prepend_before_action :lockout_spiders
 
@@ -51,7 +51,8 @@ module Webui
       end
 
       def show
-        @fileinfo = Backend::Api::BuildResults::Binaries.fileinfo_ext(@project.name, @package_name, @repository.name, @architecture.name, @filename)
+        # Use basic fileinfo for initial page load; dependencies are loaded lazily via Turbo Frame
+        @fileinfo = Backend::Api::BuildResults::Binaries.fileinfo(@project.name, @package_name, @repository.name, @architecture.name, @filename)
         raise ActiveRecord::RecordNotFound, 'Not Found' unless @fileinfo
 
         respond_to do |format|
@@ -60,6 +61,11 @@ module Webui
           end
           format.any { redirect_to download_url_for_binary(architecture_name: @architecture.name, file_name: @filename) }
         end
+      end
+
+      def dependencies
+        @fileinfo = Backend::Api::BuildResults::Binaries.fileinfo_ext(@project.name, @package_name, @repository.name, @architecture.name, @filename)
+        raise ActiveRecord::RecordNotFound, 'Not Found' unless @fileinfo
       end
 
       def dependency

--- a/src/api/app/lib/backend/api/build_results/binaries.rb
+++ b/src/api/app/lib/backend/api/build_results/binaries.rb
@@ -57,6 +57,14 @@ module Backend
           http_get(['/build/:project/:repository/:architecture/:package/rpmlint.log', project_name, repository_name, architecture_name, package_name])
         end
 
+        # Basic file info without extended dependency data
+        # @return [Hash]
+        def self.fileinfo(project_name, package_name, repository, arch, filename)
+          fileinfo = http_get(['/build/:project/:repository/:arch/:package/:filename', project_name, repository, arch, package_name, filename],
+                              defaults: { view: 'fileinfo' })
+          Xmlhash.parse(fileinfo) if fileinfo
+        end
+
         # special view on a binary file for details display
         # @return [Hash]
         def self.fileinfo_ext(project_name, package_name, repository, arch, filename, options = {})

--- a/src/api/app/views/webui/packages/binaries/_deps.html.haml
+++ b/src/api/app/views/webui/packages/binaries/_deps.html.haml
@@ -94,3 +94,6 @@
         %tr
           %th Name
       %tbody
+
+:javascript
+  initializeRemoteDatatable('#filelist-table', { columns: [{ data: 'name' }], paging: false, searching: false, info: false });

--- a/src/api/app/views/webui/packages/binaries/_fileinfo.html.haml
+++ b/src/api/app/views/webui/packages/binaries/_fileinfo.html.haml
@@ -31,20 +31,7 @@
     #{btime}
     = render TimeComponent.new(time: btime)
 
-= render partial: 'deps', locals: { fileinfo: fileinfo,
-                                    filename: filename,
-                                    project: project,
-                                    package: package,
-                                    repository: repository,
-                                    architecture: architecture }
-
-- content_for :ready_function do
-  :plain
-    initializeRemoteDatatable('#filelist-table', {
-        "columns": [
-          {"data": "name"}
-        ],
-        paging: false,
-        searching: false,
-        info: false
-      });
+= turbo_frame_tag "binary-dependencies-#{filename}",
+                  loading: 'lazy',
+                  src: project_package_repository_binary_dependencies_path(project, package, repository, architecture, filename) do
+  = render partial: 'webui/shared/loading', locals: { text: 'Loading binary details...' }

--- a/src/api/app/views/webui/packages/binaries/dependencies.html.haml
+++ b/src/api/app/views/webui/packages/binaries/dependencies.html.haml
@@ -1,0 +1,9 @@
+- @pagetitle = "Dependencies of #{@filename}"
+
+= turbo_frame_tag "binary-dependencies-#{@filename}" do
+  = render partial: 'deps', locals: { fileinfo: @fileinfo,
+                                      filename: @filename,
+                                      project: @project,
+                                      package: @package_name,
+                                      repository: @repository,
+                                      architecture: @architecture }

--- a/src/api/config/routes/webui.rb
+++ b/src/api/config/routes/webui.rb
@@ -272,6 +272,7 @@ resources :projects, only: [], param: :name do
       resources :binaries, controller: 'webui/packages/binaries', only: [:show], constraints: cons, param: :filename, path: 'binaries/:arch/' do
         get :dependency
         get :filelist
+        get :dependencies
       end
       # We wipe all binaries at once, so this is resource instead of resources
       resource :binaries, controller: 'webui/packages/binaries', only: [:destroy], constraints: cons

--- a/src/api/spec/controllers/webui/packages/binaries_controller_spec.rb
+++ b/src/api/spec/controllers/webui/packages/binaries_controller_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Webui::Packages::BinariesController, :vcr do
       end
 
       before do
-        allow(Backend::Api::BuildResults::Binaries).to receive(:fileinfo_ext).and_raise(Backend::Error, 'fake message')
+        allow(Backend::Api::BuildResults::Binaries).to receive(:fileinfo).and_raise(Backend::Error, 'fake message')
       end
 
       it { expect(response).to have_http_status(:success) }
@@ -76,7 +76,7 @@ RSpec.describe Webui::Packages::BinariesController, :vcr do
       end
 
       before do
-        allow(Backend::Api::BuildResults::Binaries).to receive(:fileinfo_ext).and_return(nil)
+        allow(Backend::Api::BuildResults::Binaries).to receive(:fileinfo).and_return(nil)
       end
 
       it { expect { subject }.to raise_error(ActiveRecord::RecordNotFound) }
@@ -85,7 +85,7 @@ RSpec.describe Webui::Packages::BinariesController, :vcr do
     context 'with a valid download url' do
       before do
         # We want to use the backend path here
-        allow(Backend::Api::BuildResults::Binaries).to receive_messages(fileinfo_ext: fake_fileinfo, download_url_for_file: nil)
+        allow(Backend::Api::BuildResults::Binaries).to receive_messages(fileinfo: fake_fileinfo, download_url_for_file: nil)
       end
 
       context 'and normal html request' do
@@ -105,6 +105,36 @@ RSpec.describe Webui::Packages::BinariesController, :vcr do
         it { expect(response).to have_http_status(:redirect) }
         it { is_expected.to redirect_to('http://test.host/build/home:tom/source_repo/x86_64/my_package/filename.txt') }
       end
+    end
+  end
+
+  describe 'GET #dependencies' do
+    let(:fake_fileinfo) { { summary: 'fileinfo', description: 'fake', provides_ext: [], requires_ext: [] } }
+
+    before do
+      login tom
+    end
+
+    context 'with valid params' do
+      before do
+        allow(Backend::Api::BuildResults::Binaries).to receive(:fileinfo_ext).and_return(fake_fileinfo)
+        get :dependencies, params: { package_name: toms_package, project_name: home_tom, repository_name: repo_for_home_tom, arch: 'x86_64', binary_filename: 'test.rpm' }
+      end
+
+      it { expect(response).to have_http_status(:success) }
+      it { expect(assigns(:fileinfo)).to eq(fake_fileinfo) }
+    end
+
+    context 'without file info' do
+      subject do
+        get :dependencies, params: { package_name: toms_package, project_name: home_tom, repository_name: repo_for_home_tom, arch: 'x86_64', binary_filename: 'nonexistent.rpm' }
+      end
+
+      before do
+        allow(Backend::Api::BuildResults::Binaries).to receive(:fileinfo_ext).and_return(nil)
+      end
+
+      it { expect { subject }.to raise_error(ActiveRecord::RecordNotFound) }
     end
   end
 end


### PR DESCRIPTION
This PR improves the binary details page load time by lazy loading dependency data using Turbo Frames, following the pattern from [RFC: Hotwire Turbo Frames Pattern](https://github.com/openSUSE/open-build-service/wiki/RFC%3A-Hotwire-Turbo-Frames-Pattern).

Fixes: #15997 

Result:

https://github.com/user-attachments/assets/d1e739a8-534d-4a44-9695-7a57d9252a8e



