### PR TITLE
Increase search box width and improve responsiveness

### DIFF
--- a/src/api/app/assets/stylesheets/webui/layout.scss
+++ b/src/api/app/assets/stylesheets/webui/layout.scss
@@ -45,6 +45,13 @@
   }
 }
 
+#top-navigation-search {
+  @extend .flex-grow-1;
+  @extend .ms-4;
+  @extend .my-auto;
+  max-width: 500px;
+}
+
 #bottom-navigation-area {
   z-index: calc(#{$zindex-modal} - 5);
   .fixed-bottom {

--- a/src/api/app/views/layouts/webui/_top_navigation.html.haml
+++ b/src/api/app/views/layouts/webui/_top_navigation.html.haml
@@ -2,7 +2,7 @@
   .container-fluid.d-flex.flex-nowrap.justify-content-between.w-100
     = link_to(root_path, class: 'navbar-brand', alt: 'Logo') do
       = image_tag(::Configuration.logo.attached? ? ::Configuration.logo : 'obs-logo_small.svg')
-    .d-flex.nav
+    .d-flex.flex-grow-1.justify-content-end.nav
       = render partial: 'layouts/webui/top_navigation_search'
       - if User.session
         .toggler.text-center.justify-content-center.nav-item

--- a/src/api/app/views/layouts/webui/_top_navigation_search.html.haml
+++ b/src/api/app/views/layouts/webui/_top_navigation_search.html.haml
@@ -1,3 +1,3 @@
-= form_tag(search_path(project: 1, package: 1, name: 1), method: :get, class: 'my-auto') do
+= form_tag(search_path(project: 1, package: 1, name: 1), method: :get, id: 'top-navigation-search') do
   = render partial: 'webui/shared/search_box', locals: { html_id: 'search_text', required: false,
                                                          button: { type: 'submit' }, placeholder: "Search (Press '/')" }


### PR DESCRIPTION
Prevent the search box from being too small on wide screens while ensuring it doesn't break the layout on smaller viewports.

| Wide viewports | Smaller viewports |
|:---: | :---: |
| <img width="1059" height="75" alt="Screenshot From 2026-02-27 10-18-12" src="https://github.com/user-attachments/assets/a6a94cd8-1609-48c8-942f-1699879a0b61" /> | <img width="588" height="75" alt="Screenshot From 2026-02-27 10-18-53" src="https://github.com/user-attachments/assets/2e217d85-5f79-40f4-9933-bb3ef986daca" /> |