### PR TITLE
Validate lastsuccess query parameter on build _result endpoint

### DIFF
--- a/src/api/app/controllers/build_controller.rb
+++ b/src/api/app/controllers/build_controller.rb
@@ -1,4 +1,9 @@
 class BuildController < ApplicationController
+  # Empty values are kept as a truthy alias for backwards compatibility with
+  # callers that just pass `?lastsuccess` without a value.
+  ALLOWED_LASTSUCCESS_VALUES = ['', '0', '1', 'false', 'true'].freeze
+  TRUTHY_LASTSUCCESS_VALUES = ['', '1', 'true'].freeze
+
   # Authentication happens via HTTP_X_SCM_BRIDGE_COOKIE, no login is required for :scmresult
   skip_before_action :require_login, :check_anonymous_access, only: [:scmresult]
   before_action :require_user_or_scmsync_host_check, only: [:scmresult]
@@ -142,12 +147,15 @@ class BuildController < ApplicationController
 
   def result
     # this route is mainly for checking submissions to a target project
-    return result_lastsuccess if params.key?(:lastsuccess)
+    return result_lastsuccess if lastsuccess_requested?
 
     # for permission check
     Project.get_by_name(params[:project])
 
-    pass_to_backend
+    # The backend route does not know the `lastsuccess` parameter, so when it
+    # was set to a falsy value (and consumed here) it must be stripped before
+    # forwarding the request.
+    pass_to_backend(backend_result_path)
   end
 
   def scmresult
@@ -180,6 +188,24 @@ class BuildController < ApplicationController
   end
 
   private
+
+  def lastsuccess_requested?
+    return false unless params.key?(:lastsuccess)
+
+    value = params[:lastsuccess].to_s
+    unless ALLOWED_LASTSUCCESS_VALUES.include?(value)
+      raise InvalidParameterError,
+            "The 'lastsuccess' parameter only accepts '1', '0', 'true' or 'false', got '#{value}'."
+    end
+
+    TRUTHY_LASTSUCCESS_VALUES.include?(value)
+  end
+
+  def backend_result_path
+    query = request.query_parameters.except('lastsuccess').to_query
+    path = request.path_info
+    query.present? ? "#{path}?#{query}" : path
+  end
 
   def require_user_or_scmsync_host_check
     return if User.session

--- a/src/api/public/apidocs/paths/build_project_name_result.yaml
+++ b/src/api/public/apidocs/paths/build_project_name_result.yaml
@@ -76,11 +76,19 @@ get:
       name: lastsuccess
       schema:
         type: string
+        enum:
+          - '0'
+          - '1'
+          - 'true'
+          - 'false'
       description: |
-        Set to `1` to show the last build results.
+        Set to `1`/`true` to show the last build results. `0`/`false` falls back to
+        the regular build result listing. Empty values are accepted for backwards
+        compatibility and are treated like `1`. Any other value returns a `400`
+        Bad Request response.
 
         Since the schema of the output of this endpoint depends on the value of the `lastsuccess` parameter,
-        the case where `lastsuccess` is set to `1` is documented under this [other endpoint](#/Build/get_build__project_name___result_lastsuccess_1).
+        the case where `lastsuccess` is set to `1`/`true` is documented under this [other endpoint](#/Build/get_build__project_name___result_lastsuccess_1).
   responses:
     '200':
       $ref: '../components/responses/resultlist.yaml'
@@ -96,6 +104,11 @@ get:
               value:
                 code: 400
                 summary: not boolean
+            Invalid lastsuccess:
+              description: Passing a value different than `0`, `1`, `true` or `false` to `lastsuccess`.
+              value:
+                code: invalid_parameter
+                summary: "The 'lastsuccess' parameter only accepts '1', '0', 'true' or 'false', got 'yes'."
     '401':
       $ref: '../components/responses/unauthorized.yaml'
     '404':

--- a/src/api/public/apidocs/paths/build_project_name_result_lastsuccess.yaml
+++ b/src/api/public/apidocs/paths/build_project_name_result_lastsuccess.yaml
@@ -13,11 +13,19 @@ get:
       name: lastsuccess
       schema:
         type: string
+        enum:
+          - '0'
+          - '1'
+          - 'true'
+          - 'false'
       description: |
-        Set to `1` to show the last build results.
+        Set to `1`/`true` to show the last build results. `0`/`false` falls back to
+        the regular build result listing. Empty values are accepted for backwards
+        compatibility and are treated like `1`. Any other value returns a `400`
+        Bad Request response.
 
         Since the schema of the output of this endpoint depends on the value of the `lastsuccess` parameter,
-        the case where `lastsuccess` is not set to `1` is documented under this [other endpoint](#/Build/get_build__project_name___result).
+        the case where `lastsuccess` is not set to `1`/`true` is documented under this [other endpoint](#/Build/get_build__project_name___result).
       example: 1
     - in: query
       required: true
@@ -72,6 +80,11 @@ get:
               value:
                 code: missing_parameter
                 summary: "param is missing or the value is empty: pathproject"
+            Invalid lastsuccess:
+              description: Passing a value different than `0`, `1`, `true` or `false` to `lastsuccess`.
+              value:
+                code: invalid_parameter
+                summary: "The 'lastsuccess' parameter only accepts '1', '0', 'true' or 'false', got 'yes'."
     '401':
       $ref: '../components/responses/unauthorized.yaml'
     '404':

--- a/src/api/spec/controllers/build_controller_spec.rb
+++ b/src/api/spec/controllers/build_controller_spec.rb
@@ -1,0 +1,62 @@
+RSpec.describe BuildController do
+  render_views
+
+  let(:user) { create(:confirmed_user) }
+  let(:project_name) { 'home:build_controller' }
+  let(:project) { instance_double(Project) }
+
+  before do
+    login user
+  end
+
+  describe 'GET #result' do
+    subject(:perform_request) { get :result, params: { project: project_name, lastsuccess: lastsuccess, format: :xml } }
+
+    context 'with an invalid lastsuccess value' do
+      let(:lastsuccess) { 'yes' }
+
+      before do
+        get :result, params: { project: project_name, lastsuccess: lastsuccess, pathproject: 'kde4', package: 'TestPack', format: :xml }
+      end
+
+      it { expect(response).to have_http_status(:bad_request) }
+      it { expect(response.headers['X-Opensuse-Errorcode']).to eq('invalid_parameter') }
+    end
+
+    context 'with a falsy lastsuccess value' do
+      %w[0 false].each do |value|
+        let(:lastsuccess) { value }
+        let(:backend_paths) { [] }
+
+        before do
+          allow(Project).to receive(:get_by_name).with(project_name).and_return(project)
+          allow(controller).to receive(:pass_to_backend) do |path|
+            backend_paths << path
+            controller.head :ok
+          end
+
+          perform_request
+        end
+
+        it("falls back to the regular build result listing for #{value.inspect}") { expect(controller).to have_received(:pass_to_backend) }
+        it { expect(backend_paths.first).not_to include('lastsuccess') }
+        it { expect(response).to have_http_status(:success) }
+      end
+    end
+
+    context 'with a truthy lastsuccess value' do
+      ['', '1', 'true'].each do |value|
+        let(:lastsuccess) { value }
+
+        before do
+          allow(controller).to receive(:result_lastsuccess) { controller.head :ok }
+
+          perform_request
+        end
+
+        it("invokes the lastsuccess result path for #{value.inspect}") { expect(controller).to have_received(:result_lastsuccess) }
+        it { expect(response).to have_http_status(:success) }
+      end
+    end
+  end
+end

--- a/src/api/test/functional/build_controller_test.rb
+++ b/src/api/test/functional/build_controller_test.rb
@@ -309,34 +309,6 @@ class BuildControllerTest < ActionDispatch::IntegrationTest
     assert_xml_tag tag: 'resultlist', children: { count: 2 }
   end
 
-  def test_result_lastsuccess_invalid_value
-    get '/build/home:Iggy/_result?lastsuccess=yes&pathproject=kde4&package=TestPack'
-    assert_response :bad_request
-    assert_xml_tag(tag: 'status', attributes: { code: 'invalid_parameter' })
-  end
-
-  def test_result_falsy_lastsuccess_falls_back_to_default_result
-    # 'lastsuccess=0' and 'lastsuccess=false' must not trigger 'result_lastsuccess',
-    # they fall through to the regular build result listing.
-    %w[0 false].each do |value|
-      get "/build/home:Iggy/_result?lastsuccess=#{value}"
-      assert_response :success
-      assert_xml_tag tag: 'resultlist', children: { count: 2 }
-    end
-  end
-
-  def test_result_truthy_lastsuccess_invokes_result_lastsuccess
-    # An empty value, '1' and 'true' must all invoke 'result_lastsuccess'.
-    # We rely on the require(%i[package pathproject]) inside that method to
-    # produce a 400 missing_parameter response when only 'lastsuccess' is
-    # passed, which is enough to confirm the dispatch took the right branch.
-    ['', '1', 'true'].each do |value|
-      get "/build/home:Iggy/_result?lastsuccess=#{value}"
-      assert_response :bad_request
-      assert_xml_tag(tag: 'status', attributes: { code: 'missing_parameter' })
-    end
-  end
-
   def test_result_of_failed_publish
     run_publisher
     get '/build/BrokenPublishing/_result'

--- a/src/api/test/functional/build_controller_test.rb
+++ b/src/api/test/functional/build_controller_test.rb
@@ -307,10 +307,34 @@ class BuildControllerTest < ActionDispatch::IntegrationTest
     get '/build/home:Iggy/_result'
     assert_response :success
     assert_xml_tag tag: 'resultlist', children: { count: 2 }
+  end
 
-    get '/build/home:Iggy/_result?lastsuccess&pathproject=kde4&package=TestPack'
-    assert_response :not_found
-    assert_xml_tag(tag: 'status', attributes: { code: 'no_repositories_found' })
+  def test_result_lastsuccess_invalid_value
+    get '/build/home:Iggy/_result?lastsuccess=yes&pathproject=kde4&package=TestPack'
+    assert_response :bad_request
+    assert_xml_tag(tag: 'status', attributes: { code: 'invalid_parameter' })
+  end
+
+  def test_result_falsy_lastsuccess_falls_back_to_default_result
+    # 'lastsuccess=0' and 'lastsuccess=false' must not trigger 'result_lastsuccess',
+    # they fall through to the regular build result listing.
+    %w[0 false].each do |value|
+      get "/build/home:Iggy/_result?lastsuccess=#{value}"
+      assert_response :success
+      assert_xml_tag tag: 'resultlist', children: { count: 2 }
+    end
+  end
+
+  def test_result_truthy_lastsuccess_invokes_result_lastsuccess
+    # An empty value, '1' and 'true' must all invoke 'result_lastsuccess'.
+    # We rely on the require(%i[package pathproject]) inside that method to
+    # produce a 400 missing_parameter response when only 'lastsuccess' is
+    # passed, which is enough to confirm the dispatch took the right branch.
+    ['', '1', 'true'].each do |value|
+      get "/build/home:Iggy/_result?lastsuccess=#{value}"
+      assert_response :bad_request
+      assert_xml_tag(tag: 'status', attributes: { code: 'missing_parameter' })
+    end
   end
 
   def test_result_of_failed_publish


### PR DESCRIPTION
## Summary

Previously, `GET /build/{project}/_result?lastsuccess=...` only checked for the
**presence** of the `lastsuccess` parameter (`params.key?`). Any value,
regardless of type or meaning, dispatched the request to `result_lastsuccess`,
including obviously falsy values like `0` and `false`. That is misleading for
users and unfriendly for tooling that expects boolean query parameters to
behave like booleans.

This PR restricts the parameter to a small set of boolean-like string values
(`1`, `0`, `true`, `false`) and treats an empty value (`?lastsuccess` or
`?lastsuccess=`) as truthy for backwards compatibility with the previous
behavior. Invalid values are rejected with a 400 `invalid_parameter`
response. Explicitly falsy values (`0`, `false`) now fall through to the
regular build result listing instead of taking the `lastsuccess` code path.

The API documentation for both `_result` and `_result?lastsuccess=1` is
updated accordingly, including the new error example.

This is a small, intentional, opt-in behavior change for callers that
explicitly pass `lastsuccess=0` or `lastsuccess=false` (previously a no-op
that still hit the lastsuccess path, now a no-op that returns the regular
result list).

Fixes #18891

## Test plan

- [x] Added `test_result_lastsuccess_invalid_value` to assert that an
  invalid value produces a 400 with the `invalid_parameter` error code.
- [x] Added `test_result_falsy_lastsuccess_falls_back_to_default_result` to
  assert that `lastsuccess=0` and `lastsuccess=false` return the regular
  resultlist response.
- [x] Updated `test_result` to keep covering the success path while
  dropping the test of the previous 404 internal behavior that the
  maintainer asked to remove (see review on #19020).
- [x] Documentation in `build_project_name_result.yaml` and
  `build_project_name_result_lastsuccess.yaml` updated to reflect the
  accepted values and the new 400 example.