### PR TITLE
Fix the project storing order for the attribute test

### DIFF
--- a/src/api/test/unit/attribute_test.rb
+++ b/src/api/test/unit/attribute_test.rb
@@ -138,8 +138,8 @@ class AttributeTest < ActiveSupport::TestCase
     # store in a project
     @project = Project.create(name: 'GNOME18')
     assert_not_nil @project
-    @project.store_attribute_xml(xml)
     @project.store
+    @project.store_attribute_xml(xml)
 
     @p = Project.find_by_name('GNOME18')
     assert_not_nil @p


### PR DESCRIPTION
This fixes the error `project 'GNOME18' does not exist` that sometimes appears when running the test suite.

We need to store the project first in order to update its attributes.