### PR TITLE
Fix bogus 403 error when modifying non-existing linked packages

### DIFF
--- a/src/api/app/controllers/source_package_controller.rb
+++ b/src/api/app/controllers/source_package_controller.rb
@@ -168,7 +168,7 @@ class SourcePackageController < SourceController
       raise WrongRouteForStagingWorkflow if @file == '_staging_workflow' && @package_name == '_project'
     else
       # we need a local package here in any case for modifications
-      @pack = Package.get_by_project_and_name(@project_name, @package_name)
+      @pack = Package.get_by_project_and_name(@project_name, @package_name, follow_project_links: false)
       # no modification or deletion of scmsynced projects and packages allowed
       check_for_scmsynced_package_and_project(project: @prj, package: @pack)
       @allowed = permissions.package_change?(@pack)


### PR DESCRIPTION
## Problem Description

The `SourcePackageController` used `Package.get_by_project_and_name` during permission checks for file `PUT` and `DELETE` operations. By default, this method follows project links. If a package (e.g., `pkg_a`) existed in a linked project (e.g., `prj_source`) but not in the destination project (e.g., `prj_dest`), and a user tried to `PUT` a file to `prj_dest/pkg_a`, the controller would find `prj_source/pkg_a` and then check if the user had permission to modify it. Since the user typically lacks permission to modify the source project, the API returned 403 Forbidden.

The correct behavior is to return 404 Not Found, as the package does not exist in the target project and cannot be modified there.

## Changes Made

### API Layer

#### source_package_controller.rb

Disabled project link following in the `check_permissions_for_file` method. This ensures that the permission check only considers packages physically present in the target project.

```diff
-       @pack = Package.get_by_project_and_name(@project_name, @package_name)
+       @pack = Package.get_by_project_and_name(@project_name, @package_name, follow_project_links: false)
```

## Verification Results

### Automated Tests

Created a reproduction test case that simulates the reported scenario:
1. `source_prj` contains `source_pkg`.
2. `dest_prj` links to `source_prj`.
3. User with write access only to `dest_prj` attempts to `PUT`/`DELETE` files in `dest_prj/source_pkg`.

**Results:**
- **Before fix:** The tests failed because the API returned `403 Forbidden`.
- **After fix:** The tests passed as the API correctly returns `404 Not Found` (Unknown Package).

Fixes #17263.