### PR TITLE
Fix strong migrations warning

### DIFF
--- a/src/api/db/migrate/20210505160725_add_kind_to_path_element_uniq_indexes.rb
+++ b/src/api/db/migrate/20210505160725_add_kind_to_path_element_uniq_indexes.rb
@@ -3,7 +3,13 @@ class AddKindToPathElementUniqIndexes < ActiveRecord::Migration[6.0]
     remove_foreign_key :path_elements, name: 'path_elements_ibfk_1'
     remove_index :path_elements, name: 'parent_repository_index'
     add_index :path_elements, %w[parent_id repository_id kind], name: 'parent_repository_index', unique: true
-    add_foreign_key 'path_elements', 'repositories', column: 'parent_id', name: 'path_elements_ibfk_1'
+
+    safety_assured do
+      execute 'SET SESSION foreign_key_checks = 0'
+      add_foreign_key :path_elements, :repositories, column: :parent_id, name: 'path_elements_ibfk_1'
+    ensure
+      execute 'SET SESSION foreign_key_checks = 1'
+    end
   end
 
   def down


### PR DESCRIPTION
`strong_migrations` is complaining about this migration because it doesn't handle how the foreign_key should be added