### PR TITLE
Concatenate URLs properly

### DIFF
--- a/src/api/app/views/webui/package/_extra_actions.html.haml
+++ b/src/api/app/views/webui/package/_extra_actions.html.haml
@@ -1,4 +1,5 @@
 - if CONFIG['software_opensuse_url']
   %li
     %i.fas.fa-download.text-secondary
-    = link_to('Download package', "#{CONFIG['software_opensuse_url']}/download.html?project=#{u project.name}&package=#{u package.name}")
+    - url = Addressable::URI.parse(CONFIG['software_opensuse_url']).join("download.html?project=#{u project.name}&package=#{u package.name}").to_s
+    = link_to('Download package', url)


### PR DESCRIPTION
Fixes https://github.com/openSUSE/open-build-service/issues/19231
Generates a well formed URL even if slices has some conflict to join.