### PR TITLE
Conditionally render package version column

### DIFF
--- a/src/api/app/datatables/package_datatable.rb
+++ b/src/api/app/datatables/package_datatable.rb
@@ -14,31 +14,43 @@ class PackageDatatable < Datatable
   end
 
   def view_columns
+    return @view_columns if @view_columns
+
     # Declare strings in this format: ModelName.column_name
     # or in aliased_join_table.column_name format
-    @view_columns ||= {
+    @view_columns = {
       name: { source: 'Package.name' },
-      version: { source: 'PackageVersion.version', cond: versions_filter },
       labels: { source: 'LabelTemplate.name' },
       changed: { source: 'Package.updated_at', searchable: false }
     }
+
+    @view_columns[:version] = { source: 'PackageVersion.version', cond: versions_filter } if show_version_column?
+
+    @view_columns
   end
 
   # rubocop:disable Naming/AccessorMethodName
   def get_raw_records
-    @project.packages.includes(:package_kinds).left_joins(:latest_local_version, :latest_upstream_version, labels: [:label_template]).references(:labels, :label_template)
+    query = @project.packages.includes(:package_kinds).left_joins(labels: [:label_template]).references(:labels, :label_template)
+
+    query = query.left_joins(:latest_local_version, :latest_upstream_version) if show_version_column?
+
+    query
   end
   # rubocop:enable Naming/AccessorMethodName
 
   def data
     records.map do |record|
-      {
+      row = {
         name: name_with_link(record),
-        version: versions_text(record),
         labels: labels_list(record.labels),
         changed: format('%{duration} ago',
                         duration: time_ago_in_words(Time.at(record.updated_at.to_i)))
       }
+
+      row[:version] = versions_text(record) if show_version_column?
+
+      row
     end
   end
 
@@ -105,5 +117,9 @@ class PackageDatatable < Datatable
     parenthesized_text = "(#{link})".html_safe # rubocop:disable Rails/OutputSafety
 
     ActionController::Base.helpers.safe_join([local, parenthesized_text].compact, ' ')
+  end
+
+  def show_version_column?
+    @show_version_column ||= Flipper.enabled?(:package_version_tracking, User.session) && @project.anitya_distribution_name.present?
   end
 end

--- a/src/api/app/views/webui/project/_project_packages.html.haml
+++ b/src/api/app/views/webui/project/_project_packages.html.haml
@@ -22,7 +22,7 @@
         %thead
           %tr
             %th.w-30 Name
-            - if Flipper.enabled?(:package_version_tracking, User.session)
+            - if Flipper.enabled?(:package_version_tracking, User.session) && project.anitya_distribution_name.present?
               %th.w-30 Version
             - if Flipper.enabled?(:labels, User.session)
               %th.w-30 Labels
@@ -47,7 +47,7 @@
   :plain
     var package_datatable_columns = [{"data": "name"}]
 
-  - if Flipper.enabled?(:package_version_tracking, User.session)
+  - if Flipper.enabled?(:package_version_tracking, User.session) && project.anitya_distribution_name.present?
     :plain
       package_datatable_columns.push({"data": "version", "orderable": false})
 


### PR DESCRIPTION
Render package version column based on Anitya distribution.

Avoid unnecessary `left_joins` on version tables when the column is hidden, improving performance.