### PR TITLE
Drop ignore column payload

### DIFF
--- a/src/api/app/models/event_subscription.rb
+++ b/src/api/app/models/event_subscription.rb
@@ -1,6 +1,4 @@
 class EventSubscription < ApplicationRecord
-  self.ignored_columns += ['payload']
-
   RECEIVER_ROLE_TEXTS = {
     maintainer: 'Maintainer',
     bugowner: 'Bugowner',


### PR DESCRIPTION
**PR 3 of 3**. Stop ignoring the payload column from AR cache

We are going to remove the payload column from the event_subscriptions table as a follow-up of PR https://github.com/openSUSE/open-build-service/pull/19180.
To do so on a safe way, according to [strong_migrations](https://github.com/ankane/strong_migrations?tab=readme-ov-file#good), we need to do it in 3 parts:

1. Ignore payload column from AR cache (PR #19190) + deploy
2. Merge migration PR + deploy (PR #19192)
3. **Remove the line introduced in 1)** (this PR) + deploy.

Why? In the past we only stored the workflow run payload in the event_subscriptions table. Since we also store the workflow run id, we no longer need to store the payload as well, we can access the latter through the association.
Moreover, we are getting [errors related to the payload](https://github.com/openSUSE/open-build-service/issues/17545). To sum up, we are trying to store a long text into a normal text field. Issue better described in PR #19180
