### PR TITLE
Pass tarlimit to webui_sourcediff

### DIFF
--- a/src/api/app/components/sourcediff_component.rb
+++ b/src/api/app/components/sourcediff_component.rb
@@ -12,8 +12,8 @@ class SourcediffComponent < ApplicationComponent
     @diff_to_superseded = diff_to_superseded
     @commented_lines = commented_lines
     @diff_not_cached = diff_not_cached
-    @webui_sourcediff = @action.webui_sourcediff({ diff_to_superseded: @diff_to_superseded, cacheonly: 1 })
     @tarlimit = tarlimit
+    @webui_sourcediff = @action.webui_sourcediff({ diff_to_superseded: @diff_to_superseded, cacheonly: 1, tarlimit: @tarlimit }.compact)
   end
 
   def expandable?(sourcediff)


### PR DESCRIPTION
Forward `tarlimit` in the component query options.

The "Expand changes" banner should now correctly disappear. 