### PR TITLE
Fix authorization for notification sti classes

### DIFF
--- a/src/api/app/controllers/concerns/webui/notifications_handler.rb
+++ b/src/api/app/controllers/concerns/webui/notifications_handler.rb
@@ -6,7 +6,7 @@ module Webui::NotificationsHandler
 
     current_notification = Notification.find(params[:notification_id])
 
-    return unless NotificationCommentPolicy.new(User.session, current_notification).update?
+    return unless NotificationPolicy.new(User.session, current_notification).update?
 
     current_notification
   end

--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -156,7 +156,7 @@ class Webui::PackageController < Webui::WebuiController
     @roles = Role.local_roles
     if User.session && params[:notification_id]
       @current_notification = Notification.find(params[:notification_id])
-      authorize @current_notification, :update?, policy_class: NotificationCommentPolicy
+      authorize @current_notification, :update?, policy_class: NotificationPolicy
     end
     @current_request_action = BsRequestAction.find(params[:request_action_id]) if User.session && params[:request_action_id]
   end

--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -173,7 +173,7 @@ class Webui::ProjectController < Webui::WebuiController
     @roles = Role.local_roles
     if User.session && params[:notification_id]
       @current_notification = Notification.find(params[:notification_id])
-      authorize @current_notification, :update?, policy_class: NotificationCommentPolicy
+      authorize @current_notification, :update?, policy_class: NotificationPolicy
     end
     @current_request_action = BsRequestAction.find(params[:request_action_id]) if User.session && params[:request_action_id]
   end

--- a/src/api/app/models/notification.rb
+++ b/src/api/app/models/notification.rb
@@ -52,6 +52,10 @@ class Notification < ApplicationRecord
   paginates_per 30
   max_paginates_per 300
 
+  def self.policy_class
+    NotificationPolicy
+  end
+
   def event
     @event ||= event_type.constantize.new(event_payload)
   end

--- a/src/api/app/policies/notification_policy.rb
+++ b/src/api/app/policies/notification_policy.rb
@@ -1,4 +1,4 @@
-class NotificationCommentPolicy < ApplicationPolicy
+class NotificationPolicy < ApplicationPolicy
   def update?
     record.subscriber == user
   end

--- a/src/api/spec/policies/notification_policy_spec.rb
+++ b/src/api/spec/policies/notification_policy_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe NotificationCommentPolicy do
+RSpec.describe NotificationPolicy do
   subject { described_class }
 
   let(:user) { create(:confirmed_user) }


### PR DESCRIPTION
Right now updating notifications throught the API is broken, well works only for `NotificationComment`.

It fails with `Pundit::NotDefinedError (unable to find policy 'NotificationPackagePolicy' for...` error because it doesn't find a matching pundit policy.

Since all notification STI classes can use the same authorization logic we can tell the models which one to use.

How to reproduce:
1. Use `osc api -X PUT "/my/notifications/{id}"` for any Notification class that is not `NotificationComment`
2. See it failing with a 500