### PR TITLE
[backend] Support reporting scmsync url for binary search

### DIFF
--- a/src/api/public/apidocs/components/parameters/withscmsyncurl.yaml
+++ b/src/api/public/apidocs/components/parameters/withscmsyncurl.yaml
@@ -1,0 +1,12 @@
+in: query
+name: withscmsyncurl
+schema:
+  type: integer
+  enum:
+    - 0
+    - 1
+description: |
+  Add the scmsync url in the results as attribute `scmsyncurl`.
+
+  A value `0` means without the scmsync url. A value `1` means with the scmsync url.
+example: 1

--- a/src/api/public/apidocs/components/responses/search/published_binary_id.yaml
+++ b/src/api/public/apidocs/components/responses/search/published_binary_id.yaml
@@ -65,11 +65,15 @@ content:
                 type: string
                 xml:
                   attribute: true
+              scmsyncurl:
+                type: string
+                xml:
+                  attribute: true
       xml:
         name: collection
         wrapped: true
     examples:
-      including_download_urls:
+      including_urls:
         value:
           matches: 2
           binary:
@@ -97,6 +101,7 @@ content:
               baseproject: home:bar
               type: rpm
               downloadurl: https://server1.myorg.org/repositories/home:/foo/openSUSE_Tumbleweed/src/package_name2-20201220-3.1.src.rpm
+              scmsyncurl: https://gitea.myorg.org/org/repo#main
         summary: Including download urls
         description: Result after adding the `withdownloadurl=1` parameter/value pair to the request.
       with_limit:

--- a/src/api/public/apidocs/paths/search_published_binary_id.yaml
+++ b/src/api/public/apidocs/paths/search_published_binary_id.yaml
@@ -12,6 +12,7 @@ get:
       example: project='home:foo'+and+name='bar'
     - $ref: '../components/parameters/limit.yaml'
     - $ref: '../components/parameters/withdownloadurl.yaml'
+    - $ref: '../components/parameters/withscmsyncurl.yaml'
   responses:
     '200':
       $ref: '../components/responses/search/published_binary_id.yaml'

--- a/src/api/public/apidocs/paths/search_published_pattern_id.yaml
+++ b/src/api/public/apidocs/paths/search_published_pattern_id.yaml
@@ -12,6 +12,7 @@ get:
       example: project='home:foo'+and+name='bar'
     - $ref: '../components/parameters/limit.yaml'
     - $ref: '../components/parameters/withdownloadurl.yaml'
+    - $ref: '../components/parameters/withscmsyncurl.yaml'
   responses:
     '200':
       $ref: '../components/responses/search/published_pattern_id.yaml'

--- a/src/api/public/apidocs/paths/search_published_repoinfo_id.yaml
+++ b/src/api/public/apidocs/paths/search_published_repoinfo_id.yaml
@@ -12,6 +12,7 @@ get:
       example: project='home:foo'
     - $ref: '../components/parameters/limit.yaml'
     - $ref: '../components/parameters/withdownloadurl.yaml'
+    - $ref: '../components/parameters/withscmsyncurl.yaml'
   responses:
     '200':
       $ref: '../components/responses/search/published_repoinfo_id.yaml'

--- a/src/backend/BSSrcServer/ScmsyncDB.pm
+++ b/src/backend/BSSrcServer/ScmsyncDB.pm
@@ -104,6 +104,24 @@ sub getscmsyncpackages {
   return @ary;
 }
 
+sub getscmsyncurl {
+  my ($project, $package) = @_;
+  return undef unless $BSConfig::source_db_sqlite;
+
+  my $db = BSSrcServer::SQLite::opendb($sourcedb, 'scmsync');
+  my $h = $db->{'sqlite'} || BSSrcServer::SQLite::connectdb($db);
+
+  my $sh = BSSQLite::dbdo_bind($h, 'SELECT scmsync_repo, scmsync_branch FROM scmsync WHERE project = ? AND package = ? LIMIT 1', [$project], [$package]);
+  my ($scmsync_repo, $scmsync_branch);
+  $sh->bind_columns(\$scmsync_repo, \$scmsync_branch);
+  my $scmsync_url;
+  if ($sh->fetch()) {
+    $scmsync_url = $scmsync_repo;
+    $scmsync_url .= "#".$scmsync_branch if $scmsync_branch;
+  }
+  return $scmsync_url;
+}
+
 
 sub movescmsync {
   my ($projid, $oprojid) = @_;

--- a/src/backend/BSXML.pm
+++ b/src/backend/BSXML.pm
@@ -1324,6 +1324,7 @@ our $binary_id = [
 	'baseproject',
 	'type',
 	'downloadurl',
+	'scmsyncurl',
 ];
 
 our $pattern_id = [

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -5802,6 +5802,16 @@ sub published_binary_projectindexfunc {
   return sort keys %bins;
 }
 
+sub search_add_scmsyncurl {
+  my ($data) = @_;
+  
+  for my $d (@$data) {
+    next unless $d->{'project'} && $d->{'package'};
+    my $scmsyncurl = BSSrcServer::ScmsyncDB::getscmsyncurl($d->{'project'}, $d->{'package'});
+    $d->{'scmsyncurl'} = $scmsyncurl if $scmsyncurl;
+  }
+}
+
 sub search_add_downloadurl {
   my ($data) = @_;
   for my $d (@$data) {
@@ -5849,6 +5859,7 @@ sub search_published_binary_id {
   $res->{'limited'} = 'true' if $limit && @$data > $limit;
   splice(@$data, $limit) if $limit && @$data > $limit;
   delete $_->{'path'} for @$data;
+  search_add_scmsyncurl($data) if $cgi->{'withscmsyncurl'};
   search_add_downloadurl($data) if $cgi->{'withdownloadurl'};
   $res->{'binary'} = $data;
   return ($res, $BSXML::collection);
@@ -8053,10 +8064,10 @@ my $dispatches = [
   '/search/package/id $match:' => \&search_pack_id,
 
   'POST:/search/published cmd:' => \&search_published_updatedb,
-  '/search/published/binary/id $match: limit:num? withdownloadurl:bool?' => \&search_published_binary_id,
-  '/search/published/binary/name $match: limit:num?' => \&search_published_binary_name,
-  '/search/published/pattern/id $match: limit:num? withdownloadurl:bool?' => \&search_published_pattern_id,
-  '/search/published/repoinfo/id $match: limit:num? withdownloadurl:bool?' => \&search_published_repoinfo_id,
+  '/search/published/binary/id $match: limit:num? withdownloadurl:bool? withscmsyncurl:bool?' => \&search_published_binary_id,
+  '/search/published/binary/name $match: limit:num? withdownloadurl:bool? withscmsyncurl:bool?' => \&search_published_binary_name,
+  '/search/published/pattern/id $match: limit:num? withdownloadurl:bool? withscmsyncurl:bool?' => \&search_published_pattern_id,
+  '/search/published/repoinfo/id $match: limit:num? withdownloadurl:bool? withscmsyncurl:bool?' => \&search_published_repoinfo_id,
 
   # service interface, just for listing for now
   '/service' => \&listservices,


### PR DESCRIPTION
It requires the "withscmsyncurl" query parameter since old clients might fail with the result and search gets slower