### PR TITLE
Remove event_subscription payload from specs

### DIFF
--- a/src/api/spec/models/event_subscription/find_for_event_spec.rb
+++ b/src/api/spec/models/event_subscription/find_for_event_spec.rb
@@ -291,7 +291,7 @@ RSpec.describe EventSubscription::FindForEvent do
           let(:event) { Event::RelationshipCreate.create(who: owner.login, user: user.login, project: project.name) }
 
           before do
-            event_subscription = create(
+            create(
               :event_subscription,
               eventtype: 'Event::RelationshipCreate',
               receiver_role: 'any_role',
@@ -299,7 +299,6 @@ RSpec.describe EventSubscription::FindForEvent do
               group: nil,
               channel: :web
             )
-            event_subscription.payload = { project: project.name }
           end
 
           it 'includes the target user' do
@@ -320,7 +319,7 @@ RSpec.describe EventSubscription::FindForEvent do
           let(:event) { Event::RelationshipCreate.create(who: owner.login, group: group.title, project: project.name) }
 
           before do
-            event_subscription = create(
+            create(
               :event_subscription,
               eventtype: 'Event::RelationshipCreate',
               receiver_role: 'any_role',
@@ -328,7 +327,6 @@ RSpec.describe EventSubscription::FindForEvent do
               group: nil,
               channel: :web
             )
-            event_subscription.payload = { project: project.name }
           end
 
           it 'includes the target group' do
@@ -370,7 +368,7 @@ RSpec.describe EventSubscription::FindForEvent do
           let(:event) { Event::RelationshipCreate.create(who: owner.login, user: user.login, package: package.name) }
 
           before do
-            event_subscription = create(
+            create(
               :event_subscription,
               eventtype: 'Event::RelationshipCreate',
               receiver_role: 'any_role',
@@ -378,7 +376,6 @@ RSpec.describe EventSubscription::FindForEvent do
               group: nil,
               channel: :web
             )
-            event_subscription.payload = { package: package.name }
           end
 
           it 'includes the target user' do
@@ -399,7 +396,7 @@ RSpec.describe EventSubscription::FindForEvent do
           let(:event) { Event::RelationshipCreate.create(who: owner.login, group: group.title, package: package.name) }
 
           before do
-            event_subscription = create(
+            create(
               :event_subscription,
               eventtype: 'Event::RelationshipCreate',
               receiver_role: 'any_role',
@@ -407,7 +404,6 @@ RSpec.describe EventSubscription::FindForEvent do
               group: nil,
               channel: :web
             )
-            event_subscription.payload = { package: package.name }
           end
 
           it 'includes the target group' do
@@ -441,7 +437,7 @@ RSpec.describe EventSubscription::FindForEvent do
           let(:event) { Event::RelationshipDelete.create(who: owner.login, user: user.login, project: project.name) }
 
           before do
-            event_subscription = create(
+            create(
               :event_subscription,
               eventtype: 'Event::RelationshipDelete',
               receiver_role: 'any_role',
@@ -449,7 +445,6 @@ RSpec.describe EventSubscription::FindForEvent do
               group: nil,
               channel: :web
             )
-            event_subscription.payload = { project: project.name }
           end
 
           it 'includes the target user' do
@@ -470,7 +465,7 @@ RSpec.describe EventSubscription::FindForEvent do
           let(:event) { Event::RelationshipDelete.create(who: owner.login, group: group.title, project: project.name) }
 
           before do
-            event_subscription = create(
+            create(
               :event_subscription,
               eventtype: 'Event::RelationshipDelete',
               receiver_role: 'any_role',
@@ -478,7 +473,6 @@ RSpec.describe EventSubscription::FindForEvent do
               group: nil,
               channel: :web
             )
-            event_subscription.payload = { project: project.name }
           end
 
           it 'includes the target group' do
@@ -501,7 +495,7 @@ RSpec.describe EventSubscription::FindForEvent do
           let(:event) { Event::RelationshipDelete.create(who: owner.login, user: user.login, package: package.name) }
 
           before do
-            event_subscription = create(
+            create(
               :event_subscription,
               eventtype: 'Event::RelationshipDelete',
               receiver_role: 'any_role',
@@ -509,7 +503,6 @@ RSpec.describe EventSubscription::FindForEvent do
               group: nil,
               channel: :web
             )
-            event_subscription.payload = { package: package.name }
           end
 
           it 'includes the target user' do
@@ -530,7 +523,7 @@ RSpec.describe EventSubscription::FindForEvent do
           let(:event) { Event::RelationshipDelete.create(who: owner.login, group: group.title, package: package.name) }
 
           before do
-            event_subscription = create(
+            create(
               :event_subscription,
               eventtype: 'Event::RelationshipDelete',
               receiver_role: 'any_role',
@@ -538,7 +531,6 @@ RSpec.describe EventSubscription::FindForEvent do
               group: nil,
               channel: :web
             )
-            event_subscription.payload = { package: package.name }
           end
 
           it 'includes the target group' do

--- a/src/api/spec/services/notification_service/notifier_spec.rb
+++ b/src/api/spec/services/notification_service/notifier_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe NotificationService::Notifier do
 
           context 'and a user is subscribed to the event' do
             before do
-              event_subscription = create(
+              create(
                 :event_subscription,
                 eventtype: 'Event::RelationshipCreate',
                 receiver_role: 'any_role',
@@ -94,7 +94,6 @@ RSpec.describe NotificationService::Notifier do
                 group: nil,
                 channel: :web
               )
-              event_subscription.payload = { project: project.name }
             end
 
             it 'creates a new notification for the target user' do
@@ -116,7 +115,7 @@ RSpec.describe NotificationService::Notifier do
 
           context 'and a group member is subscribed to the event' do
             before do
-              event_subscription = create(
+              create(
                 :event_subscription,
                 eventtype: 'Event::RelationshipCreate',
                 receiver_role: 'any_role',
@@ -124,7 +123,6 @@ RSpec.describe NotificationService::Notifier do
                 group: nil,
                 channel: :web
               )
-              event_subscription.payload = { project: project.name }
               group.groups_users.first.update(email: false)
             end
 
@@ -151,7 +149,7 @@ RSpec.describe NotificationService::Notifier do
 
           context 'and a user is subscribed to the event' do
             before do
-              event_subscription = create(
+              create(
                 :event_subscription,
                 eventtype: 'Event::RelationshipCreate',
                 receiver_role: 'any_role',
@@ -159,7 +157,6 @@ RSpec.describe NotificationService::Notifier do
                 group: nil,
                 channel: :web
               )
-              event_subscription.payload = { package: package.name }
             end
 
             it 'creates a new notification for the target user' do
@@ -181,7 +178,7 @@ RSpec.describe NotificationService::Notifier do
 
           context 'and a group is subscribed to the event' do
             before do
-              event_subscription = create(
+              create(
                 :event_subscription,
                 eventtype: 'Event::RelationshipCreate',
                 receiver_role: 'any_role',
@@ -189,7 +186,6 @@ RSpec.describe NotificationService::Notifier do
                 group: nil,
                 channel: :web
               )
-              event_subscription.payload = { package: package.name }
             end
 
             it 'creates a new notification for the target user' do
@@ -218,7 +214,7 @@ RSpec.describe NotificationService::Notifier do
 
           context 'and a user is subscribed to the event' do
             before do
-              event_subscription = create(
+              create(
                 :event_subscription,
                 eventtype: 'Event::RelationshipDelete',
                 receiver_role: 'any_role',
@@ -226,7 +222,6 @@ RSpec.describe NotificationService::Notifier do
                 group: nil,
                 channel: :web
               )
-              event_subscription.payload = { project: project.name }
             end
 
             it 'creates a new notification for the target user' do
@@ -248,7 +243,7 @@ RSpec.describe NotificationService::Notifier do
 
           context 'and a group member is subscribed to the event' do
             before do
-              event_subscription = create(
+              create(
                 :event_subscription,
                 eventtype: 'Event::RelationshipDelete',
                 receiver_role: 'any_role',
@@ -256,7 +251,6 @@ RSpec.describe NotificationService::Notifier do
                 group: nil,
                 channel: :web
               )
-              event_subscription.payload = { project: project.name }
             end
 
             it 'creates a new notification for the subscribed group members' do
@@ -282,7 +276,7 @@ RSpec.describe NotificationService::Notifier do
 
           context 'and a user is subscribed to the event' do
             before do
-              event_subscription = create(
+              create(
                 :event_subscription,
                 eventtype: 'Event::RelationshipDelete',
                 receiver_role: 'any_role',
@@ -290,7 +284,6 @@ RSpec.describe NotificationService::Notifier do
                 group: nil,
                 channel: :web
               )
-              event_subscription.payload = { package: package.name }
             end
 
             it 'creates a new notification for the target user' do
@@ -322,7 +315,7 @@ RSpec.describe NotificationService::Notifier do
 
           context 'and a group is subscribed to the event' do
             before do
-              event_subscription = create(
+              create(
                 :event_subscription,
                 eventtype: 'Event::RelationshipDelete',
                 receiver_role: 'any_role',
@@ -330,7 +323,6 @@ RSpec.describe NotificationService::Notifier do
                 group: nil,
                 channel: :web
               )
-              event_subscription.payload = { package: package.name }
             end
 
             it 'creates a new notification for the target user' do


### PR DESCRIPTION
Payload was only used for event subscriptions with scm channel. So in specs we shouldn't have added it to other kinds of event subscriptions.

You can confirm the specs run even without them.