### PR TITLE
Add anitya_distribution_synced_at to projects

### DIFF
--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -1510,24 +1510,25 @@ end
 #
 # Table name: projects
 #
-#  id                       :integer          not null, primary key
-#  anitya_distribution_name :string(255)
-#  comments_count           :integer          default(0), not null, indexed
-#  delta                    :boolean          default(TRUE), not null
-#  description              :text(65535)
-#  kind                     :string           default("standard")
-#  name                     :string(200)      not null, uniquely indexed
-#  remoteproject            :string(255)
-#  remoteurl                :string(255)
-#  report_bug_url           :string(8192)
-#  required_checks          :string(255)
-#  scmsync                  :text(65535)
-#  title                    :string(255)
-#  url                      :string(255)
-#  created_at               :datetime
-#  updated_at               :datetime
-#  develproject_id          :integer          indexed
-#  staging_workflow_id      :integer          indexed
+#  id                            :integer          not null, primary key
+#  anitya_distribution_name      :string(255)
+#  anitya_distribution_synced_at :datetime
+#  comments_count                :integer          default(0), not null, indexed
+#  delta                         :boolean          default(TRUE), not null
+#  description                   :text(65535)
+#  kind                          :string           default("standard")
+#  name                          :string(200)      not null, uniquely indexed
+#  remoteproject                 :string(255)
+#  remoteurl                     :string(255)
+#  report_bug_url                :string(8192)
+#  required_checks               :string(255)
+#  scmsync                       :text(65535)
+#  title                         :string(255)
+#  url                           :string(255)
+#  created_at                    :datetime
+#  updated_at                    :datetime
+#  develproject_id               :integer          indexed
+#  staging_workflow_id           :integer          indexed
 #
 # Indexes
 #

--- a/src/api/app/models/remote_project.rb
+++ b/src/api/app/models/remote_project.rb
@@ -57,24 +57,25 @@ end
 #
 # Table name: projects
 #
-#  id                       :integer          not null, primary key
-#  anitya_distribution_name :string(255)
-#  comments_count           :integer          default(0), not null, indexed
-#  delta                    :boolean          default(TRUE), not null
-#  description              :text(65535)
-#  kind                     :string           default("standard")
-#  name                     :string(200)      not null, uniquely indexed
-#  remoteproject            :string(255)
-#  remoteurl                :string(255)
-#  report_bug_url           :string(8192)
-#  required_checks          :string(255)
-#  scmsync                  :text(65535)
-#  title                    :string(255)
-#  url                      :string(255)
-#  created_at               :datetime
-#  updated_at               :datetime
-#  develproject_id          :integer          indexed
-#  staging_workflow_id      :integer          indexed
+#  id                            :integer          not null, primary key
+#  anitya_distribution_name      :string(255)
+#  anitya_distribution_synced_at :datetime
+#  comments_count                :integer          default(0), not null, indexed
+#  delta                         :boolean          default(TRUE), not null
+#  description                   :text(65535)
+#  kind                          :string           default("standard")
+#  name                          :string(200)      not null, uniquely indexed
+#  remoteproject                 :string(255)
+#  remoteurl                     :string(255)
+#  report_bug_url                :string(8192)
+#  required_checks               :string(255)
+#  scmsync                       :text(65535)
+#  title                         :string(255)
+#  url                           :string(255)
+#  created_at                    :datetime
+#  updated_at                    :datetime
+#  develproject_id               :integer          indexed
+#  staging_workflow_id           :integer          indexed
 #
 # Indexes
 #

--- a/src/api/db/migrate/20260226144818_add_anitya_distribution_synced_at_to_projects.rb
+++ b/src/api/db/migrate/20260226144818_add_anitya_distribution_synced_at_to_projects.rb
@@ -1,0 +1,5 @@
+class AddAnityaDistributionSyncedAtToProjects < ActiveRecord::Migration[7.2]
+  def change
+    add_column :projects, :anitya_distribution_synced_at, :datetime
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_02_19_163000) do
+ActiveRecord::Schema[7.2].define(version: 2026_02_26_144818) do
   create_table "active_storage_attachments", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -956,6 +956,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_19_163000) do
     t.string "report_bug_url", limit: 8192
     t.string "anitya_distribution_name"
     t.integer "comments_count", default: 0, null: false
+    t.datetime "anitya_distribution_synced_at"
     t.index ["comments_count"], name: "index_projects_on_comments_count"
     t.index ["develproject_id"], name: "devel_project_id_index"
     t.index ["name"], name: "projects_name_index", unique: true


### PR DESCRIPTION
Introduce a new datetime column `anitya_distribution_synced_at` to track when the anitya distribution information was last synced.