### PR TITLE
Do not add group as entity in reviewers list

### DIFF
--- a/src/api/app/components/bs_request_overview_avatars_component.rb
+++ b/src/api/app/components/bs_request_overview_avatars_component.rb
@@ -13,16 +13,12 @@ class BsRequestOverviewAvatarsComponent < ApplicationComponent
     @avatar_objects ||= if @review.for_user?
                           [@review.user]
                         elsif @review.for_group?
-                          group_avatar_objects
+                          @review.group.users
                         elsif @review.for_package?
                           package_avatar_objects
                         elsif @review.for_project?
                           project_avatar_objects
                         end
-  end
-
-  def group_avatar_objects
-    [@review.group.users, @review.group].flatten
   end
 
   def package_avatar_objects


### PR DESCRIPTION
To be discussed further: https://trello.com/c/MmYLVt46

When listing reviewer's avatars for groups, the group entity is not supposed to be counted in the list, otherwise it seems there is an additional reviewer which it doesn't actually. The information that it is a review for a group instead of a user is already provided by the group name right after the list of avatars (list or a single one in case the group is made of just one user).

## Before
<img width="1891" height="814" alt="image" src="https://github.com/user-attachments/assets/fdecec02-5ccf-4e4a-a6a1-48b0d2247326" />


## After
<img width="2018" height="917" alt="image" src="https://github.com/user-attachments/assets/2a2d6d70-457a-4467-b6de-407476ebebc2" />
