### PR TITLE
Add Sphinx attribute to filter by BsRequest id

### DIFF
--- a/src/api/app/indices/bs_request_index.rb
+++ b/src/api/app/indices/bs_request_index.rb
@@ -1,5 +1,6 @@
 ThinkingSphinx::Index.define :bs_request, with: :real_time do
   indexes comment, description, comments_bodies, reviews_reasons
 
+  has id, as: :bs_request_id, type: :integer
   has updated_at, type: :timestamp
 end


### PR DESCRIPTION
~Should be deployed with:~

```
OBSOLETE
```

Correct steps described here: https://github.com/openSUSE/open-build-service/pull/19264#issue-3930779267.

This needs to be deployed before changes introduced by #19211.

This deployement doesn't require downtime.

For reference documentation see:
- https://freelancing-gods.com/thinking-sphinx/v5/real_time
- https://freelancing-gods.com/thinking-sphinx/v5/rake_tasks#rebuilding-sphinx-indexes