### PR TITLE
Ignore breakman about Rails 7.2 EOL warning

### DIFF
--- a/src/api/config/brakeman.ignore
+++ b/src/api/config/brakeman.ignore
@@ -122,6 +122,25 @@
       "note": ""
     },
     {
+      "warning_type": "Unmaintained Dependency",
+      "warning_code": 122,
+      "fingerprint": "21ab0fe00fdd5899ffc405cff75aadb91b805ee996a614f7e27b08a287e9062d",
+      "check_name": "EOLRails",
+      "message": "Support for Rails 7.2.3.1 ends on 2026-08-09",
+      "file": "Gemfile.lock",
+      "line": 391,
+      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
+      "code": null,
+      "render_path": null,
+      "location": null,
+      "user_input": null,
+      "confidence": "Weak",
+      "cwe_id": [
+        1104
+      ],
+      "note": ""
+    },
+    {
       "warning_type": "SQL Injection",
       "warning_code": 0,
       "fingerprint": "23288c7e9dea90dd0d6a14268bf929de5b7651f16e9c2233776751400dda5d11",
@@ -249,7 +268,7 @@
       "check_name": "CrossSiteScripting",
       "message": "Unescaped model attribute",
       "file": "app/views/webui/package/_file.html.haml",
-      "line": 12,
+      "line": 13,
       "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
       "code": "::Haml::AttributeBuilder.build_data(true, \"'\", :order => (\"-#{(Unresolved Model).new[\"mtime\"]}\"))",
       "render_path": [
@@ -380,7 +399,7 @@
           "type": "controller",
           "class": "Webui::PackageController",
           "method": "users",
-          "line": 162,
+          "line": 163,
           "file": "app/controllers/webui/package_controller.rb",
           "rendered": {
             "name": "webui/package/users",
@@ -493,7 +512,7 @@
           "type": "controller",
           "class": "Webui::PackageController",
           "method": "rpmlint_result",
-          "line": 316,
+          "line": 329,
           "file": "app/controllers/webui/package_controller.rb",
           "rendered": {
             "name": "webui/package/_rpmlint_result",
@@ -527,7 +546,7 @@
           "type": "controller",
           "class": "Webui::PackageController",
           "method": "rdiff",
-          "line": 221,
+          "line": 234,
           "file": "app/controllers/webui/package_controller.rb",
           "rendered": {
             "name": "webui/package/rdiff",
@@ -561,7 +580,7 @@
           "type": "controller",
           "class": "Webui::PackageController",
           "method": "rdiff",
-          "line": 221,
+          "line": 234,
           "file": "app/controllers/webui/package_controller.rb",
           "rendered": {
             "name": "webui/package/rdiff",
@@ -619,7 +638,7 @@
           "type": "controller",
           "class": "Webui::ProjectController",
           "method": "buildresult",
-          "line": 224,
+          "line": 248,
           "file": "app/controllers/webui/project_controller.rb",
           "rendered": {
             "name": "webui/project/_buildstatus",
@@ -719,7 +738,7 @@
           "type": "controller",
           "class": "Webui::RequestController",
           "method": "beta_show",
-          "line": 50,
+          "line": 51,
           "file": "app/controllers/webui/request_controller.rb",
           "rendered": {
             "name": "webui/request/beta_show",
@@ -763,7 +782,7 @@
           "type": "controller",
           "class": "Webui::PackageController",
           "method": "rdiff",
-          "line": 221,
+          "line": 234,
           "file": "app/controllers/webui/package_controller.rb",
           "rendered": {
             "name": "webui/package/rdiff",


### PR DESCRIPTION
We know about Rails 7.2 is going to be EOL soon. But for now, let's suppress Brakeman warning and keep the PR check green.