### PR TITLE
Use shared canned responses for request review

### DIFF
--- a/src/api/app/components/add_review_collapsible_component.html.haml
+++ b/src/api/app/components/add_review_collapsible_component.html.haml
@@ -11,7 +11,9 @@
           .mb-3{ data: { 'canned-controller': '' } }
             - if Flipper.enabled?(:canned_responses, User.session)
               .d-flex.justify-content-end
-                = render CannedResponsesDropdownComponent.new(User.session.canned_responses.where(decision_type: nil).order(:title))
+                - request_canned_responses = bs_request.canned_responses.where(decision_type: nil)
+                - user_canned_responses = User.session.canned_responses.where(decision_type: nil)
+                = render CannedResponsesDropdownComponent.new(user_canned_responses.or(request_canned_responses).order(:title))
             = text_area_tag('comment', '', rows: 4, class: 'w-100 form-control', placeholder: 'Please comment on your decision')
           .mb-3
             .form-check

--- a/src/api/app/components/add_review_collapsible_component.rb
+++ b/src/api/app/components/add_review_collapsible_component.rb
@@ -1,2 +1,9 @@
 class AddReviewCollapsibleComponent < ApplicationComponent
+  attr_reader :bs_request
+
+  def initialize(bs_request)
+    super()
+
+    @bs_request = bs_request
+  end
 end

--- a/src/api/app/views/webui/request/beta_show_tabs/_conversation_aside.html.haml
+++ b/src/api/app/views/webui/request/beta_show_tabs/_conversation_aside.html.haml
@@ -5,7 +5,7 @@
       = render AddReviewDropdownComponent.new(bs_request: bs_request, user: User.session,
                                               my_open_reviews: my_open_reviews,
                                               history_elements: history_elements)
-    = render AddReviewCollapsibleComponent.new
+    = render AddReviewCollapsibleComponent.new(bs_request)
     .mb-2
       %h6
         Reviewers


### PR DESCRIPTION
This PR adds support for shared canned responses alongside the user specific ones for request reviews 