### PR TITLE
Enable comments on Release, MaintenanceRelease and MaintenanceIncident requests

### DIFF
--- a/src/api/app/controllers/webui/comments_controller.rb
+++ b/src/api/app/controllers/webui/comments_controller.rb
@@ -1,18 +1,6 @@
 class Webui::CommentsController < Webui::WebuiController
   include BuildNewComment
 
-  COMMENTABLE_TYPES = {
-    'Project' => Project,
-    'Package' => Package,
-    'BsRequest' => BsRequest,
-    'BsRequestActionSubmit' => BsRequestActionSubmit,
-    'BsRequestActionRelease' => BsRequestActionRelease,
-    'BsRequestActionMaintenanceRelease' => BsRequestActionMaintenanceRelease,
-    'BsRequestActionMaintenanceIncident' => BsRequestActionMaintenanceIncident,
-    'Report' => Report
-  }.freeze
-  private_constant :COMMENTABLE_TYPES
-
   before_action :require_login
   before_action :set_commented, only: :create
   before_action :set_comment, only: %i[moderate history]
@@ -153,7 +141,7 @@ class Webui::CommentsController < Webui::WebuiController
   end
 
   def set_commented
-    @commentable_type = COMMENTABLE_TYPES[params[:commentable_type]]
+    @commentable_type = Comment.commentable_class_for(params[:commentable_type])
     @commented = @commentable_type&.find_by(id: params[:commentable_id])
     return if @commentable_type.present?
 

--- a/src/api/app/controllers/webui/comments_controller.rb
+++ b/src/api/app/controllers/webui/comments_controller.rb
@@ -141,7 +141,8 @@ class Webui::CommentsController < Webui::WebuiController
   end
 
   def set_commented
-    @commentable_type = [Project, Package, BsRequest, BsRequestActionSubmit, Report].find { |klass| klass.name == params[:commentable_type] }
+    commentable_types = [Project, Package, BsRequest, BsRequestActionSubmit, BsRequestActionRelease, Report]
+    @commentable_type = commentable_types.find { |klass| klass.name == params[:commentable_type] }
     @commented = @commentable_type&.find_by(id: params[:commentable_id])
     return if @commentable_type.present?
 

--- a/src/api/app/controllers/webui/comments_controller.rb
+++ b/src/api/app/controllers/webui/comments_controller.rb
@@ -1,6 +1,18 @@
 class Webui::CommentsController < Webui::WebuiController
   include BuildNewComment
 
+  COMMENTABLE_TYPES = {
+    'Project' => Project,
+    'Package' => Package,
+    'BsRequest' => BsRequest,
+    'BsRequestActionSubmit' => BsRequestActionSubmit,
+    'BsRequestActionRelease' => BsRequestActionRelease,
+    'BsRequestActionMaintenanceRelease' => BsRequestActionMaintenanceRelease,
+    'BsRequestActionMaintenanceIncident' => BsRequestActionMaintenanceIncident,
+    'Report' => Report
+  }.freeze
+  private_constant :COMMENTABLE_TYPES
+
   before_action :require_login
   before_action :set_commented, only: :create
   before_action :set_comment, only: %i[moderate history]
@@ -141,9 +153,7 @@ class Webui::CommentsController < Webui::WebuiController
   end
 
   def set_commented
-    commentable_types = [Project, Package, BsRequest, BsRequestActionSubmit, BsRequestActionRelease,
-                         BsRequestActionMaintenanceRelease, BsRequestActionMaintenanceIncident, Report]
-    @commentable_type = commentable_types.find { |klass| klass.name == params[:commentable_type] }
+    @commentable_type = COMMENTABLE_TYPES[params[:commentable_type]]
     @commented = @commentable_type&.find_by(id: params[:commentable_id])
     return if @commentable_type.present?
 

--- a/src/api/app/controllers/webui/comments_controller.rb
+++ b/src/api/app/controllers/webui/comments_controller.rb
@@ -141,7 +141,8 @@ class Webui::CommentsController < Webui::WebuiController
   end
 
   def set_commented
-    commentable_types = [Project, Package, BsRequest, BsRequestActionSubmit, BsRequestActionRelease, Report]
+    commentable_types = [Project, Package, BsRequest, BsRequestActionSubmit, BsRequestActionRelease,
+                         BsRequestActionMaintenanceRelease, BsRequestActionMaintenanceIncident, Report]
     @commentable_type = commentable_types.find { |klass| klass.name == params[:commentable_type] }
     @commented = @commentable_type&.find_by(id: params[:commentable_id])
     return if @commentable_type.present?

--- a/src/api/app/models/comment.rb
+++ b/src/api/app/models/comment.rb
@@ -1,4 +1,16 @@
 class Comment < ApplicationRecord
+  COMMENTABLE_TYPES = {
+    'Project' => Project,
+    'Package' => Package,
+    'BsRequest' => BsRequest,
+    'BsRequestActionSubmit' => BsRequestActionSubmit,
+    'BsRequestActionRelease' => BsRequestActionRelease,
+    'BsRequestActionMaintenanceRelease' => BsRequestActionMaintenanceRelease,
+    'BsRequestActionMaintenanceIncident' => BsRequestActionMaintenanceIncident,
+    'Report' => Report
+  }.freeze
+  private_constant :COMMENTABLE_TYPES
+
   belongs_to :commentable, polymorphic: true, counter_cache: true # belongs to a Project, Package, BsRequest or BsRequestActionSubmit
   belongs_to :user, inverse_of: :comments
   belongs_to :moderator, class_name: 'User', optional: true
@@ -34,6 +46,10 @@ class Comment < ApplicationRecord
 
   scope :on_actions_for_request, ->(bs_request) { where(commentable: BsRequestAction.where(bs_request: bs_request)) }
   scope :without_parent, -> { where(parent_id: nil) }
+
+  def self.commentable_class_for(commentable_type_name)
+    COMMENTABLE_TYPES[commentable_type_name]
+  end
 
   def to_s
     body

--- a/src/api/app/models/comment.rb
+++ b/src/api/app/models/comment.rb
@@ -89,6 +89,7 @@ class Comment < ApplicationRecord
 
   def outdated?
     return false unless revisions?
+    return false unless commentable.respond_to?(:target_srcmd5) && commentable.respond_to?(:source_srcmd5)
     return true unless commentable.target_srcmd5 == target_rev && commentable.source_srcmd5 == source_rev
 
     false

--- a/src/api/spec/models/comment_spec.rb
+++ b/src/api/spec/models/comment_spec.rb
@@ -57,12 +57,45 @@ RSpec.describe Comment do
   end
 
   describe '#outdated?' do
-    it 'returns false when the commentable cannot compare revisions' do
-      release_action = build(:bs_request_action_release)
-      comment = build(:comment, commentable: release_action, diff_file_index: 0,
-                                source_rev: 'source_revision', target_rev: 'target_revision')
+    it 'returns false when the comment has no stored revision data' do
+      submit_action = build(:bs_request_action_submit)
+      comment = build(:comment, commentable: submit_action)
 
       expect(comment).not_to be_outdated
+    end
+
+    it 'returns false when the current revisions match the stored revisions' do
+      submit_action = build(:bs_request_action_submit)
+      allow(submit_action).to receive_messages(source_srcmd5: 'stored_source_rev',
+                                               target_srcmd5: 'stored_target_rev')
+      comment = build(:comment, commentable: submit_action, diff_file_index: 0,
+                                source_rev: 'stored_source_rev', target_rev: 'stored_target_rev')
+
+      expect(comment).not_to be_outdated
+    end
+
+    it 'returns true when the current revisions differ from the stored revisions' do
+      submit_action = build(:bs_request_action_submit)
+      allow(submit_action).to receive_messages(source_srcmd5: 'current_source_rev',
+                                               target_srcmd5: 'current_target_rev')
+      outdated_comment = build(:comment, commentable: submit_action, diff_file_index: 0,
+                                         source_rev: 'stored_source_rev', target_rev: 'stored_target_rev')
+
+      expect(outdated_comment).to be_outdated
+    end
+
+    [
+      :bs_request_action_release,
+      :bs_request_action_maintenance_release,
+      :bs_request_action_maintenance_incident
+    ].each do |action_factory|
+      it "returns false when #{action_factory} cannot compare current revisions" do
+        action = build(action_factory)
+        comment = build(:comment, commentable: action, diff_file_index: 0,
+                                  source_rev: 'stored_source_rev', target_rev: 'stored_target_rev')
+
+        expect(comment).not_to be_outdated
+      end
     end
   end
 

--- a/src/api/spec/models/comment_spec.rb
+++ b/src/api/spec/models/comment_spec.rb
@@ -56,6 +56,16 @@ RSpec.describe Comment do
     }
   end
 
+  describe '#outdated?' do
+    it 'returns false when the commentable cannot compare revisions' do
+      release_action = build(:bs_request_action_release)
+      comment = build(:comment, commentable: release_action, diff_file_index: 0,
+                                source_rev: 'source_revision', target_rev: 'target_revision')
+
+      expect(comment).not_to be_outdated
+    end
+  end
+
   describe 'blank_or_destroy' do
     context 'without children' do
       before do


### PR DESCRIPTION
Inline comment on release requests did now work. 
BsRequestActionRelease was missing as a commentable_type. Adding it required an additional check in the outdated check, as it is missing `*_srcmd5` fields.

I later discovered that the inline comments for maintenance release requests and maintenance incident didn't work either, so I added them too.