### PR TITLE
Resolve canned responses for request action comments

### DIFF
--- a/src/api/app/components/request_decision_component.html.haml
+++ b/src/api/app/components/request_decision_component.html.haml
@@ -13,7 +13,7 @@
       = render WriteAndPreviewComponent.new(form: form, preview_message_url: preview_comments_path, canned_responses_enabled: true,
                                             message_body_param: 'comment[body]',
                                             text_area_attributes: { object_name: 'reason', id_suffix: 'new_comment',
-                                            placeholder: decision_placeholder}, bs_request: @bs_request)
+                                            placeholder: decision_placeholder}, bs_request: @bs_request, user: User.session)
       .mt-2#decision-buttons-row
         %div
           - if policy(Comment.new(commentable:@bs_request)).create?

--- a/src/api/app/components/write_and_preview_component.html.haml
+++ b/src/api/app/components/write_and_preview_component.html.haml
@@ -10,11 +10,9 @@
   .tab-content.px-3
     .tab-pane.fade.show.active.my-3{ id: "write_#{text_area_attributes[:id_suffix]}",
                                      role: 'tabpanel', 'aria-labelledby': 'write-message-tab', 'data-canned-controller': '' }
-      - if Flipper.enabled?(:canned_responses, User.session) && canned_responses_enabled
+      - if user && Flipper.enabled?(:canned_responses, user) && canned_responses_enabled
         .d-flex.justify-content-end
-          - user_canned_responses = User.session.canned_responses.where(decision_type: nil)
-          - request_canned_responses = bs_request.canned_responses.where(decision_type: nil)
-          = render CannedResponsesDropdownComponent.new(user_canned_responses.or(request_canned_responses).order(:title))
+          = render CannedResponsesDropdownComponent.new(canned_responses)
       ~ form.text_area(text_area_attributes[:object_name], id: "#{text_area_attributes[:id_suffix]}_body",
         rows: text_area_attributes[:rows], required: text_area_attributes[:required],
         placeholder: text_area_attributes[:placeholder], class: 'w-100 form-control message-field')

--- a/src/api/app/components/write_and_preview_component.rb
+++ b/src/api/app/components/write_and_preview_component.rb
@@ -1,9 +1,9 @@
 class WriteAndPreviewComponent < ApplicationComponent
   attr_reader :form, :preview_message_url, :message_body_param, :text_area_attributes, :canned_responses_enabled, :commentable_id,
-              :commentable_type, :diff_file_index, :diff_line, :bs_request
+              :commentable_type, :diff_file_index, :diff_line, :bs_request, :user
 
   def initialize(form:, preview_message_url:, message_body_param:, text_area_attributes: {}, canned_responses_enabled: false,
-                 commentable_id: nil, commentable_type: nil, diff_file_index: nil, diff_line: nil, bs_request: nil)
+                 commentable_id: nil, commentable_type: nil, diff_file_index: nil, diff_line: nil, bs_request: nil, user: nil)
     super()
 
     @form = form
@@ -16,9 +16,30 @@ class WriteAndPreviewComponent < ApplicationComponent
     @diff_file_index = diff_file_index
     @diff_line = diff_line
     @bs_request = bs_request
+    @user = user
+  end
+
+  def canned_responses
+    return CannedResponse.none unless user
+
+    user_canned_responses = user.canned_responses.where(decision_type: nil)
+
+    user_canned_responses.or(request_canned_responses).order(:title)
   end
 
   private
+
+  def request_canned_responses
+    request = if bs_request.respond_to?(:canned_responses)
+                bs_request
+              elsif bs_request.respond_to?(:bs_request)
+                bs_request.bs_request
+              end
+
+    return CannedResponse.none unless request
+
+    request.canned_responses.where(decision_type: nil)
+  end
 
   def text_area_attributes_defaults
     { rows: 4, placeholder: 'Write your message here... (Markdown markup is supported)', required: true,

--- a/src/api/app/views/webui/comment/_comment_field.html.haml
+++ b/src/api/app/views/webui/comment/_comment_field.html.haml
@@ -16,7 +16,7 @@
                                         placeholder: 'Write your comment here... (Markdown markup is supported)',
                                         commentable_type: commentable.class.name.underscore, commentable_id: commentable.id,
                                         diff_file_index: defined?(diff_file_index) ? diff_file_index : nil,
-                                        diff_line_number: defined?(line_number) ? line_number : nil }, bs_request: commentable)
+                                        diff_line_number: defined?(line_number) ? line_number : nil }, bs_request: commentable, user: User.session)
   .comment-controls.my-3
     - case form_method
     - when :post

--- a/src/api/spec/components/bs_request_comment_component_spec.rb
+++ b/src/api/spec/components/bs_request_comment_component_spec.rb
@@ -70,6 +70,32 @@ RSpec.describe BsRequestCommentComponent, type: :component do
     end
   end
 
+  context 'when canned responses are enabled for a comment on a request action' do
+    let(:source_package) { create(:package, :as_submission_source) }
+    let(:target_package) { create(:package) }
+    let(:bs_request) { create(:bs_request_with_submit_action, source_package: source_package, target_package: target_package) }
+    let(:commentable) { bs_request.bs_request_actions.first }
+    let(:comment_a) { travel_to(1.day.ago) { create(:comment, commentable: commentable, body: 'Comment A') } }
+
+    before do
+      Flipper.enable(:canned_responses)
+      User.session = comment_a.user
+      create(:canned_response, user: comment_a.user, title: 'Use this reply')
+      create(:canned_response, user: create(:confirmed_user), package: source_package, title: 'Source package reply')
+      render_inline(described_class.new(comment: comment_a, commentable: commentable, level: 1))
+    end
+
+    after do
+      Flipper.disable(:canned_responses)
+    end
+
+    it 'renders canned responses for the action comment form' do
+      expect(rendered_content).to(have_text('Canned Responses')
+        .and(have_text('Use this reply'))
+        .and(have_text('Source package reply')))
+    end
+  end
+
   context 'when rendering a comment thread' do
     let!(:comment_b) { create(:comment_request, commentable: commentable, body: 'Comment B', parent: comment_a) } # level 1 => 2 nested .timeline-item-comment
     let(:comment_c) { create(:comment_request, commentable: commentable, body: 'Comment C', parent: comment_b) }


### PR DESCRIPTION
## Summary

Resolve canned responses for request action comments by looking up the parent request when the commentable object is a request action. The write and preview component now receives the current user explicitly and can combine user canned responses with request-level responses without assuming the commentable itself is a `BsRequest`.

Fixes #19744

## Test plan

- [x] `docker run --rm --network obs-validation -v /tmp/obs-19744:/obs -w /obs/src/api openbuildservice/frontend bundle exec rspec spec/components/bs_request_comment_component_spec.rb`
- [x] `docker run --rm -v /tmp/obs-19744:/obs -w /obs/src/api openbuildservice/frontend bundle exec rubocop app/components/write_and_preview_component.rb spec/components/bs_request_comment_component_spec.rb`
- [x] `docker run --rm -v /tmp/obs-19744:/obs -w /obs/src/api openbuildservice/frontend bundle exec ruby -c app/components/write_and_preview_component.rb`
- [x] `git diff --check`
