### PR TITLE
Add link_project and configure_repositories workflow steps

### DIFF
--- a/src/api/app/models/workflow/step/configure_repositories.rb
+++ b/src/api/app/models/workflow/step/configure_repositories.rb
@@ -35,6 +35,13 @@ class Workflow::Step::ConfigureRepositories < Workflow::Step
       end
     end
 
+    updates = step_instructions.slice(:rebuild, :linkedbuild).compact
+    if updates.any?
+      target_project.repositories.each do |repo|
+        repo.update!(updates)
+      end
+    end
+
     # We have to store the changes on the backend
     target_project.store(comment: "Added the following repositories to the project: #{step_instructions[:repositories].pluck(:name).compact.to_sentence}",
                          login: @token.executor.login)

--- a/src/api/app/models/workflow/step/link_project.rb
+++ b/src/api/app/models/workflow/step/link_project.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class Workflow::Step::LinkProject < Workflow::Step
+  REQUIRED_KEYS = %i[project target_project].freeze
+
+  def call
+    return if workflow_run.closed_merged_pull_request? || workflow_run.unlabeled_pull_request?
+
+    project = Project.find_by_name(step_instructions[:project])
+    target_name = step_instructions[:target_project]
+    target_project = Project.find_by_name(target_name)
+
+    project.linking_to.delete_all
+    if target_project
+      project.linking_to.create!(linked_db_project: target_project)
+    else
+      project.linking_to.create!(linked_remote_project_name: target_name)
+    end
+
+    project.store(
+      comment: "Linked project to #{target_name}",
+      login: token.executor.login
+    )
+  end
+end

--- a/src/api/spec/models/workflow/step/configure_repositories_spec.rb
+++ b/src/api/spec/models/workflow/step/configure_repositories_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe Workflow::Step::ConfigureRepositories do
     let(:step_instructions) do
       {
         project: 'OBS:Server:Unstable',
+        rebuild: 'local',
+        linkedbuild: 'all',
         repositories:
           [
             {
@@ -80,6 +82,12 @@ RSpec.describe Workflow::Step::ConfigureRepositories do
 
         it 'overwrites previously configured architectures with those in the step instructions' do
           expect(configured_architectures.map(&:name)).to eq(%w[x86_64 ppc])
+        end
+
+        it 'configures rebuild and linkedbuild strategies' do
+          expect(configured_repositories).to contain_exactly(
+            have_attributes(name: 'openSUSE_Tumbleweed', rebuild: 'local', linkedbuild: 'all')
+          )
         end
       end
 

--- a/src/api/spec/models/workflow/step/link_project_spec.rb
+++ b/src/api/spec/models/workflow/step/link_project_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Workflow::Step::LinkProject do
+  let(:project) { create(:project) }
+  let!(:target_project) { create(:project, name: 'openSUSE:Factory') }
+  let(:workflow_run) { create(:workflow_run) }
+  let(:token) { create(:workflow_token, executor: create(:confirmed_user)) }
+  let(:instructions) { { project: project.name, target_project: 'openSUSE:Factory' } }
+  let(:step) { described_class.new(workflow_run: workflow_run, token: token, step_instructions: instructions) }
+
+  it 'sets the project link' do
+    step.call
+    expect(project.reload.linking_to.first.linked_db_project).to eq(target_project)
+  end
+end


### PR DESCRIPTION
Hey Friends,

This PR implements the workflow steps requested in #19516 to support full project rebuilds with SCM/CI workflows. 

Specifically, it:
1. Introduces a new `link_project` step that creates a project link by setting the `<link project="...">` attribute in the target project's metadata.
2. Enhances the existing `configure_repositories` step to support setting the `rebuild` and `linkedbuild` repository attributes.

These changes are necessary to fully support PR/MR sources (stagings) where a linked project must automatically trigger rebuilds based on SCM actions. 

### To verify this feature:

- Run the backend and frontend in your local docker development environment.
- Prepare a test repository with an OBS workflow configuration (`.obs/workflows.yml`).
- Include the new `link_project` step and a `configure_repositories` step with the `rebuild` and `linkedbuild` properties enabled in your workflow definition.
- Trigger a workflow run via a push or pull request event.
- Check the created target project's metadata (e.g., via the WebUI or `osc meta prj <target_project>`) and verify that:
  - The `<link project="..."/>` tag is correctly set in the metadata.
  - The `<repository>` elements contain the correct `rebuild="..."` and `linkedbuild="..."` attributes.
- You can also run the RSpec test suite to verify the logic:
  `docker compose run --rm frontend bundle exec rspec spec/models/workflow/step/link_project_spec.rb spec/models/workflow/step/configure_repositories_spec.rb`

Fixes #19516
