### PR TITLE
Render counters for request types and states filter with turbo stream

### DIFF
--- a/src/api/app/controllers/concerns/webui/requests_count.rb
+++ b/src/api/app/controllers/concerns/webui/requests_count.rb
@@ -1,0 +1,22 @@
+module Webui::RequestsCount
+  extend ActiveSupport::Concern
+
+  FILTERABLE_BSREQUEST_TYPES = %w[set_bugowner change_devel delete maintenance_incident
+                                  maintenance_release release add_role submit].freeze
+
+  def counts_for_states_and_types
+    @counts_grouped_by_state = group_and_fill(@bs_requests, :state, BsRequest::VALID_REQUEST_STATES.map(&:to_s))
+    @counts_grouped_by_type  = group_and_fill(@bs_requests, :type, FILTERABLE_BSREQUEST_TYPES)
+
+    respond_to do |format|
+      format.turbo_stream { render 'webui/shared/bs_requests/counts_for_states_and_types' }
+    end
+  end
+
+  private
+
+  def group_and_fill(relation, column, keys)
+    counts = relation.group(column).order(column).count
+    keys.index_with { |key| counts.fetch(key, 0) }
+  end
+end

--- a/src/api/app/controllers/webui/groups/bs_requests_controller.rb
+++ b/src/api/app/controllers/webui/groups/bs_requests_controller.rb
@@ -6,6 +6,7 @@ module Webui
       before_action :set_bs_request
 
       include Webui::RequestsFilter
+      include Webui::RequestsCount
 
       REQUEST_METHODS = {
         'all_requests_table' => :requests,

--- a/src/api/app/controllers/webui/packages/bs_requests_controller.rb
+++ b/src/api/app/controllers/webui/packages/bs_requests_controller.rb
@@ -2,6 +2,7 @@ module Webui
   module Packages
     class BsRequestsController < Webui::WebuiController
       include Webui::RequestsFilter
+      include Webui::RequestsCount
 
       before_action :set_project
       before_action :set_package

--- a/src/api/app/controllers/webui/projects/bs_requests_controller.rb
+++ b/src/api/app/controllers/webui/projects/bs_requests_controller.rb
@@ -2,6 +2,7 @@ module Webui
   module Projects
     class BsRequestsController < WebuiController
       include Webui::RequestsFilter
+      include Webui::RequestsCount
 
       before_action :set_project
       before_action :redirect_legacy

--- a/src/api/app/controllers/webui/users/bs_requests_controller.rb
+++ b/src/api/app/controllers/webui/users/bs_requests_controller.rb
@@ -6,6 +6,7 @@ module Webui
       before_action :set_bs_requests
 
       include Webui::RequestsFilter
+      include Webui::RequestsCount
 
       REQUEST_METHODS = {
         'all_requests_table' => :requests,

--- a/src/api/app/views/webui/projects/bs_requests/index.html.haml
+++ b/src/api/app/views/webui/projects/bs_requests/index.html.haml
@@ -8,4 +8,5 @@
       .card-body
         = render(partial: 'webui/shared/bs_requests/form',
                 locals: { selected_filter: @selected_filter, bs_requests_creators: @bs_requests_creators,
-                          url: projects_requests_path(@project), bs_requests: @bs_requests, viewed_object: 'Project' })
+                          url: projects_requests_path(@project), bs_requests: @bs_requests, viewed_object: 'Project',
+                          controller_path: 'webui/projects/bs_requests' })

--- a/src/api/app/views/webui/shared/_check_box.haml
+++ b/src/api/app/views/webui/shared/_check_box.haml
@@ -6,5 +6,8 @@
         - if defined?(label_icon)
           %i.me-1{ class: label_icon }
         = label
+  - if defined?(turbo_stream_counter_id)
+    %span{ id: turbo_stream_counter_id }
+      %i.fas.fa-spinner.fa-spin
   - if defined?(amount) && amount.positive?
     %span= amount

--- a/src/api/app/views/webui/shared/bs_requests/_form.html.haml
+++ b/src/api/app/views/webui/shared/bs_requests/_form.html.haml
@@ -9,7 +9,8 @@
         .collapse#content-selector-filters
           = render partial: 'webui/shared/bs_requests/requests_filter',
                    locals: { selected_filter: selected_filter, url: url,
-                             viewed_object: viewed_object }
+                             viewed_object: viewed_object,
+                             controller_path: controller_path }
     .col-md-8.col-lg-9.px-0.px-md-3.d-none.content-list-loading
       = render partial: 'webui/shared/loading', locals: { text: 'Loading...', wrapper_css: ['loading'] }
     .col-md-8.col-lg-9.px-0.px-md-3.content-list#requests-list

--- a/src/api/app/views/webui/shared/bs_requests/_requests_filter.html.haml
+++ b/src/api/app/views/webui/shared/bs_requests/_requests_filter.html.haml
@@ -28,7 +28,8 @@
         = render partial: 'webui/shared/check_box', locals: { label: render(BsRequestStateBadgeComponent.new(state: state)),
                                                               key: "states[#{state}]", name: 'states[]',
                                                               value: state,
-                                                              checked: selected_filter[:states]&.include?(state.to_s) }
+                                                              checked: selected_filter[:states]&.include?(state.to_s),
+                                                              turbo_stream_counter_id: "request_counter_for_state_#{state}" }
 
   .mt-2.mb-2.accordion-item.border-0.auto-submit-on-change
     .px-3.py-2.accordion-button.no-style{ data: { 'bs-toggle': 'collapse', 'bs-target': '#request-filter-action' },
@@ -39,42 +40,50 @@
       = render partial: 'webui/shared/check_box', locals: { label: 'Bugowner Change', key: 'action_types[set_bugowner]',
                                                             name: 'action_types[]', value: 'set_bugowner',
                                                             label_icon: action_type_icon('set_bugowner'),
-                                                            checked: selected_filter[:action_types]&.include?('set_bugowner')}
+                                                            checked: selected_filter[:action_types]&.include?('set_bugowner'),
+                                                            turbo_stream_counter_id: 'request_counter_for_type_set_bugowner' }
 
       = render partial: 'webui/shared/check_box', locals: { label: 'Change Devel Project', key: 'action_types[change_devel]',
                                                             name: 'action_types[]', value: 'change_devel',
                                                             label_icon: action_type_icon('change_devel'),
-                                                            checked: selected_filter[:action_types]&.include?('change_devel')}
+                                                            checked: selected_filter[:action_types]&.include?('change_devel'),
+                                                            turbo_stream_counter_id: 'request_counter_for_type_change_devel' }
 
       = render partial: 'webui/shared/check_box', locals: { label: 'Delete', key: 'action_types[delete]',
                                                             name: 'action_types[]', value: 'delete',
                                                             label_icon: action_type_icon('delete'),
-                                                            checked: selected_filter[:action_types]&.include?('delete')}
+                                                            checked: selected_filter[:action_types]&.include?('delete'),
+                                                            turbo_stream_counter_id: 'request_counter_for_type_delete' }
 
       = render partial: 'webui/shared/check_box', locals: { label: 'Maintenance Incident', key: 'action_types[maintenance_incident]',
                                                             name: 'action_types[]', value: 'maintenance_incident',
                                                             label_icon: action_type_icon('maintenance_incident'),
-                                                            checked: selected_filter[:action_types]&.include?('maintenance_incident')}
+                                                            checked: selected_filter[:action_types]&.include?('maintenance_incident'),
+                                                            turbo_stream_counter_id: 'request_counter_for_type_maintenance_incident' }
 
       = render partial: 'webui/shared/check_box', locals: { label: 'Maintenance Release', key: 'action_types[maintenance_release]',
                                                             name: 'action_types[]', value: 'maintenance_release',
                                                             label_icon: action_type_icon('maintenance_release'),
-                                                            checked: selected_filter[:action_types]&.include?('maintenance_release')}
+                                                            checked: selected_filter[:action_types]&.include?('maintenance_release'),
+                                                            turbo_stream_counter_id: 'request_counter_for_type_maintenance_release' }
 
       = render partial: 'webui/shared/check_box', locals: { label: 'Release', key: 'action_types[release]',
                                                             name: 'action_types[]', value: 'release',
                                                             label_icon: action_type_icon('release'),
-                                                            checked: selected_filter[:action_types]&.include?('release')}
+                                                            checked: selected_filter[:action_types]&.include?('release'),
+                                                            turbo_stream_counter_id: 'request_counter_for_type_release' }
 
       = render partial: 'webui/shared/check_box', locals: { label: 'Role Change', key: 'action_types[add_role]',
                                                             name: 'action_types[]', value: 'add_role',
                                                             label_icon: action_type_icon('add_role'),
-                                                            checked: selected_filter[:action_types]&.include?('add_role')}
+                                                            checked: selected_filter[:action_types]&.include?('add_role'),
+                                                            turbo_stream_counter_id: 'request_counter_for_type_add_role' }
 
       = render partial: 'webui/shared/check_box', locals: { label: 'Submit', key: 'action_types[submit]',
                                                             name: 'action_types[]', value: 'submit',
                                                             label_icon: action_type_icon('submit'),
-                                                            checked: selected_filter[:action_types]&.include?('submit')}
+                                                            checked: selected_filter[:action_types]&.include?('submit'),
+                                                            turbo_stream_counter_id: 'request_counter_for_type_submit' }
 
   .mt-2.mb-2.accordion-item.border-0.auto-submit-on-change
     .px-3.py-2.accordion-button.no-style{ data: { 'bs-toggle': 'collapse', 'bs-target': '#request-filter-priority' },
@@ -253,5 +262,8 @@
   = link_to('Clear', url, class: 'btn btn-light border')
 
 - content_for(:content_for_head, javascript_include_tag('webui/content-selector-filters'))
+-# turbo frame used to trigger the turbo stream which updates the request filter counters
+= turbo_frame_tag("request_filter_counts_processor", src: url_for(controller_path: controller_path,
+                                                                  action: 'counts_for_states_and_types', format: :turbo_stream))
 
 -# haml-lint:enable ViewLength

--- a/src/api/app/views/webui/shared/bs_requests/counts_for_states_and_types.turbo_stream.erb
+++ b/src/api/app/views/webui/shared/bs_requests/counts_for_states_and_types.turbo_stream.erb
@@ -1,0 +1,10 @@
+<% @counts_grouped_by_state.each do |state, count| %>
+  <%= turbo_stream.update "request_counter_for_state_#{state}" do %>
+    <span><%= count %></span>
+  <% end %>
+<% end %>
+<% @counts_grouped_by_type.each do |type, count| %>
+  <%= turbo_stream.update "request_counter_for_type_#{type}" do %>
+    <span><%= count %></span>
+  <% end %>
+<% end %>

--- a/src/api/app/views/webui/users/bs_requests/index.html.haml
+++ b/src/api/app/views/webui/users/bs_requests/index.html.haml
@@ -6,4 +6,5 @@
       .card-body
         = render(partial: 'webui/shared/bs_requests/form',
                 locals: { selected_filter: @selected_filter, bs_requests_creators: @bs_requests_creators,
-                          url: @url, bs_requests: @bs_requests, viewed_object: 'You' })
+                          url: @url, bs_requests: @bs_requests, viewed_object: 'You',
+                          controller_path: 'webui/users/bs_requests' })

--- a/src/api/config/routes/webui.rb
+++ b/src/api/config/routes/webui.rb
@@ -348,7 +348,9 @@ resources :requests, only: [], param: :number, controller: 'webui/request' do
 end
 
 get 'projects/:project/requests' => 'webui/projects/bs_requests#index', constraints: cons, as: 'projects_requests'
+get 'projects/:project/requests/counts_for_states_and_types' => 'webui/projects/bs_requests#counts_for_states_and_types', constraints: cons
 get 'projects/:project/packages/:package/requests' => 'webui/packages/bs_requests#index', constraints: cons, as: 'packages_requests'
+get 'projects/:project/packages/:package/requests/counts_for_states_and_types' => 'webui/packages/bs_requests#counts_for_states_and_types', constraints: cons
 get 'notification/autocomplete_projects' => 'webui/users/notifications#autocomplete_projects', as: 'notification_autocomplete_projects'
 
 controller 'webui/search' do
@@ -374,7 +376,11 @@ end
 
 scope :my do
   resources :tasks, only: [:index], controller: 'webui/users/tasks', as: :my_tasks
-  resources :requests, only: [:index], controller: 'webui/users/bs_requests', as: :my_requests
+  resources :requests, only: [:index], controller: 'webui/users/bs_requests', as: :my_requests do
+    collection do
+      get :counts_for_states_and_types
+    end
+  end
 
   resources :notifications, only: [:index], controller: 'webui/users/notifications', as: :my_notifications do
     collection do
@@ -437,7 +443,11 @@ end
 
 resources :groups, only: %i[index show new create edit update], param: :title, constraints: cons, controller: 'webui/groups' do
   resources :user, only: %i[create destroy update], param: :user_login, constraints: cons, controller: 'webui/groups/users'
-  resources :requests, only: [:index], controller: 'webui/groups/bs_requests'
+  resources :requests, only: [:index], controller: 'webui/groups/bs_requests' do
+    collection do
+      get :counts_for_states_and_types
+    end
+  end
 
   collection do
     get :autocomplete


### PR DESCRIPTION
Using turbo streams over turbo frames enables us to render multiple counters in one go...

Implements the counter for request types and states filter on the request index for users, groups, projects and packages.

The counter for the "involvement" filters are following in another PR, since I need to move, split and refactor some code first...

<img width="1489" height="1353" alt="image" src="https://github.com/user-attachments/assets/a31f05cb-a20c-4d27-8564-2382bb6f9b9e" />
