### PR TITLE
Remove inconsistent request badge in group requests

### DIFF
--- a/src/api/app/views/webui/groups/bs_requests/index.html.haml
+++ b/src/api/app/views/webui/groups/bs_requests/index.html.haml
@@ -11,8 +11,6 @@
       %li.nav-item
         %a.nav-link.active
           Group Requests
-          %span.badge.text-bg-primary
-            = @bs_requests.count
   .card-body
     .tab-content
       .tab-pane.active


### PR DESCRIPTION
Remove the request counter to avoid redundancy and potential confusion. The badge was static and did not reflect changes when filters were applied.

The badge is only removed from the Groups Requests view. It stays outside, in the group page:

| | |
|:---: | :---: |
| <img width="431" height="155" alt="Screenshot From 2026-02-24 13-09-07" src="https://github.com/user-attachments/assets/d9ec219e-b69b-4774-8de2-555ca294cb58" /> | <img width="431" height="155" alt="Screenshot From 2026-02-24 13-09-15" src="https://github.com/user-attachments/assets/ce3eb439-2dca-4246-82dd-426c25e0780a" /> |


Fixes #19158.