### PR TITLE
Move check for notification icons to notifications helper spec

### DIFF
--- a/src/api/spec/features/webui/users/notifications_spec.rb
+++ b/src/api/spec/features/webui/users/notifications_spec.rb
@@ -109,36 +109,6 @@ RSpec.describe 'User notifications', :js do
     end
   end
 
-  context 'when the notification is about a relationship with package' do
-    let(:package) { create(:package_with_maintainer, maintainer: user) }
-    let(:event_payload) { { package: package.name, project: package.project.name } }
-    let!(:notification) { create(:notification_for_project, :web_notification, :relationship_create_for_project, notifiable: package, event_payload: event_payload, subscriber: user) }
-
-    before do
-      login user
-      visit my_notifications_path
-    end
-
-    it 'renders the correct icon' do
-      expect(page).to have_css("i.fa-user-tag[title='Relationship notification']")
-    end
-  end
-
-  context 'when the notification is about a comment for project' do
-    let(:project) { create(:project, maintainer: user) }
-    let(:comment) { create(:comment, commentable: project) }
-    let!(:notification) { create(:notification_for_comment, :web_notification, :comment_for_project, notifiable: comment, subscriber: user) }
-
-    before do
-      login user
-      visit my_notifications_path
-    end
-
-    it 'renders the correct icon' do
-      expect(page).to have_css("i.fa-comments[title='Comment notification']")
-    end
-  end
-
   context 'when the notification is about a comment for report' do
     let!(:notification) { create(:notification_for_comment, :web_notification, :comment_for_report, subscriber: user) }
 

--- a/src/api/spec/helpers/webui/notification_helper_spec.rb
+++ b/src/api/spec/helpers/webui/notification_helper_spec.rb
@@ -31,16 +31,30 @@ RSpec.describe Webui::NotificationHelper do
   end
 
   describe '#notification_icon' do
-    context 'when the notification is about a request' do
-      let(:notification) { create(:notification_for_request, :request_created) }
+    subject { notification_icon(notification) }
 
-      it { expect(notification_icon(notification)).to include('fa-code-pull-request') }
+    context 'when the notification is about a comment for project' do
+      let(:notification) { create(:notification_for_comment, :comment_for_project) }
+
+      it { expect(subject).to have_css(".fa-comments[title='Comment notification']") }
     end
 
     context 'when the notification is about a relationship' do
       let(:notification) { create(:notification_for_project, :relationship_create_for_project) }
 
-      it { expect(notification_icon(notification)).to include('fa-user-tag') }
+      it { expect(subject).to include('fa-user-tag') }
+    end
+
+    context 'when the notification is about a relationship with package' do
+      let(:notification) { create(:notification_for_project, :relationship_create_for_project) }
+
+      it { expect(subject).to have_css(".fa-user-tag[title='Relationship notification']") }
+    end
+
+    context 'when the notification is about a request' do
+      let(:notification) { create(:notification_for_request, :request_created) }
+
+      it { expect(subject).to include('fa-code-pull-request') }
     end
   end
 


### PR DESCRIPTION
Testing notification icons at the feature level is redundant and slow since the logic is already covered in the helper specifications.

This change removes the icon check from `notifications_spec.rb` and ensures the coverage is maintained in `notifications_helper_spec.rb`.