### PR TITLE
Measure host request header as tag

### DIFF
--- a/src/api/app/controllers/application_controller.rb
+++ b/src/api/app/controllers/application_controller.rb
@@ -251,7 +251,8 @@ class ApplicationController < ActionController::Base
       anonymous: !User.session,
       spider: spider_request?,
       interconnect: false,
-      interface: :api
+      interface: :api,
+      host: request.headers['Host'] || :unknown
     }
     if in_beta
       Flipper.preload_all.map(&:name).each do |feature_name|

--- a/src/api/app/controllers/webui/webui_controller.rb
+++ b/src/api/app/controllers/webui/webui_controller.rb
@@ -217,7 +217,8 @@ class Webui::WebuiController < ActionController::Base
       anonymous: !User.session,
       spider: @spider_bot,
       interconnect: false,
-      interface: :webui
+      interface: :webui,
+      host: request.headers['Host'] || :unknown
     }
     if in_beta
       Flipper.preload_all.map(&:name).each do |feature_name|


### PR DESCRIPTION
On openSUSE production we might want to know if something came in via build.opensuse.org or api.opensuse.org