### PR TITLE
Use shared canned responses when requesting a review

### DIFF
--- a/src/api/app/views/webui/request/_add_reviewer_dialog.html.haml
+++ b/src/api/app/views/webui/request/_add_reviewer_dialog.html.haml
@@ -28,9 +28,13 @@
             = render partial: 'webui/shared/search_box', locals: { html_id: 'review_package', label: 'Package:', required: true,
                                                                      data: { source: autocomplete_packages_path } }
 
-          .mb-3
-            = label_tag(:review_comment, 'Comment for reviewer:')
-            = text_area_tag('review_comment', '', row: 3, class: 'form-control')
+          .mb-3{ data: { 'canned-controller': '' } }
+            - if Flipper.enabled?(:canned_responses, User.session)
+              .d-flex.justify-content-end
+                - request_canned_responses = bs_request.canned_responses.where(decision_type: nil)
+                - user_canned_responses = User.session.canned_responses.where(decision_type: nil)
+                = render CannedResponsesDropdownComponent.new(user_canned_responses.or(request_canned_responses).order(:title))
+            = text_area_tag('review_comment', '', row: 3, class: 'form-control', placeholder: 'Comment for reviewer')
         .modal-footer
           = render partial: 'webui/shared/dialog_action_buttons'
 

--- a/src/api/app/views/webui/request/beta_show_tabs/_ask_for_review.html.haml
+++ b/src/api/app/views/webui/request/beta_show_tabs/_ask_for_review.html.haml
@@ -1,4 +1,4 @@
 %button.btn.btn-outline-secondary.btn-sm{ data: { 'bs-toggle': 'modal', 'bs-target': '#add-reviewer-modal' }, title: 'Add Reviewer' }
   %i.fas.fa-plus-circle.me-1.text-outline-secondary
   %span.nav-item-name Add Reviewer
-= render partial: 'add_reviewer_dialog'
+= render partial: 'add_reviewer_dialog', locals: { bs_request: bs_request }

--- a/src/api/app/views/webui/request/beta_show_tabs/_conversation_aside.html.haml
+++ b/src/api/app/views/webui/request/beta_show_tabs/_conversation_aside.html.haml
@@ -12,7 +12,7 @@
     .mb-4
       = render partial: 'webui/request/beta_show_tabs/review_summary', collection: request_reviews, as: :review
   - if policy(bs_request).add_reviews?
-    = render partial: 'webui/request/beta_show_tabs/ask_for_review'
+    = render partial: 'webui/request/beta_show_tabs/ask_for_review', locals: { bs_request: bs_request }
 
   -# PACKAGE MAINTAINERS
   - unless package_maintainers.empty?

--- a/src/api/spec/features/webui/requests_spec.rb
+++ b/src/api/spec/features/webui/requests_spec.rb
@@ -209,7 +209,7 @@ RSpec.describe 'Requests', :js, :vcr do
         desktop? ? click_link('Add a Review') : click_menu_link('Actions', 'Add a Review')
         find_by_id('review_type').select('User')
         fill_in 'review_user', with: reviewer.login
-        fill_in 'Comment for reviewer:', with: 'Please review'
+        fill_in 'review_comment', with: 'Please review'
         click_button('Accept')
         expect(page).to have_text(/Open review for\s+#{reviewer.login}/)
         expect(page).to have_text('Request 1')


### PR DESCRIPTION
This PR adds support for shared canned responses alongside the user specific ones when requesting a review