### PR TITLE
Display the version in the notifications' list

### DIFF
--- a/src/api/app/models/concerns/notification_request.rb
+++ b/src/api/app/models/concerns/notification_request.rb
@@ -12,13 +12,17 @@ module NotificationRequest
   def request_source
     return '' if size_of_bs_request_actions > 1
 
-    [first_bs_request_action.source_project, first_bs_request_action.source_package].compact.join(' / ')
+    text = [first_bs_request_action.source_project, first_bs_request_action.source_package].compact.join(' / ')
+    text << version_suffix(bs_request.source_package_latest_local_version)
+    text
   end
 
   def request_target
     return first_bs_request_action.target_project if size_of_bs_request_actions > 1
 
-    [first_bs_request_action.target_project, first_bs_request_action.target_package].compact.join(' / ')
+    text = [first_bs_request_action.target_project, first_bs_request_action.target_package].compact.join(' / ')
+    text << version_suffix(bs_request.target_package_latest_local_version)
+    text
   end
 
   private
@@ -29,5 +33,11 @@ module NotificationRequest
 
   def size_of_bs_request_actions
     @size_of_bs_request_actions ||= bs_request.bs_request_actions.size
+  end
+
+  def version_suffix(version)
+    return '' unless Flipper.enabled?(:package_version_tracking, User.session) && version.present?
+
+    " (#{version})"
   end
 end


### PR DESCRIPTION
### Before

<img width="726" height="210" alt="Screenshot From 2026-03-23 14-20-20" src="https://github.com/user-attachments/assets/709033d4-10ef-4f56-9457-096f2b8fd66f" />

### After

<img width="726" height="210" alt="Screenshot From 2026-03-23 14-16-43" src="https://github.com/user-attachments/assets/be91e54a-c2dc-4590-83bd-f591c9a86e73" />

## For reviewers

I created a setup using my development environment.

For the source package:
- branch `opensuse.org:network / Radicale` into `home:Iggy / Radicale`
- set `openSUSE` as Anytia distribution for project `home:Iggy`
- launch `SyncLocalPackageVersionJob.perform_now('home:Iggy')` in a Rails console

For the target package:
- branch `opensuse.org:openSUSE:Factory / Radicale` into `home:Admin / Radicale`
- launch `SyncLocalPackageVersionJob.perform_now('home:Admin')` in a Rails console

Create a request from the source to the target package.

Log in as Admin and see the notification.