### PR TITLE
Fix appeal and decisions filters

### DIFF
--- a/src/api/app/controllers/concerns/webui/notifications_filter.rb
+++ b/src/api/app/controllers/concerns/webui/notifications_filter.rb
@@ -18,6 +18,7 @@ module Webui::NotificationsFilter
     relations_kind << notifications.for_reports if filter_kind.include?('reports')
     relations_kind << notifications.for_workflow_runs if filter_kind.include?('workflow_runs')
     relations_kind << notifications.for_appealed_decisions if filter_kind.include?('appealed_decisions')
+    relations_kind << notifications.for_decisions if filter_kind.include?('decisions')
     relations_kind << notifications.for_member_on_groups if filter_kind.include?('member_on_groups')
     relations_kind << notifications.for_upstream_package_version_changed if filter_kind.include?('upstream_package_version_changed')
 

--- a/src/api/app/controllers/person/notifications_controller.rb
+++ b/src/api/app/controllers/person/notifications_controller.rb
@@ -4,7 +4,7 @@ module Person
     include Webui::NotificationsFilter
 
     ALLOWED_FILTERS = %w[all comments requests incoming_requests outgoing_requests relationships_created relationships_deleted build_failures
-                         reports reviews workflow_runs appealed_decisions member_on_groups].freeze
+                         reports reviews workflow_runs appealed_decisions decisions member_on_groups].freeze
     ALLOWED_STATES = %w[unread read].freeze
 
     before_action :set_filter_kind, only: :index

--- a/src/api/app/controllers/webui/users/notifications_controller.rb
+++ b/src/api/app/controllers/webui/users/notifications_controller.rb
@@ -2,7 +2,7 @@ class Webui::Users::NotificationsController < Webui::WebuiController
   include Webui::NotificationsFilter
 
   ALLOWED_FILTERS = %w[all comments requests incoming_requests outgoing_requests relationships_created relationships_deleted build_failures
-                       reports reviews workflow_runs appealed_decisions member_on_groups upstream_package_version_changed].freeze
+                       reports reviews workflow_runs appealed_decisions decisions member_on_groups upstream_package_version_changed].freeze
   ALLOWED_STATES = %w[all unread read].freeze
   ALLOWED_REPORT_FILTERS = %w[with_decision without_decision reportable_type].freeze
 
@@ -17,6 +17,7 @@ class Webui::Users::NotificationsController < Webui::WebuiController
     'reports' => 'Report',
     'workflow_runs' => 'WorkflowRun',
     'appealed_decisions' => 'Appeal',
+    'decisions' => 'Decision',
     'comments' => 'Comment',
     'requests' => 'BsRequest',
     'member_on_groups' => 'Group'

--- a/src/api/app/controllers/webui/users/notifications_controller.rb
+++ b/src/api/app/controllers/webui/users/notifications_controller.rb
@@ -16,7 +16,7 @@ class Webui::Users::NotificationsController < Webui::WebuiController
   NOTIFICATION_TYPES_KEY_MAP = {
     'reports' => 'Report',
     'workflow_runs' => 'WorkflowRun',
-    'appealed_decisions' => 'Decision',
+    'appealed_decisions' => 'Appeal',
     'comments' => 'Comment',
     'requests' => 'BsRequest',
     'member_on_groups' => 'Group'

--- a/src/api/app/models/event/appeal_created.rb
+++ b/src/api/app/models/event/appeal_created.rb
@@ -14,7 +14,7 @@ module Event
     end
 
     def event_object
-      ::Decision.find_by(payload['decision_id'])
+      ::Decision.find(payload['decision_id'])
     end
 
     def parameters_for_notification

--- a/src/api/app/models/event/appeal_created.rb
+++ b/src/api/app/models/event/appeal_created.rb
@@ -13,12 +13,12 @@ module Event
       "Appeal to #{appeal.decision.reports.first.reportable&.class&.name || appeal.decision.reports.first.reportable_type} decision".squish
     end
 
-    def event_object
-      ::Decision.find(payload['decision_id'])
-    end
-
     def parameters_for_notification
       super.merge(notifiable_type: 'Appeal', type: 'NotificationReport')
+    end
+
+    def event_object
+      Appeal.find(payload['id'])
     end
   end
 end

--- a/src/api/app/models/event/decision.rb
+++ b/src/api/app/models/event/decision.rb
@@ -13,7 +13,7 @@ module Event
     end
 
     def event_object
-      Report.find_by(payload['report_last_id'])
+      Report.find(payload['report_last_id'])
     end
   end
 end

--- a/src/api/app/models/event/report.rb
+++ b/src/api/app/models/event/report.rb
@@ -15,7 +15,7 @@ module Event
     end
 
     def event_object
-      ::Report.find_by(payload['report_last_id'])
+      ::Report.find(payload['report_last_id'])
     end
   end
 end

--- a/src/api/app/models/notification.rb
+++ b/src/api/app/models/notification.rb
@@ -38,6 +38,7 @@ class Notification < ApplicationRecord
   scope :for_build_failures, -> { where(event_type: 'Event::BuildFail') }
   scope :for_reports, -> { where(notifiable_type: 'Report') }
   scope :for_workflow_runs, -> { where(notifiable_type: 'WorkflowRun') }
+  scope :for_decisions, -> { where(notifiable_type: 'Decision') }
   scope :for_appealed_decisions, -> { where(notifiable_type: 'Appeal') }
   scope :for_comments, -> { where(notifiable_type: 'Comment') }
   scope :for_requests, -> { where(notifiable_type: 'BsRequest') }

--- a/src/api/app/models/notification.rb
+++ b/src/api/app/models/notification.rb
@@ -38,7 +38,7 @@ class Notification < ApplicationRecord
   scope :for_build_failures, -> { where(event_type: 'Event::BuildFail') }
   scope :for_reports, -> { where(notifiable_type: 'Report') }
   scope :for_workflow_runs, -> { where(notifiable_type: 'WorkflowRun') }
-  scope :for_appealed_decisions, -> { where(notifiable_type: 'Decision') }
+  scope :for_appealed_decisions, -> { where(notifiable_type: 'Appeal') }
   scope :for_comments, -> { where(notifiable_type: 'Comment') }
   scope :for_requests, -> { where(notifiable_type: 'BsRequest') }
   scope :for_member_on_groups, -> { where(notifiable_type: 'Group') }

--- a/src/api/app/views/webui/users/notifications/_notification_filter.html.haml
+++ b/src/api/app/views/webui/users/notifications/_notification_filter.html.haml
@@ -70,7 +70,13 @@
                                       label_icon: 'fas fa-hand',
                                       checked: selected_filter[:kind]&.include?('appealed_decisions'),
                                       turbo_stream_counter_id: 'counts_for_appealed_decisions_notifications' }
-        = render partial: 'webui/shared/check_box',
+          = render partial: 'webui/shared/check_box',
+                            locals: { label: 'Decisions',
+                                      key: 'kind[decisions]', name: 'kind[]', value: 'decisions',
+                                      label_icon: 'fas fa-clipboard-check',
+                                      checked: selected_filter[:kind]&.include?('decisions'),
+                                      turbo_stream_counter_id: 'counts_for_decisions_notifications' }
+          = render partial: 'webui/shared/check_box',
                           locals: { label: 'Groups Membership',
                                     key: 'kind[member_on_groups]', name: 'kind[]', value: 'member_on_groups',
                                     label_icon: 'fas fa-people-group',

--- a/src/api/app/views/webui/users/notifications/_notification_filter.html.haml
+++ b/src/api/app/views/webui/users/notifications/_notification_filter.html.haml
@@ -50,6 +50,12 @@
                                                     label_icon: 'fas fa-xmark text-danger',
                                                     checked: selected_filter[:kind]&.include?('build_failures'),
                                                     turbo_stream_counter_id: 'counts_for_build_failures_notifications' }
+        = render partial: 'webui/shared/check_box',
+                          locals: { label: 'Workflow Runs',
+                                    key: 'kind[workflow_runs]', name: 'kind[]', value: 'workflow_runs',
+                                    label_icon: 'fas fa-book-open',
+                                    checked: selected_filter[:kind]&.include?('workflow_runs'),
+                                    turbo_stream_counter_id: 'counts_for_workflow_runs_notifications' }
         - if policy(Report.new).notify?
           = render partial: 'webui/shared/check_box',
                             locals: { label: 'Reports',
@@ -57,12 +63,6 @@
                                       label_icon: 'fas fa-flag',
                                       checked: selected_filter[:kind]&.include?('reports'),
                                       turbo_stream_counter_id: 'counts_for_reports_notifications' }
-        = render partial: 'webui/shared/check_box',
-                          locals: { label: 'Workflow Runs',
-                                    key: 'kind[workflow_runs]', name: 'kind[]', value: 'workflow_runs',
-                                    label_icon: 'fas fa-book-open',
-                                    checked: selected_filter[:kind]&.include?('workflow_runs'),
-                                    turbo_stream_counter_id: 'counts_for_workflow_runs_notifications' }
         - if Flipper.enabled?(:content_moderation, User.session)
           = render partial: 'webui/shared/check_box',
                             locals: { label: 'Appeals',
@@ -76,7 +76,7 @@
                                       label_icon: 'fas fa-clipboard-check',
                                       checked: selected_filter[:kind]&.include?('decisions'),
                                       turbo_stream_counter_id: 'counts_for_decisions_notifications' }
-          = render partial: 'webui/shared/check_box',
+        = render partial: 'webui/shared/check_box',
                           locals: { label: 'Groups Membership',
                                     key: 'kind[member_on_groups]', name: 'kind[]', value: 'member_on_groups',
                                     label_icon: 'fas fa-people-group',

--- a/src/api/app/views/webui/users/notifications/_notification_filter.html.haml
+++ b/src/api/app/views/webui/users/notifications/_notification_filter.html.haml
@@ -65,7 +65,7 @@
                                     turbo_stream_counter_id: 'counts_for_workflow_runs_notifications' }
         - if Flipper.enabled?(:content_moderation, User.session)
           = render partial: 'webui/shared/check_box',
-                            locals: { label: 'Appealed Decisions',
+                            locals: { label: 'Appeals',
                                       key: 'kind[appealed_decisions]', name: 'kind[]', value: 'appealed_decisions',
                                       label_icon: 'fas fa-hand',
                                       checked: selected_filter[:kind]&.include?('appealed_decisions'),


### PR DESCRIPTION
So far we had _Appealed Decisions_ filter which listed the notifications related to decisions even if they were appealed or not.

Now there are two filters:
 - _Decisions_ filter: lists all the notifications related to decisions even if they were appealed or not.
 - _Appealed Decisions_ filter:  lists all the notifications related to appeals

<img width="1476" height="786" alt="Screenshot 2026-04-21 at 14-49-55 Notifications - Open Build Service" src="https://github.com/user-attachments/assets/42a09493-0b09-40b7-b4d4-b6def7a7bd31" />


