### PR TITLE
Implement missing parameters_for_notification

### DIFF
--- a/src/api/app/models/event/appeal_created.rb
+++ b/src/api/app/models/event/appeal_created.rb
@@ -16,6 +16,10 @@ module Event
     def event_object
       ::Decision.find_by(payload['decision_id'])
     end
+
+    def parameters_for_notification
+      super.merge(notifiable_type: 'Appeal', type: 'NotificationReport')
+    end
   end
 end
 


### PR DESCRIPTION
Implement missing _parameters_for_notification_ for Event::AppealCreated. It caused that we haven't received any Appeal notification so far.

The creation of the notification never happened because the lack of _parameters_for_notification_, and therefore _notifiable_type_, made this method return false: 
https://github.com/openSUSE/open-build-service/blob/5d2a2cb98b282c9fec291345c70a177cb795d7df/src/api/app/services/notification_service/notifier.rb#L92

This screenshot shows a Decision notification and, on top, its corresponding Appeal notification, which wasn't displayed so far.

<img width="1140" height="490" alt="Screenshot 2026-04-20 at 22-08-57 Notifications - Open Build Service" src="https://github.com/user-attachments/assets/4510b107-8a79-46b0-8c89-073fb9bfd457" />

## Testing Tips

- Login with a Moderator user and appeal a decision.
- Login with Admin and check that now they receives a notification of the Appeal.
