### PR TITLE
Scope user autocomplete to project/package relationships

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -15,7 +15,8 @@ class Webui::PackageController < Webui::WebuiController
   before_action :set_project, only: %i[show edit update index users requests statistics revisions
                                        new branch_diff_info rdiff create remove
                                        save_person save_group remove_role view_file
-                                       buildresult rpmlint_result rpmlint_log rpmlint_summary files template_data]
+                                       buildresult rpmlint_result rpmlint_log rpmlint_summary files template_data
+                                       autocomplete_users]
 
   before_action :check_scmsync, only: %i[requests revisions statistics users]
 
@@ -23,7 +24,7 @@ class Webui::PackageController < Webui::WebuiController
                                        branch_diff_info rdiff remove
                                        save_person save_group remove_role view_file
                                        buildresult rpmlint_result rpmlint_log rpmlint_summary files
-                                       users template_data]
+                                       users template_data autocomplete_users]
   # rubocop:enable Rails/LexicallyScopedActionFilter
   before_action :lints_list, only: %i[rpmlint_summary]
 
@@ -159,6 +160,18 @@ class Webui::PackageController < Webui::WebuiController
       authorize @current_notification, :update?, policy_class: NotificationPolicy
     end
     @current_request_action = BsRequestAction.find(params[:request_action_id]) if User.session && params[:request_action_id]
+  end
+
+  def autocomplete_users
+    roles = %w[maintainer bugowner reviewer]
+    user_ids = @package.relationships.joins(:role).where(roles: { title: roles }).pluck(:user_id)
+    user_ids << @project.relationships.joins(:role).where(roles: { title: roles }).pluck(:user_id)
+    user_ids = user_ids.flatten.uniq
+    render json: User.where(id: user_ids)
+                 .starting_with(params[:term])
+                     .order(Arel.sql('length(login)'), :login)
+                     .limit(50)
+                     .pluck(:login)
   end
 
   # TODO: Remove this once request_index beta is rolled out

--- a/src/api/app/views/webui/package/side_links/_assignments.html.haml
+++ b/src/api/app/views/webui/package/side_links/_assignments.html.haml
@@ -21,6 +21,6 @@
           = hidden_field_tag(:package_id, package.id)
           .col-auto
             = render partial: 'webui/shared/search_box', locals: { html_id: 'assignments_search', html_name: 'assignee', required: false,
-          data: { source: autocomplete_users_path }, button: { type: 'submit' }, placeholder: 'Assign to' }
+          data: { source: package_autocomplete_users_path(project, package) }, button: { type: 'submit' }, placeholder: 'Assign to' }
           .col-auto
             = submit_tag 'Assign', class: 'btn btn-sm btn-secondary'

--- a/src/api/config/routes/webui.rb
+++ b/src/api/config/routes/webui.rb
@@ -71,6 +71,7 @@ controller 'webui/package' do
     get 'package/edit/:project/:package' => :edit, constraints: cons, as: 'edit_package'
     patch 'package/update' => :update, constraints: cons
     get 'package/autocomplete' => :autocomplete
+    get 'package/autocomplete_users/:project/:package' => :autocomplete_users, constraints: cons, as: 'package_autocomplete_users'
   end
 end
 

--- a/src/api/spec/controllers/webui/package_controller_spec.rb
+++ b/src/api/spec/controllers/webui/package_controller_spec.rb
@@ -636,4 +636,28 @@ RSpec.describe Webui::PackageController, :vcr do
       it { expect(response).to have_http_status(:forbidden) }
     end
   end
+
+  describe 'GET #automplete_users' do
+    let(:package) { create(:package, project: target_project) }
+    let(:relationship_user) { create(:confirmed_user, login: 'test_user') }
+    let!(:relationship) { create(:relationship_project_user, project: target_project, user: relationship_user) }
+
+    context 'returns users with relationship association' do
+      before do
+        login(admin)
+        get :autocomplete_users, params: { project: target_project, package: package, term: 'te' }
+      end
+
+      it { expect(response.parsed_body).to eql([relationship_user.login]) }
+    end
+
+    context 'does not return user without relationship association' do
+      before do
+        login(admin)
+        get :autocomplete_users, params: { project: target_project, package: package, term: user.login }
+      end
+
+      it { expect(response.parsed_body).to eql([]) }
+    end
+  end
 end


### PR DESCRIPTION
Previously we were using `User.autocomplete_login` for assigning users to package. This was too broad, returning results from a global scope instead of filtering for project/package relationships.