### PR TITLE
[backend] bs_servicedispatch: catch transient errors when sending bac…

### DIFF
--- a/src/backend/BSSrcServer/Service.pm
+++ b/src/backend/BSSrcServer/Service.pm
@@ -224,7 +224,11 @@ sub addrev_service {
 	BSSrcrep::addmeta_service($projid, $packid, $files, $servicemark, $rev->{'srcmd5'}, $lxservicemd5);
       }
     };
-    $error = $@ if $@;
+    if ($@) {
+      $error = $@;
+      # die if this is a transient error and we were called from the service dispatch
+      die("Transient error for $projid/$packid: $error") if $rev->{'rev'} eq 'obsscm' && is_transient_error($error) && $commitobsscm != \&commitobsscm;
+    }
   }
   BSSrcrep::addmeta_serviceerror($projid, $packid, $servicemark, $error) if $error;
   notify_serviceresult($rev, $error);
@@ -360,6 +364,19 @@ sub writeresultascpio {
   $cpiofd->flush();
 }
 
+sub is_transient_error {
+  my ($error) = @_; 
+  return 1 if $error =~ /^5\d\d/;
+  if ($error =~ /^400/) {
+    return 1 if $error =~ /Too many open files/;
+    return 1 if $error =~ /No space left on device/;
+    return 1 if $error =~ /Not enough space/;
+    return 1 if $error =~ /Resource temporarily unavailable/;
+  }
+  return 1 if $error =~ /^rpc timeout/;
+  return 0;
+}
+
 # send the request to the service deamon and collect the result
 # modifies the files hash
 sub doservicerpc {
@@ -393,7 +410,7 @@ sub doservicerpc {
     BSUtil::cleandir($odir);
     rmdir($odir);
     my $error = $@ || 'error';
-    die("Transient error for $projid/$packid: $error") if $error =~ /^5/;
+    die("Transient error for $projid/$packid: $error") if is_transient_error($error);
     die("RPC error for $projid/$packid: $error") if $error !~ /^\d/;
     $error = "service daemon error:\n $error";
     return $error;

--- a/src/backend/bs_servicedispatch
+++ b/src/backend/bs_servicedispatch
@@ -92,8 +92,13 @@ sub runservice_obsscm {
   push @send, { 'name' => '_service', 'data' => BSSrcServer::Service::generate_obs_scm_bridge_service($data) };
   my $files = {};
   my $error = BSSrcServer::Service::doservicerpc($rev, $files, \@send, 1);
-  return 'retry' if $error && $error =~ /\nTRANSIENT ERROR:[^\n]+\z/s;
-  BSSrcServer::Service::addrev_service($rev, $servicemark, $files, $error);
+  return 'retry' if $error && $error =~ /^Transient error/;		# from the service dispatch
+  return 'retry' if $error && $error =~ /\nTRANSIENT ERROR:[^\n]+\z/s;	# from the service run itself
+  eval { BSSrcServer::Service::addrev_service($rev, $servicemark, $files, $error) };
+  if ($@) {
+    return 'retry' if $@ =~ /^Transient error/;				# could not send result to src server
+    die($@);
+  }
   return $error ? 'failed' : 'succeeded';
 }
 
@@ -143,6 +148,8 @@ sub runservice {
   push @send, map {BSRevision::revcpiofile($rev, $_, $oldfiles->{$_})} grep {!$sendfiles->{$_}} sort(keys %$oldfiles);
 
   my $error = BSSrcServer::Service::doservicerpc($rev, $files, \@send);
+  return 'retry' if $error && $error =~ /^Transient error/;		# from the service dispatch
+  return 'retry' if $error && $error =~ /\nTRANSIENT ERROR:[^\n]+\z/s;	# from the service run itself
   BSSrcServer::Service::addrev_service($rev, $servicemark, $files, $error, $lxservicemd5);
   return $error ? 'failed' : 'succeeded';
 }


### PR DESCRIPTION
…k the result

We used to fail the service run if we could not reach the src server for some reason (e.g. rpc timeout).
We now retry the service run instead.