### PR TITLE
Refactor notification_icon helper

### DIFF
--- a/src/api/app/helpers/webui/notification_helper.rb
+++ b/src/api/app/helpers/webui/notification_helper.rb
@@ -6,7 +6,7 @@ module Webui::NotificationHelper
 
   NOTIFICATION_ICON = {
     'BsRequest' => 'fa-code-pull-request', 'Comment' => 'fa-comments',
-    'Package' => 'fa-xmark text-danger',
+    'Package' => 'fa-archive',
     'Report' => 'fa-flag', 'Decision' => 'fa-clipboard-check',
     'Appeal' => 'fa-hand', 'WorkflowRun' => 'fa-book-open',
     'Group' => 'fa-people-group'
@@ -30,8 +30,8 @@ module Webui::NotificationHelper
   def notification_icon(notification)
     if notification.event_type.in?(['Event::RelationshipCreate', 'Event::RelationshipDelete'])
       tag.i(class: %w[fas fa-user-tag], title: 'Relationship notification')
-    elsif notification.event_type.in?(['Event::UpstreamPackageVersionChanged'])
-      tag.i(class: %w[fas fa-archive])
+    elsif notification.event_type.in?(['Event::BuildFail'])
+      tag.i(class: %w[fas fa-xmark text-danger])
     elsif NOTIFICATION_ICON[notification.notifiable_type].present?
       tag.i(class: ['fas', NOTIFICATION_ICON[notification.notifiable_type]], title: NOTIFICATION_TITLE[notification.notifiable_type])
     end


### PR DESCRIPTION
There are three types of notifications with Package as notifiable_type: build fail, upstream version and relationship related notifications. They use three different icons but it makes more sense to have a package icon as the default one instead of a red cross.

The following screenshot shows notifications of the three types after these changes were applied. They look as they used to.

<img width="1851" height="855" alt="Screenshot 2026-02-24 at 16-10-10 Notifications - Open Build Service" src="https://github.com/user-attachments/assets/c7897da7-91d0-4673-9f7b-81fbc4ff1068" />
