### PR TITLE
Replace removed `Package#source_path` call in WebuiHelper

### DIFF
--- a/src/api/app/helpers/webui/webui_helper.rb
+++ b/src/api/app/helpers/webui/webui_helper.rb
@@ -62,7 +62,7 @@ module Webui::WebuiHelper
 
   def image_template_icon(template)
     default_icon = image_url('drive-optical-48.png')
-    icon = template.source_path('_icon') if template.icon?
+    icon = Package.source_path(template.project.name, template.name, '_icon') if template.icon?
     capture_haml do
       content_tag(:object, data: icon || default_icon, type: 'image/png', title: template.title, width: 32, height: 32) do
         content_tag(:img, src: default_icon, alt: template.title, width: 32, height: 32)


### PR DESCRIPTION
This should have been included in a previous refactoring, #19245.

Fix #19251.