### PR TITLE
feat: Add 'Merge Service' button to package view

### DIFF
--- a/src/api/app/controllers/webui/packages/trigger_controller.rb
+++ b/src/api/app/controllers/webui/packages/trigger_controller.rb
@@ -8,6 +8,20 @@ module Webui
 
       after_action :verify_authorized
 
+      def merge_service
+        authorize @object_to_authorize, :update?
+
+        Backend::Api::Sources::Package.merge_service(@project.name, @package_name, User.session.to_s)
+        flash[:success] = 'Services successfully merged'
+      rescue Timeout::Error => e
+        flash[:error] = "Error while merging services for #{@project.name}/#{@package_name}: #{e.message}"
+      rescue Backend::Error => e
+        error = Xmlhash::XMLHash.new(error: e.summary)[:error]
+        flash[:error] = "Error while merging services for #{@project.name}/#{@package_name}: #{error}"
+      ensure
+        redirect_back_or_to package_show_path(@project, @package_name)
+      end
+
       def services
         authorize @object_to_authorize, :update?
 

--- a/src/api/app/views/webui/package/_show_actions.html.haml
+++ b/src/api/app/views/webui/package/_show_actions.html.haml
@@ -16,6 +16,7 @@
 
       - if services.present?
         = render partial: 'webui/package/show_actions/trigger_services', locals: { package: package, project: project }
+      = render partial: 'webui/package/show_actions/merge_service', locals: { package: package, project: project }
     - else
       = render partial: 'webui/package/show_actions/request_role_addition', locals: { package: package, project: project }
       = render partial: 'webui/package/show_actions/request_deletion', locals: { package: package, project: project }

--- a/src/api/app/views/webui/package/show_actions/_merge_service.html.haml
+++ b/src/api/app/views/webui/package/show_actions/_merge_service.html.haml
@@ -1,0 +1,7 @@
+%li.nav-item
+  = link_to merge_service_project_package_trigger_path(project_name: project, package_name: package),
+            method: :post,
+            class: 'nav-link',
+            title: 'Merge Services' do
+    %i.fas.fa-object-group.fa-fw.me-2
+    %span.nav-item-name Merge Services

--- a/src/api/config/routes/webui.rb
+++ b/src/api/config/routes/webui.rb
@@ -285,6 +285,8 @@ resources :projects, only: [], param: :name do
           post 'rebuild' => :rebuild
           post 'abort_build' => :abort_build
           post 'services' => :services
+
+          post 'merge_service' => :merge_service
         end
       end
     end

--- a/src/api/spec/controllers/webui/packages/trigger_controller_spec.rb
+++ b/src/api/spec/controllers/webui/packages/trigger_controller_spec.rb
@@ -53,4 +53,40 @@ RSpec.describe Webui::Packages::TriggerController, :vcr do
       it { expect(flash[:error]).to eq('Error while triggering abort build for my_project/my_package: no repository defined') }
     end
   end
+
+  describe 'POST #merge_service' do
+    subject(:trigger_merge_service) { post :merge_service, params: { project_name: project, package_name: package } }
+
+    let(:package) { create(:package_with_file, name: 'my_package', project: project) }
+
+    context 'when merging services succeeds' do
+      before do
+        allow(Backend::Api::Sources::Package).to receive(:merge_service).and_return('<status code="ok"/>')
+        trigger_merge_service
+      end
+
+      it { expect(flash[:success]).to eq('Services successfully merged') }
+      it { expect(response).to redirect_to(package_show_path(project, package)) }
+    end
+
+    context 'when merging services fails' do
+      before do
+        allow(Backend::Api::Sources::Package).to receive(:merge_service).and_raise(Backend::Error.new('some error'))
+        trigger_merge_service
+      end
+
+      it { expect(flash[:error]).to eq('Error while merging services for my_project/my_package: some error') }
+      it { expect(response).to redirect_to(package_show_path(project, package)) }
+    end
+
+    context 'when merging services times out' do
+      before do
+        allow(Backend::Api::Sources::Package).to receive(:merge_service).and_raise(Timeout::Error.new('execution expired'))
+        trigger_merge_service
+      end
+
+      it { expect(flash[:error]).to eq('Error while merging services for my_project/my_package: execution expired') }
+      it { expect(response).to redirect_to(package_show_path(project, package)) }
+    end
+  end
 end


### PR DESCRIPTION
Hi friends,

### Summary  
Adds a **"Merge Services"** action to the package view in the Web UI, allowing users to manually trigger merging of services defined in a `_service` file.

### Changes  
- Added `merge_service` action in `TriggerController` with proper authorization (`update?`)  
- Integrated backend call to `Backend::Api::Sources::Package.merge_service`  
- Implemented error handling for `Backend::Error` and `Timeout::Error`  
- Added POST route for `merge_service`  
- Introduced `_merge_service.html.haml` partial and added it to package actions UI  
- Added controller specs covering success, failure, and timeout scenarios  

### Testing  
- Verified controller specs for all cases (success, backend error, timeout)  
- Manually tested via Web UI:  
  - Triggered **Merge Services** action  
  - Verified flash messages and redirect behavior  
- Ensured existing actions (`services`, `rebuild`, `abort_build`) remain unaffected  

### Notes  
- Requires `update?` permission  
- Applicable only to packages containing a `_service` file  

Screenshot
<img width="1512" height="822" alt="Screenshot 2026-03-17 at 10 59 51 AM" src="https://github.com/user-attachments/assets/78b6a03b-e8b1-461c-9971-9497e332071f" />

Fixes #9704