### PR TITLE
[backend] change default network for service container to `slirp4netns`

### DIFF
--- a/src/backend/BSConfig.pm.template
+++ b/src/backend/BSConfig.pm.template
@@ -356,7 +356,7 @@ our $local_registry_signatures_extension = 1;
 #our $containers_root="$bsdir/service/containers";
 #
 # option which network should be used when running WITH_NET
-#our $container_network_opt = "--net slirp4netns";
+our $container_network_opt = "--network slirp4netns";
 
 ## Server where mirrored gems could be found - used in services like obs-service-bundle_gems
 # our $gems_mirror = '';

--- a/src/backend/call-service-in-container
+++ b/src/backend/call-service-in-container
@@ -176,7 +176,7 @@ echo "echo Running ${COMMAND[@]} --outdir $INNEROUTDIR" >> "$MOUNTDIR/${INNERSCR
 
 if [ "$WITH_NET" != "1" ] ; then
   printlog "Using docker without network"
-  CONTAINER_NETWORK_OPT="--net=none"
+  CONTAINER_NETWORK_OPT="--network none"
 else
   printlog "Using docker with network"
   CONTAINER_NETWORK_OPT=`obs_admin --query-config container_network_opt`


### PR DESCRIPTION
The new obs_scm_bridge service requires access from the service containers to the OBS-Appliance.