### PR TITLE
Switch the label filter default

### DIFF
--- a/src/api/app/models/workflow.rb
+++ b/src/api/app/models/workflow.rb
@@ -125,7 +125,7 @@ class Workflow # rubocop:disable Metrics/ClassLength
   # Execute only if labeled or unlabeled
   def label_matches_labels_filter?
     return true unless workflow_run.labeled_pull_request? || workflow_run.unlabeled_pull_request?
-    return true unless supported_filters.key?(:labels)
+    return false unless supported_filters.key?(:labels)
 
     labels_only = filters[:labels].fetch(:only, [])
     labels_ignore = filters[:labels].fetch(:ignore, [])

--- a/src/api/spec/models/workflow_spec.rb
+++ b/src/api/spec/models/workflow_spec.rb
@@ -384,14 +384,14 @@ RSpec.describe Workflow, :vcr do
       it { expect(subject.send(:label_matches_labels_filter?)).to be_truthy }
     end
 
-    context "workflow instructions don't have labels filter" do
+    context 'no labels filter and label event' do
       let!(:workflow_run) { create(:workflow_run, :pull_request_labeled, token: token) }
       let(:yaml) do
         { steps: [{ branch_package: { source_project: 'test-project', source_package: 'test-package', target_project: 'test-project' } }] }
       end
 
-      it 'does not stop the execution of steps' do
-        expect(subject.send(:label_matches_labels_filter?)).to be_truthy
+      it 'does stop the execution of steps' do
+        expect(subject.send(:label_matches_labels_filter?)).to be_falsey
       end
     end
 


### PR DESCRIPTION
If there is *no* label filter setup, then all label actions passed the filter. That means an unlabeld event for *any* label acts like a closed/merged pull request.

This is not what people expect so turn this around. If there is no label filter setup, do *not* run anything in case of label events.