### PR TITLE
Workflow runs look&feel aligned to common filters layout

### DIFF
--- a/src/api/app/views/webui/workflow_runs/index.html.haml
+++ b/src/api/app/views/webui/workflow_runs/index.html.haml
@@ -1,28 +1,30 @@
 - @pagetitle = 'Workflow Runs'
 
 .row
-  .col-md-4.col-lg-3.px-0.px-md-3.sticky-top#filter-desktop
-    .card.mb-3
-      %strong.d-block.d-md-none.p-3{ data: { 'bs-toggle': 'collapse', 'bs-target': '#content-selector-filters' },
-                                  aria: { expanded: true, controls: 'filters' } }
-        Filtered by: #{params[:status]&.humanize}
-        %i.float-end.mt-1.fa.fa-chevron-down#workflow-runs-dropdown-trigger
-      .collapse#content-selector-filters
-        = render WorkflowRunFilterComponent.new(token: @token, selected_filter: @selected_filter,
-                                                workflow_runs_relation: @workflow_runs_relation)
-  .col-md-8.col-lg-9.px-0.px-md-3.d-none.content-list-loading
-    = render partial: 'webui/shared/loading', locals: { text: 'Loading...', wrapper_css: ['loading'] }
-  .col-md-8.col-lg-9.px-0.px-md-3.content-list#workflow-run-list
+  .px-0.px-md-3.mb-3
     .card
       .card-body
-        - if @workflow_runs.blank?
-          .text-center
-            %p There are no workflow runs available
-        - else
-          .text-center
-            %span.ms-3= page_entries_info(@workflow_runs)
-          .p-3#workflow-runs
-            - @workflow_runs.each do |workflow_run|
-              .border-bottom.py-2{ id: "workflow-run-heading#{workflow_run.id}" }
-                = render(WorkflowRunRowComponent.new(workflow_run: workflow_run, token_id: @token.id))
-            = paginate @workflow_runs, views_prefix: 'webui'
+        .row
+          .col-md-4.col-lg-3.px-0.px-md-3.sticky-top#filter-desktop
+            .card.border-start-0.border-top-0.border-bottom-0.rounded-0
+              %strong.d-block.d-md-none.p-3{ data: { 'bs-toggle': 'collapse', 'bs-target': '#content-selector-filters' },
+                                          aria: { expanded: true, controls: 'filters' } }
+                Filtered by: #{params[:status]&.humanize}
+                %i.float-end.mt-1.fa.fa-chevron-down#workflow-runs-dropdown-trigger
+              .collapse#content-selector-filters
+                = render WorkflowRunFilterComponent.new(token: @token, selected_filter: @selected_filter,
+                                                        workflow_runs_relation: @workflow_runs_relation)
+          .col-md-8.col-lg-9.px-0.px-md-3.d-none.content-list-loading
+            = render partial: 'webui/shared/loading', locals: { text: 'Loading...', wrapper_css: ['loading'] }
+          .col-md-8.col-lg-9.px-0.px-md-3.content-list#workflow-run-list
+            - if @workflow_runs.blank?
+              .text-center.my-3
+                %p There are no workflow runs available
+            - else
+              .text-center.my-3
+                %span.ms-3= page_entries_info(@workflow_runs)
+              .p-3#workflow-runs
+                - @workflow_runs.each do |workflow_run|
+                  .border-bottom.py-2{ id: "workflow-run-heading#{workflow_run.id}" }
+                    = render(WorkflowRunRowComponent.new(workflow_run: workflow_run, token_id: @token.id))
+                = paginate @workflow_runs, views_prefix: 'webui'


### PR DESCRIPTION
Same as https://github.com/openSUSE/open-build-service/pull/19798

# Before
<img width="1296" height="348" alt="image" src="https://github.com/user-attachments/assets/4d38edab-6bb0-4228-8104-1a051c592d49" />


# After
<img width="1487" height="428" alt="image" src="https://github.com/user-attachments/assets/07bb2302-fc16-49fc-8004-623a5e7f7382" />
