### PR TITLE
Create GlobalRoleAssigned event when a global role is assigned to a user

### DIFF
--- a/src/api/app/models/event/global_role_assigned.rb
+++ b/src/api/app/models/event/global_role_assigned.rb
@@ -1,0 +1,6 @@
+module Event
+  class GlobalRoleAssigned < Base
+    self.description = 'User received an important role'
+    payload_keys :role, :user, :who
+  end
+end

--- a/src/api/app/models/role.rb
+++ b/src/api/app/models/role.rb
@@ -47,7 +47,7 @@ class Role < ApplicationRecord
   end
 
   def self.global_roles
-    ['Admin']
+    %w[Admin Staff Moderator]
   end
 
   def self.ids_with_permission(perm_string)

--- a/src/api/app/models/roles_user.rb
+++ b/src/api/app/models/roles_user.rb
@@ -3,6 +3,15 @@ class RolesUser < ApplicationRecord
   belongs_to :role
 
   validates :role, uniqueness: { scope: :user }
+  after_create :create_global_role_assignment_event
+
+  private
+
+  def create_global_role_assignment_event
+    return if Role.global_roles.exclude?(role.title) || User.session.nil?
+
+    Event::GlobalRoleAssigned.create(role: role.title, user: user.login, who: User.session.login)
+  end
 end
 
 # == Schema Information

--- a/src/api/spec/models/role_spec.rb
+++ b/src/api/spec/models/role_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Role do
   end
 
   describe '::global_roles' do
-    let(:expected_global_roles) { ['Admin'] }
+    let(:expected_global_roles) { %w[Admin Staff Moderator] }
 
     it 'returns an array with all global role titles' do
       expect(Role.global_roles).to match_array(expected_global_roles)

--- a/src/api/spec/models/user_spec.rb
+++ b/src/api/spec/models/user_spec.rb
@@ -586,4 +586,29 @@ RSpec.describe User do
 
     it { expect(confirmed_user.bs_requests.pluck(:description)).to contain_exactly('incoming', 'outgoing', 'user_review', 'project_review', 'package_review') }
   end
+
+  describe 'global role assignment event' do
+    let(:non_admin_role) { create(:role) }
+
+    before do
+      User.session = admin_user
+    end
+
+    it 'creates a GlobalRoleAssigned event when an admin role is added' do
+      expect { user.roles << Role.where(title: 'Admin').last }.to change(Event::GlobalRoleAssigned, :count).by(1)
+
+      event = Event::GlobalRoleAssigned.last
+      expect(event.payload).to include(
+        'role' => 'Admin',
+        'user' => user.login,
+        'who' => admin_user.login
+      )
+    end
+
+    it 'does not create an event for non-global roles' do
+      expect do
+        user.roles << non_admin_role
+      end.not_to change(Event::GlobalRoleAssigned, :count)
+    end
+  end
 end


### PR DESCRIPTION
Extracted from #16479. 
This PR only covers the creation of a new event `Event::GlobalRoleAssigned`