### PR TITLE
Remove event subscription payload

### DIFF
--- a/src/api/app/models/event_subscription.rb
+++ b/src/api/app/models/event_subscription.rb
@@ -119,7 +119,6 @@ end
 #  channel         :integer          default("disabled"), not null
 #  enabled         :boolean          default(FALSE)
 #  eventtype       :string(255)      not null
-#  payload         :text(65535)
 #  receiver_role   :string(255)      not null
 #  created_at      :datetime
 #  updated_at      :datetime

--- a/src/api/db/migrate/20260128155710_remove_payload_from_event_subscription.rb
+++ b/src/api/db/migrate/20260128155710_remove_payload_from_event_subscription.rb
@@ -1,0 +1,5 @@
+class RemovePayloadFromEventSubscription < ActiveRecord::Migration[7.2]
+  def change
+    safety_assured { remove_column :event_subscriptions, :payload, :text }
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_01_27_121427) do
+ActiveRecord::Schema[7.2].define(version: 2026_01_28_155710) do
   create_table "active_storage_attachments", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -503,7 +503,6 @@ ActiveRecord::Schema[7.2].define(version: 2026_01_27_121427) do
     t.integer "channel", default: 0, null: false
     t.boolean "enabled", default: false
     t.integer "token_id"
-    t.text "payload"
     t.integer "package_id"
     t.integer "workflow_run_id"
     t.integer "bs_request_id"


### PR DESCRIPTION
**PR 2 of 3**. Removal migration

We are going to remove the payload column from the event_subscriptions table as a follow-up of PR https://github.com/openSUSE/open-build-service/pull/19180.
To do so on a safe way, according to [strong_migrations](https://github.com/ankane/strong_migrations?tab=readme-ov-file#good), we need to do it in 3 parts:

1. Ignore payload column from AR cache (PR #19190) + deploy
2. **Merge migration PR + deploy** (this PR)
3. Remove the line introduced in 1) + deploy.

Why? In the past we only stored the workflow run payload in the event_subscriptions table. Since we also store the workflow run id, we no longer need to store the payload as well, we can access the latter through the association.
Moreover, we are getting [errors related to the payload](https://github.com/openSUSE/open-build-service/issues/17545). To sum up, we are trying to store a long text into a normal text field. Issue better described in PR #19180
