### PR TITLE
Limit Sphinx reindexing to specific field changes

### DIFF
--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -88,7 +88,7 @@ class Package < ApplicationRecord
   after_destroy :delete_from_sphinx
 
   after_save :write_to_backend
-  after_save :populate_to_sphinx
+  after_save :populate_to_sphinx, if: :needs_sphinx_update?
 
   after_rollback :reset_cache
 
@@ -1374,6 +1374,14 @@ class Package < ApplicationRecord
     [new_activity, 100].min
 
     self.activity_index = new_activity
+  end
+
+  def needs_sphinx_update?
+    return true if previously_new_record?
+
+    relevant_columns = %w[name title description project_id activity_index]
+
+    saved_changes.keys.intersect?(relevant_columns)
   end
 
   def populate_to_sphinx

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -25,7 +25,7 @@ class Project < ApplicationRecord
 
   after_destroy :delete_from_sphinx
   after_save :discard_cache
-  after_save :populate_to_sphinx
+  after_save :populate_to_sphinx, if: :needs_sphinx_update?
 
   after_save :sync_upstream_package_version, :sync_local_package_version, if: -> { saved_change_to_anitya_distribution_name? }
   after_rollback :reset_cache
@@ -1485,6 +1485,14 @@ class Project < ApplicationRecord
 
   def calculate_missing_checks
     combined_status_reports.map(&:missing_checks).flatten
+  end
+
+  def needs_sphinx_update?
+    return true if previously_new_record?
+
+    relevant_columns = %w[name title description]
+
+    saved_changes.keys.intersect?(relevant_columns)
   end
 
   def populate_to_sphinx


### PR DESCRIPTION
Previously, the `populate_to_sphinx` job was triggered on every save, including timestamps. This change constrains the reindexing to only occur when core indexed fields  are modified.

By implementing these changes, the number of unnecessary project and package reindexations will be significantly reduced.