### PR TITLE
Refactor existing specs to use factories

### DIFF
--- a/src/api/spec/models/bs_request_spec.rb
+++ b/src/api/spec/models/bs_request_spec.rb
@@ -721,99 +721,66 @@ RSpec.describe BsRequest, :vcr do
   end
 
   describe '#source_package_latest_local_version' do
-    let(:bs_request) { BsRequest.new }
-    let(:action) { BsRequestActionSubmit.new }
-    let(:source_project) { instance_double(Project) }
-    let(:source_package) { instance_double(Package) }
-    let(:local_version) { instance_double(PackageVersionLocal, version: '1.0.0') }
-
-    before do
-      bs_request.bs_request_actions = [action]
-      allow(action).to receive_messages(source_project_object: source_project, source_package_object: source_package)
-    end
-
     context 'when the request has multiple actions' do
       before do
-        bs_request.bs_request_actions << BsRequestActionSubmit.new
+        submit_request.bs_request_actions << create(:bs_request_action_maintenance_release, source_project: source_project.name,
+                                                                                            source_package: source_package.name,
+                                                                                            target_project: target_project.name)
       end
 
       it 'returns nil' do
-        expect(bs_request.source_package_latest_local_version).to be_nil
+        expect(submit_request.source_package_latest_local_version).to be_nil
       end
     end
 
     context 'when the action is not a submit action' do
-      let(:action) { BsRequestActionDelete.new }
-
       it 'returns nil' do
-        expect(bs_request.source_package_latest_local_version).to be_nil
+        expect(delete_request.source_package_latest_local_version).to be_nil
       end
     end
 
     context 'when the action is a submit action' do
       context 'when the source project does not have an anitya distribution name' do
-        before do
-          allow(source_project).to receive(:anitya_distribution_name).and_return(nil)
-        end
-
         it 'returns nil' do
-          expect(bs_request.source_package_latest_local_version).to be_nil
+          expect(submit_request.source_package_latest_local_version).to be_nil
         end
       end
 
       context 'when the source project has an anitya distribution name' do
         before do
-          allow(source_project).to receive(:anitya_distribution_name).and_return('openSUSE')
+          source_project.update_column(:anitya_distribution_name, 'openSUSE') # rubocop:disable Rails/SkipsModelValidations
         end
 
         context 'when the source package has no latest local version' do
-          before do
-            allow(source_package).to receive(:latest_local_version).and_return(nil)
-          end
-
           it 'returns nil' do
-            expect(bs_request.source_package_latest_local_version).to be_nil
+            expect(submit_request.source_package_latest_local_version).to be_nil
           end
         end
 
         context 'when the source package has a latest local version' do
-          before do
-            allow(source_package).to receive(:latest_local_version).and_return(local_version)
-          end
+          let!(:local_version) { create(:package_version_local, version: '1.0.0', package: source_package) }
 
           it 'returns the version' do
-            expect(bs_request.source_package_latest_local_version).to eq('1.0.0')
+            expect(submit_request.source_package_latest_local_version).to eq('1.0.0')
           end
         end
       end
     end
   end
 
+  # Only test the happy path as the implementation is identical to #source_package_latest_local_version which is fully tested above.
   describe '#target_package_latest_local_version' do
-    let(:bs_request) { BsRequest.new }
-    let(:action) { BsRequestActionSubmit.new }
-    let(:target_project) { instance_double(Project) }
-    let(:target_package) { instance_double(Package) }
-    let(:local_version) { instance_double(PackageVersionLocal, version: '2.5.1') }
-
-    before do
-      bs_request.bs_request_actions = [action]
-      allow(action).to receive_messages(target_project_object: target_project, target_package_object: target_package)
-    end
-
     context 'when the action is a submit action' do
       context 'when the target project has an anitya distribution name' do
         before do
-          allow(target_project).to receive(:anitya_distribution_name).and_return('openSUSE')
+          target_project.update_column(:anitya_distribution_name, 'openSUSE') # rubocop:disable Rails/SkipsModelValidations
         end
 
         context 'when the target package has a latest local version' do
-          before do
-            allow(target_package).to receive(:latest_local_version).and_return(local_version)
-          end
+          let!(:local_version) { create(:package_version_local, version: '2.5.1', package: target_package) }
 
           it 'returns the version' do
-            expect(bs_request.target_package_latest_local_version).to eq('2.5.1')
+            expect(submit_request.target_package_latest_local_version).to eq('2.5.1')
           end
         end
       end


### PR DESCRIPTION
Instead of instanciating objects and calling instance_double, let's use factories and reuse what is already declared at the beginning of the spec.