### PR TITLE
Reject release targets that point back to the same repository

### DIFF
--- a/src/api/app/models/project/update_from_xml_command.rb
+++ b/src/api/app/models/project/update_from_xml_command.rb
@@ -251,6 +251,8 @@ class Project
 
         raise SaveError, "Project '#{release_target['project']}' does not exist." unless project
 
+        raise SaveError, 'Using same repository as release target element is not allowed' if release_target['project'] == self.project.name && repository == xml_hash['name']
+
         raise SaveError, "Can not use remote repository as release target '#{project}/#{repository}'" if project.defines_remote_instance?
 
         target_repo = Repository.find_by_project_and_name(project.name, repository)

--- a/src/api/spec/models/project/update_from_xml_command_spec.rb
+++ b/src/api/spec/models/project/update_from_xml_command_spec.rb
@@ -94,6 +94,36 @@ RSpec.describe Project::UpdateFromXmlCommand do
           Project::SaveError, "Can not use remote repository as release target '#{remote_project.name}/remote_repo'"
         )
       end
+
+      it 'raises an error if the release target points back to the same repository' do
+        xml_hash = Xmlhash.parse(
+          <<-XML
+            <project name="#{project.name}">
+              <repository name="repo_1">
+                <releasetarget project="#{project.name}" repository="repo_1" trigger="manual" />
+              </repository>
+            </project>
+          XML
+        )
+        expect { Project::UpdateFromXmlCommand.new(project).send(:update_repositories, xml_hash, false) }.to raise_error(
+          Project::SaveError, 'Using same repository as release target element is not allowed'
+        )
+      end
+
+      it 'allows a release target pointing to a sibling repository in the same project' do
+        xml_hash = Xmlhash.parse(
+          <<-XML
+            <project name="#{project.name}">
+              <repository name="repo_1">
+                <releasetarget project="#{project.name}" repository="repo_2" trigger="manual" />
+              </repository>
+              <repository name="repo_2" />
+            </project>
+          XML
+        )
+        expect { Project::UpdateFromXmlCommand.new(project).send(:update_repositories, xml_hash, false) }.not_to raise_error
+        expect(repository1.release_targets.first.target_repository).to eq(repository2)
+      end
     end
 
     describe 'repository architecture' do


### PR DESCRIPTION
## Summary

When a `<releasetarget>` element references the very repository that
contains it, e.g.

```xml
<project name=\"home:user:foo\">
  <repository name=\"images\">
    <releasetarget project=\"home:user:foo\" repository=\"images\" trigger=\"manual\"/>
  </repository>
</project>
```

OBS happily accepts the meta and the project can subsequently get stuck
in an \"outdated (was: succeeded: Releasing via trigger event ...)\" loop
because releasing the repository keeps re-triggering itself
(see #16936 for the original report).

This PR mirrors the existing self-reference check that `<path>` elements
already enforce in the same place and refuses to save such project meta
during `UpdateFromXmlCommand#update_release_targets`. Cross-repository
release targets within the same project (e.g. `containerfile -> images`)
are still allowed.

Fixes #16936

## Test plan

- [x] Added a spec to assert that an XML meta with a release target
  pointing back to the same repository raises
  `Project::SaveError, 'Using same repository as release target element is not allowed'`.
- [x] Added a spec to confirm a release target that points to a
  **different** repository in the same project is still accepted and
  persisted correctly.
- [x] Verified the regression path with the meta from the issue
  (`<releasetarget project=\"\$same\" repository=\"\$same\"/>`)
  is now rejected at save time rather than silently producing the
  releasing-loop behaviour.