### PR TITLE
Remove `irb` gem from Gemfile

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -117,7 +117,6 @@ gem 'rexml'
 # The following gems have a pin: they are default gems in our ruby 3.4 package and we rather use those, then maintaining them in our bundle.
 # Also, they are used by bundler so version mismatches cause problems when booting the app in passenger
 gem 'base64', '0.2.0', require: false
-gem 'irb', '1.16.0'
 gem 'stringio', '3.1.2'
 gem 'strscan', '3.1.2'
 

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -657,7 +657,6 @@ DEPENDENCIES
   highline
   importmap-rails
   influxdb-rails
-  irb (= 1.16.0)
   jquery-datatables
   jquery-rails
   jquery-ui-rails


### PR DESCRIPTION
We don't use `irb` since a long time since we replaced it with the `pry` console. Therefore there is no need to explicitly require it in the `Gemfile`.
The version pin applied in the `Gemfile` is not required. We pinned the version to match the one used by the ruby core, since `irb` is part of ruby's standard gems and we wanted to avoid version mismatch conflicts (when passenger loads its ruby dependencies upfront).
However the version that is defined in the pin right now (1.16) doesn't match the one from the ruby core anyhow (1.14.3). Therefore it is not required to do so.

`irb` will stay part of the bundle since other gems require it (like railties), but we dont need to explicitly require it in the Gemfile.