### PR TITLE
UI for assigning packages to canned responses

### DIFF
--- a/src/api/app/assets/javascripts/webui/autocomplete.js
+++ b/src/api/app/assets/javascripts/webui/autocomplete.js
@@ -54,9 +54,9 @@ $(document).ready(function() {
     });
   });
 
-  $('#linked_project, #review_project, #project_name, #project').on('autocompletechange', function() {
+  $('#linked_project, #review_project, #project_name, #canned_response_project, #project').on('autocompletechange', function() {
     var projectName = $(this).val(),
-        packageInput = $('#linked_package, #review_package, #package_name, #package');
+        packageInput = $('#linked_package, #review_package, #package_name, #canned_response_package, #package');
 
     if (!packageInput.is(':visible')) return;
 

--- a/src/api/app/controllers/webui/users/canned_responses_controller.rb
+++ b/src/api/app/controllers/webui/users/canned_responses_controller.rb
@@ -59,6 +59,12 @@ class Webui::Users::CannedResponsesController < Webui::WebuiController
   end
 
   def canned_response_params
-    params.require(:canned_response).permit(:title, :content, :decision_type)
+    if params[:canned_response][:package].present?
+      params[:canned_response][:package_id] = Package.find_by_project_and_name(params[:canned_response][:project], params[:canned_response][:package])&.id
+    elsif params[:canned_response][:project].present?
+      params[:canned_response][:project_id] = Project.find_by_name(params[:canned_response][:project])&.id
+    end
+
+    params.require(:canned_response).except(:project, :package).permit(:title, :content, :decision_type, :package_id, :project_id)
   end
 end

--- a/src/api/app/views/webui/users/canned_responses/_new_modal.html.haml
+++ b/src/api/app/views/webui/users/canned_responses/_new_modal.html.haml
@@ -1,0 +1,35 @@
+.modal.fade#create-canned-response-modal{ tabindex: -1, role: 'dialog', aria: { labelledby: 'create-canned-response-modal-label', hidden: true } }
+  .modal-dialog.modal-dialog-centered{ role: 'document' }
+    .modal-content
+      .card
+        .card-body
+          %h4 Create a new canned response
+          = form_for(canned_response) do |f|
+            .mb-3
+              = f.label :title, 'Title:'
+              = f.text_field :title, class: classes_with_validation(canned_response, :title), required: true, maxlength: 255
+            .mb-3
+              = f.label :content, 'Content:'
+              = f.text_area :content, rows: 5, class: classes_with_validation(canned_response, :content), required: true, maxlength: 65535
+            - if policy(Decision.new).create?
+              .mb-3
+                = f.label :decision_type, "Choose 'cleared' or 'favored' if this is a decision's reason"
+                - types = CannedResponse.decision_types.keys.to_h { |t| [t.humanize, t] }
+                = f.select(:decision_type, types, { include_blank: 'none', selected: nil }, class: 'form-select')
+            .mb-3
+              = render partial: 'webui/shared/search_box',
+                       locals: { html_id: "canned_response_project",
+                                 html_name: "canned_response[project]",
+                                 label: 'Project:',
+                                 required: false,
+                                 data: { source: autocomplete_projects_path } }
+            .mb-3
+              = render partial: 'webui/shared/search_box',
+                       locals: { html_id: "canned_response_package",
+                                 html_name: "canned_response[package]",
+                                 label: 'Package:',
+                                 required: false,
+                                 disabled: true,
+                                 data: { source: autocomplete_packages_path } }
+            = f.submit 'Create', class: 'btn btn-primary'
+            = button_tag('Cancel', type: 'reset', class: 'btn btn-light',

--- a/src/api/app/views/webui/users/canned_responses/edit.html.haml
+++ b/src/api/app/views/webui/users/canned_responses/edit.html.haml
@@ -15,4 +15,20 @@
           = f.label :decision_type, "Choose 'cleared' or 'favored' if this is a decision's reason"
           - types = CannedResponse.decision_types.keys.to_h { |t| [t.humanize, t] }
           = f.select(:decision_type, types , { include_blank: 'none' }, class: 'form-select')
+      .mb-3
+        = render partial: 'webui/shared/search_box',
+                 locals: { html_id: "canned_response_project",
+                           html_name: "canned_response[project]",
+                           label: 'Project:',
+                           required: false,
+                           value: f.object.package&.project || f.object.project,
+                           data: { source: autocomplete_projects_path } }
+      .mb-3
+        = render partial: 'webui/shared/search_box',
+                 locals: { html_id: "canned_response_package",
+                           html_name: "canned_response[package]",
+                           label: 'Package:',
+                           required: false,
+                           value: f.object.package,
+                           data: { source: autocomplete_packages_path } }
       = f.submit 'Save', class: 'btn btn-primary'

--- a/src/api/app/views/webui/users/canned_responses/index.html.haml
+++ b/src/api/app/views/webui/users/canned_responses/index.html.haml
@@ -77,39 +77,4 @@
         %i.fas.fa-plus-circle.text-primary
         Create Canned Response
 
-.modal.fade#create-canned-response-modal{ tabindex: -1, role: 'dialog', aria: { labelledby: 'create-canned-response-modal-label', hidden: true } }
-  .modal-dialog.modal-dialog-centered{ role: 'document' }
-    .modal-content
-      .card
-        .card-body
-          %h4 Create a new canned response
-          = form_for(@canned_response) do |f|
-            .mb-3
-              = f.label :title, 'Title:'
-              = f.text_field :title, class: classes_with_validation(@canned_response, :title), required: true, maxlength: 255
-            .mb-3
-              = f.label :content, 'Content:'
-              = f.text_area :content, rows: 5, class: classes_with_validation(@canned_response, :content), required: true, maxlength: 65535
-            - if policy(Decision.new).create?
-              .mb-3
-                = f.label :decision_type, "Choose 'cleared' or 'favored' if this is a decision's reason"
-                - types = CannedResponse.decision_types.keys.to_h { |t| [t.humanize, t] }
-                = f.select(:decision_type, types, { include_blank: 'none', selected: nil }, class: 'form-select')
-            .mb-3
-              = render partial: 'webui/shared/search_box',
-                       locals: { html_id: "canned_response_project",
-                                 html_name: "canned_response[project]",
-                                 label: 'Project:',
-                                 required: false,
-                                 data: { source: autocomplete_projects_path } }
-            .mb-3
-              = render partial: 'webui/shared/search_box',
-                       locals: { html_id: "canned_response_package",
-                                 html_name: "canned_response[package]",
-                                 label: 'Package:',
-                                 required: false,
-                                 disabled: true,
-                                 data: { source: autocomplete_packages_path } }
-            = f.submit 'Create', class: 'btn btn-primary'
-            = button_tag('Cancel', type: 'reset', class: 'btn btn-light',
-                         data: { 'bs-toggle': 'modal', 'bs-target': '#create-canned-response-modal' })
+= render partial: 'new_modal', locals: { canned_response: @canned_response }

--- a/src/api/app/views/webui/users/canned_responses/index.html.haml
+++ b/src/api/app/views/webui/users/canned_responses/index.html.haml
@@ -19,6 +19,16 @@
                 = render(CardComponent.new) do |component|
                   .canned-response-card-text.mb-2
                     = render partial: 'webui/shared/collapsible_text', locals: { text: canned_response.content, render_markdown: true }
+                  - if canned_response.package
+                    .mb-2
+                      %strong Package:
+                      = link_to(package_show_path(canned_response.package.project, canned_response.package)) do
+                        #{canned_response.package.project}/#{canned_response.package}
+                  - elsif canned_response.project
+                    .mb-2
+                      %strong Project:
+                      = link_to(project_show_path(canned_response.project)) do
+                        #{canned_response.project}
 
                   - component.with_header do
                     = canned_response.title
@@ -85,6 +95,21 @@
                 = f.label :decision_type, "Choose 'cleared' or 'favored' if this is a decision's reason"
                 - types = CannedResponse.decision_types.keys.to_h { |t| [t.humanize, t] }
                 = f.select(:decision_type, types, { include_blank: 'none', selected: nil }, class: 'form-select')
+            .mb-3
+              = render partial: 'webui/shared/search_box',
+                       locals: { html_id: "canned_response_project",
+                                 html_name: "canned_response[project]",
+                                 label: 'Project:',
+                                 required: false,
+                                 data: { source: autocomplete_projects_path } }
+            .mb-3
+              = render partial: 'webui/shared/search_box',
+                       locals: { html_id: "canned_response_package",
+                                 html_name: "canned_response[package]",
+                                 label: 'Package:',
+                                 required: false,
+                                 disabled: true,
+                                 data: { source: autocomplete_packages_path } }
             = f.submit 'Create', class: 'btn btn-primary'
             = button_tag('Cancel', type: 'reset', class: 'btn btn-light',
                          data: { 'bs-toggle': 'modal', 'bs-target': '#create-canned-response-modal' })


### PR DESCRIPTION
Follow up to #19703

<img width="608" height="725" alt="Screenshot From 2026-05-18 15-34-09" src="https://github.com/user-attachments/assets/21ee6f1b-c800-4b91-ad70-41819da43e07" />
<img width="480" height="292" alt="Screenshot From 2026-05-18 15-33-55" src="https://github.com/user-attachments/assets/825aef17-6375-455e-aedc-e2c784794924" />
