### PR TITLE
Rescue from exceptions thrown on invalid text search expressions

### DIFF
--- a/src/api/app/controllers/concerns/webui/requests_filter.rb
+++ b/src/api/app/controllers/concerns/webui/requests_filter.rb
@@ -108,6 +108,9 @@ module Webui::RequestsFilter
     end
 
     @bs_requests = @bs_requests.where(id: BsRequest.search_for_ids(@selected_filter['search'], per_page: TEXT_SEARCH_MAX_RESULTS))
+  rescue ThinkingSphinx::ParseError
+    flash.now[:error] = "Check your search expression. Use the <a href='https://sphx.org/docs/sphinx3.html#cheat-sheet' target='blank'>syntax guide</a> for help."
+    @bs_requests = BsRequest.none
   end
 
   def filter_labels


### PR DESCRIPTION
### After the changes

<img width="994" height="300" alt="Screenshot From 2026-01-30 10-32-29" src="https://github.com/user-attachments/assets/fdbe5a68-a434-4a6e-bfbc-80f15820c4e1" />

