### PR TITLE
Models and scopes needed for the notification filter by packages

### DIFF
--- a/src/api/.database_consistency.todo.yml
+++ b/src/api/.database_consistency.todo.yml
@@ -1497,6 +1497,10 @@ Notification:
   web:
     ThreeStateBooleanChecker:
       enabled: false
+NotifiedPackage:
+  index_notified_packages_on_notification_id:
+    RedundantIndexChecker:
+      enabled: false
 NotifiedProject:
   index_notified_projects_on_notification_id:
     RedundantIndexChecker:

--- a/src/api/app/models/notification.rb
+++ b/src/api/app/models/notification.rb
@@ -10,6 +10,7 @@ class Notification < ApplicationRecord
 
   has_many :notified_projects, dependent: :destroy
   has_many :projects, through: :notified_projects
+  has_many :notified_packages, dependent: :destroy
   has_and_belongs_to_many :groups
 
   serialize :event_payload, coder: JSON
@@ -47,6 +48,7 @@ class Notification < ApplicationRecord
   scope :for_token_membership_update, -> { where(notifiable_type: 'Token::Workflow') }
 
   scope :for_project_name, ->(project_name) { joins(:projects).where(projects: { name: project_name }) }
+  scope :for_notifiable_package_name, ->(package_name) { joins(:notified_packages).where(notified_packages: { package_name: package_name }) }
   scope :for_group_title, ->(group_title) { joins(:groups).where(groups: { title: group_title }) }
   scope :for_request_state, ->(request_state) { joins(:bs_request).where(bs_request: { state: request_state }) }
   scope :stale, -> { where(created_at: ...(CONFIG['notifications_lifetime'] ||= 365).days.ago) }

--- a/src/api/app/models/notified_package.rb
+++ b/src/api/app/models/notified_package.rb
@@ -1,0 +1,32 @@
+class NotifiedPackage < ApplicationRecord
+  belongs_to :notification
+
+  validates :notification_id, uniqueness: { scope: :package_name }
+  validates :package_name, presence: true, length: { maximum: 255 }
+
+  scope :for_user_web_notifications, ->(user) {
+    joins(:notification)
+      .merge(user.notifications.for_web)
+      .distinct
+  }
+end
+
+# == Schema Information
+#
+# Table name: notified_packages
+#
+#  id              :bigint           not null, primary key
+#  package_name    :string(255)      not null, uniquely indexed => [notification_id], indexed
+#  created_at      :datetime         not null
+#  notification_id :bigint           not null, indexed, uniquely indexed => [package_name]
+#
+# Indexes
+#
+#  index_notified_packages_on_notification_id                   (notification_id)
+#  index_notified_packages_on_notification_id_and_package_name  (notification_id,package_name) UNIQUE
+#  index_notified_packages_on_package_name                      (package_name)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (notification_id => notifications.id)
+#

--- a/src/api/app/services/notified_packages.rb
+++ b/src/api/app/services/notified_packages.rb
@@ -1,0 +1,46 @@
+class NotifiedPackages
+  def initialize(notification)
+    @notification = notification
+    @notifiable = notification.notifiable
+  end
+
+  # rubocop:disable Metrics/CyclomaticComplexity
+  def call
+    return [] if @notifiable.blank?
+
+    case @notification.notifiable_type
+    when 'Package'
+      [@notifiable.name]
+    when 'Comment'
+      case @notifiable.commentable_type
+      when 'Package'
+        [@notifiable.commentable.name]
+      when 'BsRequest'
+        package_names_from_request(@notifiable.commentable)
+      when 'BsRequestAction'
+        package_names_from_request(@notifiable.commentable.bs_request)
+      else
+        []
+      end
+    when 'BsRequest'
+      package_names_from_request(@notifiable)
+    when 'Report'
+      @notifiable.reportable.is_a?(Package) ? [@notifiable.reportable.name] : []
+    when 'Decision'
+      @notifiable.reports.filter_map { |r| r.reportable.name if r.reportable.is_a?(Package) }.uniq
+    when 'Appeal'
+      @notifiable.decision.reports.filter_map { |r| r.reportable.name if r.reportable.is_a?(Package) }.uniq
+    else
+      []
+    end.compact.uniq
+  end
+  # rubocop:enable Metrics/CyclomaticComplexity
+
+  private
+
+  def package_names_from_request(bs_request)
+    bs_request.bs_request_actions.flat_map do |action|
+      [action.source_package, action.target_package]
+    end.compact.uniq
+  end
+end

--- a/src/api/db/migrate/20260603102753_create_notified_packages.rb
+++ b/src/api/db/migrate/20260603102753_create_notified_packages.rb
@@ -1,0 +1,28 @@
+class CreateNotifiedPackages < ActiveRecord::Migration[7.2]
+  def up
+    create_table :notified_packages do |t|
+      t.bigint :notification_id, null: false
+      t.string :package_name, limit: 255, null: false
+      t.datetime :created_at, null: false
+
+      t.index :notification_id, name: 'index_notified_packages_on_notification_id'
+      t.index :package_name, name: 'index_notified_packages_on_package_name'
+      t.index [:notification_id, :package_name], unique: true,
+              name: 'index_notified_packages_on_notification_id_and_package_name'
+    end
+
+    safety_assured do
+      begin
+        execute "SET SESSION foreign_key_checks = 0"
+        add_foreign_key :notified_packages, :notifications
+      ensure
+        execute "SET SESSION foreign_key_checks = 1"
+      end
+    end
+  end
+
+  def down
+    remove_foreign_key :notified_packages, :notifications
+    drop_table :notified_packages
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_05_15_101229) do
+ActiveRecord::Schema[7.2].define(version: 2026_06_03_102753) do
   create_table "active_storage_attachments", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -820,6 +820,15 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_15_101229) do
     t.index ["web"], name: "index_notifications_on_web"
   end
 
+  create_table "notified_packages", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "notification_id", null: false
+    t.string "package_name", null: false
+    t.datetime "created_at", null: false
+    t.index ["notification_id", "package_name"], name: "index_notified_packages_on_notification_id_and_package_name", unique: true
+    t.index ["notification_id"], name: "index_notified_packages_on_notification_id"
+    t.index ["package_name"], name: "index_notified_packages_on_package_name"
+  end
+
   create_table "notified_projects", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "notification_id", null: false
     t.integer "project_id", null: false
@@ -1373,6 +1382,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_15_101229) do
   add_foreign_key "labels", "label_templates"
   add_foreign_key "maintained_projects", "projects", column: "maintenance_project_id", name: "maintained_projects_ibfk_2"
   add_foreign_key "maintained_projects", "projects", name: "maintained_projects_ibfk_1"
+  add_foreign_key "notified_packages", "notifications"
   add_foreign_key "package_issues", "issues", name: "package_issues_ibfk_2"
   add_foreign_key "package_issues", "packages", name: "package_issues_ibfk_1"
   add_foreign_key "package_kinds", "packages", name: "package_kinds_ibfk_1"

--- a/src/api/lib/tasks/notified_packages.rake
+++ b/src/api/lib/tasks/notified_packages.rake
@@ -1,0 +1,15 @@
+namespace :notifications do
+  desc 'Backfill notified_packages for existing notifications'
+  task backfill_notified_packages: :environment do
+    Notification.in_batches do |batch|
+      batch.each do |notification|
+        package_names = NotifiedPackages.new(notification).call
+        next if package_names.empty?
+
+        NotifiedPackage.insert_all(
+          package_names.map { |name| { notification_id: notification.id, package_name: name, created_at: Time.current } }
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is the first part of the notification filter by packages.

Contains only the scopes, models and services to be used later by the rest of the implementation.
 
This is intended to be deployed on production, and tested in isolation to look for performance issues before wiring it up to the notification filter.

## Some Background
This is a second attept, the [first one ](https://github.com/openSUSE/open-build-service/pull/18251) was reverted due to performance issues on production.

This one addresses the performance issues by implementing an intermediate model called NotifiedPackage that stores the relationships between notifications and the several notifiables having associations with packages. That way, when fetching the notifications, filtering by packages and while getting results for the autocomplete in the filter we just look for precomputed packages for the notifications we want to show. Much faster than the previous attempt.

## What Is This For?
We have the `NotifiedPackage` model. This wires together a `Notification` and a `Package`. We fill it when the notification is being created.

The model has a scope called `for_user_web_notifications` that return the `NotifiedPackage`s associated with the user's notifications. Later we'll use this to extract the package names for the filter autocomplete, and to know if we have to show the notification filter for packages.

We have a `for_notifiable_package_name` notification scope, that returns the notifications associated with a specific package name. This is the main filter mechanism, it is used when we fill in the package filter in the UI and a request is sent to the notifications controller.

We have the NotifiedPackages service. It's role is to get the package names associated with a specific `Notification`, navigating the appropriate associations depending of the notification type.

There's also a backfilling task to be run just after deploying to create `NotifiedPackage` models for previous notifications so they benefit from this mechanism.

## Performance Analysis

### For the `for_notifiable_package_name` scope:
```
=> EXPLAIN SELECT `notifications`.* FROM `notifications` INNER JOIN `notified_packages` ON `notified_packages`.`notification_id` = `notifications`.`id` WHERE `notified_packages`.`package_name` = 'pack'
+----+-------------+-------------------+--------+------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------+---------+---------------------------------------------------+------+-----------------------+
| id | select_type | table             | type   | possible_keys                                                                                                                                  | key                                     | key_len | ref                                               | rows | Extra                 |
+----+-------------+-------------------+--------+------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------+---------+---------------------------------------------------+------+-----------------------+
|  1 | SIMPLE      | notified_packages | ref    | index_notified_packages_on_notification_id_and_package_name,index_notified_packages_on_notification_id,index_notified_packages_on_package_name | index_notified_packages_on_package_name | 1022    | const                                             | 1    | Using index condition |
|  1 | SIMPLE      | notifications     | eq_ref | PRIMARY                                                                                                                                        | PRIMARY                                 | 8       | api_development.notified_packages.notification_id | 1    |                       |
+----+-------------+-------------------+--------+------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------+---------+---------------------------------------------------+------+-----------------------+
2 rows in set (0.00 sec)
```
There are no `ALL` values in the `type` column (that would indicate a full table scan, which is bad). The `ref` and `eq_ref` values tell us that the query would likely use the table indexes indicated in the `possible_keys` column , and here we can see it using them, as shown in the `keys` column.

### The `for_user_web_notifications` scope:
```
=> EXPLAIN SELECT DISTINCT `notified_packages`.* FROM `notified_packages` INNER JOIN `notifications` ON `notifications`.`id` = `notified_packages`.`notification_id` WHERE `notifications`.`subscriber_id` = 1 AND `notifications`.`subscriber_type` = 'User' AND `notifications`.`web` = TRUE
+----+-------------+-------------------+--------+--------------------------------------------------------------------------------------------------------+---------+---------+---------------------------------------------------+------+-----------------------+
| id | select_type | table             | type   | possible_keys                                                                                          | key     | key_len | ref                                               | rows | Extra                 |
+----+-------------+-------------------+--------+--------------------------------------------------------------------------------------------------------+---------+---------+---------------------------------------------------+------+-----------------------+
|  1 | SIMPLE      | notified_packages | ALL    | index_notified_packages_on_notification_id_and_package_name,index_notified_packages_on_notification_id | NULL    | NULL    | NULL                                              | 24   | Using temporary       |
|  1 | SIMPLE      | notifications     | eq_ref | PRIMARY,index_notifications_on_subscriber_type_and_subscriber_id,index_notifications_on_web            | PRIMARY | 8       | api_development.notified_packages.notification_id | 1    | Using where; Distinct |
+----+-------------+-------------------+--------+--------------------------------------------------------------------------------------------------------+---------+---------+---------------------------------------------------+------+-----------------------+
2 rows in set (0.00 sec)
```

There is an `ALL` value in the `type` column for the first row, that means the query is not using the the `index_notified_packages_on_notification_id` key even if it is shown as possible key to use, but this is due to the low amount of records in development (24). I expect the db engine to pick up the key to be used in production due to the larger volume of data.
