### PR TITLE
Shared canned responses for request comments and decisions

### DIFF
--- a/src/api/app/components/request_decision_component.html.haml
+++ b/src/api/app/components/request_decision_component.html.haml
@@ -13,7 +13,7 @@
       = render WriteAndPreviewComponent.new(form: form, preview_message_url: preview_comments_path, canned_responses_enabled: true,
                                             message_body_param: 'comment[body]',
                                             text_area_attributes: { object_name: 'reason', id_suffix: 'new_comment',
-                                            placeholder: decision_placeholder})
+                                            placeholder: decision_placeholder}, bs_request: @bs_request)
       .mt-2#decision-buttons-row
         %div
           - if policy(Comment.new(commentable:@bs_request)).create?

--- a/src/api/app/components/write_and_preview_component.html.haml
+++ b/src/api/app/components/write_and_preview_component.html.haml
@@ -12,7 +12,9 @@
                                      role: 'tabpanel', 'aria-labelledby': 'write-message-tab', 'data-canned-controller': '' }
       - if Flipper.enabled?(:canned_responses, User.session) && canned_responses_enabled
         .d-flex.justify-content-end
-          = render CannedResponsesDropdownComponent.new(User.session.canned_responses.where(decision_type: nil).order(:title))
+          - user_canned_responses = User.session.canned_responses.where(decision_type: nil)
+          - request_canned_responses = bs_request.canned_responses.where(decision_type: nil)
+          = render CannedResponsesDropdownComponent.new(user_canned_responses.or(request_canned_responses).order(:title))
       ~ form.text_area(text_area_attributes[:object_name], id: "#{text_area_attributes[:id_suffix]}_body",
         rows: text_area_attributes[:rows], required: text_area_attributes[:required],
         placeholder: text_area_attributes[:placeholder], class: 'w-100 form-control message-field')

--- a/src/api/app/components/write_and_preview_component.rb
+++ b/src/api/app/components/write_and_preview_component.rb
@@ -1,9 +1,9 @@
 class WriteAndPreviewComponent < ApplicationComponent
   attr_reader :form, :preview_message_url, :message_body_param, :text_area_attributes, :canned_responses_enabled, :commentable_id,
-              :commentable_type, :diff_file_index, :diff_line
+              :commentable_type, :diff_file_index, :diff_line, :bs_request
 
   def initialize(form:, preview_message_url:, message_body_param:, text_area_attributes: {}, canned_responses_enabled: false,
-                 commentable_id: nil, commentable_type: nil, diff_file_index: nil, diff_line: nil)
+                 commentable_id: nil, commentable_type: nil, diff_file_index: nil, diff_line: nil, bs_request: nil)
     super()
 
     @form = form
@@ -15,6 +15,7 @@ class WriteAndPreviewComponent < ApplicationComponent
     @commentable_type = commentable_type
     @diff_file_index = diff_file_index
     @diff_line = diff_line
+    @bs_request = bs_request
   end
 
   private

--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -1055,6 +1055,12 @@ class BsRequest < ApplicationRecord
     bs_request_actions.any?(&:involves_hidden_project?)
   end
 
+  def canned_responses
+    package_ids = bs_request_actions.pluck(:source_package_id, :target_package_id).flatten.uniq
+    CannedResponse.where(package_id: package_ids)
+  end
+
+
   private
 
   # returns true if we have reached a state that we can't get out anymore

--- a/src/api/app/views/webui/comment/_comment_field.html.haml
+++ b/src/api/app/views/webui/comment/_comment_field.html.haml
@@ -16,7 +16,7 @@
                                         placeholder: 'Write your comment here... (Markdown markup is supported)',
                                         commentable_type: commentable.class.name.underscore, commentable_id: commentable.id,
                                         diff_file_index: defined?(diff_file_index) ? diff_file_index : nil,
-                                        diff_line_number: defined?(line_number) ? line_number : nil })
+                                        diff_line_number: defined?(line_number) ? line_number : nil }, bs_request: commentable)
   .comment-controls.my-3
     - case form_method
     - when :post


### PR DESCRIPTION
~Depends on #19703~

This PR adds support for shared canned responses alongside the user specific ones for request comments and decisions 