### PR TITLE
Notifications look&feel aligned to request index layout

### DIFF
--- a/src/api/app/views/webui/users/notifications/_notifications_list.html.haml
+++ b/src/api/app/views/webui/users/notifications/_notifications_list.html.haml
@@ -1,35 +1,30 @@
 - if notifications.total_count == 0
-  .card
-    .card-body
-      %p
-        There are no notifications for the current filter selection
-
+  .text-center.my-3
+    There are no notifications for the current filter selection
 - else
   :ruby
     update_path = my_notifications_path(kind: selected_filter[:kind], state: selected_filter[:state],
                                         project: selected_filter[:project], group: selected_filter[:group],
                                         page: params[:page])
   = form_tag(update_path, method: :put, remote: true) do
-    .card
-      .card-body.pt-1
-        = render(NotificationActionBarComponent.new(state: selected_filter[:state],
-                                                    update_path: update_path,
-                                                    total_count_notifications: notifications.count))
-        .text-center
-          %span.ms-3= page_entries_info notifications, entry_name: ''
-          - if notifications.total_count > Notification::THRESHOLD_TO_RECOMMEND_NOTIFICATION_MANAGEMENT
-            - unless cookies[:hide_notifications_banner]
-              .alert.alert-warning.d-flex.align-items-center.mt-2.justify-content-between
-                .flex-grow-1.d-flex
-                  .me-4
-                    %i.fa.fa-exclamation-triangle.me-2
-                    Too many notifications?
-                    = link_to 'Manage your subscriptions', my_subscriptions_path, class: 'alert-link'
-                .p-2.d-flex
-                  %button.btn-close{ type: "button", data: { bs_dismiss: "alert" }, aria: { label: "Close" }, id: "dismiss-banner-btn" }
+    = render(NotificationActionBarComponent.new(state: selected_filter[:state],
+                                                update_path: update_path,
+                                                total_count_notifications: notifications.count))
+    .text-center
+      %span.ms-3= page_entries_info notifications, entry_name: ''
+      - if notifications.total_count > Notification::THRESHOLD_TO_RECOMMEND_NOTIFICATION_MANAGEMENT
+        - unless cookies[:hide_notifications_banner]
+          .alert.alert-warning.d-flex.align-items-center.mt-2.justify-content-between
+            .flex-grow-1.d-flex
+              .me-4
+                %i.fa.fa-exclamation-triangle.me-2
+                Too many notifications?
+                = link_to 'Manage your subscriptions', my_subscriptions_path, class: 'alert-link'
+            .p-2.d-flex
+              %button.btn-close{ type: "button", data: { bs_dismiss: "alert" }, aria: { label: "Close" }, id: "dismiss-banner-btn" }
 
-        .list-group.list-group-flush.mt-3
-          = render partial: 'notification', collection: notifications, locals: { selected_filter: selected_filter, page: params[:page] }
+    .list-group.list-group-flush.mt-3
+      = render partial: 'notification', collection: notifications, locals: { selected_filter: selected_filter, page: params[:page] }
 
   = paginate notifications, views_prefix: 'webui', window: 2, params: { action: 'index', id: nil }
   = render partial: 'page_size_navigation', locals: { paginated_objects: notifications }

--- a/src/api/app/views/webui/users/notifications/index.html.haml
+++ b/src/api/app/views/webui/users/notifications/index.html.haml
@@ -2,22 +2,27 @@
 
 = render partial: 'index_actions'
 
+
 .row
-  .col-md-4.col-lg-3.px-0.px-md-3.sticky-top#filter-desktop
-    .card.mb-3
-      %strong.d-block.d-md-none.p-3{ data: { 'bs-toggle': 'collapse', 'bs-target': '#content-selector-filters' },
-                                  aria: { expanded: true, controls: 'filters' } }
-        Filtered by state:
-        = @filter_state.to_s.humanize
-        and type:
-        = @filter_kind.map { |s| s.to_s.humanize }.join(', ')
-        %i.float-end.mt-1.fa.fa-chevron-down#notifications-dropdown-trigger
-      .collapse#content-selector-filters
-        = render partial: 'notification_filter', locals: { selected_filter: @selected_filter,
-                                                           projects_for_filter: @projects_for_filter,
-                                                           groups_for_filter: @groups_for_filter }
-  .col-md-8.col-lg-9.px-0.px-md-3.d-none.content-list-loading
-    = render partial: 'webui/shared/loading', locals: { text: 'Loading...', wrapper_css: ['loading'] }
-  .col-md-8.col-lg-9.px-0.px-md-3.content-list#notifications-list
-    = render partial: 'notifications_list', locals: { notifications: @notifications,
-                                                      selected_filter: @selected_filter }
+  .px-0.px-md-3.mb-3
+    .card
+      .card-body
+        .row
+          .col-md-4.col-lg-3.px-0.px-md-3.sticky-top#filter-desktop
+            .card.border-start-0.border-top-0.border-bottom-0.rounded-0
+              %strong.d-block.d-md-none.p-3{ data: { 'bs-toggle': 'collapse', 'bs-target': '#content-selector-filters' },
+                                          aria: { expanded: true, controls: 'filters' } }
+                Filtered by state:
+                = @filter_state.to_s.humanize
+                and type:
+                = @filter_kind.map { |s| s.to_s.humanize }.join(', ')
+                %i.float-end.mt-1.fa.fa-chevron-down#notifications-dropdown-trigger
+              .collapse#content-selector-filters
+                = render partial: 'notification_filter', locals: { selected_filter: @selected_filter,
+                                                                  projects_for_filter: @projects_for_filter,
+                                                                  groups_for_filter: @groups_for_filter }
+          .col-md-8.col-lg-9.px-0.px-md-3.d-none.content-list-loading
+            = render partial: 'webui/shared/loading', locals: { text: 'Loading...', wrapper_css: ['loading'] }
+          .col-md-8.col-lg-9.px-0.px-md-3.content-list#notifications-list
+            = render partial: 'notifications_list', locals: { notifications: @notifications,
+                                                              selected_filter: @selected_filter }


### PR DESCRIPTION
Give Notifications page the same layout to the RequestIndex which is more compact, clean with less borders/boxed and more _breathing_ space.

# Before
<img width="1237" height="415" alt="image" src="https://github.com/user-attachments/assets/81882535-01ad-4ebf-968a-e5f575bc082d" />


# After

<img width="1414" height="464" alt="image" src="https://github.com/user-attachments/assets/78d8d0bf-9e5f-4d2c-97f3-bb995a6664fa" />



# Request Index layout
<img width="1397" height="540" alt="image" src="https://github.com/user-attachments/assets/d05bcdf9-51af-4b46-bd51-2deeacadfcfa" />
