### PR TITLE
Allow admins to set label templates on projects

### DIFF
--- a/src/api/app/policies/label_template_policy.rb
+++ b/src/api/app/policies/label_template_policy.rb
@@ -1,6 +1,7 @@
 class LabelTemplatePolicy < ApplicationPolicy
   def index?
     return false unless Flipper.enabled?(:labels, @user)
+    return true if @user.admin?
     return false unless record.project.maintainers.include?(@user)
 
     true

--- a/src/api/spec/policies/label_template_policy_spec.rb
+++ b/src/api/spec/policies/label_template_policy_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe LabelTemplatePolicy do
   let(:project) { create(:project, maintainer: user) }
   let(:label_template) { create(:label_template, project: project) }
   let(:another_user) { create(:confirmed_user) }
+  let(:admin_user) { create(:admin_user) }
 
   before do
     Flipper.enable(:labels)
@@ -13,5 +14,6 @@ RSpec.describe LabelTemplatePolicy do
   permissions :index?, :create?, :new?, :update?, :destroy?, :edit? do
     it { is_expected.to permit(user, label_template) }
     it { is_expected.not_to permit(another_user, label_template) }
+    it { is_expected.to permit(admin_user, label_template) }
   end
 end


### PR DESCRIPTION
Admin users should have permission to do so...

Fixes https://trello.com/c/IjyTnfS8/134-project-label-templates-tab-not-shown-for-admin-user