### PR TITLE
Adapt contribution guides to fight AI slop

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,4 @@
+<!--  Thanks for sending a pull request!  Here are some tips for you:
+
+1. If this is your first time, please read our contributor guidelines: https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
+-->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,6 +122,20 @@ Please make sure to mind our continuous integration cycle that includes:
 
 If one of the goes wrong for your pull request please address the issue.
 
+## AI Guidance
+
+Using AI tools to help write your contribution is acceptable, as long as you follow the principles described below. 
+
+As the author, you are *accountable* for the code you submit. Contributing to Open Build Service means vouching for the quality, license compliance, and utility of your contribution.
+
+Do not leave the first review of AI generated changes to the reviewers. Verify the changes (code review, testing, etc.) before submitting your contribution. Reviewers may ask questions about your AI-assisted code, and if you cannot explain why a change was made, the PR will be closed.
+
+When responding to review comments, you must do so without relying on AI tools. Reviewers want to engage directly with you, not with generated responses from your AI tool. If you do not engage directly with reviewers, the PR will be closed.
+
+You **MUST** disclose if you have used generative AI tools in preparing portions of your contribution. The recommended method is an `Assisted-by:` [git commit message trailer](https://git-scm.com/docs/SubmittingPatches#commit-trailers) like
+
+`Assisted-by: AGENT_NAME:MODEL_VERSION`
+
 ## Tell Us If You Need Help
 
 The Open Build Service developer community is here for you. If you are stuck


### PR DESCRIPTION
An AI "policy". Wording is ~~stolen~~ inspired from 

- https://github.com/kubernetes/community/blob/main/contributors/guide/pull-requests.md#ai-guidance
- https://docs.fedoraproject.org/en-US/council/policy/ai-contribution-policy/
- https://docs.kernel.org/process/coding-assistants.html#attribution