### PR TITLE
Remove redundant `source_path` Package instance method

### DIFF
--- a/src/api/app/controllers/source_package_command_controller.rb
+++ b/src/api/app/controllers/source_package_command_controller.rb
@@ -273,7 +273,7 @@ class SourcePackageCommandController < SourceController
       @package.save!
     end
 
-    path = @package.source_path
+    path = Package.source_path(@package.project.name, @package.name)
     path << build_query_from_hash(params, %i[cmd rev user comment oproject opackage orev expand
                                              keeplink repairlink linkrev olinkrev requestid
                                              withvrev noservice dontupdatesource])

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -501,10 +501,6 @@ class Package < ApplicationRecord
     path
   end
 
-  def source_path(file = nil, opts = {})
-    Package.source_path(project.name, name, file, opts)
-  end
-
   def source_file(file, opts = {})
     Backend::Api::Sources::File.content(project.name, name, file, opts)
   end

--- a/src/api/spec/models/package_spec.rb
+++ b/src/api/spec/models/package_spec.rb
@@ -315,10 +315,10 @@ RSpec.describe Package, :vcr do
     end
   end
 
-  describe '#source_path' do
-    it { expect(package_with_file.source_path).to eq('/source/home:tom/package_with_files') }
-    it { expect(package_with_file.source_path('icon')).to eq('/source/home:tom/package_with_files/icon') }
-    it { expect(package_with_file.source_path('icon', format: :html)).to eq('/source/home:tom/package_with_files/icon?format=html') }
+  describe '.source_path' do
+    it { expect(Package.source_path(package_with_file.project.name, package_with_file.name)).to                        eq('/source/home:tom/package_with_files') }
+    it { expect(Package.source_path(package_with_file.project.name, package_with_file.name, 'icon')).to                eq('/source/home:tom/package_with_files/icon') }
+    it { expect(Package.source_path(package_with_file.project.name, package_with_file.name, 'icon', format: :html)).to eq('/source/home:tom/package_with_files/icon?format=html') }
   end
 
   describe '.what_depends_on' do


### PR DESCRIPTION
The instance method is a wrapper delegating to the class method `Package.source_path`. It is only used in one place.