### PR TITLE
split full project name into first and last element, rathern than fir…

### DIFF
--- a/src/api/app/services/workflows/yaml_to_workflows_service.rb
+++ b/src/api/app/services/workflows/yaml_to_workflows_service.rb
@@ -38,7 +38,11 @@ module Workflows
     end
 
     def parse_workflow_configuration(workflow_configuration)
-      scm_organization_name, scm_repository_name = @workflow_run.target_repository_full_name.split('/')
+      # target_repository_full_name can contain multi-level names, with the first element being the
+      # "project" (or "organization") name and the last element being the actual repository name.
+      # everything inbetween will be "sub-group" names
+      scm_organization_name = @workflow_run.target_repository_full_name.split('/')[ 1]
+      scm_repository_name = @workflow_run.target_repository_full_name.split('/')[ -1]
 
       # The PR number is only present in webhook events for pull requests, so we have a default value in case someone doesn't use
       # this correctly. Here, we cannot inform users about this since we're processing the whole workflows file


### PR DESCRIPTION
OBS workflows provide a number of "variables", that can be used in the workflow YAML files. Two of these variables (SCM_ORGANIZATION_NAME SCM_REPOSITORY_NAME) are deducted from the "target_repository_full_name", which is filled with a value from the web request sent by the SCM to trigger the workflow.

With at least Gitlab, that target_repository_full_name can have more than two elements (separated by "/"), basically the names of the top-level group and optionally sub-groups, followed by the SCM project name as the last element:

group:subgroup:subgroup:project

With the current implementation, OBS workflow assumes that the first element names the organization and the second element names the project. (This may be the typical case for Github projects).

With this PR, that code is changed to set SCM_REPOSITORY_NAME to the *last* element of the "target_repository_full_name".

This way, using SCM_REPOSITORY_NAME as a variable in workflow YAML files will reference the project name, even with multi-level names in Gitlab.

/fixes https://github.com/openSUSE/open-build-service/issues/19816
/addlabel Backend