### PR TITLE
Affected user receives the global role notification

### DIFF
--- a/src/api/app/models/event/global_role_assigned.rb
+++ b/src/api/app/models/event/global_role_assigned.rb
@@ -15,7 +15,7 @@ module Event
               when 'Moderator'
                 User.admins.or(User.moderators)
               end
-      users.where.not(login: payload['who']).uniq if users
+      User.where(id: users).or(User.where(login: payload['user'])).where.not(login: payload['who'])
     end
 
     def parameters_for_notification

--- a/src/api/spec/models/event/global_role_assigned_spec.rb
+++ b/src/api/spec/models/event/global_role_assigned_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe Event::GlobalRoleAssigned, type: :model do
+  describe '#admin_moderator_or_staffs' do
+    let!(:admin) { create(:admin_user) }
+    let!(:staff) { create(:staff_user) }
+    let!(:moderator) { create(:moderator) }
+    let!(:affected_user) { create(:confirmed_user, login: 'affected_user') }
+    let!(:originator) { create(:admin_user) }
+
+    context "when the enabled role is 'Staff'" do
+      let(:event) do
+        described_class.new('role' => 'Staff', 'user' => affected_user.login, 'who' => originator.login)
+      end
+
+      it 'notifies admins, staff, and the target user, but excludes the originator' do
+        result = event.admin_moderator_or_staffs
+        expect(result).to include(admin, staff, affected_user)
+        expect(result).not_to include(moderator, originator)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Not only their colleagues on the role but themselves should receive the notification about a global role enabled or disabled.
