### PR TITLE
Fix inline comments

### DIFF
--- a/src/api/app/models/bs_request_action.rb
+++ b/src/api/app/models/bs_request_action.rb
@@ -867,6 +867,11 @@ class BsRequestAction < ApplicationRecord
     Project.unscoped.find_by(name: source_project)&.embargo_date
   end
 
+  def canned_responses
+    package_ids = self.bs_request.bs_request_actions.pluck(:source_package_id, :target_package_id).flatten.uniq
+    CannedResponse.where(package_id: package_ids)
+  end
+
   private
 
   def cache_diffs


### PR DESCRIPTION
After the canned responses for bs_request got introduced the inline comments are not working anymore.
The `write_and_preview_component` gets the `bs_request` passed from the `_comment_field` partial as commentable.
In the case of inline comments this is a `bs_request_action` and not a `bs_request`.

Right now it fails with:
`ActionView::Template::Error (undefined method 'canned_responses' for an instance of BsRequestActionRelease)`

Fixes https://github.com/openSUSE/open-build-service/issues/19746