### PR TITLE
Cleanup `bs_request_action` attributes after validations got introduced

### DIFF
--- a/src/api/db/data/20260728131917_bs_request_action_correct_the_data.rb
+++ b/src/api/db/data/20260728131917_bs_request_action_correct_the_data.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class BsRequestActionCorrectTheData < ActiveRecord::Migration[7.2]
+  # rubocop:disable Metrics/CyclomaticComplexity
+  # rubocop:disable Rails/SkipsModelValidations
+  def up
+    BsRequestAction.in_batches do |batch|
+      batch.find_each do |bs_request_action|
+        case bs_request_action.type
+        when 'add_role'
+          bs_request_action.update_columns(source_project: nil, source_package: nil, source_rev: nil, sourceupdate: nil, target_releaseproject: nil, target_repository: nil)
+        when 'change_devel'
+          bs_request_action.update_columns(group_name: nil, person_name: nil, role: nil, source_rev: nil, sourceupdate: nil, target_releaseproject: nil, target_repository: nil)
+        when 'delete'
+          bs_request_action.update_columns(source_project: nil, source_package: nil, source_rev: nil, sourceupdate: nil, group_name: nil, person_name: nil, role: nil, target_releaseproject: nil)
+        when 'maintenance_incident'
+          bs_request_action.update_columns(group_name: nil, person_name: nil, role: nil)
+        when 'maintenance_release', 'release'
+          bs_request_action.update_columns(group_name: nil, person_name: nil, role: nil, target_releaseproject: nil)
+        when 'set_bugowner'
+          bs_request_action.update_columns(source_project: nil, source_package: nil, source_rev: nil, sourceupdate: nil, role: nil, target_releaseproject: nil, target_repository: nil)
+        when 'submit'
+          bs_request_action.update_columns(group_name: nil, person_name: nil, role: nil, target_releaseproject: nil, target_repository: nil)
+        end
+      end
+    end
+  end
+  # rubocop:enable Rails/SkipsModelValidations
+  # rubocop:enable Metrics/CyclomaticComplexity
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/src/api/db/data/20260728131917_bs_request_action_correct_the_data.rb
+++ b/src/api/db/data/20260728131917_bs_request_action_correct_the_data.rb
@@ -4,26 +4,119 @@ class BsRequestActionCorrectTheData < ActiveRecord::Migration[7.2]
   # rubocop:disable Metrics/CyclomaticComplexity
   # rubocop:disable Rails/SkipsModelValidations
   def up
-    BsRequestAction.in_batches do |batch|
-      batch.find_each do |bs_request_action|
-        case bs_request_action.type
-        when 'add_role'
-          bs_request_action.update_columns(source_project: nil, source_package: nil, source_rev: nil, sourceupdate: nil, target_releaseproject: nil, target_repository: nil)
-        when 'change_devel'
-          bs_request_action.update_columns(group_name: nil, person_name: nil, role: nil, source_rev: nil, sourceupdate: nil, target_releaseproject: nil, target_repository: nil)
-        when 'delete'
-          bs_request_action.update_columns(source_project: nil, source_package: nil, source_rev: nil, sourceupdate: nil, group_name: nil, person_name: nil, role: nil, target_releaseproject: nil)
-        when 'maintenance_incident'
-          bs_request_action.update_columns(group_name: nil, person_name: nil, role: nil)
-        when 'maintenance_release', 'release'
-          bs_request_action.update_columns(group_name: nil, person_name: nil, role: nil, target_releaseproject: nil)
-        when 'set_bugowner'
-          bs_request_action.update_columns(source_project: nil, source_package: nil, source_rev: nil, sourceupdate: nil, role: nil, target_releaseproject: nil, target_repository: nil)
-        when 'submit'
-          bs_request_action.update_columns(group_name: nil, person_name: nil, role: nil, target_releaseproject: nil, target_repository: nil)
-        end
-      end
-    end
+# 1. 'add_role'
+BsRequestAction.where(type: 'add_role')
+  .where(
+    'source_project IS NOT NULL OR source_package IS NOT NULL OR ' \
+    'source_rev IS NOT NULL OR sourceupdate IS NOT NULL OR ' \
+    'target_releaseproject IS NOT NULL OR target_repository IS NOT NULL'
+  ).in_batches do |relation|
+    relation.update_all(
+      source_project: nil,
+      source_package: nil,
+      source_rev: nil,
+      sourceupdate: nil,
+      target_releaseproject: nil,
+      target_repository: nil
+    )
+end
+
+# 2. 'change_devel'
+BsRequestAction.where(type: 'change_devel')
+  .where(
+    'group_name IS NOT NULL OR person_name IS NOT NULL OR ' \
+    'role IS NOT NULL OR source_rev IS NOT NULL OR ' \
+    'sourceupdate IS NOT NULL OR target_releaseproject IS NOT NULL OR ' \
+    'target_repository IS NOT NULL'
+  ).in_batches do |relation|
+    relation.update_all(
+      group_name: nil,
+      person_name: nil,
+      role: nil,
+      source_rev: nil,
+      sourceupdate: nil,
+      target_releaseproject: nil,
+      target_repository: nil
+    )
+end
+
+# 3. 'delete'
+BsRequestAction.where(type: 'delete')
+  .where(
+    'source_project IS NOT NULL OR source_package IS NOT NULL OR ' \
+    'source_rev IS NOT NULL OR sourceupdate IS NOT NULL OR ' \
+    'group_name IS NOT NULL OR person_name IS NOT NULL OR ' \
+    'role IS NOT NULL OR target_releaseproject IS NOT NULL'
+  ).in_batches do |relation|
+    relation.update_all(
+      source_project: nil,
+      source_package: nil,
+      source_rev: nil,
+      sourceupdate: nil,
+      group_name: nil,
+      person_name: nil,
+      role: nil,
+      target_releaseproject: nil
+    )
+end
+
+# 4. 'maintenance_incident'
+BsRequestAction.where(type: 'maintenance_incident')
+  .where('group_name IS NOT NULL OR person_name IS NOT NULL OR role IS NOT NULL')
+  .in_batches do |relation|
+    relation.update_all(
+      group_name: nil,
+      person_name: nil,
+      role: nil
+    )
+end
+
+# 5. 'maintenance_release', 'release'
+BsRequestAction.where(type: ['maintenance_release', 'release'])
+  .where('group_name IS NOT NULL OR person_name IS NOT NULL OR role IS NOT NULL OR target_releaseproject IS NOT NULL')
+  .in_batches do |relation|
+    relation.update_all(
+      group_name: nil,
+      person_name: nil,
+      role: nil,
+      target_releaseproject: nil
+    )
+end
+
+# 6. 'set_bugowner'
+BsRequestAction.where(type: 'set_bugowner')
+  .where(
+    'source_project IS NOT NULL OR source_package IS NOT NULL OR ' \
+    'source_rev IS NOT NULL OR sourceupdate IS NOT NULL OR ' \
+    'role IS NOT NULL OR target_releaseproject IS NOT NULL OR ' \
+    'target_repository IS NOT NULL'
+  ).in_batches do |relation|
+    relation.update_all(
+      source_project: nil,
+      source_package: nil,
+      source_rev: nil,
+      sourceupdate: nil,
+      role: nil,
+      target_releaseproject: nil,
+      target_repository: nil
+    )
+end
+
+# 7. 'submit'
+BsRequestAction.where(type: 'submit')
+  .where(
+    'group_name IS NOT NULL OR person_name IS NOT NULL OR ' \
+    'role IS NOT NULL OR target_releaseproject IS NOT NULL OR ' \
+    'target_repository IS NOT NULL'
+  ).in_batches do |relation|
+    relation.update_all(
+      group_name: nil,
+      person_name: nil,
+      role: nil,
+      target_releaseproject: nil,
+      target_repository: nil
+    )
+end
   end
   # rubocop:enable Rails/SkipsModelValidations
   # rubocop:enable Metrics/CyclomaticComplexity

--- a/src/api/db/data_schema.rb
+++ b/src/api/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 2026_07_23_180842)
+DataMigrate::Data.define(version: 2026_07_28_131917)


### PR DESCRIPTION
We cleaned up and corrected some validations performed on the `bs_request_action` models in
https://github.com/openSUSE/open-build-service/pull/19178. After those validations proven to be correct, we can cleanup the database with a data migration.

The data migration got extracted from previously mentioned PR in order to be performed independently after the validations proved to be correct once used in production.

DO NOT MERGE: Lets double check if the validations turned out to behave correctly on all of our production systems. 