### PR TITLE
Add ReleaseNotes-2.10.33

### DIFF
--- a/ReleaseNotes-2.10.32
+++ b/ReleaseNotes-2.10.32
@@ -16,19 +16,3 @@ Updates
 
  * Support for Leap-16.0 and SLES-16.0 as server system added
  * Updated perl-BSSolv dependency library
-
-=======
-Bugfixes
-========
-
-Frontend:
- * Update rack RubyGem to version 2.2.23
-   - [CVE-2026-34763] Root directory disclosure via unescaped regex interpolation in Rack::Directory.
-   - [CVE-2026-34230] Avoid O(n^2) algorithm in Rack::Utils.select_best_encoding which could lead to denial of service.
-   - [CVE-2026-26961] Raise error for multipart requests with multiple boundary parameters.
-   - [CVE-2026-34786] Rack::Static header_rules bypass via URL-encoded path mismatch.
-   - [CVE-2026-34831] Content-Length mismatch in Rack::Files error responses.
-   - [CVE-2026-34826] Multipart byte range processing allows denial of service via excessive overlapping ranges.
-   - [CVE-2026-34830] Rack::Sendfile header-based X-Accel-Mapping regex injection enables unauthorized X-Accel-Redirect.
-   - [CVE-2026-34785] Rack::Static prefix matching can expose unintended files under the static root.
-   - [CVE-2026-34829] Multipart parsing without Content-Length header allows unbounded chunked file uploads.

--- a/ReleaseNotes-2.10.33
+++ b/ReleaseNotes-2.10.33
@@ -1,0 +1,27 @@
+#
+# Open Build Service 2.10.33
+#
+
+Please read the README.md file for initial installation
+instructions or use the OBS Appliance from
+
+  http://openbuildservice.org/download/
+
+The dist/README.UPDATERS file has information for people updating
+from a previous OBS release.
+
+=======
+Bugfixes
+========
+
+Frontend:
+ * Update rack RubyGem to version 2.2.23
+   - [CVE-2026-34763] Root directory disclosure via unescaped regex interpolation in Rack::Directory.
+   - [CVE-2026-34230] Avoid O(n^2) algorithm in Rack::Utils.select_best_encoding which could lead to denial of service.
+   - [CVE-2026-26961] Raise error for multipart requests with multiple boundary parameters.
+   - [CVE-2026-34786] Rack::Static header_rules bypass via URL-encoded path mismatch.
+   - [CVE-2026-34831] Content-Length mismatch in Rack::Files error responses.
+   - [CVE-2026-34826] Multipart byte range processing allows denial of service via excessive overlapping ranges.
+   - [CVE-2026-34830] Rack::Sendfile header-based X-Accel-Mapping regex injection enables unauthorized X-Accel-Redirect.
+   - [CVE-2026-34785] Rack::Static prefix matching can expose unintended files under the static root.
+   - [CVE-2026-34829] Multipart parsing without Content-Length header allows unbounded chunked file uploads.


### PR DESCRIPTION
The latest changes (rack update) were mentioned in the already-existing ReleaseNotes-2.10.32, but they correspond to a new minor release.