### PR TITLE
[webui] allow trigger service in webui when using scmsync

### DIFF
--- a/src/api/app/views/webui/package/_show_actions.html.haml
+++ b/src/api/app/views/webui/package/_show_actions.html.haml
@@ -14,7 +14,7 @@
       - if package.kiwi_image? && policy(package).update?
         = render partial: 'webui/package/show_actions/view_kiwi', locals: { package_id: package.id }
 
-      - if services.present?
+      - if services.present? || package.scmsync?
         = render partial: 'webui/package/show_actions/trigger_services', locals: { package: package, project: project }
     - else
       = render partial: 'webui/package/show_actions/request_role_addition', locals: { package: package, project: project }


### PR DESCRIPTION
In scmsync mode, if you do not use an SCM bridge (such as GitHub), builds will be triggered via webhooks. 

However, there are times when you still need to trigger a build manually (for example, due to network issues or webhooks are unavailable).