### PR TITLE
Revert "Revert "Add Sphinx attribute to filter by BsRequest id""

### DIFF
--- a/src/api/app/indices/bs_request_index.rb
+++ b/src/api/app/indices/bs_request_index.rb
@@ -1,5 +1,6 @@
 ThinkingSphinx::Index.define :bs_request, with: :real_time do
   indexes comment, description, comments_bodies, reviews_reasons
 
+  has id, as: :bs_request_id, type: :integer
   has updated_at, type: :timestamp
 end


### PR DESCRIPTION
Reverts openSUSE/open-build-service#19262.

Reverting the revert. The original logic is fine, but the deployment steps are cumbersome.

Instructions to perform the reindex, after the codebase of this PR is deployed:
```
run_in_api rails ts:configure RAILS_ENV=production
systemctl stop obs-sphinx.service
run_in_api rails ts:rt:rebuild INDEX_FILTER=bs_request_core INDEX_ONLY=true RAILS_ENV=production
run_in_api rails ts:stop
systemctl start obs-sphinx.service
systemctl restart obs-api-support.target
```