### PR TITLE
Indicate when the version was last fetched in package view

### DIFF
--- a/src/api/app/views/webui/package/_side_links.html.haml
+++ b/src/api/app/views/webui/package/_side_links.html.haml
@@ -25,6 +25,9 @@
   - if package.scmsync
     = render partial: 'webui/package/side_links/show_scmsync', locals: { package: package }
 
+  - if Flipper.enabled?(:package_version_tracking, User.session) && package.project.anitya_distribution_name.present?
+    = render partial: 'webui/package/side_links/show_anitya_sync_time', locals: { package: package }
+
   = render partial: 'extra_actions', locals: { project: project, package: package }
 
   = render partial: 'webui/package/side_links/checkout_package', locals: { project: project, package: package }

--- a/src/api/app/views/webui/package/side_links/_show_anitya_sync_time.html.haml
+++ b/src/api/app/views/webui/package/side_links/_show_anitya_sync_time.html.haml
@@ -1,0 +1,8 @@
+%li
+  %i.fas.fa-sync-alt.text-info
+  - if package.latest_upstream_version&.updated_at?
+    Upstream version info updated
+    = time_ago_in_words(package.latest_upstream_version&.updated_at)
+    ago
+  - else
+    Upstream version info not synced yet


### PR DESCRIPTION
Included in this PR are two commits to compare two approaches for indicating when the last version check/update was made. 

I also want to base the final PR on the work currently done by Lukas, as I expect his changes will affect how/when the indicator will be shown.

The two variants are
- A new column, for which we change data tables and the haml template
- Add a "Fetched X ago" line after/under the Version text.

I strongly prefer the addition line, as it is more compact, but I'm unsure about the correct CSS to use, and if it is wise to "hook in" the "versions_text" builder.