### PR TITLE
Revert "[api] set ssl options in database.yml"

### DIFF
--- a/src/api/config/database.yml.example
+++ b/src/api/config/database.yml.example
@@ -16,9 +16,6 @@ production:
   timeout: 15
   pool: 30
   reconnect: true
-  # Remove the next 2 lines if you don't use self-signed certificate
-  ssl_verify_server_cert: false
-  ssl_mode: :required
 
 development:
   adapter: mysql2


### PR DESCRIPTION
Reverts openSUSE/open-build-service#19599

Can't disable cert verification for everyone because we are using a self-signed certificate in some environment...

Let's do this in the appliance configuration instead?