### PR TITLE
Use `:meta` protocol instead of binary for Dalli/Memcached

### DIFF
--- a/src/api/config/environments/development.rb
+++ b/src/api/config/environments/development.rb
@@ -37,9 +37,9 @@ OBSApi::Application.configure do
 
   # Use memcache for cache/session storage
   config.cache_store = if CONFIG['memcached_host']
-                         [:mem_cache_store, CONFIG['memcached_host']]
+                         [:mem_cache_store, CONFIG['memcached_host'], { protocol: :meta }]
                        else
-                         :mem_cache_store
+                         [:mem_cache_store, { protocol: :meta }]
                        end
   config.session_store :cache_store
 

--- a/src/api/config/environments/production.rb
+++ b/src/api/config/environments/production.rb
@@ -8,9 +8,9 @@ OBSApi::Application.configure do
 
   # Use memcache for cache/session storage
   config.cache_store = if CONFIG['memcached_host']
-                         [:mem_cache_store, CONFIG['memcached_host']]
+                         [:mem_cache_store, CONFIG['memcached_host'], { protocol: :meta }]
                        else
-                         :mem_cache_store
+                         [:mem_cache_store, { protocol: :meta }]
                        end
   config.session_store :cache_store
 


### PR DESCRIPTION
Switch the Memcached protocol from binary to `:meta` to get rid of deprecation warnings in Dalli 4.x.

This change is a previous step to the upcoming Dalli 5.0 upgrade, as the binary protocol will be removed in that version. The `:meta` protocol is supported by Memcached 1.6+, which is already available in our environment.

Once the gem is updated to 5.x, these changes should be reverted, as the default configuration in 5.x will align with this behavior.

See:
- https://github.com/petergoldstein/dalli/blob/main/5.0-Upgrade.md
- https://github.com/petergoldstein/dalli/wiki/Requirements-and-Integrations
- https://github.com/openSUSE/open-build-service/pull/19238#issuecomment-3879024015