### PR TITLE
New subscription visible on default subscriptions page

### DIFF
--- a/src/api/app/models/event_subscription/form.rb
+++ b/src/api/app/models/event_subscription/form.rb
@@ -61,6 +61,8 @@ class EventSubscription
     end
 
     def non_enabled_events
+      return [] unless subscriber # For default subscriptions
+
       EVENTS_IN_BETA.filter { |_, feature| !Flipper.enabled?(feature, subscriber) }.keys
     end
   end


### PR DESCRIPTION
When an Admin went to Configuration > Notifications didn't see the new event type after the recent changes. This PR fixes it.

Admins should see all the events no matter if they are in beta or not, so they can enable/disable the default subscriptions for every user. 

In the code base, subscriber is nil in case of default subscription, we don't have to ask Flipper for them.