### PR TITLE
Add event for user or group token membership updates

### DIFF
--- a/src/api/app/models/event/token_membership_update.rb
+++ b/src/api/app/models/event/token_membership_update.rb
@@ -1,0 +1,26 @@
+module Event
+  class TokenMembershipUpdate < Base
+    self.description = 'Share or unshare token with user or group'
+
+    payload_keys :token_id, :user_login, :group_title, :who, :action
+  end
+end
+
+# == Schema Information
+#
+# Table name: events
+#
+#  id          :bigint           not null, primary key
+#  eventtype   :string(255)      not null, indexed
+#  mails_sent  :boolean          default(FALSE), indexed
+#  payload     :text(16777215)
+#  undone_jobs :integer          default(0)
+#  created_at  :datetime         indexed
+#  updated_at  :datetime
+#
+# Indexes
+#
+#  index_events_on_created_at  (created_at)
+#  index_events_on_eventtype   (eventtype)
+#  index_events_on_mails_sent  (mails_sent)
+#

--- a/src/api/app/models/token/workflow.rb
+++ b/src/api/app/models/token/workflow.rb
@@ -7,12 +7,16 @@ class Token::Workflow < Token
                           foreign_key: :token_id,
                           association_foreign_key: :user_id,
                           dependent: :destroy,
+                          after_add: ->(token, user) { Event::TokenMembershipUpdate.create(token_id: token.id, user_login: user.login, who: User.session&.login, action: 'share') },
+                          after_remove: ->(token, user) { Event::TokenMembershipUpdate.create(token_id: token.id, user_login: user.login, who: User.session&.login, action: 'unshare') },
                           inverse_of: :users
   has_and_belongs_to_many :groups,
                           join_table: :workflow_token_groups,
                           foreign_key: :token_id,
                           association_foreign_key: :group_id,
                           dependent: :destroy,
+                          after_add: ->(token, group) { Event::TokenMembershipUpdate.create(token_id: token.id, group_title: group.title, who: User.session&.login, action: 'share') },
+                          after_remove: ->(token, group) { Event::TokenMembershipUpdate.create(token_id: token.id, group_title: group.title, who: User.session&.login, action: 'unshare') },
                           inverse_of: :groups
 
   validates :scm_token, presence: true

--- a/src/api/spec/models/token/workflow_spec.rb
+++ b/src/api/spec/models/token/workflow_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe Token::Workflow do
-  describe '#call' do
-    let(:token_user) { create(:confirmed_user, :with_home, login: 'Iggy') }
-    let(:workflow_token) { create(:workflow_token, executor: token_user) }
+  let(:token_user) { create(:confirmed_user, :with_home, login: 'Iggy') }
+  let(:workflow_token) { create(:workflow_token, executor: token_user) }
 
+  describe '#call' do
     context 'with wrong SCM token' do
       let(:yaml_downloader) { instance_double(Workflows::YAMLDownloader) }
       let(:workflow_run) { create(:workflow_run, token: workflow_token, response_url: 'https://example.com') }
@@ -249,6 +249,26 @@ RSpec.describe Token::Workflow do
 
       it 'returns no validation errors' do
         expect { subject }.not_to(change(SCMStatusReport, :count))
+      end
+    end
+  end
+
+  describe 'token sharing' do
+    let(:other_user) { create(:confirmed_user, :with_home, login: 'Peter') }
+
+    context 'share with user' do
+      it 'creates an event' do
+        expect { workflow_token.users << other_user }.to change(Event::TokenMembershipUpdate, :count).by(1)
+      end
+    end
+
+    context 'unshare user' do
+      before do
+        workflow_token.users << other_user
+      end
+
+      it 'creates an event' do
+        expect { workflow_token.users.delete(other_user) }.to change(Event::TokenMembershipUpdate, :count).by(1)
       end
     end
   end


### PR DESCRIPTION
This is the first PR in a series to introduce notifications when a token is shared or unshared with a user or a group.

Once a [Workflow Token is shared/unshared](https://build.opensuse.org/my/tokens/5158/users) with a user or group the system creates an event which will be used to send notifications later on.