### PR TITLE
Add InfluxDB tags to track enabled beta features

### DIFF
--- a/src/api/app/controllers/webui/webui_controller.rb
+++ b/src/api/app/controllers/webui/webui_controller.rb
@@ -210,12 +210,21 @@ class Webui::WebuiController < ActionController::Base
   end
 
   def set_influxdb_data
-    InfluxDB::Rails.current.tags = {
-      beta: User.possibly_nobody.in_beta?,
+    in_beta = User.possibly_nobody.in_beta?
+
+    tags = {
+      beta: in_beta,
       anonymous: !User.session,
       spider: @spider_bot,
       interconnect: false,
       interface: :webui
     }
+    if in_beta
+      Flipper.preload_all.map(&:name).each do |feature_name|
+        tags[:"beta_#{feature_name}"] = Flipper.enabled?(feature_name.to_sym, User.possibly_nobody)
+      end
+    end
+
+    InfluxDB::Rails.current.tags = tags
   end
 end


### PR DESCRIPTION
Refactor `set_influxdb_data` to use local variables.

Iterate over `Flipper.preload_all` when the user is in beta. Add `beta_#{feature_name}` tags with their boolean Flipper status.