### PR TITLE
Clarify build failure notifications

### DIFF
--- a/src/api/app/helpers/webui/notification_helper.rb
+++ b/src/api/app/helpers/webui/notification_helper.rb
@@ -41,6 +41,8 @@ module Webui::NotificationHelper
 
   def description(notification)
     case notification.event_type
+    when 'Event::BuildFail'
+      description_for_build_failure(notification)
     when 'Event::ReportForUser'
       description_for_user_report(notification)
     when 'Event::ReportForComment'
@@ -67,6 +69,16 @@ module Webui::NotificationHelper
   end
 
   private
+
+  def description_for_build_failure(notification)
+    payload = notification.event_payload
+
+    safe_join([
+                content_tag(:div, "Package: #{payload['project']} / #{payload['package']}"),
+                content_tag(:div, "Repository: #{payload['repository']} / #{payload['arch']}"),
+                content_tag(:div, "Build Reason: #{payload['reason']}")
+              ])
+  end
 
   def number_of_hidden_avatars(avatar_objects)
     [0, avatar_objects.size - MAXIMUM_DISPLAYED_AVATARS].max

--- a/src/api/app/models/notification_package.rb
+++ b/src/api/app/models/notification_package.rb
@@ -31,7 +31,7 @@ class NotificationPackage < Notification
     when 'Event::RelationshipDelete'
       "Removed as #{event_payload['role']} of a package"
     when 'Event::BuildFail'
-      "Package #{event_payload['package']} on #{event_payload['project']} project failed to build against #{event_payload['repository']} / #{event_payload['arch']}"
+      "#{event_payload['project']}/#{event_payload['package']} failed to build"
     when 'Event::UpstreamPackageVersionChanged'
       "New upstream version for #{event_payload['package']}"
     end

--- a/src/api/spec/helpers/webui/notification_helper_spec.rb
+++ b/src/api/spec/helpers/webui/notification_helper_spec.rb
@@ -59,6 +59,36 @@ RSpec.describe Webui::NotificationHelper do
   end
 
   describe '#description' do
+    context 'when the notification is about a build failure' do
+      let(:package) { create(:package) }
+      let(:notification) do
+        create(
+          :notification_for_package,
+          :build_failure,
+          notifiable: package,
+          event_payload: {
+            project: 'OBS:Server:Unstable',
+            package: 'obs-server',
+            repository: 'openSUSE_Factory_zSystems',
+            arch: 's390x',
+            reason: 'source change'
+          }
+        )
+      end
+
+      it 'contains the package detail' do
+        expect(description(notification)).to include('Package: OBS:Server:Unstable / obs-server')
+      end
+
+      it 'contains the repository detail' do
+        expect(description(notification)).to include('Repository: openSUSE_Factory_zSystems / s390x')
+      end
+
+      it 'contains the reason detail' do
+        expect(description(notification)).to include('Build Reason: source change')
+      end
+    end
+
     context 'when the notification is about a report for user' do
       let(:spammer) { create(:confirmed_user, login: 'trouble_maker') }
       let(:report_for_user) { create(:report, reportable: spammer, reason: 'This is a spammer!') }

--- a/src/api/spec/models/notification_package_spec.rb
+++ b/src/api/spec/models/notification_package_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe NotificationPackage do
+  describe '#link_text' do
+    context 'when the notification is about a build failure' do
+      let(:notification) do
+        create(
+          :notification_for_package,
+          :build_failure,
+          event_payload: {
+            project: 'OBS:Server:Unstable',
+            package: 'obs-server',
+            repository: 'openSUSE_Factory_zSystems',
+            arch: 's390x',
+            reason: 'source change'
+          }
+        )
+      end
+
+      it { expect(notification.link_text).to eq('OBS:Server:Unstable/obs-server failed to build') }
+    end
+  end
+end


### PR DESCRIPTION
  Shorten build failure notifications and show package, repository, and reason more clearly.

To test, create a sample notification, for example `bundle exec rake "dev:notifications:data[2]"` and visit `/my/notifications?kind=build_failures`


Before:
<img width="1605" height="316" alt="image" src="https://github.com/user-attachments/assets/7ba6fe6f-1bff-4eaa-8bb9-fbdded9028c3" />

With this Patch:
<img width="1605" height="316" alt="image" src="https://github.com/user-attachments/assets/1827b50f-17d3-4939-87ba-88eea5ee0050" />
