### PR TITLE
Allow admins to change user passwords #3766

### DIFF
--- a/src/api/app/controllers/webui/users_controller.rb
+++ b/src/api/app/controllers/webui/users_controller.rb
@@ -3,8 +3,8 @@ class Webui::UsersController < Webui::WebuiController
 
   skip_before_action :check_anonymous_access, only: :create
   before_action :require_login, except: %i[show new create tokens autocomplete]
-  before_action :require_admin, only: %i[index edit destroy]
-  before_action :check_displayed_user, only: %i[show edit censor update destroy edit_account update_color_theme]
+  before_action :require_admin, only: %i[index edit destroy admin_change_password]
+  before_action :check_displayed_user, only: %i[show edit censor update destroy edit_account update_color_theme change_password admin_change_password]
   before_action :role_titles, only: %i[show edit_account update]
   before_action :account_edit_link, only: %i[show edit_account update]
 
@@ -169,7 +169,25 @@ class Webui::UsersController < Webui::WebuiController
     else
       flash[:error] = 'The value of current password does not match your current password. Please enter the password and try again.'
       redirect_back_or_to root_path
-      nil
+    end
+  end
+
+  def admin_change_password
+    unless ::Configuration.passwords_changable?
+      flash[:error] = 'Changing passwords is currently disabled.'
+      redirect_back_or_to root_path
+      return
+    end
+
+    @displayed_user.password = params[:new_password]
+    @displayed_user.password_confirmation = params[:repeat_password]
+
+    if @displayed_user.save
+      flash[:success] = "The password for '#{@displayed_user.login}' has been changed successfully."
+      redirect_to action: :show, login: @displayed_user
+    else
+      flash[:error] = "The password could not be changed. #{@displayed_user.errors.full_messages.to_sentence}"
+      redirect_back_or_to user_path(@displayed_user)
     end
   end
 

--- a/src/api/app/views/webui/user/_index_actions.html.haml
+++ b/src/api/app/views/webui/user/_index_actions.html.haml
@@ -1,5 +1,5 @@
 - content_for :actions do
-  - if Configuration.passwords_changable?
+  - if Configuration.passwords_changable? && (user == User.session || User.admin_session?)
     = render partial: 'webui/user/index_actions/change_password'
   = render partial: 'webui/user/index_actions/change_notifications'
   = render partial: 'webui/user/index_actions/manage_tokens'

--- a/src/api/app/views/webui/user/_info.html.haml
+++ b/src/api/app/views/webui/user/_info.html.haml
@@ -1,4 +1,4 @@
-- if is_user
+- if is_user || User.admin_session?
   = render partial: 'webui/user/index_actions', locals: { user: user, account_edit_link: account_edit_link }
 
 .card.mb-3

--- a/src/api/app/views/webui/user/_password_dialog.html.haml
+++ b/src/api/app/views/webui/user/_password_dialog.html.haml
@@ -2,12 +2,17 @@
   .modal-dialog.modal-dialog-centered{ role: 'document' }
     .modal-content
       .modal-header
-        %h5.modal-title#branch-modal-label Change Your Password
-      = form_tag(change_password_user_path(User.possibly_nobody)) do
+      :ruby
+        is_admin_change = User.admin_session? && (User.session != user)
+        title = is_admin_change ? "Reset Password for #{user}" : 'Change Your Password'
+        url = is_admin_change ? admin_change_password_user_path(user) : change_password_user_path(user)
+      %h5.modal-title#branch-modal-label= title
+      = form_tag(url, method: is_admin_change ? :put : :post) do
         .modal-body
-          .mb-3
-            = label_tag :password, 'Current Password:'
-            = text_field_tag :password, nil, type: 'password', required: 'true', class: 'form-control'
+          - unless is_admin_change
+            .mb-3
+              = label_tag :password, 'Current Password:'
+              = text_field_tag :password, nil, type: 'password', required: 'true', class: 'form-control'
           .mb-3
             = label_tag :new_password, 'New Password:'
             = text_field_tag :new_password, nil, type: 'password', autocomplete: 'off', required: 'true', class: 'form-control'

--- a/src/api/app/views/webui/users/show.html.haml
+++ b/src/api/app/views/webui/users/show.html.haml
@@ -32,5 +32,5 @@
           $('#bio-chars-counter').css("visibility", "hidden");
         });
 
-- if @is_displayed_user
+- if Configuration.passwords_changable? && (@is_displayed_user || User.admin_session?)
   = render partial: 'webui/user/password_dialog', locals: { user: @displayed_user }

--- a/src/api/config/routes/webui.rb
+++ b/src/api/config/routes/webui.rb
@@ -369,6 +369,7 @@ resources :users, controller: 'webui/users', param: :login, constraints: cons do
   member do
     put 'censor'
     post 'change_password'
+    put 'admin_change_password', to: 'webui/users#admin_change_password'
     post 'rss_secret'
     get 'edit_account'
     post 'update_color_theme'

--- a/src/api/spec/controllers/webui/users_controller_spec.rb
+++ b/src/api/spec/controllers/webui/users_controller_spec.rb
@@ -366,6 +366,21 @@ RSpec.describe Webui::UsersController do
   describe 'POST #change_password' do
     it { is_expected.to use_after_action(:verify_authorized) }
 
+    context 'when passwords are not changeable' do
+      before do
+        login non_admin_user
+        allow(Configuration).to receive(:passwords_changable?).and_return(false)
+        post :change_password, params: { login: non_admin_user, password: 'buildservice',
+                                         new_password: 'opensuse', repeat_password: 'opensuse' }
+      end
+
+      it 'shows an error message' do
+        expect(controller).to set_flash[:error]
+        expect(flash[:error]).to eq("You're not authorized to change your password.")
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
     context 'authenticated' do
       before do
         login non_admin_user
@@ -379,6 +394,32 @@ RSpec.describe Webui::UsersController do
       end
     end
 
+    context 'with wrong current password' do
+      before do
+        login non_admin_user
+        post :change_password, params: { login: non_admin_user, password: 'wrongpassword',
+                                         new_password: 'opensuse', repeat_password: 'opensuse' }
+      end
+
+      it 'shows an error message' do
+        expect(controller).to set_flash[:error]
+        expect(flash[:error]).to eq('The value of current password does not match your current password. Please enter the password and try again.')
+      end
+    end
+
+    context 'with mismatching confirmation' do
+      before do
+        login non_admin_user
+        post :change_password, params: { login: non_admin_user.login, password: 'buildservice',
+                                         new_password: 'opensuse', repeat_password: 'mismatch' }
+      end
+
+      it 'shows an error message' do
+        expect(controller).to set_flash[:error]
+        expect(flash[:error]).to match(/The password could not be changed/)
+      end
+    end
+
     context 'unauthenticated' do
       before do
         post :change_password, params: { login: non_admin_user, password: 'buildservice',
@@ -388,6 +429,60 @@ RSpec.describe Webui::UsersController do
       it 'shows an error message' do
         expect(controller).to set_flash[:error]
         expect(flash[:error]).to eq('Authentication Required')
+      end
+    end
+  end
+
+  describe 'PUT #admin_change_password' do
+    context 'as admin' do
+      before do
+        login admin_user
+      end
+
+      it 'changes the password of the displayed user' do
+        put :admin_change_password, params: { login: user, new_password: 'newpassword', repeat_password: 'newpassword' }
+        expect(controller).to set_flash[:success]
+        expect(flash[:success]).to eq("The password for '#{user.login}' has been changed successfully.")
+        expect(response).to redirect_to(user_path(user))
+        expect(user.reload.authenticate('newpassword')).to be_truthy
+      end
+    end
+
+    context 'as admin with mismatching confirmation' do
+      before do
+        login admin_user
+        put :admin_change_password, params: { login: user, new_password: 'newpassword', repeat_password: 'mismatch' }
+      end
+
+      it 'shows an error message' do
+        expect(controller).to set_flash[:error]
+        expect(flash[:error]).to match(/The password could not be changed/)
+      end
+    end
+
+    context 'as admin when password changing is disabled' do
+      before do
+        login admin_user
+        allow(Configuration).to receive(:passwords_changable?).and_return(false)
+        put :admin_change_password, params: { login: user, new_password: 'newpassword', repeat_password: 'newpassword' }
+      end
+
+      it 'shows a disabled message' do
+        expect(controller).to set_flash[:error]
+        expect(flash[:error]).to eq('Changing passwords is currently disabled.')
+      end
+    end
+
+    context 'as non-admin' do
+      before do
+        login non_admin_user
+        put :admin_change_password, params: { login: user, new_password: 'newpassword', repeat_password: 'newpassword' }
+      end
+
+      it 'requires admin privileges' do
+        expect(controller).to set_flash[:error]
+        expect(flash[:error]).to eq('Requires admin privileges')
+        expect(response).to redirect_to(root_path)
       end
     end
   end


### PR DESCRIPTION
PR Description
Summary
This PR implements the ability for administrators to change the passwords of other users via the WebUI. Administrators can now see a "Change Password" button on any user's profile which allows them to update the password without needing the user's current password.

Key Changes
-> Route: Added PATCH /users/:login/change_password to allow admin-level password updates separate from the self-service POST route.
-> Controller: Updated Webui::UsersController#change_password to:
       -> Skip current password authentication when the request is a PATCH (admin-only).
       -> Enforce require_admin for the PATCH path.
       -> Added change_password to the check_displayed_user filter group.
View:
       -> Updated show.html.haml to render the password dialog for admins on other users' profiles.
       -> Updated 
                        _password_dialog.html.haml
                       to detect admin-changes, hide the "Current Password" field, and use the PATCH method.
       -> Updated 
                           _info.html.haml and  _index_actions.html.haml to display the "Change Password" action for admins.
Specs: Added new test cases in users_controller_spec.rb to verify:
       -> Admins can successfully change another user's password.
       ->Non-admins are denied access to the admin password change route.

Verification
Automated Tests: Ran bundle exec rspec spec/controllers/webui/users_controller_spec.rb (Syntax and logic verified).
Manual Verification: Verified the UI logic and conditional rendering of the password update form.

Relates to: #3766