### PR TITLE
Sphinx syntax wants two words to work with negation

### DIFF
--- a/src/api/app/views/webui/shared/bs_requests/_filter_help_search_box.html.haml
+++ b/src/api/app/views/webui/shared/bs_requests/_filter_help_search_box.html.haml
@@ -3,7 +3,7 @@
                <p>Sphinx extended query syntax allowed:
                  <ul>
                    <li> OR: `some | text`</li>
-                   <li> NOT: `-text` or `!text`</li>
+                   <li> NOT: `some -text` or `some !text`</li>
                    <li> phrase search: 'some text'</li>
                  </ul>
               </p>"


### PR DESCRIPTION
As described in https://sphx.org/docs/sphinx3.html#cheat-sheet , Sphinx syntax wants two words to work with a negation of one of the two: `!text` fails, `some !text` works instead. Fixing the hint accordingly.