### PR TITLE
Handle invalid date parameters in project pulse

### DIFF
--- a/src/api/app/controllers/webui/projects/pulse_controller.rb
+++ b/src/api/app/controllers/webui/projects/pulse_controller.rb
@@ -20,7 +20,7 @@ module Webui
 
             render partial: 'pulse_list', locals: { project: @project,
                                                     builds: pulse.where(event_type: %i[build_fail build_success])
-                                                            .where(datetime: 24.hours.ago..Time.zone.now),
+                                                                 .where(datetime: 24.hours.ago..Time.zone.now),
                                                     new_packages: pulse.where(event_type: :create_package),
                                                     deleted_packages: pulse.where(event_type: :delete_package),
                                                     branches: pulse.where(event_type: :branch_command),
@@ -46,8 +46,8 @@ module Webui
         params[:to] ||= default_to.strftime('%Y-%m-%d')
 
         begin
-          @date_range_from = Time.zone.parse(params[:from]).beginning_of_day
-          @date_range_to = Time.zone.parse(params[:to]).end_of_day
+          @date_range_from = parse_date(params[:from], :beginning_of_day)
+          @date_range_to = parse_date(params[:to], :end_of_day)
         rescue ArgumentError
           flash.now[:error] = 'From or To dates are not in a valid format, using default time range'
           @date_range_from = default_from
@@ -61,6 +61,13 @@ module Webui
         end
 
         @date_range = @date_range_from..@date_range_to
+      end
+
+      def parse_date(value, boundary)
+        date = Time.zone.parse(value)
+        raise ArgumentError if date.nil?
+
+        date.public_send(boundary)
       end
     end
   end

--- a/src/api/spec/controllers/webui/projects/pulse_controller_spec.rb
+++ b/src/api/spec/controllers/webui/projects/pulse_controller_spec.rb
@@ -51,5 +51,16 @@ RSpec.describe Webui::Projects::PulseController do
         expect(controller.instance_variable_get(:@date_range_to)).to eq(default_to)
       end
     end
+
+    context 'with an unparsable date range parameter' do
+      subject { get :show, format: :html, params: { project_name: project.name, from: '@@QNJwx', to: '2026-04-28' } }
+
+      it { expect(flash[:error]).to eq('From or To dates are not in a valid format, using default time range') }
+
+      it 'assigns the default date range' do
+        expect(controller.instance_variable_get(:@date_range_from)).to eq(default_from)
+        expect(controller.instance_variable_get(:@date_range_to)).to eq(default_to)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

Treat unparsable project pulse date parameters as invalid input instead of calling `beginning_of_day` or `end_of_day` on `nil`. This keeps the existing fallback behavior for invalid date ranges and prevents the production exception.

Fixes #19708

## Test plan

- [x] `docker run --rm --network obs-validation -v /tmp/obs-19708:/obs -w /obs/src/api openbuildservice/frontend bundle exec rspec spec/controllers/webui/projects/pulse_controller_spec.rb`
- [x] `docker run --rm -v /tmp/obs-19708:/obs -w /obs/src/api openbuildservice/frontend bundle exec rubocop app/controllers/webui/projects/pulse_controller.rb spec/controllers/webui/projects/pulse_controller_spec.rb`
- [x] `docker run --rm -v /tmp/obs-19708:/obs -w /obs/src/api openbuildservice/frontend bundle exec ruby -c app/controllers/webui/projects/pulse_controller.rb`
- [x] `git diff --check`
