### PR TITLE
Fix crash when creating an existing patchinfo package

### DIFF
--- a/src/api/app/controllers/webui/patchinfo_controller.rb
+++ b/src/api/app/controllers/webui/patchinfo_controller.rb
@@ -32,10 +32,16 @@ class Webui::PatchinfoController < Webui::WebuiController
   def create
     authorize @project, :update?, policy_class: ProjectPolicy
 
-    if !@project.exists_package?('patchinfo') && !Patchinfo.new.create_patchinfo(@project.name, nil)
-      flash[:error] = 'Error creating patchinfo'
+    begin
+      if !@project.exists_package?('patchinfo') && !Patchinfo.new.create_patchinfo(@project.name, nil)
+        flash[:error] = 'Error creating patchinfo'
+        redirect_to(controller: 'project', action: 'show', project: @project) && return
+      end
+    rescue ActiveRecord::RecordInvalid => e
+      flash[:error] = e.record.errors.full_messages.to_sentence
       redirect_to(controller: 'project', action: 'show', project: @project) && return
     end
+
     @package = @project.packages.find_by_name('patchinfo')
     unless @package.patchinfo
       flash[:error] = "Patchinfo not found for #{elide(params[:project])}"

--- a/src/api/spec/controllers/webui/patchinfo_controller_spec.rb
+++ b/src/api/spec/controllers/webui/patchinfo_controller_spec.rb
@@ -101,6 +101,22 @@ RSpec.describe Webui::PatchinfoController, :vcr do
 
       it { expect(response).to redirect_to(edit_patchinfo_path(project: project, package: 'patchinfo')) }
     end
+
+    context 'when patchinfo package already exists (validation failure)' do
+      before do
+        # Stub backend calls to avoid connection errors
+        allow(Backend::Api::Build::Project).to receive(:binarylist).and_return(fake_build_results)
+        allow_any_instance_of(Package).to receive(:patchinfo).and_return(fake_patchinfo_with_binaries)
+        # Mock exists_package? to return false to force creation attempt
+        allow_any_instance_of(Project).to receive(:exists_package?).with('patchinfo', any_args).and_return(false)
+        # Create a package that will cause validation error
+        create(:package, name: 'patchinfo', project: user.home_project)
+        post :create, params: { project: user.home_project }
+      end
+
+      it { expect(response).to redirect_to(project_show_path(user.home_project)) }
+      it { expect(flash[:error]).to include('already has a package with the name `patchinfo`') }
+    end
   end
 
   describe 'POST #update_issues' do


### PR DESCRIPTION
Hey Friends,

this PR resolves a crash in the Patchinfo creation flow when a package with the name "patchinfo" already exists in the project. Instead of throwing an `ActiveRecord::RecordInvalid` exception, the controller now catches it and shows a user-friendly error message.

### Expected Behavior:
- If a "patchinfo" package already exists, the system should not crash.
- The user should be redirected back gracefully.
- A clear flash error message should be displayed indicating that the package already exists.

### To verify this change:

- Go to a project where you have permissions (e.g., your home project).
- Create a package named `patchinfo` manually if it doesn't exist.
- Click on "Create patchinfo" in the project actions.
- You should be redirected back to the project page with a flash error: "Validation failed: Project ... already has a package with the name `patchinfo`".

### Automated tests:

Run the regression test to ensure the fix works as expected:
```bash
bundle exec rspec spec/controllers/webui/patchinfo_controller_spec.rb:114
```

### Detailed Changes:
- Modified `PatchinfoController#create` to rescue `ActiveRecord::RecordInvalid`.
- Added a regression test in `patchinfo_controller_spec.rb` to cover the validation failure scenario.

Fixes #18711