### PR TITLE
Show group reviewers in a modal

### DIFF
--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -37,7 +37,7 @@ class Webui::RequestController < Webui::WebuiController
     @is_target_maintainer = @bs_request.target_maintainer?(User.session)
     @my_open_reviews = ReviewsFinder.new(@bs_request.reviews).open_reviews_for_user(User.session).reject(&:staging_project?)
     @history_elements = @bs_request.history_elements.includes(:user)
-    @request_reviews = @bs_request.reviews.includes(%i[user group]).for_non_staging_projects(@target_project)
+    @request_reviews = @bs_request.reviews.includes(:user, group: :users).for_non_staging_projects(@target_project)
 
     # retrieve a list of all package maintainers that are assigned to at least one target package
     @package_maintainers = @bs_request.target_package_maintainers

--- a/src/api/app/views/webui/request/beta_show_tabs/_review_group_members_modal.html.haml
+++ b/src/api/app/views/webui/request/beta_show_tabs/_review_group_members_modal.html.haml
@@ -1,0 +1,22 @@
+- group = review.group
+- users = group&.users&.sort_by(&:login) || []
+
+.modal.fade{ id: modal_id, tabindex: -1, role: 'dialog', aria: { labelledby: "#{modal_id}-label", hidden: true } }
+  .modal-dialog.modal-dialog-centered{ role: 'document' }
+    .modal-content
+      .modal-header
+        %h5.modal-title{ id: "#{modal_id}-label" }
+          Members of #{review.by_group}
+      .modal-body
+        - if group.nil?
+          %p This group does not exist.
+        - elsif users.empty?
+          %p This group does not have members.
+        - else
+          %ul.list-unstyled.mb-0
+            - users.each do |user|
+              %li.mb-2
+                = user_with_realname_and_icon(user.login, short: true)
+      .modal-footer
+        %button.btn.btn-sm.btn-outline-secondary.px-4{ data: { 'bs-dismiss': 'modal' } }
+          OK

--- a/src/api/app/views/webui/request/beta_show_tabs/_review_summary.html.haml
+++ b/src/api/app/views/webui/request/beta_show_tabs/_review_summary.html.haml
@@ -13,7 +13,9 @@
     - if review.for_user?
       = user_with_realname_and_icon(review.by_user, short: true, no_icon: true)
     - elsif review.for_group?
-      = link_to(review.by_group, group_path(Group.find_by(title: review.by_group)))
+      - modal_id = "review-group-members-#{review.id}-modal"
+      = link_to(review.by_group, '#', role: 'button', data: { 'bs-toggle': 'modal', 'bs-target': "##{modal_id}" })
+      = render partial: 'webui/request/beta_show_tabs/review_group_members_modal', locals: { review:, modal_id: }
     - elsif review.for_package?
       = project_or_package_link(project: review.by_project, package: review.by_package, short: true)
     - elsif review.for_project?

--- a/src/api/spec/features/beta/webui/requests_spec.rb
+++ b/src/api/spec/features/beta/webui/requests_spec.rb
@@ -33,6 +33,39 @@ RSpec.describe 'Requests', :vcr do
     end
   end
 
+  context 'with a group review', :js do
+    let(:review_member) { create(:confirmed_user, login: 'review_member') }
+    let(:another_review_member) { create(:confirmed_user, login: 'another_review_member') }
+    let(:review_group) { create(:group, title: 'factory-staging', users: [review_member, another_review_member]) }
+    let(:bs_request) { create(:delete_bs_request, creator: submitter, target_project: target_project) }
+    let(:review) { create(:review, by_group: review_group.title, bs_request: bs_request) }
+    let(:modal_id) { "review-group-members-#{review.id}-modal" }
+
+    before do
+      review
+      login submitter
+      visit request_show_path(bs_request.number)
+    end
+
+    it 'opens the group members modal from the reviewers list' do
+      expect(page).to have_css("##{modal_id}", visible: :hidden)
+      within('#side-links') { click_link review_group.title }
+
+      within("##{modal_id}", visible: :visible) do
+        expect(page).to have_css('.modal-title', text: "Members of #{review_group.title}")
+      end
+    end
+
+    it 'lists the group members in the modal' do
+      within('#side-links') { click_link review_group.title }
+
+      within("##{modal_id}") do
+        expect(page).to have_link(review_member.login, href: user_path(review_member))
+        expect(page).to have_link(another_review_member.login, href: user_path(another_review_member))
+      end
+    end
+  end
+
   it 'has all the action types partial view files' do
     missing_files = required_files.reject { |file| File.exist?(file) }
 


### PR DESCRIPTION
Show group reviewers on the request page in a modal instead of linking to the group page:

<img width="1719" height="745" alt="image" src="https://github.com/user-attachments/assets/3db1cfa8-9a68-4695-95d1-07327b512e09" />
