### PR TITLE
Merge workflow run event source filters

### DIFF
--- a/src/api/app/components/workflow_run_filter_component.html.haml
+++ b/src/api/app/components/workflow_run_filter_component.html.haml
@@ -71,17 +71,11 @@
           = render partial: 'webui/shared/info_popover', locals: { position: 'bottom', text: event_source_info_text }
         .selected-content.small.ms-1
       .px-4.pb-2.accordion-collapse.collapse.show#workflow-filter-event-source
-        = render partial: 'webui/shared/input', locals: { html_id: 'pr_mr',
+        = render partial: 'webui/shared/input', locals: { html_id: 'event_source',
                                                           class: 'auto-submit-on-change',
-                                                          placeholder: 'eg. 12345',
-                                                          label: 'PR/MR',
-                                                          value: @selected_filter[:pr_mr] }
-        .mt-1
-          = render partial: 'webui/shared/input', locals: { html_id: 'commit_sha',
-                                                            class: 'auto-submit-on-change',
-                                                            placeholder: 'eg. 97561db8664eaf86a1e4c7b77d5fb5d5bff6681e',
-                                                            label: 'Commit',
-                                                            value: @selected_filter[:commit_sha] }
+                                                          placeholder: 'eg. 12345 or 97561db8664eaf86a1e4c7b77d5fb5d5bff6681e',
+                                                          label: 'MR/PR or Commit',
+                                                          value: @selected_filter[:event_source] }
   .text-center.mt-4.mb-4
     = link_to('Clear', token_workflow_runs_path(@token, []), class: 'btn btn-light border')
 

--- a/src/api/app/components/workflow_run_row_component.html.haml
+++ b/src/api/app/components/workflow_run_row_component.html.haml
@@ -11,12 +11,11 @@
           %span= formatted_event_source_name || "Unknown source"
           %span
             - if event_source_name
-              - field_to_filter_by = hook_event.in?(['pull_request', 'Merge Request Hook']) ? 'pr_mr' : 'commit_sha'
               = link_to event_source_url, { class: 'link-secondary mx-1',
                                             title: "Go to Event Source #{formatted_event_source_name}",
                                             target: '_blank' } do
                 %i.fa.fa-xs.fa-link.text-secondary
-              = link_to "?#{field_to_filter_by}=#{event_source_name}", { class: 'link-secondary mx-1', title: "Filter by this Event Source" } do
+              = link_to "?event_source=#{event_source_name}", { class: 'link-secondary mx-1', title: "Filter by this Event Source" } do
                 %i.fa.fa-xs.fa-filter.text-secondary
         .px-1
           %span= workflow_run.created_at

--- a/src/api/app/controllers/webui/workflow_runs_controller.rb
+++ b/src/api/app/controllers/webui/workflow_runs_controller.rb
@@ -11,13 +11,12 @@ class Webui::WorkflowRunsController < Webui::WebuiController
     relation = relation.with_statuses(status_params) if status_params.any?
     relation = relation.with_types(event_type_params) if event_type_params.any?
     relation = relation.with_actions(request_action) if request_action.any?
-    relation = relation.with_event_source_name(params[:pr_mr]) if params[:pr_mr].present?
-    relation = relation.with_event_source_name(params[:commit_sha]) if params[:commit_sha].present?
+    relation = relation.with_event_source_name(params[:event_source]) if params[:event_source].present?
 
     @workflow_runs_relation = relation
     @workflow_runs = relation.all.page(params[:page])
 
-    @selected_filter = { status: status_params, event_type: event_type_params, request_action: request_action, pr_mr: params[:pr_mr], commit_sha: params[:commit_sha] }
+    @selected_filter = { status: status_params, event_type: event_type_params, request_action: request_action, event_source: params[:event_source] }
     @token = Token::Workflow.find(params[:token_id])
   end
 


### PR DESCRIPTION
Use a single event_source filter for pr/mr numbers and commit hashes, and update row filter links to use the same query parameter.

Old:
<img width="563" height="372" alt="image" src="https://github.com/user-attachments/assets/194ce1fa-9b4e-4172-8df2-5a65c874dabd" />


New:
<img width="563" height="372" alt="image" src="https://github.com/user-attachments/assets/59f07cdf-9ceb-4a57-8600-7dbf59ff08da" />