### PR TITLE
[backend] reproduciblecheck: write a reproduciblecheck.log file

### DIFF
--- a/src/backend/BSSched/BuildJob/Reproduciblecheck.pm
+++ b/src/backend/BSSched/BuildJob/Reproduciblecheck.pm
@@ -317,6 +317,23 @@ sub jobfinished {
   # write meta file
   my $meta = "$jobdatadir/meta";
   writestr($meta, undef, "$reprojobid  $packid\n");
+
+  my $checkresult;
+  my $checklog = "$jobdatadir/reproduciblecheck.log";
+  if (-e $checklog) {
+    my $fd;
+    my $log = "\n";
+    if (open($fd, '<', $checklog)) {
+      sysseek($fd, -4096, 2);
+      sysread($fd, $log, 4096, 1);
+      close($fd);
+    }
+    $checkresult = $1 if $log =~ /\nResult:\s+(\S+)/;
+  }
+  if (!defined($checkresult)) {
+    BSUtil::appendstr("$jobdatadir/logfile", "\ncould not parse reproduciblecheck.log\n");
+    $code = 'failed';
+  }
   
   # update packstatus so that it doesn't fall back to scheduled
   BSSched::BuildJob::patchpackstatus($gctx, $prp, $packid, $code, $job);
@@ -344,6 +361,16 @@ sub jobfinished {
 
   my $jobhist = BSSched::BuildJob::makejobhist($info, $status, $js, 'succeeded');
   BSSched::BuildJob::addbuildstats($jobdatadir, $dst, $jobhist) if -e "$jobdatadir/_statistics";
+
+  # save reproduciblecheck.log if not PASS
+  if (uc($checkresult) ne 'PASS') {
+    mkdir_p("$gdst/:reproduciblecheck.fail");
+    unlink("$jobdatadir/reproduciblecheck.dup");
+    link("$jobdatadir/reproduciblecheck.log", "$jobdatadir/reproduciblecheck.dup");
+    rename("$jobdatadir/reproduciblecheck.dup", "$gdst/:reproduciblecheck.fail/$packid");
+  } else {
+    unlink("$gdst/:reproduciblecheck.fail/$packid");
+  }
 
   # update build result directory and full tree
   my $dstcache = $ectx->{'dstcache'};

--- a/src/backend/bs_check_consistency
+++ b/src/backend/bs_check_consistency
@@ -594,7 +594,8 @@ if (-d "$buildroot" && $check_build) {
 		  }
 		} elsif (-d "$pra/$prap") {
 		  if ($prap eq ":logfiles.fail"
-			|| $prap eq ":logfiles.success") {
+			|| $prap eq ":logfiles.success"
+			|| $prap eq ":reproduciblecheck.fail") {
 			# fine, probably no need to check
 		  } elsif ($prap eq ":meta") {
 		    next unless $do_check_meta;

--- a/src/backend/templates/obs-reproduciblecheck.spec
+++ b/src/backend/templates/obs-reproduciblecheck.spec
@@ -15,6 +15,7 @@ reproduciblecheck
 %build
 cd %_sourcedir
 odir="%_topdir/OTHER"
+resultfile="$odir/reproduciblecheck.log"
 mkdir -p "$odir"
 
 mkdir -p a b
@@ -27,6 +28,7 @@ for f in b_* ; do
   test -e "$f" && cp -a "$f" "b/${f#b_}"
   test -e "$f" && mv "$f" "$odir/${f#b_}"
 done
+rm -f "$resultfile"
 
 fail=
 for f in a/* ; do
@@ -34,15 +36,18 @@ for f in a/* ; do
   f="${f#a/}"
   if ! test -e "b/$f" ; then
     echo "$f: missing in directory 'b'"
+    echo "MISS $f" >> "$resultfile"
     fail=1
   else
     test "$f" = "${f%.rpm}" || rpm --delsign "a/$f"
     test "$f" = "${f%.rpm}" || rpm --delsign "b/$f"
     if ! cmp -s "a/$f" "b/$f" ; then
       echo "$f: not identical"
+      echo "FAIL $f" >> "$resultfile"
       fail=1
     else
       echo "$f: ok"
+      echo "PASS $f" >> "$resultfile"
     fi
   fi
 done
@@ -53,16 +58,20 @@ for f in b/* ; do
   f="${f#b/}"
   if ! test -e "a/$f" ; then
     echo "$f: missing in directory 'a'"
+    echo "MISS $f" >> "$resultfile"
     fail=1
   fi
 done
 
 echo
+echo >> "$resultfile"
 if test -z "$fail" ; then
-  echo "Result: OK"
-  echo "----------"
+  echo "Result: PASS" >> "$resultfile"
+  echo "result: PASS"
+  echo "------------"
 else
-  echo "Result: FAIL"
+  echo "Result: FAIL" >> "$resultfile"
+  echo "result: FAIL"
   echo "------------"
 fi
 


### PR DESCRIPTION
This is in the spirit of rpmlint.log.

Also put failed checks into a :reproduciblecheck.fail directory.