### PR TITLE
Web notifications for global role assigned events

### DIFF
--- a/src/api/app/helpers/webui/notification_helper.rb
+++ b/src/api/app/helpers/webui/notification_helper.rb
@@ -9,7 +9,8 @@ module Webui::NotificationHelper
     'Package' => 'fa-archive',
     'Report' => 'fa-flag', 'Decision' => 'fa-clipboard-check',
     'Appeal' => 'fa-hand', 'WorkflowRun' => 'fa-book-open',
-    'Group' => 'fa-people-group', 'Token::Workflow' => 'fa-key'
+    'Group' => 'fa-people-group', 'Token::Workflow' => 'fa-key',
+    'User' => 'fa-crown'
   }.freeze
 
   NOTIFICATION_TITLE = {

--- a/src/api/app/models/event/global_role_assigned.rb
+++ b/src/api/app/models/event/global_role_assigned.rb
@@ -16,5 +16,11 @@ module Event
         User.staff.or(User.admins).uniq
       end
     end
+
+    def parameters_for_notification
+      super.merge({ notifiable_type: 'User',
+                    notifiable_id: ::User.find_by(login: payload['user']).id,
+                    type: 'NotificationUser' })
+    end
   end
 end

--- a/src/api/app/models/event/global_role_assigned.rb
+++ b/src/api/app/models/event/global_role_assigned.rb
@@ -7,14 +7,15 @@ module Event
     receiver_roles :admin_moderator_or_staff
 
     def admin_moderator_or_staffs
-      case payload['role']
-      when 'Admin'
-        User.admins
-      when 'Moderator'
-        User.moderators.or(User.admins).uniq
-      when 'Staff'
-        User.staff.or(User.admins).uniq
-      end
+      users = case payload['role']
+              when 'Admin'
+                User.admins
+              when 'Staff'
+                User.admins.or(User.staff)
+              when 'Moderator'
+                User.admins.or(User.moderators)
+              end
+      users.where.not(login: payload['who']).uniq if users
     end
 
     def parameters_for_notification

--- a/src/api/app/models/notification_user.rb
+++ b/src/api/app/models/notification_user.rb
@@ -1,0 +1,24 @@
+class NotificationUser < Notification
+  def description
+    subscriber_name = subscriber.login == event_payload['user'] ? 'you' : event_payload['user']
+    "'#{event_payload['who']}' gave the '#{event_payload['role']}' role to '#{subscriber_name}'"
+  end
+
+  def excerpt
+    ''
+  end
+
+  def avatar_objects
+    User.where(login: event_payload['who'])
+  end
+
+  def link_text
+    'New Global Role Assigned'
+  end
+
+  def link_path
+    return unless User.exists?(login: event_payload['user'])
+
+    Rails.application.routes.url_helpers.user_path(event_payload['user'], notification_id: id)
+  end
+end

--- a/src/api/app/queries/outdated_notifications_finder/user.rb
+++ b/src/api/app/queries/outdated_notifications_finder/user.rb
@@ -1,0 +1,10 @@
+class OutdatedNotificationsFinder::User
+  def initialize(scope, parameters)
+    @scope = scope
+    @parameters = parameters
+  end
+
+  def call
+    @scope.where(notifiable_type: 'User', notifiable_id: @parameters[:notifiable_id])
+  end
+end

--- a/src/api/app/services/notification_service/notifier.rb
+++ b/src/api/app/services/notification_service/notifier.rb
@@ -37,7 +37,8 @@ module NotificationService
       'WorkflowRun' => ::WorkflowRun,
       'Appeal' => ::Appeal,
       'Group' => ::Group,
-      'Token::Workflow' => ::Token::Workflow
+      'Token::Workflow' => ::Token::Workflow,
+      'User' => ::User
     }.freeze
     ALLOWED_CHANNELS = {
       web: NotificationService::WebChannel,
@@ -53,7 +54,8 @@ module NotificationService
                         'Event::FavoredDecision',
                         'Event::WorkflowRunFail',
                         'Event::AddedUserToGroup',
-                        'Event::RemovedUserFromGroup'].freeze
+                        'Event::RemovedUserFromGroup',
+                        'Event::GlobalRoleAssigned'].freeze
 
     def initialize(event)
       @event = event

--- a/src/api/app/services/notification_service/notifier.rb
+++ b/src/api/app/services/notification_service/notifier.rb
@@ -24,7 +24,8 @@ module NotificationService
                         'Event::AssignmentCreate',
                         'Event::AssignmentDelete',
                         'Event::UpstreamPackageVersionChanged',
-                        'Event::TokenMembershipUpdate'].freeze
+                        'Event::TokenMembershipUpdate',
+                        'Event::GlobalRoleAssigned'].freeze
     CHANNELS = %i[web rss].freeze
     ALLOWED_NOTIFIABLE_TYPES = {
       'BsRequest' => ::BsRequest,

--- a/src/api/app/services/notification_service/web_channel.rb
+++ b/src/api/app/services/notification_service/web_channel.rb
@@ -11,7 +11,8 @@ module NotificationService
       'Appeal' => OutdatedNotificationsFinder::Appeal,
       'WorkflowRun' => OutdatedNotificationsFinder::WorkflowRun,
       'Group' => OutdatedNotificationsFinder::Group,
-      'Token::Workflow' => OutdatedNotificationsFinder::TokenWorkflow
+      'Token::Workflow' => OutdatedNotificationsFinder::TokenWorkflow,
+      'User' => OutdatedNotificationsFinder::User
     }.freeze
 
     def initialize(subscription, event)

--- a/src/api/app/services/notified_projects.rb
+++ b/src/api/app/services/notified_projects.rb
@@ -28,7 +28,7 @@ class NotifiedProjects
       [@notifiable.project]
     when 'Project'
       [@notifiable]
-    when 'Report', 'Decision', 'Appeal', 'WorkflowRun', 'Group', 'Token::Workflow'
+    when 'Report', 'Decision', 'Appeal', 'WorkflowRun', 'Group', 'Token::Workflow', 'User'
       []
     end
   end

--- a/src/api/spec/factories/event_subscriptions.rb
+++ b/src/api/spec/factories/event_subscriptions.rb
@@ -165,5 +165,13 @@ FactoryBot.define do
       user
       group { nil }
     end
+
+    factory :event_subscription_global_role_assigned do
+      eventtype { 'Event::GlobalRoleAssigned' }
+      receiver_role { 'admin_moderator_or_staff' }
+      channel { :instant_email }
+      user
+      group { nil }
+    end
   end
 end

--- a/src/api/spec/factories/notification.rb
+++ b/src/api/spec/factories/notification.rb
@@ -72,6 +72,16 @@ FactoryBot.define do
       end
     end
 
+    factory :notification_for_global_role_assignment, class: 'NotificationUser' do
+      event_type { 'Event::GlobalRoleAssigned' }
+      notifiable factory: [:user]
+      web { true }
+
+      after(:build) do |notification, evaluator|
+        notification.event_payload['user'] ||= evaluator.user.login
+      end
+    end
+
     factory :notification_for_project, class: 'NotificationProject' do
       trait :relationship_create_for_project do
         event_type { 'Event::RelationshipCreate' }

--- a/src/api/spec/features/webui/users/notification_user_spec.rb
+++ b/src/api/spec/features/webui/users/notification_user_spec.rb
@@ -1,0 +1,21 @@
+require 'browser_helper'
+
+RSpec.describe 'NotificationUser', :js do
+  let(:user) { create(:confirmed_user) }
+  let(:admin_user) { create(:admin_user) }
+  let(:event_payload) { { role: 'Admin', who: admin_user.login, user: user.login } }
+
+  context 'upstream version changed on a package' do
+    let!(:notification) { create(:notification_for_global_role_assignment, subscriber: user, notifiable: user, event_payload: event_payload) }
+
+    before do
+      login user
+      visit my_notifications_path
+    end
+
+    it 'contains a link pointing to the user' do
+      expect(page).to have_link('New Global Role Assigned',
+                                href: "/users/#{user.login}?notification_id=#{notification.id}")
+    end
+  end
+end


### PR DESCRIPTION
~Depends on #19582 and #19594~

This pr implements the web notification for `Event::GlobalRoleAssigned`

<img width="751" height="226" alt="image" src="https://github.com/user-attachments/assets/7d43f464-17c8-4044-a664-519fc0465c0d" />
