### PR TITLE
[backend] Fail a patchinfo job if we cannot retrieve the issue trackers

### DIFF
--- a/src/backend/BSSched/BuildJob/Patchinfo.pm
+++ b/src/backend/BSSched/BuildJob/Patchinfo.pm
@@ -711,16 +711,16 @@ sub build {
 
   # fetch defined issue trackers from src server. FIXME: cache this
   # XXX: this is not an async call!
-  my @references;
-  my $issue_trackers;
   my $param = {
     'uri' => "$BSConfig::srcserver/issue_trackers",
     'timeout' => 30,
   };
-  eval {
-    $issue_trackers = BSRPC::rpc($param, $BSXML::issue_trackers);
-  };
-  warn($@) if $@;
+  my $issue_trackers = eval { BSRPC::rpc($param, $BSXML::issue_trackers) };
+  if ($@) {
+    warn($@);
+    $broken ||= 'could not retrieve issue trackers';
+  }
+  my @references;
   if ($issue_trackers) {
     for my $b (@{$patchinfo->{'issue'} || []}) {
       my $it = (grep {$_->{'name'} eq $b->{'tracker'}} @{$issue_trackers->{'issue-tracker'} || []})[0];


### PR DESCRIPTION
This is way better than just leaving out the references in the updateinfo file.