### PR TITLE
Add help text and link to label template pages

### DIFF
--- a/src/api/app/views/webui/label_templates/index.html.haml
+++ b/src/api/app/views/webui/label_templates/index.html.haml
@@ -4,7 +4,13 @@
 
   .card-body
     %h3= @pagetitle
-    %p Define instance wide Label Templates used for labeling projects.
+    %p
+      Global label templates that you make available for projects across this OBS instance.
+      Project maintainers can apply these labels to projects, and users can search for projects by label.
+      = link_to 'Read more in the Labels documentation',
+                'https://openbuildservice.org/help/manuals/obs-user-guide/cha-obs-labels',
+                target: '_blank',
+                rel: 'noopener'
     %ul.list-unstyled
       - @label_templates.each do |label_template|
         %li.mb-2

--- a/src/api/app/views/webui/projects/label_templates/index.html.haml
+++ b/src/api/app/views/webui/projects/label_templates/index.html.haml
@@ -4,6 +4,12 @@
 
   .card-body
     %h3= @pagetitle
+    %p
+      Label templates that you can apply to this projects packages and requests to this project.
+      = link_to 'Read more in the Labels documentation',
+                'https://openbuildservice.org/help/manuals/obs-user-guide/cha-obs-labels',
+                target: '_blank',
+                rel: 'noopener'
     %ul.list-unstyled
       - @label_templates.each do |label_template|
         %li.mb-2


### PR DESCRIPTION
 This adds context sensitive help to the label template overview pages:

  - Global label templates: `/label_templates`
  - Project label templates: `/projects/<project_name>/label_templates`

Global:
<img width="2052" height="494" alt="image" src="https://github.com/user-attachments/assets/e5a4d742-8c62-4ec0-8100-acd40fbdf7d6" />
Project:
<img width="2020" height="741" alt="image" src="https://github.com/user-attachments/assets/69c23111-82bd-4250-b3bd-db04e67aba1d" />


