### PR TITLE
Support `buildemptyflavor` attribute in multibuild xml

### DIFF
--- a/docs/api/api/multibuild.rng
+++ b/docs/api/api/multibuild.rng
@@ -7,6 +7,14 @@
 
   <define name="multibuild-element">
     <element ns="" name="multibuild">
+      <optional>
+        <attribute name="buildemptyflavor">
+          <choice>
+            <value>true</value>
+            <value>false</value>
+          </choice>
+        </attribute>
+      </optional>
       <choice>
         <oneOrMore>
           <element ns="" name="flavor">

--- a/src/backend/BSVerify.pm
+++ b/src/backend/BSVerify.pm
@@ -462,6 +462,9 @@ sub verify_dod {
 
 sub verify_multibuild {
   my ($mb) = @_;
+  if (defined $mb->{'buildemptyflavor'} && $mb->{'buildemptyflavor'} ne 'true' && $mb->{'buildemptyflavor'} ne 'false') {
+    die("buildemptyflavor must be either 'true' or 'false'\n");
+  }
   die("multibuild cannot have both package and flavor elements\n") if $mb->{'package'} && $mb->{'flavor'};
   for my $packid (@{$mb->{'package'} || []}) {
     verify_packid($packid);

--- a/src/backend/BSXML.pm
+++ b/src/backend/BSXML.pm
@@ -2122,6 +2122,7 @@ our $publishedpath = [
 
 our $multibuild = [
     'multibuild' =>
+	'buildemptyflavor',
       [ 'package' ],	# obsolete
       [ 'flavor' ],
 ];

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -1668,6 +1668,10 @@ sub getprojpack {
 	# a buildinfo query
 	my $mb = BSSrcServer::Multibuild::updatemultibuild($projid, $packid, $files, $cgi->{'ignoredisable'} ? 0 : 1);
 	unshift @packages, map {"$packid:$_"} @{$mb->{'flavor'} || $mb->{'package'} || []} if $mb;
+	if ($mb && defined($mb->{'buildemptyflavor'}) && $mb->{'buildemptyflavor'} eq 'false') {
+	  $pinfo->{'error'} = 'excluded';
+	  next;
+	}
 
 	if ($packid eq '_pattern') {
 	  $jinfo->{'patternmd5'} = $pinfo->{'srcmd5'};

--- a/src/backend/t/0001-BSVerify-verify_multibuild.t
+++ b/src/backend/t/0001-BSVerify-verify_multibuild.t
@@ -1,0 +1,60 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use Test::More tests => 8;
+
+require_ok('BSVerify');
+
+my @valid_cases = (
+  {
+    name => 'attribute omitted keeps compatibility',
+    data => { flavor => ['default'] },
+  },
+  {
+    name => 'buildemptyflavor true is accepted',
+    data => { buildemptyflavor => 'true', flavor => ['default'] },
+  },
+  {
+    name => 'buildemptyflavor false is accepted',
+    data => { buildemptyflavor => 'false', flavor => ['default'] },
+  },
+);
+
+for my $tc (@valid_cases) {
+  my $err;
+  eval { BSVerify::verify_multibuild($tc->{data}); };
+  $err = $@;
+  ok(!$err, $tc->{name});
+}
+
+my @invalid_cases = (
+  {
+    name => 'buildemptyflavor invalid value is rejected',
+    data => { buildemptyflavor => 'maybe', flavor => ['default'] },
+    pattern => qr/buildemptyflavor must be either 'true' or 'false'/,
+  },
+  {
+    name => 'buildemptyflavor must be lowercase true/false',
+    data => { buildemptyflavor => 'False', flavor => ['default'] },
+    pattern => qr/buildemptyflavor must be either 'true' or 'false'/,
+  },
+  {
+    name => 'package and flavor together are still rejected',
+    data => { buildemptyflavor => 'false', package => ['pkg1'], flavor => ['flv1'] },
+    pattern => qr/multibuild cannot have both package and flavor elements/,
+  },
+  {
+    name => 'flavor with colon is still rejected',
+    data => { buildemptyflavor => 'true', flavor => ['bad:flavor'] },
+    pattern => qr/flavor .* is illegal in multibuild/,
+  },
+);
+
+for my $tc (@invalid_cases) {
+  my $err;
+  eval { BSVerify::verify_multibuild($tc->{data}); };
+  $err = $@;
+  like($err, $tc->{pattern}, $tc->{name});
+}

--- a/src/backend/t/0501-BSSrcServer-Multibuild-buildemptyflavor.t
+++ b/src/backend/t/0501-BSSrcServer-Multibuild-buildemptyflavor.t
@@ -1,0 +1,110 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use FindBin;
+use lib "$FindBin::Bin/lib";
+
+use Test::More tests => 8;
+
+use Test::Mock::BSConfig;
+
+require_ok('BSSrcServer::Multibuild');
+
+{
+	no warnings 'redefine';
+
+	local *BSSrcServer::Multibuild::getcache = sub {
+		return {
+			'mypackage' => {
+				'flavor' => [ 'flavor1', 'flavor2' ],
+			},
+		};
+	};
+
+	my @got = BSSrcServer::Multibuild::addmultibuildpackages('home:Admin', undef, 'mypackage');
+	is_deeply(
+		\@got,
+		[ 'mypackage', 'mypackage:flavor1', 'mypackage:flavor2' ],
+		'default behavior keeps base package and adds flavored packages'
+	);
+}
+
+{
+	no warnings 'redefine';
+
+	local *BSSrcServer::Multibuild::getcache = sub {
+		return {
+			'mypackage' => {
+				'buildemptyflavor' => 'true',
+				'flavor' => [ 'flavor1' ],
+			},
+		};
+	};
+
+	my @got = BSSrcServer::Multibuild::addmultibuildpackages('home:Admin', undef, 'mypackage');
+	is_deeply(
+		\@got,
+		[ 'mypackage', 'mypackage:flavor1' ],
+		'buildemptyflavor=true keeps the base package'
+	);
+}
+
+{
+	no warnings 'redefine';
+
+	local *BSSrcServer::Multibuild::getcache = sub {
+		return {
+			'mypackage' => {
+				'buildemptyflavor' => 'false',
+				'flavor' => [ 'flavor1', 'flavor2' ],
+			},
+		};
+	};
+
+	my %origins = ( 'mypackage' => 'origin:Project' );
+	my @got = BSSrcServer::Multibuild::addmultibuildpackages('home:Admin', \%origins, 'mypackage');
+
+	is_deeply(
+		\@got,
+		[ 'mypackage', 'mypackage:flavor1', 'mypackage:flavor2' ],
+		'buildemptyflavor=false keeps the base package in the list (excluded via pinfo in src server)'
+	);
+	is(
+		$origins{'mypackage:flavor1'},
+		'origin:Project',
+		'origin copied to first flavored package'
+	);
+	is(
+		$origins{'mypackage:flavor2'},
+		'origin:Project',
+		'origin copied to second flavored package'
+	);
+	ok(!exists $origins{'mypackage:unknown'}, 'no extra origin entries are created');
+}
+
+# Multiple base packages: buildemptyflavor setting is per-package
+{
+	no warnings 'redefine';
+
+	local *BSSrcServer::Multibuild::getcache = sub {
+		return {
+			'pkg_a' => {
+				'buildemptyflavor' => 'false',
+				'flavor' => [ 'flavor1' ],
+			},
+			'pkg_b' => {
+				'flavor' => [ 'flavor2' ],
+			},
+		};
+	};
+
+	my @got = BSSrcServer::Multibuild::addmultibuildpackages('home:Admin', undef, 'pkg_a', 'pkg_b');
+
+	is_deeply(
+		\@got,
+		[ 'pkg_a', 'pkg_a:flavor1', 'pkg_b', 'pkg_b:flavor2' ],
+		'both base packages are kept regardless of buildemptyflavor'
+	);
+}


### PR DESCRIPTION
When using multibuilds, users may want to build only flavored packages and skip the base package. This change adds support for the new `buildemptyflavor` attribute on `_multibuild` xml, and makes backend package selection/scheduling work correctly in that mode.

Example usage:

```xml
<multibuild buildemptyflavor="false">
  <flavor>flavor1</flavor>
  <flavor>flavor2</flavor>
</multibuild>
```

With this configuration, `mypackage:flavor1` and `mypackage:flavor2` are built, while `mypackage` (base package) is not added to the build package list.

The multibuild handling now excludes the base package when requested, while keeping default behavior unchanged if the attribute is not set. The source server logic is also adjusted so projects are not incorrectly skipped when the package list contains only flavors, and multibuild cache refresh/requeue logic continues to work when flavors change.

This includes validation/schema updates for the new attribute and backend tests covering:

* valid/invalid `buildemptyflavor` values
* base package inclusion/exclusion behavior
* flavor matching and stale flavor update paths

Side-effects:

* opt-in behavior only (`buildemptyflavor=false`)
* existing multibuild projects keep current behavior by default

Screenshot example of when using `buildemptyflavor="true"`, or without using the `buildemptyflavor` (default):
<img width="772" height="793" alt="image" src="https://github.com/user-attachments/assets/e09b3e57-599b-44c7-842f-77f8e76e18d5" />


Screenshot example of when using `buildemptyflavor="false"`:
<img width="772" height="532" alt="image" src="https://github.com/user-attachments/assets/cf1e8552-3ebc-48cb-a56a-d9fe47b763bb" />

