### PR TITLE
Skip scmsync projects from autocleanup

### DIFF
--- a/src/api/app/jobs/project_create_auto_cleanup_requests_job.rb
+++ b/src/api/app/jobs/project_create_auto_cleanup_requests_job.rb
@@ -81,6 +81,8 @@ These requests are not created for projects with open requests or if you remove 
   def project_ready_to_autoclean?(project)
     # project may be locked?
     return false if project.locked?
+    # projects managed in external scm cannot accept requests
+    return false if project.scmsync.present?
     # open requests do block the cleanup
     return false if open_requests_count(project.name).positive?
     return false unless project.check_weak_dependencies?


### PR DESCRIPTION
Errbit has tracked thousands of errors with messages like this one,  raised on `ProjectCreateAutoCleanupRequestsJob`.

> The target project home:x:y is managed in an external SCM: https://src.opensuse.org/x-y/z

Creating auto-cleanup requests for SCM-sync projects makes no sense so far. So we better prevent it to even try.

See on Errbit: https://errbit.opensuse.org/apps/5620ca2bdc71fa00b1000000/problems/691eae6884bf460d19e8f3d4

Fixes: https://github.com/openSUSE/open-build-service/issues/18852