### PR TITLE
Remove unused `@unread_notifications_count` variable

### DIFF
--- a/src/api/app/controllers/webui/users/notifications_controller.rb
+++ b/src/api/app/controllers/webui/users/notifications_controller.rb
@@ -53,7 +53,6 @@ class Webui::Users::NotificationsController < Webui::WebuiController
       format.js do
         render partial: 'update', locals: {
           notifications: @notifications,
-          unread_notifications_count: unread_notifications.count,
           selected_filter: @selected_filter,
           total_count_notifications: @notifications.count,
           user: User.session

--- a/src/api/app/views/layouts/webui/webui.html.haml
+++ b/src/api/app/views/layouts/webui/webui.html.haml
@@ -42,7 +42,7 @@
   %body{ class: feature_css_class }
     #grid
       #top-navigation-area
-        = render partial: 'layouts/webui/top_navigation', locals: { unread_notifications_count: @unread_notifications_count }
+        = render partial: 'layouts/webui/top_navigation'
       .navbar-themed-colors#left-navigation-area{ class: "#{'collapsed' if sidebar_collapsed?}" }
         = render partial: 'layouts/webui/left_navigation', locals: { spider_bot: @spider_bot }
         = render partial: 'layouts/webui/left_navigation_collapse_button'
@@ -74,8 +74,7 @@
 
       - if !current_page?(signup_path) && !current_page?(new_session_path)
         #bottom-navigation-area
-          = render partial: 'layouts/webui/bottom_navigation',locals: { spider_bot: @spider_bot,
-                                                                        unread_notifications_count: @unread_notifications_count }
+          = render partial: 'layouts/webui/bottom_navigation',locals: { spider_bot: @spider_bot }
 
       -# Collapsible menu shared between top and bottom navigation
       - if User.session

--- a/src/api/app/views/webui/users/notifications/_update.js.erb
+++ b/src/api/app/views/webui/users/notifications/_update.js.erb
@@ -1,4 +1,4 @@
 $('#content-selector-filters').html("<%= j(render partial: 'notification_filter', locals: { selected_filter: selected_filter, projects_for_filter: @projects_for_filter, groups_for_filter: @groups_for_filter }) %>");
 $('#notifications-list').html("<%= j(render partial: 'notifications_list', locals: { notifications: notifications, selected_filter: selected_filter, total_count_notifications: total_count_notifications }) %>");
 $('#flash').html("<%= escape_javascript(render(layout: false, partial: 'layouts/webui/flash', object: flash)) %>");
-$('#top-notifications-counter, #bottom-notifications-counter').html("<%= escape_javascript(render partial: 'layouts/webui/unread_notifications_counter', locals: { unread_notifications_count: unread_notifications_count }) %>");
+$('#top-notifications-counter, #bottom-notifications-counter').html("<%= escape_javascript(render partial: 'layouts/webui/unread_notifications_counter') %>");


### PR DESCRIPTION
This variable gets never set and is not used since a while anymore. It used to be set in the webui controller, but since a while the navigation bars fetch the value directly from the notification controller via a turbo frame.