### PR TITLE
fix: return 400 for invalid _meta XML on inherited packages

### DIFF
--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -425,9 +425,10 @@ Naming/VariableNumber:
     - 'test/functional/source_controller_test.rb'
     - 'test/unit/project_test.rb'
 
-# Offense count: 54
+# Offense count: 55
 RSpec/AnyInstance:
   Exclude:
+    - 'spec/controllers/source_package_meta_controller_spec.rb'
     - 'spec/controllers/staging/excluded_requests_controller_spec.rb'
     - 'spec/controllers/status_project_controller_spec.rb'
     - 'spec/controllers/webui/architectures_controller_spec.rb'

--- a/src/api/app/controllers/source_package_meta_controller.rb
+++ b/src/api/app/controllers/source_package_meta_controller.rb
@@ -49,20 +49,38 @@ class SourcePackageMetaController < SourceController
       authorize pkg, :update?
 
       change_package_protection_level?(pkg)
+
+      pkg.comment = params[:comment]
+      pkg.update_from_xml(@request_data)
     else
       prj = Project.get_by_name(@project_name)
       # necessary to pass the policy_class here
       # if its remote prj is a string
       authorize prj, :update?, policy_class: ProjectPolicy
       pkg = prj.packages.new(name: @package_name)
+      pkg.comment = params[:comment]
+      return unless update_inherited_package_from_xml(pkg)
     end
 
-    pkg.comment = params[:comment]
-    pkg.update_from_xml(@request_data)
     render_ok
   end
 
   private
+
+  # The package only exists via project inheritance, so we build and save a new
+  # local package. Saving it can raise ActiveRecord::RecordNotSaved, which -
+  # unlike the existing-package path - is not mapped to a client error and would
+  # otherwise surface as a 500. Treat it as a 400, the same validation error
+  # users get for a non-inherited package (#19529). The authorization check in
+  # #update stays outside this rescue so authorization failures keep returning
+  # 403. Returns false when an error was rendered so #update skips render_ok.
+  def update_inherited_package_from_xml(pkg)
+    pkg.update_from_xml(@request_data)
+    true
+  rescue ActiveRecord::RecordNotSaved => e
+    render_error status: 400, errorcode: 'invalid_record', message: e.message
+    false
+  end
 
   def change_package_protection_level?(pkg)
     # TODO: use pundit

--- a/src/api/spec/controllers/source_package_meta_controller_spec.rb
+++ b/src/api/spec/controllers/source_package_meta_controller_spec.rb
@@ -77,5 +77,107 @@ RSpec.describe SourcePackageMetaController, :vcr do
       it { expect(response).to have_http_status(:bad_request) }
       it { expect(Xmlhash.parse(response.body)['code']).to eq('validation_failed') }
     end
+
+    context 'inherited package' do
+      let(:package_name) { 'foo' }
+      let(:linked_project) { create(:project_with_package, package_name: package_name) }
+      let(:local_project) { create(:project, maintainer: user) }
+      let!(:link_association) { create(:linked_project, project: local_project, linked_db_project: linked_project) }
+
+      context 'with well-formated XML' do
+        let(:meta) do
+          <<~META
+            <package name="#{package_name}" project="#{local_project.name}">
+              <title>My inherited package</title>
+              <description/>
+            </package>
+          META
+        end
+
+        before do
+          login user
+          link_association
+          put :update, params: { project: local_project,
+                                 package: package_name },
+                       body: meta, format: :xml
+        end
+
+        it { expect(response).to have_http_status(:success) }
+
+        it 'creates a local package' do
+          expect(local_project.packages.exists?(name: package_name)).to be(true)
+        end
+      end
+
+      context 'with invalid XML' do
+        let(:meta) { '<title/>' }
+
+        before do
+          login user
+          link_association
+          put :update, params: { project: local_project,
+                                 package: package_name },
+                       body: meta, format: :xml
+        end
+
+        it { expect(response).to have_http_status(:bad_request) }
+        it { expect(Xmlhash.parse(response.body)['code']).to eq('validation_failed') }
+      end
+
+      # The inherited-package branch builds a non-persisted package and saves it.
+      # When that save aborts, Rails raises ActiveRecord::RecordNotSaved, which is
+      # not mapped to a client error globally and previously surfaced as a 500
+      # (#19529). The controller now maps it to a 400, matching the existing
+      # (persisted) package path.
+      context 'when saving the new package raises ActiveRecord::RecordNotSaved' do
+        let(:meta) do
+          <<~META
+            <package name="#{package_name}" project="#{local_project.name}">
+              <title>My inherited package</title>
+              <description/>
+            </package>
+          META
+        end
+
+        before do
+          login user
+          link_association
+          allow_any_instance_of(Package).to receive(:update_from_xml).and_raise(ActiveRecord::RecordNotSaved.new('Failed to save the record'))
+          put :update, params: { project: local_project,
+                                 package: package_name },
+                       body: meta, format: :xml
+        end
+
+        it { expect(response).to have_http_status(:bad_request) }
+        it { expect(Xmlhash.parse(response.body)['code']).to eq('invalid_record') }
+      end
+
+      context 'without permission to update the local project' do
+        let(:other_user) { create(:confirmed_user, login: 'jerry') }
+        let(:local_project) { create(:project, maintainer: other_user) }
+        let(:meta) do
+          <<~META
+            <package name="#{package_name}" project="#{local_project.name}">
+              <title>My inherited package</title>
+              <description/>
+            </package>
+          META
+        end
+
+        before do
+          login user
+          link_association
+          put :update, params: { project: local_project,
+                                 package: package_name },
+                       body: meta, format: :xml
+        end
+
+        it { expect(response).to have_http_status(:forbidden) }
+
+        it 'does not create a local package' do
+          expect(local_project.packages.exists?(name: package_name)).to be(false)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

`PUT source/:project/:package/_meta` with a body that fails package validation returned **HTTP 500** when the package is *inherited* (exists only via a project link, not as a real package in the project), but correctly returned **HTTP 400** for a non-inherited package. This maps the inherited path to a 400 so both code paths agree.

## Why this matters

As reported in #19529, the same malformed request behaves inconsistently:

```
$ osc api source/openSUSE:Factory:RISCV/python-eventlet/_meta -X PUT -d '<package .../>'
Server returned an error: HTTP Error 500: Internal Server Error
```

`@eduardoj` diagnosed that this only happens on inherited packages (`python-eventlet` is inherited), while a non-inherited package correctly returns:

```
HTTP Error 400: Bad Request
package validation error: 1:0: ERROR: Expecting element package, got title
```

A 500 leaks an internal error for what is really a client input problem, and the divergence between the two paths is confusing.

## Changes

In `SourcePackageMetaController#update`, the `else` branch (taken when the package exists only via project inheritance) builds an in-memory `prj.packages.new(name: ...)` and calls `update_from_xml`. On that path a save failure raises `ActiveRecord::RecordNotSaved`, which - unlike the existing-package path - is not mapped to a client error by `RescueHandler`, so it fell through to the generic 500 handler.

- Extracted the inherited-package save into `update_inherited_package_from_xml`, which rescues `ActiveRecord::RecordNotSaved` and renders a `400` with errorcode `invalid_record` (the same errorcode `RescueHandler` already uses for `ActiveRecord::RecordInvalid`).
- The `authorize` call stays outside the rescue, so authorization failures keep returning `403`.
- The existing (persisted) package path is unchanged, and valid XML on an inherited package still creates the package.

## Testing

Added request specs in `source_package_meta_controller_spec.rb` covering:
- valid `_meta` PUT against an inherited package still succeeds and creates the local package;
- invalid `_meta` XML against an inherited package returns `400` (was `500`);
- a `RecordNotSaved` from the inherited save maps to `400 invalid_record`;
- an authorization failure on the inherited path still returns `403`.

The existing non-inherited bad-XML `400` test is retained for parity. `rubocop` and the full `rspec` suite were not run locally (the suite needs a backend); both run in CI. `source_package_meta_controller_spec.rb` was added to the existing `RSpec/AnyInstance` `.rubocop_todo.yml` exclude list, consistent with the other controller specs that stub model behavior.

Fixes #19529

AI was used for assistance.
