### PR TITLE
Keep notification filters when returning from targets

### DIFF
--- a/src/api/app/controllers/concerns/webui/notifications_handler.rb
+++ b/src/api/app/controllers/concerns/webui/notifications_handler.rb
@@ -1,6 +1,10 @@
 module Webui::NotificationsHandler
   extend ActiveSupport::Concern
 
+  included do
+    helper_method :notification_target_path_with_return_to, :notification_return_to_path, :notification_context_params
+  end
+
   def handle_notification
     return unless User.session && params[:notification_id]
 
@@ -9,5 +13,34 @@ module Webui::NotificationsHandler
     return unless NotificationPolicy.new(User.session, current_notification).update?
 
     current_notification
+  end
+
+  private
+
+  def notification_target_path_with_return_to(path)
+    uri = URI.parse(path)
+    return_to_query = { return_to: request.fullpath }.to_query
+    uri.query = [uri.query, return_to_query].compact_blank.join('&')
+    uri.to_s
+  rescue URI::InvalidURIError
+    path
+  end
+
+  def notification_return_to_path
+    uri = URI.parse(params[:return_to].to_s)
+
+    return my_notifications_path if uri.scheme.present? || uri.host.present?
+    return my_notifications_path unless uri.path == my_notifications_path
+
+    uri.to_s
+  rescue URI::InvalidURIError
+    my_notifications_path
+  end
+
+  def notification_context_params
+    {
+      notification_id: params[:notification_id],
+      return_to: params[:return_to]
+    }.compact
   end
 end

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -52,7 +52,8 @@ class Webui::RequestController < Webui::WebuiController
 
   # TODO: Remove this once request_show_redesign is rolled out
   def show
-    redirect_to request_beta_show_path(params[:number], params[:request_action_id], { notification_id: params[:notification_id] }) if Flipper.enabled?(:request_show_redesign, User.possibly_nobody)
+    redirect_to(request_beta_show_path(params[:number], params[:request_action_id], notification_context_params)) && return if Flipper.enabled?(:request_show_redesign, User.possibly_nobody)
+
     @diff_limit = params[:full_diff] ? 0 : nil
     @is_author = @bs_request.creator == User.possibly_nobody.login
 
@@ -405,7 +406,7 @@ class Webui::RequestController < Webui::WebuiController
   end
 
   def check_beta_user_redirect
-    redirect_to request_show_path(params[:number], params[:request_action_id], { notification_id: params[:notification_id] }) unless Flipper.enabled?(:request_show_redesign, User.possibly_nobody)
+    redirect_to request_show_path(params[:number], params[:request_action_id], notification_context_params) unless Flipper.enabled?(:request_show_redesign, User.possibly_nobody)
   end
 
   def addreview_opts

--- a/src/api/app/controllers/webui/users/notifications_controller.rb
+++ b/src/api/app/controllers/webui/users/notifications_controller.rb
@@ -1,5 +1,6 @@
 class Webui::Users::NotificationsController < Webui::WebuiController
   include Webui::NotificationsFilter
+  include Webui::NotificationsHandler
 
   ALLOWED_FILTERS = %w[all comments requests incoming_requests outgoing_requests relationships_created relationships_deleted build_failures
                        reports reviews workflow_runs appealed_decisions decisions member_on_groups upstream_package_version_changed token_membership_update
@@ -53,7 +54,7 @@ class Webui::Users::NotificationsController < Webui::WebuiController
     paginate_notifications
 
     respond_to do |format|
-      format.html { redirect_to my_notifications_path }
+      format.html { redirect_to notification_return_to_path }
       format.js do
         render partial: 'update', locals: {
           notifications: @notifications,

--- a/src/api/app/views/layouts/webui/_notification_toolbar.html.haml
+++ b/src/api/app/views/layouts/webui/_notification_toolbar.html.haml
@@ -1,22 +1,23 @@
 .notification-toolbar.sticky-top.navbar.bg-body-secondary.border-bottom
   .container-fluid
     - if request_action
-      = link_to(request_show_path(number: request_action.bs_request.number, request_action_id: request_action.id, notification_id: notification),
+      = link_to(request_show_path(number: request_action.bs_request.number, request_action_id: request_action.id, notification_id: notification,
+                                  return_to: notification_return_to_path),
                 class: 'btn btn-sm btn-outline-secondary', title: 'Back to request action') do
         %i.fas.fa-arrow-left
         Back to request action "#{request_action.type.titleize}"
     - else
-      = link_to(my_notifications_path, class: 'btn btn-sm btn-outline-secondary', title: 'Back to notifications') do
+      = link_to(notification_return_to_path, class: 'btn btn-sm btn-outline-secondary', title: 'Back to notifications') do
         %i.fas.fa-arrow-left
         Back to notifications
       - if notification.unread?
-        = link_to(my_notifications_path(notification_ids: [notification.id], button: 'read'),
+        = link_to(my_notifications_path(notification_ids: [notification.id], button: 'read', return_to: notification_return_to_path),
                   id: dom_id(notification, :update), method: :put,
                   class: 'btn btn-sm btn-outline-success', title: 'Mark as read') do
           %i.fas.fa-check
           Mark as read
       - else
-        = link_to(my_notifications_path(notification_ids: [notification.id], button: 'unread'),
+        = link_to(my_notifications_path(notification_ids: [notification.id], button: 'unread', return_to: notification_return_to_path),
                   id: dom_id(notification, :update), method: :put,
                   class: 'btn btn-sm btn-outline-success', title: 'Mark as unread') do
           %i.fas.fa-undo

--- a/src/api/app/views/webui/users/notifications/_notification.html.haml
+++ b/src/api/app/views/webui/users/notifications/_notification.html.haml
@@ -10,7 +10,7 @@
         .col
           = notification_icon(notification)
           - if notification.link_path.present?
-            = link_to(notification.link_text, notification.link_path, class: 'mx-1')
+            = link_to(notification.link_text, notification_target_path_with_return_to(notification.link_path), class: 'mx-1')
           - else
             %span.fst-italic.mx-1
               = notification.link_text

--- a/src/api/spec/controllers/concerns/notifications_handler_spec.rb
+++ b/src/api/spec/controllers/concerns/notifications_handler_spec.rb
@@ -1,0 +1,36 @@
+RSpec.describe ApplicationController do # rubocop:disable RSpec/SpecFilePathFormat
+  controller do
+    include Webui::NotificationsHandler
+
+    def index
+      head :ok
+    end
+  end
+
+  describe '#notification_target_path_with_return_to' do
+    let(:target_path) { controller.send(:notification_target_path_with_return_to, '/request/show/1?notification_id=2') }
+    let(:uri) { URI.parse(target_path) }
+    let(:query) { Rack::Utils.parse_nested_query(uri.query) }
+
+    it 'adds the current request path as return_to' do
+      get :index, params: { kind: 'requests' }
+
+      expect(uri.path).to eq('/request/show/1')
+      expect(query).to include('notification_id' => '2', 'return_to' => request.fullpath)
+    end
+
+    it 'returns the original path when the target path is invalid' do
+      get :index
+
+      expect(controller.send(:notification_target_path_with_return_to, 'http://[::1')).to eq('http://[::1')
+    end
+  end
+
+  describe '#notification_return_to_path' do
+    it 'returns the notifications path when the return path is invalid' do
+      get :index, params: { return_to: 'http://[::1' }
+
+      expect(controller.send(:notification_return_to_path)).to eq(my_notifications_path)
+    end
+  end
+end

--- a/src/api/spec/controllers/webui/request_controller_spec.rb
+++ b/src/api/spec/controllers/webui/request_controller_spec.rb
@@ -42,6 +42,21 @@ RSpec.describe Webui::RequestController, :vcr do
       end
     end
 
+    context 'when redirecting to the beta request page' do
+      let(:notification) { create(:notification_for_request, :web_notification, notifiable: bs_request, subscriber: receiver) }
+      let(:return_to) { '/my/notifications?kind%5B%5D=requests&state=unread' }
+
+      before do
+        allow(Flipper).to receive(:enabled?).and_call_original
+        allow(Flipper).to receive(:enabled?).with(:request_show_redesign, anything).and_return(true)
+        get :show, params: { number: bs_request.number, notification_id: notification.id, return_to: return_to }
+      end
+
+      it 'preserves the notification return path' do
+        expect(response).to redirect_to(request_beta_show_path(bs_request.number, notification_id: notification.id, return_to: return_to))
+      end
+    end
+
     context 'when there are package maintainers' do
       # The hint will only be shown, when the target package has at least one
       # maintainer. So we'll gonna add a maintainer to the target package.

--- a/src/api/spec/controllers/webui/users/notifications_controller_spec.rb
+++ b/src/api/spec/controllers/webui/users/notifications_controller_spec.rb
@@ -283,6 +283,41 @@ RSpec.describe Webui::Users::NotificationsController do
       end
     end
 
+    context 'when a user marks a notification as read from a notification target page' do
+      subject do
+        login user
+        put :update, params: { notification_ids: [state_change_notification.id], user_login: user.login,
+                               button: 'read', return_to: return_to }
+      end
+
+      context 'with a valid notifications return path' do
+        let(:return_to) { '/my/notifications?kind%5B%5D=requests&state=unread' }
+
+        it 'redirects to the filtered notifications page' do
+          subject
+          expect(response).to redirect_to(return_to)
+        end
+      end
+
+      context 'with an external return path' do
+        let(:return_to) { 'https://example.com/my/notifications?kind%5B%5D=requests' }
+
+        it 'redirects to the default notifications page' do
+          subject
+          expect(response).to redirect_to(my_notifications_path)
+        end
+      end
+
+      context 'with an unrelated internal return path' do
+        let(:return_to) { '/project/show/home:foo' }
+
+        it 'redirects to the default notifications page' do
+          subject
+          expect(response).to redirect_to(my_notifications_path)
+        end
+      end
+    end
+
     context 'when a user tries to mark other user notifications as read' do
       subject! do
         login user_to_log_in

--- a/src/api/spec/features/webui/users/notification_package_spec.rb
+++ b/src/api/spec/features/webui/users/notification_package_spec.rb
@@ -16,8 +16,10 @@ RSpec.describe 'NotificationPackage', :js do
     end
 
     it 'contains a link pointing to the report' do
+      notification_path = "/package/show/#{notification.notifiable.project.name}/#{notification.notifiable.name}"
+
       expect(page).to have_link("New upstream version for #{notification.notifiable.name}",
-                                href: "/package/show/#{notification.notifiable.project.name}/#{notification.notifiable.name}?notification_id=#{notification.id}")
+                                href: "#{notification_path}?notification_id=#{notification.id}&return_to=%2Fmy%2Fnotifications")
     end
 
     it 'contains a description' do

--- a/src/api/spec/features/webui/users/notification_user_spec.rb
+++ b/src/api/spec/features/webui/users/notification_user_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'NotificationUser', :js do
 
     it 'contains a link pointing to the user' do
       expect(page).to have_link('New Global Role Assigned',
-                                href: "/users/#{user.login}?notification_id=#{notification.id}")
+                                href: "/users/#{user.login}?notification_id=#{notification.id}&return_to=%2Fmy%2Fnotifications")
     end
   end
 end

--- a/src/api/spec/features/webui/users/notifications_spec.rb
+++ b/src/api/spec/features/webui/users/notifications_spec.rb
@@ -100,13 +100,28 @@ RSpec.describe 'User notifications', :js do
       end
     end
 
+    context 'when returning from a request notification' do
+      let!(:notification_for_request) { create(:notification_for_request, :web_notification, :request_state_change, subscriber: user) }
+
+      before do
+        visit my_notifications_path(kind: 'requests')
+        click_link notification_for_request.link_text
+        click_link 'Back to notifications'
+      end
+
+      it 'preserves the request notification filter' do
+        expect(page).to have_current_path(my_notifications_path(kind: 'requests'), ignore_query: false)
+      end
+    end
+
     context 'when having less notifications than the maximum per page' do
       it { expect(page).to have_no_text("Mark all as 'Read'") }
     end
 
     context 'when the notification is about a comment for report' do
       it 'contains a link pointing to the report' do
-        expect(page).to have_link('Comment on Report', href: "/reports/#{notification_for_reports_comment.notifiable.commentable_id}")
+        report_path = "/reports/#{notification_for_reports_comment.notifiable.commentable_id}"
+        expect(page).to have_link('Comment on Report', href: "#{report_path}?return_to=%2Fmy%2Fnotifications")
       end
 
       it 'mentions which user commented on the report' do


### PR DESCRIPTION
Keep notification filters when returning from notification target pages. Notifications links now carry a retrun_to URL so that "Back to Notifications" and "Mark as read/unread" return to the same filtered notifications list.