### PR TITLE
Fix SQL error in request counts by unscoping existing order

### DIFF
--- a/src/api/app/controllers/concerns/webui/requests_count.rb
+++ b/src/api/app/controllers/concerns/webui/requests_count.rb
@@ -27,7 +27,7 @@ module Webui::RequestsCount
   end
 
   def group_and_fill(relation, column, keys)
-    counts = relation.group(column).order(column).count
+    counts = relation.unscope(:order).group(column).count
     keys.index_with { |key| counts.fetch(key, 0) }
   end
 end


### PR DESCRIPTION
The `@bs_requests` relation passed to `Webui::RequestsCount` already includes an `.order()` clause applied by the `filter_sort` method.

Improve efficiency of SQL queries performed to retrieve the counters by removing previous sorting before grouping and counting.