### PR TITLE
[backend] properly discard stale exit events

### DIFF
--- a/src/backend/BSStdServer.pm
+++ b/src/backend/BSStdServer.pm
@@ -457,6 +457,8 @@ sub server {
         $request_content = shift @$args;
       }
     }
+    # startup, if we still have an exit file now, it is stale
+    unlink "$rundir/$runname.exit";
   }
 
   my $bsdir = $BSConfig::bsdir || "/srv/obs";

--- a/src/backend/BSUtil.pm
+++ b/src/backend/BSUtil.pm
@@ -692,6 +692,8 @@ sub restartexit {
     waituntilgone("$runfile.restart");
     exit(0);
   }
+  # startup, if we still have an exit file now, it is stale
+  unlink "$runfile.exit";
 }
 
 sub xsystem {


### PR DESCRIPTION
in BSStdServer (used in bs_publish, bs_signer)
in BSUtil (used in bs_repserver)