### PR TITLE
Improve SCM link prominence on package and project pages (#18061)

### DIFF
--- a/src/api/app/views/webui/package/side_links/_show_scmsync.html.haml
+++ b/src/api/app/views/webui/package/side_links/_show_scmsync.html.haml
@@ -1,5 +1,4 @@
 %li
-  %i.fas.fa-info-circle.text-info
-  Developed at
-  = link_to package.scmsync do
-    SCM
+  = link_to package.scmsync, title: 'View source repository' do
+    %i.fas.fa-link
+    View SCM Repository


### PR DESCRIPTION
Hi friends,

## Summary

Improve visibility and clarity of SCM managed packages by presenting the SCM link as a standard, scannable sidebar entry.

## Changes

* Replaced the previous inline SCM text/link with a standard sidebar link
* Updated label to **"View SCM Repository"** for clearer intent
* Used a neutral link icon (`fa-link`) to avoid misleading semantics
* Ensured the link follows existing sidebar link patterns for consistency
* Removed redundant inline SCM text from the package view

## Result

* SCM link is easier to find and visually scannable
* Users can directly access the source repository from the sidebar
* Improved UI clarity without affecting existing behavior

## Notes

* Avoids misleading terminology or icons (e.g., branch icon)
* Keeps UI consistent with existing sidebar design
* Focused on minimal, non-disruptive changes

## Screenshots

<img width="1507" height="810" alt="Screenshot 2026-03-28 at 9 03 32 AM" src="https://github.com/user-attachments/assets/0c4c0d5d-215f-416f-be50-b175d14dd8b5" />



Fixes #18061 