### PR TITLE
feat: Make OBS user documentation more visible

### DIFF
--- a/src/api/app/helpers/webui/webui_helper.rb
+++ b/src/api/app/helpers/webui/webui_helper.rb
@@ -319,6 +319,12 @@ module Webui::WebuiHelper
     url = ::Configuration.contact_url || "mailto:#{::Configuration.admin_email}"
     link_to(name, url)
   end
+
+  def link_to_user_documentation(url)
+    tag.span(class: 'ms-2 small text-muted') do
+      link_to(t('webui.documentation_link_text'), url, target: '_blank', rel: 'noopener')
+    end
+  end
 end
 
 # rubocop:enable Metrics/ModuleLength

--- a/src/api/app/views/webui/projects/label_templates/index.html.haml
+++ b/src/api/app/views/webui/projects/label_templates/index.html.haml
@@ -3,7 +3,9 @@
   = render(partial: 'webui/project/tabs', locals: { project: @project })
 
   .card-body
-    %h3= @pagetitle
+    %h3
+      = @pagetitle
+      = link_to_user_documentation('https://openbuildservice.org/help/manuals/obs-user-guide/cha-obs-labels.html#id-1.2.8.9.7')
     %ul.list-unstyled
       - @label_templates.each do |label_template|
         %li.mb-2

--- a/src/api/app/views/webui/projects/meta/show.html.haml
+++ b/src/api/app/views/webui/projects/meta/show.html.haml
@@ -7,7 +7,9 @@
   = render(partial: 'webui/project/tabs', locals: { project: @project })
 
   .card-body
-    %h3= @pagetitle
+    %h3
+      = @pagetitle
+      = link_to_user_documentation('https://openbuildservice.org/help/manuals/obs-user-guide/cha-obs-concepts.html#sec.obs.concepts.project_metadata')
     - if User.possibly_nobody.can_modify?(@project)
       = render partial: 'webui/shared/editor', locals: { text: @meta, mode: 'xml',
         save: { url: project_meta_path(@project), method: :put,

--- a/src/api/app/views/webui/projects/project_configuration/show.html.haml
+++ b/src/api/app/views/webui/projects/project_configuration/show.html.haml
@@ -7,7 +7,9 @@
   = render(partial: 'webui/project/tabs', locals: { project: @project })
 
   .card-body
-    %h3= @pagetitle
+    %h3
+      = @pagetitle
+      = link_to_user_documentation('https://openbuildservice.org/help/manuals/obs-user-guide/cha-obs-prjconfig.html')
     - if User.possibly_nobody.can_modify?(@project)
       = render partial: 'webui/shared/editor', locals: { text: @content, mode: 'prjconf',
         save: { url: project_config_path, method: :put,

--- a/src/api/config/locales/en.yml
+++ b/src/api/config/locales/en.yml
@@ -38,3 +38,6 @@ en:
     attributes:
       staging/request_exclusion:
         bs_request_id: 'Request'
+
+  webui:
+    documentation_link_text: "Documentation ↗"

--- a/src/api/spec/helpers/webui/webui_helper_spec.rb
+++ b/src/api/spec/helpers/webui/webui_helper_spec.rb
@@ -215,4 +215,13 @@ RSpec.describe Webui::WebuiHelper do
       expect(valid_xml_id('10.2')).to eq('_10_2')
     end
   end
+
+  describe '#link_to_user_documentation' do
+    it 'returns a span with the correct link and attributes' do
+      result = link_to_user_documentation('https://example.com')
+
+      expect(result).to include('class="ms-2 small text-muted"', 'target="_blank"', 'rel="noopener"',
+                                'href="https://example.com"', 'Documentation')
+    end
+  end
 end


### PR DESCRIPTION
Hi friends 

This PR improves the visibility of OBS user documentation directly in the Web UI by adding quick access links in relevant project pages.

### What’s added

* Added **Documentation ↗ links** in:

  * Label Templates page
  * Meta Configuration page
  * Project Configuration page

* Introduced a helper method to keep the implementation consistent:

  * `link_to_user_documentation(url)`

* Used a consistent UI pattern (`ms-2 small text-muted`) to match existing design.

### Why this change

Users often need to refer to OBS documentation while working in the UI.
This change makes it easier to access relevant documentation **without leaving the context of the page**.

### Verification

* Meta Configuration → working and link visible
* Label Templates → working and link visible
* Project Configuration → shows 404 if no `prjconf` exists (expected OBS behavior), link still visible

### Note

The `Project Configuration` page returns `ActiveRecord::RecordNotFound` when no build configuration is defined.
This is **existing expected behavior** and not related to this PR.

### Scope

This PR is limited to **UI changes only** and does not modify any backend logic.

### Screenshots

<img width="1512" height="820" alt="Screenshot 2026-03-29 at 11 10 52 AM" src="https://github.com/user-attachments/assets/5a67613f-dfdf-4dd7-8aea-b6096fe812da" />

<img width="1503" height="816" alt="Screenshot 2026-03-29 at 8 55 25 AM" src="https://github.com/user-attachments/assets/44bae319-5686-45a0-9ab6-cea2d849a460" />

<img width="1512" height="824" alt="Screenshot 2026-03-29 at 8 55 12 AM" src="https://github.com/user-attachments/assets/cb926736-8a3e-496a-bbff-c7643574446e" />



fixes #1363 