### PR TITLE
Include number in the routes constraints

### DIFF
--- a/src/api/app/lib/routes_helper/routes_constraints.rb
+++ b/src/api/app/lib/routes_helper/routes_constraints.rb
@@ -24,6 +24,7 @@ module RoutesHelper
       staging_project_copy_name: %r{[^/]*},
       request_action_id: /\d*/,
       request_number: /\d*/,
+      number: /\d*/,
       line: /diff_\d+_n\d+/,
       source_rev: /[0-9a-f]{32}/,
       target_rev: /[0-9a-f]{32}/

--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -389,7 +389,7 @@ class BsRequest < ApplicationRecord
   end
 
   def to_param
-    number
+    number.to_s
   end
 
   def render_xml(opts = {})


### PR DESCRIPTION

Fixes https://github.com/openSUSE/open-build-service/issues/19658

With URLs like "_/requests/1350860>_" we are getting 500 errors instead of 404 Not Found.

Some webui routes use the `number` parameter,
https://github.com/openSUSE/open-build-service/blob/ac4520bf43bff43ec76a01311828d88e185b89d7/src/api/config/routes/webui.rb#L324
however, it wasn't included in the constraints. Only `request_number` parameter was included, which is mainly used in the api routes file.

The number constraint will make the app return a 404 Not Found instead
of a 500 errors when the URL parameter contains non-numeric characters.
