### PR TITLE
Join labels for project datatable searches

### DIFF
--- a/src/api/app/datatables/project_datatable.rb
+++ b/src/api/app/datatables/project_datatable.rb
@@ -17,7 +17,9 @@ class ProjectDatatable < Datatable
 
   # rubocop:disable Naming/AccessorMethodName
   def get_raw_records
-    options[:projects]
+    options[:projects].left_joins(label_globals: :label_template_global)
+                      .includes(label_globals: :label_template_global)
+                      .references(:label_globals, :label_template_global).distinct
   end
   # rubocop:enable Naming/AccessorMethodName
 

--- a/src/api/spec/controllers/webui/project_controller_spec.rb
+++ b/src/api/spec/controllers/webui/project_controller_spec.rb
@@ -170,6 +170,43 @@ RSpec.describe Webui::ProjectController, :vcr do
     it { expect(assigns(:roles)).to match_array(Role.local_roles) }
   end
 
+  describe 'GET #subprojects' do
+    let(:parent_project) { create(:project, name: 'ParentProject') }
+    let!(:subproject) { create(:project, name: 'ParentProject:Subproject') }
+    let(:label_template_global) { create(:label_template_global, name: 'Packaging') }
+    let(:another_label_template_global) { create(:label_template_global, name: 'Package Maintenance') }
+    let(:datatable_params) do
+      {
+        project: parent_project.name,
+        type: 'subproject',
+        draw: '1',
+        columns: {
+          '0' => { data: 'name', searchable: 'true', orderable: 'true', search: { value: '', regex: 'false' } },
+          '1' => { data: 'labels', searchable: 'true', orderable: 'true', search: { value: '', regex: 'false' } },
+          '2' => { data: 'title', searchable: 'true', orderable: 'true', search: { value: '', regex: 'false' } }
+        },
+        order: { '0' => { column: '0', dir: 'asc' } },
+        start: '0',
+        length: '25',
+        search: { value: 'pack', regex: 'false' }
+      }
+    end
+
+    before do
+      create(:label_global, project: subproject, label_template_global: label_template_global)
+      create(:label_global, project: subproject, label_template_global: another_label_template_global)
+      get :subprojects, params: datatable_params, format: :json
+    end
+
+    it { expect(response).to have_http_status(:ok) }
+
+    it 'finds subprojects by global label name' do
+      expect(json_response['recordsFiltered']).to eq(1)
+      expect(json_response['data'].size).to eq(1)
+      expect(json_response['data'].first['name']).to include(subproject.name)
+    end
+  end
+
   describe 'GET #new' do
     before do
       login user


### PR DESCRIPTION
## Summary

Join and eager load global label templates in the project datatable query so subproject, sibling, and parent project searches can filter by label names. The query also keeps distinct project rows so multiple matching labels do not duplicate a project in the datatable results.

Fixes #19695

## Test plan

- [x] `docker run --rm --network obs-validation -v /tmp/obs-19695:/obs -w /obs/src/api openbuildservice/frontend bundle exec rspec spec/controllers/webui/project_controller_spec.rb:173`
- [x] `docker run --rm -v /tmp/obs-19695:/obs -w /obs/src/api openbuildservice/frontend bundle exec rubocop app/datatables/project_datatable.rb spec/controllers/webui/project_controller_spec.rb`
- [x] `docker run --rm -v /tmp/obs-19695:/obs -w /obs/src/api openbuildservice/frontend bundle exec ruby -c app/datatables/project_datatable.rb`
- [x] `git diff --check`
