### PR TITLE
[backend] fix forwarding of redis notifications

### DIFF
--- a/src/backend/BSFileQueue.pm
+++ b/src/backend/BSFileQueue.pm
@@ -30,17 +30,25 @@ use Fcntl qw(:DEFAULT :flock);
 
 use BSUtil;
 
-sub add {
-  my ($fn, @r) = @_;
-  die unless $r[0];
-  s/([\000-\037%|=\177-\237])/sprintf("%%%02X", ord($1))/ge for @r;
-  my $line = join('|', @r)."\n";
+sub add_multiple {
+  my ($fn, @mr) = @_;
   my $fd;
   BSUtil::lockopen($fd, '>>', $fn);
   my $oldlen = -s $fd;
-  (syswrite($fd, $line) || 0) == length($line) || die("syswrite $fn: $!\n");
+  while (@mr) {
+    my @r = @{shift @mr};
+    die unless $r[0];
+    s/([\000-\037%|=\177-\237])/sprintf("%%%02X", ord($1))/ge for @r;
+    my $line = join('|', @r)."\n";
+    (syswrite($fd, $line) || 0) == length($line) || die("syswrite $fn: $!\n");
+  }
   close($fd);
   return $oldlen ? 0 : 1;
+}
+
+sub add {
+  my ($fn, @r) = @_;
+  return add_multiple($fn, \@r);
 }
 
 sub openqueue {

--- a/src/backend/bs_srcserver
+++ b/src/backend/bs_srcserver
@@ -7364,7 +7364,7 @@ sub add_redis_notifications {
   my ($payload) = @_;
   my $redisdir = "$eventdir/redis";
   mkdir_p($redisdir) unless -d $redisdir;
-  my $needping = BSFileQueue::add("$redisdir/queue", @$payload);
+  my $needping = BSFileQueue::add_multiple("$redisdir/queue", @$payload);
   BSUtil::ping("$redisdir/.ping") if $needping;
 }
 


### PR DESCRIPTION
The add_redis_notifications function actually wants to add multiple redis events. So add a new BSFileQueue::add_multiple method.