### PR TITLE
Display searchable local version

### DIFF
--- a/src/api/app/datatables/package_datatable.rb
+++ b/src/api/app/datatables/package_datatable.rb
@@ -148,13 +148,17 @@ class PackageDatatable < Datatable # rubocop:disable Metrics/ClassLength
   def versions_text_for_users_in_labels_beta(record:, local_version:, upstream_version:)
     return if local_version.blank? && upstream_version.blank?
 
-    if upstream_version.blank?
-      release_monitoring_search_link(record, local_version)
-    elsif local_version == upstream_version
-      release_monitoring_package_link(record, local_version)
-    else
-      release_monitoring_package_link(record, "#{upstream_version} available")
-    end
+    link = if upstream_version.blank?
+             release_monitoring_search_link(record, local_version)
+           elsif local_version == upstream_version
+             release_monitoring_package_link(record, local_version)
+           else
+             release_monitoring_package_link(record, "#{upstream_version} available")
+           end
+
+    parenthesized_text = "(#{link})".html_safe # rubocop:disable Rails/OutputSafety
+
+    ActionController::Base.helpers.safe_join([local_version, parenthesized_text].compact, ' ')
   end
 
   def show_version_column?


### PR DESCRIPTION
The package list allows to search by local version, however, the result doesn't show the value we are searching for.
The reason is that, at some point, we stopped displaying "29.1 (30.0 available)" and diplayed only "30.0 available".

The issue only happened when the Labels beta feature was enabled.

Before:

<img width="988" height="313" alt="Screenshot 2026-03-19 at 18-41-36 Show openSUSE Factory - Open Build Service" src="https://github.com/user-attachments/assets/250648dd-5573-4c31-a361-fc81ec3c9d47" />


After:

<img width="1003" height="322" alt="Screenshot 2026-03-19 at 18-40-53 Show openSUSE Factory - Open Build Service" src="https://github.com/user-attachments/assets/ccc87d32-baf7-49ac-9378-d7bc45ca14e3" />
