### PR TITLE
Isolate reused search term in full_text_search_spec

### DIFF
--- a/src/api/spec/models/full_text_search_spec.rb
+++ b/src/api/spec/models/full_text_search_spec.rb
@@ -43,9 +43,10 @@ RSpec.describe FullTextSearch do
     end
 
     context 'specifying classes' do
-      let!(:project) { create(:project, name: 'test', title: '', description: '') }
-      let!(:package) { create(:package, name: 'test', project: project, title: '', description: '') }
-      let(:search_param_text) { { text: 'test' } }
+      let(:search_term) { "test#{SecureRandom.hex(4)}" }
+      let!(:project) { create(:project, name: search_term, title: '', description: '') }
+      let!(:package) { create(:package, name: search_term, project: project, title: '', description: '') }
+      let(:search_param_text) { { text: search_term } }
 
       context 'without any class' do
         let(:search_params) { search_param_text }


### PR DESCRIPTION
## Description:

Issue #19814 reported intermittent `ThinkingSphinx::Search::StaleIdsException` in `spec/models/full_text_search_spec.rb` on the current `master` branch.

The flaky `specifying classes` examples reused the literal search term `test` while `:thinking_sphinx` specs use `DatabaseCleaner` deletion. When stale RT rows from earlier examples still matched that same query, Thinking Sphinx could return stale ids.

This PR keeps the existing `:thinking_sphinx` helper lifecycle and instead makes the reused search term unique per example in that flaky context. That isolates the examples without restarting Sphinx for every example.

Closes #19814.

## Checklist:

- [x] I have reproduced the stale-id failure on a clean clone of the latest upstream `master`.
- [x] I have run focused validation in the repo Docker environment using `bundle exec rspec spec/models/full_text_search_spec.rb --seed 58371`.
- [x] I have run broader Thinking Sphinx validation in the repo Docker environment using `bundle exec rspec --tag thinking_sphinx --seed 58371`.