### PR TITLE
Improve handling of large diffs in WebUI

### DIFF
--- a/src/api/app/components/diff_list_component.html.haml
+++ b/src/api/app/components/diff_list_component.html.haml
@@ -25,3 +25,6 @@
                                      source_file: source_file(file_info.dig('old', 'name')),
                                      target_file: target_file(name),
                                      source_rev:, target_rev:))
+        - if commentable && file_info.dig('diff', 'shown').to_i < file_info.dig('diff', 'lines').to_i
+          .alert.alert-warning.mt-2
+            This file's diff is truncated. #{link_to 'Show full diff', request_changes_path(commentable.bs_request, commentable, tarlimit: 0)}

--- a/src/api/app/components/sourcediff_component.html.haml
+++ b/src/api/app/components/sourcediff_component.html.haml
@@ -38,3 +38,6 @@
                                            commentable: commentable, commented_lines: @commented_lines,
                                            source_package: source_package, target_package: target_package,
                                            source_rev: source_rev, target_rev: target_rev))
+          - if sourcediff['files']&.values&.any? { |f| f.dig('diff', 'shown').to_i < f.dig('diff', 'lines').to_i }
+            .alert.alert-warning.mt-2
+              This file's diff is truncated. #{link_to 'Show full diff', request_changes_path(@bs_request, @action, tarlimit: 0)}

--- a/src/api/spec/components/sourcediff_component_spec.rb
+++ b/src/api/spec/components/sourcediff_component_spec.rb
@@ -34,4 +34,11 @@ RSpec.describe SourcediffComponent, :vcr, type: :component do
       expect(rendered_content).to have_css("turbo-frame#file-0[loading=\"lazy\"][src=\"#{first_file_url}\"]")
     end
   end
+
+  it 'renders the warning when diff lines are hidden' do
+    action = bs_request.bs_request_actions.first
+    allow(action).to receive(:webui_sourcediff).and_return([{ 'files' => { 'f' => { 'diff' => { 'shown' => '5', 'lines' => '10' } } } }])
+    render_inline(described_class.new(bs_request: bs_request, action: action, diff_not_cached: false))
+    expect(rendered_content).to have_text("This file's diff is truncated.")
+  end
 end


### PR DESCRIPTION
### Summary
Improve handling of large diffs in the WebUI by ensuring truncation warnings are clearly visible at the point where the diff is cut off.

### Problem
Currently, when a diff is truncated in the WebUI, the warning message is not always visible at the exact truncation point.

This makes it unclear to users that the displayed diff is incomplete, especially when scrolling through large files.

### Solution
- Add truncation warning directly at the point where the diff is truncated
- Use inline logic in existing HAML templates to avoid architectural changes
- Keep the implementation minimal and scoped to diff rendering

### Changes
- Update HAML views to display truncation warning at the bottom of truncated diffs
- Ensure no changes to component structure or backend logic
- Add/update unit test to verify truncation labeling

### Verification
Run:
```bash
bundle exec rspec spec/components/sourcediff_component_spec.rb