### PR TITLE
Fix crash while handling ActiveRecord::RecordNotUnique in Webui::RescueHandler.

### DIFF
--- a/src/api/app/controllers/concerns/webui/rescue_handler.rb
+++ b/src/api/app/controllers/concerns/webui/rescue_handler.rb
@@ -39,8 +39,8 @@ module Webui::RescueHandler
       redirect_to root_path, error: RegistrationDisabledError.new.default_message
     end
 
-    rescue_from ActiveRecord::RecordNotUnique do |exception|
-      message = "This #{exception.record.class} already exists."
+    rescue_from ActiveRecord::RecordNotUnique do
+      message = 'This record already exists.'
 
       if request.xhr?
         render json: { error: message }, status: :conflict


### PR DESCRIPTION
ActiveRecord::RecordNotUnique does not expose a "record" instance.

The global rescue handler introduced in https://github.com/openSUSE/open-build-service/pull/19153 attempted to access
"exception.record", which caused a production error: undefined method "record" for ActiveRecord::RecordNotUnique

This change removes that assumption and handles the exception with a generic duplicate record message instead, preventing the crash while keeping the existing UX behaviour.
Fixes #19256.