### PR TITLE
Do not create version notifications if not in beta

### DIFF
--- a/src/api/app/models/event/base.rb
+++ b/src/api/app/models/event/base.rb
@@ -27,6 +27,10 @@ module Event
          Event::Assignment, Event::UpstreamPackageVersionChanged]
       end
 
+      def notification_feature_flag
+        nil
+      end
+
       def classnames
         @classnames || [name]
       end

--- a/src/api/app/models/event/upstream_package_version_changed.rb
+++ b/src/api/app/models/event/upstream_package_version_changed.rb
@@ -8,6 +8,10 @@ module Event
 
     receiver_roles :develpackage_or_package_maintainer
 
+    def self.notification_feature_flag
+      :package_version_tracking
+    end
+
     def parameters_for_notification
       super.merge(notifiable_type: 'Package',
                   notifiable_id: ::Package.find_by_project_and_name(payload['project'], payload['package'])&.id,

--- a/src/api/app/models/event_subscription/find_for_event.rb
+++ b/src/api/app/models/event_subscription/find_for_event.rb
@@ -78,11 +78,17 @@ class EventSubscription
 
     private
 
+    def allowed_by_feature_flag?(user)
+      return true if event.class.notification_feature_flag.blank?
+
+      Flipper.enabled?(event.class.notification_feature_flag, user)
+    end
+
     def expand_receivers(receivers, channel)
       receivers.inject([]) do |new_receivers, receiver|
         case receiver
         when User
-          new_receivers << receiver if receiver.active?
+          new_receivers << receiver if receiver.active? && allowed_by_feature_flag?(receiver)
           puts "Skipped receiver #{receiver} because it's inactive" if @debug && !receiver.active?
         when Group
           new_receivers += expand_receivers_for_groups(receiver, channel)
@@ -101,7 +107,7 @@ class EventSubscription
       return [receiver] if channel == :web || receiver.email.present?
 
       puts "Expanding group #{receiver}..." if @debug
-      receiver.email_users
+      receiver.email_users.select { |user| allowed_by_feature_flag?(user) }
     end
     # rubocop: enable Rails/Output
   end


### PR DESCRIPTION
Introduce `notification_feature_flag` method for Events.

Update `expand_receivers` to filter individual users by event feature flag.

Update `expand_receivers_for_groups` to filter group members by event feature flag.