### PR TITLE
Improve comments_count data migration

### DIFF
--- a/src/api/db/data/20260127123201_prefill_comments_count_values.rb
+++ b/src/api/db/data/20260127123201_prefill_comments_count_values.rb
@@ -3,8 +3,10 @@
 class PrefillCommentsCountValues < ActiveRecord::Migration[7.2]
   def up
     # rubocop:disable Rails/SkipsModelValidations
-    Comment.group(:commentable_type, :commentable_id).select(:commentable_type, :commentable_id, 'COUNT(id) as comments_count').each do |comment|
-      comment.commentable.update_columns(comments_count: comment.comments_count)
+    Comment.group(:commentable_type, :commentable_id)
+           .select(:id, :commentable_type, :commentable_id, 'COUNT(id) as comments_count')
+           .find_each.each do |comment|
+      comment.commentable.update_columns(comments_count: comment.comments_count) if comment.commentable
     end
     # rubocop:enable Rails/SkipsModelValidations
   end


### PR DESCRIPTION
To make it run in batches and skip commentables that are nil. There are thousands of comments related to projects, packages, reports, bs_requests and bs_request_actions.

Why `find_each` (and not `find_in_batches` or `in_batches`)? Because according to [this documentation](https://api.rubyonrails.org/classes/ActiveRecord/Batches.html) it's the best option if we end up accessing each element individually. Literally "To be yielded each record one by one, use find_each instead."