### PR TITLE
Preload project in source/target maintainer checks

### DIFF
--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -888,12 +888,12 @@ class BsRequest < ApplicationRecord
 
   # Check if 'user' is maintainer in _all_ request sources:
   def source_maintainer?(user)
-    bs_request_actions.includes(:source_project_object, :source_package_object).all? { |action| action.source_maintainer?(user) }
+    bs_request_actions.includes(:source_project_object, { source_package_object: :project }).all? { |action| action.source_maintainer?(user) }
   end
 
   # Check if 'user' is maintainer in _all_ request targets:
   def target_maintainer?(user)
-    bs_request_actions.includes(:target_package_object, :target_project_object).all? { |action| action.target_maintainer?(user) }
+    bs_request_actions.includes({ target_package_object: :project }, :target_project_object).all? { |action| action.target_maintainer?(user) }
   end
 
   def sanitize!


### PR DESCRIPTION
This is the minimal WIP, which avoids any conditional, which would be needed to get rid of the rest of the bullet warnings.