### PR TITLE
Validate confirmed query parameter on Person endpoint

### DIFF
--- a/src/api/app/controllers/person_controller.rb
+++ b/src/api/app/controllers/person_controller.rb
@@ -1,6 +1,11 @@
 require 'xmlhash'
 
 class PersonController < ApplicationController
+  # Empty values are kept as a truthy alias for backwards compatibility. They are
+  # marked as deprecated through the `Deprecation` response header.
+  ALLOWED_CONFIRMED_VALUES = ['', '0', '1', 'false', 'true'].freeze
+  TRUTHY_CONFIRMED_VALUES = ['', '1', 'true'].freeze
+
   validate_action grouplist: { method: :get, response: :directory }
   validate_action register: { method: :put, response: :status }
   validate_action register: { method: :post, response: :status }
@@ -14,7 +19,7 @@ class PersonController < ApplicationController
   def show
     @list = if params[:prefix]
               User.where('login LIKE ?', "#{params[:prefix]}%")
-            elsif params[:confirmed]
+            elsif confirmed_filter?
               User.confirmed
             else
               User.not_deleted
@@ -203,6 +208,20 @@ class PersonController < ApplicationController
   end
 
   private
+
+  def confirmed_filter?
+    return false unless params.key?(:confirmed)
+
+    value = params[:confirmed].to_s
+    unless ALLOWED_CONFIRMED_VALUES.include?(value)
+      raise InvalidParameterError,
+            "The 'confirmed' parameter only accepts '1', '0', 'true' or 'false', got '#{value}'."
+    end
+
+    response.headers['Deprecation'] = 'true' if value.empty?
+
+    TRUTHY_CONFIRMED_VALUES.include?(value)
+  end
 
   def set_user
     @user = User.find_by(login: params[:login])

--- a/src/api/public/apidocs/paths/person.yaml
+++ b/src/api/public/apidocs/paths/person.yaml
@@ -15,8 +15,21 @@ get:
       name: confirmed
       schema:
         type: string
+        enum:
+          - '0'
+          - '1'
+          - 'true'
+          - 'false'
       required: false
-      description: List only active users. This parameter is interpreted as `true` if present, `false` otherwise.
+      description: |
+        Set to `1`/`true` to list only active users. Set to `0`/`false` to list
+        all users that are not deleted. Any other value returns a `400`
+        Bad Request response.
+
+        Passing the parameter without a value is **deprecated** and will be
+        removed in a future release. For backwards compatibility it is currently
+        still accepted and treated like `1`. When used without a value the
+        response will include a `Deprecation: true` header.
       example: 1
 
   responses:
@@ -41,6 +54,18 @@ get:
               - name: 'user_2'
               - name: 'user_3'
               - name: 'Requestor'
+    '400':
+      description: Bad Request.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          examples:
+            Invalid confirmed:
+              description: Passing a value different than `0`, `1`, `true` or `false` to `confirmed`.
+              value:
+                code: invalid_parameter
+                summary: "The 'confirmed' parameter only accepts '1', '0', 'true' or 'false', got 'yes'."
   tags:
     - Person
 

--- a/src/api/test/functional/person_controller_test.rb
+++ b/src/api/test/functional/person_controller_test.rb
@@ -19,12 +19,40 @@ class PersonControllerTest < ActionDispatch::IntegrationTest
     get '/person?confirmed=1'
     assert_response :success
     assert_no_xml_tag tag: 'entry', attributes: { name: 'unconfirmed_user' }
+    assert_nil response.headers['Deprecation']
+
+    get '/person?confirmed=true'
+    assert_response :success
+    assert_no_xml_tag tag: 'entry', attributes: { name: 'unconfirmed_user' }
+
+    get '/person?confirmed=0'
+    assert_response :success
+    assert_xml_tag tag: 'entry', attributes: { name: 'unconfirmed_user' }
+
+    get '/person?confirmed=false'
+    assert_response :success
+    assert_xml_tag tag: 'entry', attributes: { name: 'unconfirmed_user' }
 
     get '/person/'
     assert_response :success
 
     get '/person?prefix=s'
     assert_response :success
+  end
+
+  def test_index_confirmed_invalid_value
+    login_adrian
+    get '/person?confirmed=yes'
+    assert_response :bad_request
+    assert_xml_tag(tag: 'status', attributes: { code: 'invalid_parameter' })
+  end
+
+  def test_index_confirmed_without_value_is_deprecated
+    login_adrian
+    get '/person?confirmed'
+    assert_response :success
+    assert_no_xml_tag tag: 'entry', attributes: { name: 'unconfirmed_user' }
+    assert_equal 'true', response.headers['Deprecation']
   end
 
   def test_ichain


### PR DESCRIPTION
## Summary

`GET /person` previously only checked for the presence of the `confirmed`
parameter (`params[:confirmed]` is truthy). That means that callers passing
`confirmed=0` or `confirmed=false` were silently treated the same as
`confirmed=1`, which is unexpected and unfriendly for tooling that wants to
use the API with proper boolean query parameters.

This PR restricts the parameter to a small set of boolean-like string values
(`1`, `0`, `true`, `false`). Invalid values are rejected with a 400
`invalid_parameter` response. Explicitly falsy values (`0`, `false`) now
correctly return the full, not-deleted user list instead of only confirmed
users.

Empty values (`?confirmed` or `?confirmed=`) continue to be accepted as a
truthy alias to avoid breaking existing callers. As discussed by
@eduardoj on the previous PR review (#19019), this usage is marked as
**deprecated**: responses to such requests now include a `Deprecation: true`
header (per RFC 8594) and the API documentation has been updated to call
out that the empty-value form will be removed in a future release.

Fixes #18957

## Test plan

- [x] Extended `test_index` to cover the four accepted values
  (`1`, `true`, `0`, `false`) and assert that no `Deprecation` header is
  returned for explicit values.
- [x] Added `test_index_confirmed_invalid_value` asserting that an
  invalid value produces a 400 with the `invalid_parameter` error code.
- [x] Added `test_index_confirmed_without_value_is_deprecated` asserting
  that the deprecated empty form still works **and** sets the
  `Deprecation: true` response header.
- [x] Updated `person.yaml` API documentation to describe the accepted
  values, the new 400 example, and the deprecation of the empty form.