### PR TITLE
[ci] add test case for 'osc search'

### DIFF
--- a/dist/t/osc/0030_create_and_build_package.ts
+++ b/dist/t/osc/0030_create_and_build_package.ts
@@ -26,6 +26,8 @@ ok(prepare_package(), 'Checking preparation of package');
 
 ok(commit_package(), 'Checking initial commit of package obs-testpackage');
 
+ok(search_package(), 'Checking if search via osc works');
+
 ok(wait_for_buildresults(), 'Checking if build succeeded');
 
 exit 0;
@@ -86,6 +88,14 @@ sub commit_package {
   print STDERR @output if $?;
   return !$?;
 }
+
+sub search_package {
+  my @output = `osc -H search -s obs-test`;
+  print STDERR @output if $?;
+  return !$?;
+}
+
+
 
 sub wait_for_buildresults {
 


### PR DESCRIPTION
This patch contains some code to test the OBS search function in our appliance using osc

Fixes: #19580