### PR TITLE
Include .ddeb packages in APT repository index

### DIFF
--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -1096,6 +1096,7 @@ sub fixup_scanpackages_output {
   open ($f2, '>', "$file.tmp") || die("$file.tmp: $!\n");
   while (<$f>) {
     s/^Filename: \.\//Filename: /;
+    s/^Filename: (.*)\.ddeb\.deb$/Filename: $1.ddeb/;
     print $f2 $_ or die("$file.tmp: $!\n");
   }
   close($f);
@@ -1107,9 +1108,13 @@ sub createrepo_debian {
   my ($extrep, $projid, $repoid, $data, $options) = @_;
 
   print "    running dpkg-scanpackages\n";
+  # temporarily symlink .ddeb to .deb so dpkg-scanpackages picks them up
+  qsystem('find', $extrep, '-name', '*.ddeb', '-exec', 'ln', '-s', '{}', '{}.deb', ';');
   if (qsystem('chdir', $extrep, 'stdout', 'Packages.new', 'dpkg-scanpackages', '-m', '.', '/dev/null')) {
+    qsystem('find', $extrep, '-name', '*.ddeb.deb', '-delete');
     die("    dpkg-scanpackages failed: $?\n");
   }
+  qsystem('find', $extrep, '-name', '*.ddeb.deb', '-delete');
   fixup_scanpackages_output("$extrep/Packages.new");
   compress_and_rename("$extrep/Packages.new", "$extrep/Packages");
   # create an empty Packages file for empty repositories


### PR DESCRIPTION
### Description
This Pull Request fixes an issue where `.ddeb` (debug) packages were not being included in the `Packages` index for APT repositories. Ubuntu and some Debian-based systems use the `.ddeb` extension for debug symbols, but `dpkg-scanpackages` only scans for `.deb` files by default.

### Technical Changes
- **Temporary Symlinking**: In `createrepo_debian`, all `.ddeb` files are temporarily symlinked to `.deb` files. This allows `dpkg-scanpackages` to find and index them without requiring specialized tool flags that might not be available on all supported platforms.
- **Index Fixup**: The `fixup_scanpackages_output` function was updated to rename the `Filename:` entries in the generated `Packages` file from `.ddeb.deb` back to `.ddeb`.
- **Cleanup**: Ensured that the temporary symlinks are deleted immediately after the indexing step, even in case of failure.

### Verification
- The symlink approach is a standard way to handle non-standard extensions in APT repository tools.
- The path substitution accurately restores the original file names in the repository metadata.

Closes #19057
