### PR TITLE
Add link to documentation Anitya Distribution Name

### DIFF
--- a/src/api/app/views/webui/project/_edit.html.haml
+++ b/src/api/app/views/webui/project/_edit.html.haml
@@ -12,14 +12,14 @@
       = form.label(:report_bug_url, 'Report Bug URL:')
       = form.url_field(:report_bug_url, class: 'form-control')
   .mb-3
-    = form.label(:anitya_distribution_name) do
-      Anitya Distribution Name
-      %small.form-text
-        = link_to 'Version Tracking Guide',
-          'https://openbuildservice.org/help/manuals/obs-user-guide/cha-obs-versiontracking',
-          target: '_blank',
-          rel: 'noopener'
+    = form.label(:anitya_distribution_name, 'Anitya Distribution Name:')
     = form.text_field(:anitya_distribution_name, class: 'form-control')
+    .form-text.text-muted
+      Check the
+      = link_to 'Version Tracking Guide',
+        'https://openbuildservice.org/help/manuals/obs-user-guide/cha-obs-versiontracking',
+        target: '_blank',
+        rel: 'noopener'
   .mb-3
     = form.label(:description, 'Description:')
     = render WriteAndPreviewComponent.new(form: form, preview_message_url: project_preview_description_path,


### PR DESCRIPTION
Link to Version Tracking documentation (added in openSUSE/obs-docu#446) to clarify how the Anitya Distribution Name is  used for upstream version tracking.