### PR TITLE
Add project versions view to SourceProjectController

### DIFF
--- a/src/api/app/controllers/source_project_controller.rb
+++ b/src/api/app/controllers/source_project_controller.rb
@@ -61,6 +61,8 @@ class SourceProjectController < SourceController
         render_project_issues
       when 'info'
         pass_to_backend
+      when 'versions'
+        render_project_versions
       else
         raise InvalidParameterError, "'#{params[:view]}' is not a valid 'view' parameter value."
       end
@@ -73,6 +75,11 @@ class SourceProjectController < SourceController
   def render_project_issues
     set_issues_defaults
     render partial: 'source/project_issues', formats: [:xml]
+  end
+
+  def render_project_versions
+    @packages = @project.packages.includes(:latest_local_version, :latest_upstream_version).select(:id, :name)
+    render partial: 'source/project_versions', formats: [:xml]
   end
 
   def render_project_packages

--- a/src/api/app/views/source/_project_versions.xml.builder
+++ b/src/api/app/views/source/_project_versions.xml.builder
@@ -1,0 +1,8 @@
+xml.project(name: @project.name) do
+  @packages.each do |pkg|
+    xml.package(project: @project.name, name: pkg.name) do
+      xml.version(pkg.latest_local_version&.version, type: 'local')
+      xml.version(pkg.latest_upstream_version&.version, type: 'upstream')
+    end
+  end
+end

--- a/src/api/public/apidocs/paths/source_project_name.yaml
+++ b/src/api/public/apidocs/paths/source_project_name.yaml
@@ -28,12 +28,14 @@ get:
           - issues
           - productlist
           - verboseproductlist
+          - versions
       description: |
         Specify which sections should be included in the packages list.
 
         * `issues`: Show all tracked issues for all the packages.
         * `productlist`: Show all contained products.
         * `verboseproductlist`: List all contained products with detailed information about the product.
+        * `versions`: List local and upstream versions for all the packages.
 
         Example of a result when `issues` is selected:
         ```
@@ -99,6 +101,24 @@ get:
             <version>20230108</version>
           </product>
         </productlist>
+        ```
+
+        Example of a result when `versions` is selected:
+        ```
+        <project name="openSUSE:Factory">
+          <package project="openSUSE:Factory" name="apache2">
+            <version type="local">2.4.43</version>
+            <version type="upstream">2.4.66</version>
+          </package>
+          <package project="openSUSE:Factory" name="000package">
+            <version type="local">2.71.82</version>
+            <version type="upstream"/>
+          </package>
+          <package project="openSUSE:Factory" name="package_a">
+            <version type="local"/>
+            <version type="upstream">3.14.15</version>
+          </package>
+        </project>
         ```
   responses:
     '200':

--- a/src/api/public/apidocs/paths/source_project_name_view_info.yaml
+++ b/src/api/public/apidocs/paths/source_project_name_view_info.yaml
@@ -14,11 +14,12 @@ get:
           - issues
           - productlist
           - verboseproductlist
+          - versions
       description: |
         Specify which information about each package should be returned.
 
         * `info`: Show source version, md5sums and build description files of all packages belonging to a project.
-        * `issues`, `productlist`, `verboseproductlist`:
+        * `issues`, `productlist`, `verboseproductlist`, `versions`:
           See this [other endpoint](<#/Sources - Packages/get_source__project_name_>) for details.
       example: info
     - in: query


### PR DESCRIPTION
Expose a new `view=versions` response that renders local and upstream versions for all packages in a project.

I created this WIP PR to get feedback. Also work in progress is the documentation for this change.

Is `&view=versions` the right call here? Having empty version tags if no version is available?

Example query: 
```
curl -X 'GET' http://localhost:3000/source/openSUSE:Leap:15.4?view=versions&arch=x86_64'

<project name="openSUSE:Leap:15.4">
  <package project="openSUSE:Leap:15.4" name="bash">
    <local/>
    <upstream>5.3</upstream>
  </package>
  <package project="openSUSE:Leap:15.4" name="cacti">
    <local/>
    <upstream>1.2.30</upstream>
  </package>
  <package project="openSUSE:Leap:15.4" name="cacti-spine">
    <local/>
    <upstream>1.2.30</upstream>
  </package>
</project>
```
