### PR TITLE
Fix #18995: Make package name clickable on failed build log page

### DIFF
--- a/src/api/app/views/webui/packages/build_log/live_build_log.html.haml
+++ b/src/api/app/views/webui/packages/build_log/live_build_log.html.haml
@@ -5,7 +5,10 @@
   - unless @project.scmsync
     = render partial: 'webui/package/tabs', locals: { project: @project, package: @package }
   .card-body
-    %h3= @pagetitle
+    %h3
+      Build Log for Package
+      = link_to(@package_name, package_show_path(project: @project, package: @package_name))
+      (Project #{@project})
     %p
       %strong Repository:
       = @repository


### PR DESCRIPTION
Description
Hey Friends,

This PR makes the package name a clickable link in the live build log page header. Previously, the package name was static text, making it difficult for users to quickly navigate back to the package overview when reviewing a failed build log. This change improves navigation consistency across the Web UI.

To verify this feature
Go to any package page in your local OBS instance.
Click on a build status (e.g., "failed" or "building") to visit the Live Build Log page.
In the header that says Build Log for Package <package_name> (Project <project_name>), click on the package name.
Verify that it correctly redirects you back to the package overview page.
Automated Tests: Verified via 
BuildLogController
 spec with render_views enabled. The test confirms that the package name is correctly rendered as a link: it { expect(response.body).to include("<a href=\"/package/show/my_project/my_package\">my_package</a>") }
 

<img width="1511" height="817" alt="Screenshot 2026-02-23 at 11 22 11 AM" src="https://github.com/user-attachments/assets/c4b123b3-382d-4c96-b21d-6b25fa418302" />

https://github.com/user-attachments/assets/086ab240-491a-4514-9022-1e8417b2d907
 
 
 Fixes #18995