### PR TITLE
Trigger migrations tests in CircleCI when strong migrations gem is upgraded

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,5 +23,6 @@ workflows:
             src/api/Gemfile.lock run-passenger-and-ruby-default-gem-tests true
             src/api/app/assets/javascripts/.* run-javascripts-linter true
             src/api/public/apidocs/.* run-apidocs-linter true
+            src/api/vendor/cache/strong_migrations-.* run-migrations-tests true
           base-revision: master
           config-path: .circleci/conditional_config.yml


### PR DESCRIPTION
That way we can catch and fix anything added by the gem before merging it.