### PR TITLE
Rename notification management links to subscriptions

### DIFF
--- a/src/api/app/views/webui/user/index_actions/_change_notifications.haml
+++ b/src/api/app/views/webui/user/index_actions/_change_notifications.haml
@@ -1,4 +1,4 @@
 %li.nav-item
-  = link_to(my_subscriptions_path, class: 'nav-link', title: 'Manage Your Notifications') do
+  = link_to(my_subscriptions_path, class: 'nav-link', title: 'Manage Your Subscriptions') do
     %i.fas.fa-fw.me-2.fa-bell
-    %span.nav-item-name Manage Your Notifications
+    %span.nav-item-name Manage Your Subscriptions

--- a/src/api/app/views/webui/users/notifications/_index_actions.html.haml
+++ b/src/api/app/views/webui/users/notifications/_index_actions.html.haml
@@ -1,5 +1,5 @@
 - content_for :actions do
   %li.nav-item
-    = link_to(my_subscriptions_path, class: 'nav-link', title: 'Manage Your Notifications') do
+    = link_to(my_subscriptions_path, class: 'nav-link', title: 'Manage Your Subscriptions') do
       %i.fas.fa-edit.fa-fw.me-2
-      %span.nav-item-name Manage Your Notifications
+      %span.nav-item-name Manage Your Subscriptions


### PR DESCRIPTION
The card said
> Let’s use “Your Subscriptions” always

Removing the "Manage", would break the consistency with other actions, like "Manage Your Tokes" and "Manage Canned Responses". 

