### PR TITLE
Fix roles-users associations

### DIFF
--- a/src/api/app/models/role.rb
+++ b/src/api/app/models/role.rb
@@ -18,7 +18,8 @@ class Role < ApplicationRecord
   has_many :relationships, dependent: :destroy
 
   # roles have n:m relations for users
-  has_and_belongs_to_many :users, -> { distinct }
+  has_many :roles_users, inverse_of: :role, dependent: :destroy
+  has_many :users, -> { distinct }, through: :roles_users
   # roles have n:m relations to groups
   has_and_belongs_to_many :groups, -> { distinct }
   # roles have n:m relations to permissions

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -19,7 +19,7 @@ class User < ApplicationRecord
 
   has_many :watched_items, dependent: :destroy
   has_many :groups_users, inverse_of: :user
-  has_many :roles_users, inverse_of: :user
+  has_many :roles_users, inverse_of: :user, dependent: :destroy
   has_many :roles, through: :roles_users
   has_many :relationships, inverse_of: :user, dependent: :destroy
 

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -753,7 +753,13 @@ class User < ApplicationRecord
   end
 
   def update_globalroles(global_roles)
-    roles.replace(global_roles + roles.where(global: false))
+    # Preserve existing non-global roles when updating global roles.
+    target_roles = global_roles + roles.where(global: false)
+    roles_to_remove = roles - target_roles
+    roles_to_add = target_roles - roles
+
+    roles.destroy(*roles_to_remove) if roles_to_remove.any?
+    roles << roles_to_add if roles_to_add.any?
   end
 
   def display_name


### PR DESCRIPTION
There is a join model, RolesUser, between Role and User. Therefore, we expect to have 'has_many :through' associations on both sides. However, that's true on the User side but not on the Role side which has been using 'has_and_belongs_to_many'.

[has_many :through vs has_and_belongs_to_many](https://guides.rubyonrails.org/association_basics.html#has-many-through-vs-has-and-belongs-to-many)

<img width="938" height="878" alt="Screenshot From 2026-06-01 15-38-27" src="https://github.com/user-attachments/assets/f3dec227-08a7-4911-a4a2-cdcfdcc0894c" />


Apart from that, using `roles.replace` doesn't trigger the callbacks, so I adapt the code to do so.
