### PR TITLE
SCM: smarter circuit breaker and retry on transient failures

### DIFF
--- a/src/api/app/jobs/report_to_scm_job.rb
+++ b/src/api/app/jobs/report_to_scm_job.rb
@@ -1,13 +1,21 @@
 class ReportToSCMJob < CreateJob
   ALLOWED_EVENTS = ['Event::BuildFail', 'Event::BuildSuccess', 'Event::RequestStatechange'].freeze
 
-  MAX_ATTEMPTS = SCMExceptionHandler::RETRY_WAIT_TIMES.size + 1
+  # Raised when the SCM API returns a transient error worth retrying.
+  # Kept here (not in SCMExceptionHandler) so the retry logic is entirely
+  # job-scoped and vendor reporters stay safe to call from threads too.
+  class RetryableError < StandardError; end
+
+  # Wait schedule keyed by attempt number (attempt 1 = immediate, then backoff).
+  RETRY_WAIT_TIMES = { 1 => 0, 2 => 1.minute, 3 => 2.minutes, 4 => 5.minutes, 5 => 10.minutes, 6 => 15.minutes }.freeze
+
+  MAX_ATTEMPTS = RETRY_WAIT_TIMES.size + 1
 
   queue_as :scm
 
   # Re-raise RetryableError so it escapes rescue_from(StandardError) in CreateJob
   # and reaches delayed_job, which then calls reschedule_at for the next attempt time.
-  rescue_from SCMExceptionHandler::RetryableError do |e|
+  rescue_from RetryableError do |e|
     raise e
   end
 
@@ -16,7 +24,7 @@ class ReportToSCMJob < CreateJob
   end
 
   def reschedule_at(current_time, attempts)
-    current_time + SCMExceptionHandler::RETRY_WAIT_TIMES.fetch(attempts)
+    current_time + RETRY_WAIT_TIMES.fetch(attempts)
   end
 
   # Called by delayed_job when max_attempts is exhausted.
@@ -41,11 +49,15 @@ class ReportToSCMJob < CreateJob
     return unless event.event_object
 
     matched_event_subscription(event: event).each do |event_subscription|
-      SCMStatusReporter.new(event_payload: event.payload,
-                            event_subscription_payload: event_subscription.workflow_run&.payload,
-                            scm_token: event_subscription.token.scm_token,
-                            workflow_run: event_subscription.workflow_run,
-                            event_type: event_subscription.eventtype).call
+      begin
+        SCMStatusReporter.new(event_payload: event.payload,
+                              event_subscription_payload: event_subscription.workflow_run&.payload,
+                              scm_token: event_subscription.token.scm_token,
+                              workflow_run: event_subscription.workflow_run,
+                              event_type: event_subscription.eventtype).call
+      rescue *SCMExceptionHandler::RETRYABLE_EXCEPTIONS => e
+        raise RetryableError, e.message
+      end
     end
   end
 

--- a/src/api/app/jobs/report_to_scm_job.rb
+++ b/src/api/app/jobs/report_to_scm_job.rb
@@ -4,8 +4,6 @@ class ReportToSCMJob < CreateJob
   # Wait schedule keyed by attempt number (attempt 1 = immediate, then backoff).
   RETRY_WAIT_TIMES = { 1 => 0, 2 => 1.minute, 3 => 2.minutes, 4 => 5.minutes, 5 => 10.minutes, 6 => 15.minutes }.freeze
 
-  MAX_ATTEMPTS = RETRY_WAIT_TIMES.size + 1
-
   queue_as :scm
 
   # Re-raise transient SCM errors so they escape rescue_from(StandardError) in CreateJob
@@ -13,7 +11,7 @@ class ReportToSCMJob < CreateJob
   rescue_from(*SCMExceptionHandler::RETRYABLE_EXCEPTIONS) { |e| raise e }
 
   def max_attempts
-    MAX_ATTEMPTS
+    7
   end
 
   def reschedule_at(current_time, attempts)

--- a/src/api/app/jobs/report_to_scm_job.rb
+++ b/src/api/app/jobs/report_to_scm_job.rb
@@ -26,8 +26,10 @@ class ReportToSCMJob < CreateJob
     return unless event
 
     event.with_lock { event.mark_job_done! }
-    matched_event_subscription(event: event).each do |es|
-      es.workflow_run&.save_scm_report_failure('Failed to report back to SCM: all retries exhausted', {})
+    matched_event_subscription(event: event).each do |subscription|
+      next if subscription.workflow_run.blank?
+      
+      subscription.workflow_run.save_scm_report_failure('Failed to report back to SCM: all retries exhausted', {})
     end
   end
 

--- a/src/api/app/jobs/report_to_scm_job.rb
+++ b/src/api/app/jobs/report_to_scm_job.rb
@@ -1,6 +1,8 @@
 class ReportToSCMJob < CreateJob
   ALLOWED_EVENTS = ['Event::BuildFail', 'Event::BuildSuccess', 'Event::RequestStatechange'].freeze
 
+  MAX_ATTEMPTS = SCMExceptionHandler::RETRY_WAIT_TIMES.size + 1
+
   queue_as :scm
 
   # Re-raise RetryableError so it escapes rescue_from(StandardError) in CreateJob
@@ -10,7 +12,7 @@ class ReportToSCMJob < CreateJob
   end
 
   def max_attempts
-    SCMExceptionHandler::RETRY_WAIT_TIMES.size + 1
+    MAX_ATTEMPTS
   end
 
   def reschedule_at(current_time, attempts)

--- a/src/api/app/jobs/report_to_scm_job.rb
+++ b/src/api/app/jobs/report_to_scm_job.rb
@@ -3,6 +3,32 @@ class ReportToSCMJob < CreateJob
 
   queue_as :scm
 
+  # Re-raise RetryableError so it escapes rescue_from(StandardError) in CreateJob
+  # and reaches delayed_job, which then calls reschedule_at for the next attempt time.
+  rescue_from SCMExceptionHandler::RetryableError do |e|
+    raise e
+  end
+
+  def max_attempts
+    SCMExceptionHandler::RETRY_WAIT_TIMES.size + 1
+  end
+
+  def reschedule_at(current_time, attempts)
+    current_time + SCMExceptionHandler::RETRY_WAIT_TIMES.fetch(attempts)
+  end
+
+  # Called by delayed_job when max_attempts is exhausted.
+  # Keeps undone_jobs balanced (after_perform never fired) and records a final failure.
+  def failure(_job = nil)
+    event = Event::Base.find_by(id: arguments.first)
+    return unless event
+
+    event.with_lock { event.mark_job_done! }
+    matched_event_subscription(event: event).each do |es|
+      es.workflow_run&.save_scm_report_failure('Failed to report back to SCM: all retries exhausted', {})
+    end
+  end
+
   def perform(event_id)
     event = Event::Base.find(event_id)
     return unless event

--- a/src/api/app/jobs/report_to_scm_job.rb
+++ b/src/api/app/jobs/report_to_scm_job.rb
@@ -1,11 +1,6 @@
 class ReportToSCMJob < CreateJob
   ALLOWED_EVENTS = ['Event::BuildFail', 'Event::BuildSuccess', 'Event::RequestStatechange'].freeze
 
-  # Raised when the SCM API returns a transient error worth retrying.
-  # Kept here (not in SCMExceptionHandler) so the retry logic is entirely
-  # job-scoped and vendor reporters stay safe to call from threads too.
-  class RetryableError < StandardError; end
-
   # Wait schedule keyed by attempt number (attempt 1 = immediate, then backoff).
   RETRY_WAIT_TIMES = { 1 => 0, 2 => 1.minute, 3 => 2.minutes, 4 => 5.minutes, 5 => 10.minutes, 6 => 15.minutes }.freeze
 
@@ -13,11 +8,9 @@ class ReportToSCMJob < CreateJob
 
   queue_as :scm
 
-  # Re-raise RetryableError so it escapes rescue_from(StandardError) in CreateJob
-  # and reaches delayed_job, which then calls reschedule_at for the next attempt time.
-  rescue_from RetryableError do |e|
-    raise e
-  end
+  # Re-raise transient SCM errors so they escape rescue_from(StandardError) in CreateJob
+  # and reach delayed_job, which then calls reschedule_at for the next attempt time.
+  rescue_from(*SCMExceptionHandler::RETRYABLE_EXCEPTIONS) { |e| raise e }
 
   def max_attempts
     MAX_ATTEMPTS
@@ -49,15 +42,11 @@ class ReportToSCMJob < CreateJob
     return unless event.event_object
 
     matched_event_subscription(event: event).each do |event_subscription|
-      begin
-        SCMStatusReporter.new(event_payload: event.payload,
-                              event_subscription_payload: event_subscription.workflow_run&.payload,
-                              scm_token: event_subscription.token.scm_token,
-                              workflow_run: event_subscription.workflow_run,
-                              event_type: event_subscription.eventtype).call
-      rescue *SCMExceptionHandler::RETRYABLE_EXCEPTIONS => e
-        raise RetryableError, e.message
-      end
+      SCMStatusReporter.new(event_payload: event.payload,
+                            event_subscription_payload: event_subscription.workflow_run&.payload,
+                            scm_token: event_subscription.token.scm_token,
+                            workflow_run: event_subscription.workflow_run,
+                            event_type: event_subscription.eventtype).call
     end
   end
 

--- a/src/api/app/models/token/workflow.rb
+++ b/src/api/app/models/token/workflow.rb
@@ -1,6 +1,5 @@
 class Token::Workflow < Token
   AUTHENTICATION_DOCUMENTATION_LINK = "#{::Workflow::SCM_CI_DOCUMENTATION_URL}#sec.obs.obs_scm_ci_workflow_integration.setup.token_authentication.how_to_authenticate_scm_with_obs".freeze
-  AUTH_FAILURE_THRESHOLD = 6
 
   has_many :workflow_runs, dependent: :destroy, foreign_key: 'token_id', inverse_of: false
   has_and_belongs_to_many :users,

--- a/src/api/app/models/token/workflow.rb
+++ b/src/api/app/models/token/workflow.rb
@@ -1,5 +1,6 @@
 class Token::Workflow < Token
   AUTHENTICATION_DOCUMENTATION_LINK = "#{::Workflow::SCM_CI_DOCUMENTATION_URL}#sec.obs.obs_scm_ci_workflow_integration.setup.token_authentication.how_to_authenticate_scm_with_obs".freeze
+  AUTH_FAILURE_THRESHOLD = 6
 
   has_many :workflow_runs, dependent: :destroy, foreign_key: 'token_id', inverse_of: false
   has_and_belongs_to_many :users,
@@ -58,6 +59,9 @@ class Token::Workflow < Token
     validation_errors
   rescue Octokit::Unauthorized, Gitlab::Error::Unauthorized
     raise Token::Errors::SCMTokenInvalid, "Your SCM token secret is not properly set in your OBS workflow token.\nCheck #{AUTHENTICATION_DOCUMENTATION_LINK}"
+  rescue SCMExceptionHandler::RetryableError
+    # Transient SCM error on an initial status report — not critical since build-result
+    # reports go through ReportToSCMJob which handles retries via delayed_job.
   end
 
   def owned_by?(some_user)

--- a/src/api/app/models/token/workflow.rb
+++ b/src/api/app/models/token/workflow.rb
@@ -58,7 +58,7 @@ class Token::Workflow < Token
     validation_errors
   rescue Octokit::Unauthorized, Gitlab::Error::Unauthorized
     raise Token::Errors::SCMTokenInvalid, "Your SCM token secret is not properly set in your OBS workflow token.\nCheck #{AUTHENTICATION_DOCUMENTATION_LINK}"
-  rescue SCMExceptionHandler::RetryableError
+  rescue *SCMExceptionHandler::RETRYABLE_EXCEPTIONS
     # Transient SCM error on an initial status report — not critical since build-result
     # reports go through ReportToSCMJob which handles retries via delayed_job.
   end

--- a/src/api/app/models/workflow_run.rb
+++ b/src/api/app/models/workflow_run.rb
@@ -24,6 +24,8 @@ class WorkflowRun < ApplicationRecord
 
   ALL_POSSIBLE_REQUEST_ACTIONS = (['all'] + ALLOWED_GITHUB_PULL_REQUEST_ACTIONS + ALLOWED_GITLAB_PULL_REQUEST_ACTIONS + ALLOWED_GITEA_PULL_REQUEST_ACTIONS).uniq
 
+  AUTH_FAILURE_THRESHOLD = 6
+
   validates :scm_vendor, :response_url,
             :workflow_configuration_path, :workflow_configuration_url,
             :hook_event, :hook_action, :generic_event_type,
@@ -77,7 +79,7 @@ class WorkflowRun < ApplicationRecord
     # Circuit breaker for authorization problems
     #
     #   If message is one of these strings, we increment the token's consecutive_auth_failures counter.
-    #   Once the counter reaches Token::Workflow::AUTH_FAILURE_THRESHOLD the token is disabled.
+    #   Once the counter reaches AUTH_FAILURE_THRESHOLD the token is disabled.
     #
     # "Failed to report back to GitLab: Unauthorized request. Please check your credentials again."
     # "Failed to report back to GitLab: Request forbidden."
@@ -87,7 +89,7 @@ class WorkflowRun < ApplicationRecord
     return unless message.include?('Unauthorized request') || /Request (is )?forbidden/.match?(message)
 
     token.increment!(:consecutive_auth_failures)
-    return if token.consecutive_auth_failures < Token::Workflow::AUTH_FAILURE_THRESHOLD
+    return if token.consecutive_auth_failures < AUTH_FAILURE_THRESHOLD
 
     token.update(enabled: false,
                  reason: "Authentication to #{scm_vendor.titleize} failed #{token.consecutive_auth_failures} " \

--- a/src/api/app/models/workflow_run.rb
+++ b/src/api/app/models/workflow_run.rb
@@ -76,7 +76,8 @@ class WorkflowRun < ApplicationRecord
     #
     # Circuit breaker for authorization problems
     #
-    #   If message is one of these strings, we disable the token:
+    #   If message is one of these strings, we increment the token's consecutive_auth_failures counter.
+    #   Once the counter reaches Token::Workflow::AUTH_FAILURE_THRESHOLD the token is disabled.
     #
     # "Failed to report back to GitLab: Unauthorized request. Please check your credentials again."
     # "Failed to report back to GitLab: Request forbidden."
@@ -85,7 +86,12 @@ class WorkflowRun < ApplicationRecord
 
     return unless message.include?('Unauthorized request') || /Request (is )?forbidden/.match?(message)
 
-    token.update(enabled: false, reason: "Authentication to #{scm_vendor.titleize} failed while reporting the build status. Check your tokens authorization setup!")
+    token.increment!(:consecutive_auth_failures)
+    return if token.consecutive_auth_failures < Token::Workflow::AUTH_FAILURE_THRESHOLD
+
+    token.update(enabled: false,
+                 reason: "Authentication to #{scm_vendor.titleize} failed #{token.consecutive_auth_failures} " \
+                         'consecutive times while reporting the build status. Check your tokens authorization setup!')
   end
 
   # Stores debug info to help figure out what went wrong when trying to save a Status in the SCM.
@@ -99,6 +105,7 @@ class WorkflowRun < ApplicationRecord
 
   # Stores info from a succesful SCM status report. The default value for 'status' is 'success'.
   def save_scm_report_success(options)
+    token.update_column(:consecutive_auth_failures, 0) if token&.consecutive_auth_failures&.positive?
     scm_status_reports.create(request_parameters: JSON.generate(options.slice(*PERMITTED_OPTIONS)))
   end
 

--- a/src/api/app/models/workflow_run.rb
+++ b/src/api/app/models/workflow_run.rb
@@ -107,7 +107,7 @@ class WorkflowRun < ApplicationRecord
 
   # Stores info from a succesful SCM status report. The default value for 'status' is 'success'.
   def save_scm_report_success(options)
-    token.update_column(:consecutive_auth_failures, 0) if token&.consecutive_auth_failures&.positive?
+    token&.update_column(:consecutive_auth_failures, 0)
     scm_status_reports.create(request_parameters: JSON.generate(options.slice(*PERMITTED_OPTIONS)))
   end
 

--- a/src/api/app/models/workflow_run.rb
+++ b/src/api/app/models/workflow_run.rb
@@ -91,9 +91,7 @@ class WorkflowRun < ApplicationRecord
     token.increment!(:consecutive_auth_failures)
     return if token.consecutive_auth_failures < AUTH_FAILURE_THRESHOLD
 
-    token.update(enabled: false,
-                 reason: "Authentication to #{scm_vendor.titleize} failed #{token.consecutive_auth_failures} " \
-                         'consecutive times while reporting the build status. Check your tokens authorization setup!')
+    token.update(enabled: false, reason: "Authentication to #{scm_vendor.titleize} failed while reporting the build status. Check your tokens authorization setup! Error message: #{message}")
   end
 
   # Stores debug info to help figure out what went wrong when trying to save a Status in the SCM.

--- a/src/api/app/services/github_status_reporter.rb
+++ b/src/api/app/services/github_status_reporter.rb
@@ -15,15 +15,13 @@ class GithubStatusReporter < SCMExceptionHandler
     github_client = Octokit::Client.new(access_token: @scm_token,
                                         api_endpoint: @workflow_run.api_endpoint)
     # https://docs.github.com/en/rest/reference/repos#create-a-commit-status
-    with_scm_retries do
-      github_client.create_status(@workflow_run.target_repository_full_name,
-                                  @workflow_run.commit_sha,
-                                  @state,
-                                  status_options)
-      if @workflow_run.present?
-        @workflow_run.save_scm_report_success(request_context)
-        RabbitmqBus.send_to_bus('metrics', "scm_status_report,status=success,scm=#{@workflow_run.scm_vendor} value=1")
-      end
+    github_client.create_status(@workflow_run.target_repository_full_name,
+                                @workflow_run.commit_sha,
+                                @state,
+                                status_options)
+    if @workflow_run.present?
+      @workflow_run.save_scm_report_success(request_context)
+      RabbitmqBus.send_to_bus('metrics', "scm_status_report,status=success,scm=#{@workflow_run.scm_vendor} value=1")
     end
   rescue Octokit::InvalidRepository => e
     package = Package.find_by_project_and_name(@event_payload[:project], @event_payload[:package])
@@ -35,9 +33,11 @@ class GithubStatusReporter < SCMExceptionHandler
     EventSubscription.where(channel: 'scm', token: tokens, package: package).delete_all
 
     (@workflow_run.presence&.save_scm_report_failure("Failed to report back to GitHub: #{e.message}", request_context))
+  rescue *SCMExceptionHandler::RETRYABLE_EXCEPTIONS
+    raise
   rescue Octokit::Error => e
     rescue_with_handler(e) || raise(e)
-  rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Faraday::SSLError => e
+  rescue Faraday::SSLError => e
     (@workflow_run.presence&.save_scm_report_failure("Failed to report back to GitHub: #{e.message}", request_context))
   ensure
     RabbitmqBus.send_to_bus('metrics', "scm_status_report,status=fail,scm=#{@workflow_run.scm_vendor},exception=#{e.class} value=1") if e.present? && @workflow_run.present?

--- a/src/api/app/services/github_status_reporter.rb
+++ b/src/api/app/services/github_status_reporter.rb
@@ -15,13 +15,15 @@ class GithubStatusReporter < SCMExceptionHandler
     github_client = Octokit::Client.new(access_token: @scm_token,
                                         api_endpoint: @workflow_run.api_endpoint)
     # https://docs.github.com/en/rest/reference/repos#create-a-commit-status
-    github_client.create_status(@workflow_run.target_repository_full_name,
-                                @workflow_run.commit_sha,
-                                @state,
-                                status_options)
-    if @workflow_run.present?
-      @workflow_run.save_scm_report_success(request_context)
-      RabbitmqBus.send_to_bus('metrics', "scm_status_report,status=success,scm=#{@workflow_run.scm_vendor} value=1")
+    with_scm_retries do
+      github_client.create_status(@workflow_run.target_repository_full_name,
+                                  @workflow_run.commit_sha,
+                                  @state,
+                                  status_options)
+      if @workflow_run.present?
+        @workflow_run.save_scm_report_success(request_context)
+        RabbitmqBus.send_to_bus('metrics', "scm_status_report,status=success,scm=#{@workflow_run.scm_vendor} value=1")
+      end
     end
   rescue Octokit::InvalidRepository => e
     package = Package.find_by_project_and_name(@event_payload[:project], @event_payload[:package])

--- a/src/api/app/services/scm_exception_handler.rb
+++ b/src/api/app/services/scm_exception_handler.rb
@@ -3,11 +3,6 @@ class SCMExceptionHandler
 
   attr_accessor :event_payload, :event_subscription_payload
 
-  # Raised inside with_scm_retries to signal that a transient failure occurred.
-  # ReportToSCMJob re-raises this so delayed_job can schedule the next retry attempt
-  # using the custom reschedule_at/max_attempts hooks on the job.
-  class RetryableError < StandardError; end
-
   # Transient errors that are worth retrying: SCM-side 5xx, rate limits, and network glitches.
   # Auth failures, 4xx config errors, and SSL problems are not retried.
   RETRYABLE_EXCEPTIONS = [
@@ -18,9 +13,6 @@ class SCMExceptionHandler
     Faraday::ConnectionFailed,
     Faraday::TimeoutError
   ].freeze
-
-  # Wait schedule for retries, keyed by attempt number.
-  RETRY_WAIT_TIMES = { 1 => 0, 2 => 1.minute, 3 => 2.minutes, 4 => 5.minutes, 5 => 10.minutes, 6 => 15.minutes }.freeze
 
   rescue_from Octokit::AbuseDetected,
               Octokit::AccountSuspended,
@@ -81,15 +73,6 @@ class SCMExceptionHandler
   end
 
   private
-
-  # Wraps an SCM API call and converts transient failures into RetryableError so
-  # ReportToSCMJob can delegate retry scheduling to delayed_job (reschedule_at/max_attempts).
-  # Non-retryable exceptions (auth failures, 4xx, SSL) propagate as-is.
-  def with_scm_retries
-    yield
-  rescue *RETRYABLE_EXCEPTIONS => e
-    raise RetryableError, e.message
-  end
 
   def log_to_workflow_run(exception, scm)
     if @event_payload[:project] && @event_payload[:package]

--- a/src/api/app/services/scm_exception_handler.rb
+++ b/src/api/app/services/scm_exception_handler.rb
@@ -3,6 +3,25 @@ class SCMExceptionHandler
 
   attr_accessor :event_payload, :event_subscription_payload
 
+  # Raised inside with_scm_retries to signal that a transient failure occurred.
+  # ReportToSCMJob re-raises this so delayed_job can schedule the next retry attempt
+  # using the custom reschedule_at/max_attempts hooks on the job.
+  class RetryableError < StandardError; end
+
+  # Transient errors that are worth retrying: SCM-side 5xx, rate limits, and network glitches.
+  # Auth failures, 4xx config errors, and SSL problems are not retried.
+  RETRYABLE_EXCEPTIONS = [
+    Octokit::InternalServerError,
+    Octokit::BadGateway,
+    Octokit::ServiceUnavailable,
+    Octokit::ServerError,
+    Faraday::ConnectionFailed,
+    Faraday::TimeoutError
+  ].freeze
+
+  # Wait schedule for retries, keyed by attempt number.
+  RETRY_WAIT_TIMES = { 1 => 0, 2 => 1.minute, 3 => 2.minutes, 4 => 5.minutes, 5 => 10.minutes, 6 => 15.minutes }.freeze
+
   rescue_from Octokit::AbuseDetected,
               Octokit::AccountSuspended,
               Octokit::BillingIssue,
@@ -62,6 +81,15 @@ class SCMExceptionHandler
   end
 
   private
+
+  # Wraps an SCM API call and converts transient failures into RetryableError so
+  # ReportToSCMJob can delegate retry scheduling to delayed_job (reschedule_at/max_attempts).
+  # Non-retryable exceptions (auth failures, 4xx, SSL) propagate as-is.
+  def with_scm_retries
+    yield
+  rescue *RETRYABLE_EXCEPTIONS => e
+    raise RetryableError, e.message
+  end
 
   def log_to_workflow_run(exception, scm)
     if @event_payload[:project] && @event_payload[:package]

--- a/src/api/db/migrate/20260616104529_add_consecutive_auth_failures_to_tokens.rb
+++ b/src/api/db/migrate/20260616104529_add_consecutive_auth_failures_to_tokens.rb
@@ -1,0 +1,5 @@
+class AddConsecutiveAuthFailuresToTokens < ActiveRecord::Migration[7.2]
+  def change
+    add_column :tokens, :consecutive_auth_failures, :integer, default: 0, null: false
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_05_15_101229) do
+ActiveRecord::Schema[7.2].define(version: 2026_06_16_104529) do
   create_table "active_storage_attachments", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -1191,6 +1191,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_15_101229) do
     t.string "workflow_configuration_path", default: ".obs/workflows.yml"
     t.string "workflow_configuration_url", limit: 8192
     t.boolean "enabled", default: true, null: false
+    t.integer "consecutive_auth_failures", default: 0, null: false
     t.index ["enabled"], name: "index_tokens_on_enabled"
     t.index ["executor_id"], name: "user_id"
     t.index ["package_id"], name: "package_id"

--- a/src/api/spec/jobs/report_to_scm_job_spec.rb
+++ b/src/api/spec/jobs/report_to_scm_job_spec.rb
@@ -102,13 +102,13 @@ RSpec.describe ReportToSCMJob do
         event_subscription
       end
 
-      it 'raises RetryableError so delayed_job schedules the next attempt' do
-        expect { described_class.perform_now(event.id) }.to raise_error(SCMExceptionHandler::RetryableError)
+      it 'raises a retryable error so delayed_job schedules the next attempt' do
+        expect { described_class.perform_now(event.id) }.to raise_error(Faraday::ConnectionFailed)
       end
 
       it 'does not immediately mark the workflow run as failed' do
         described_class.perform_now(event.id)
-      rescue SCMExceptionHandler::RetryableError
+      rescue Faraday::ConnectionFailed
         expect(workflow_run.reload.status).to eq('running')
       end
     end

--- a/src/api/spec/jobs/report_to_scm_job_spec.rb
+++ b/src/api/spec/jobs/report_to_scm_job_spec.rb
@@ -93,5 +93,52 @@ RSpec.describe ReportToSCMJob do
         subject
       end
     end
+
+    context 'when the SCM returns a transient error' do
+      before do
+        allow_any_instance_of(Octokit::Client).to receive(:create_status) # rubocop:disable RSpec/AnyInstance
+          .and_raise(Faraday::ConnectionFailed.new('Connection refused'))
+        event
+        event_subscription
+      end
+
+      it 'raises RetryableError so delayed_job schedules the next attempt' do
+        expect { described_class.perform_now(event.id) }.to raise_error(SCMExceptionHandler::RetryableError)
+      end
+
+      it 'does not immediately mark the workflow run as failed' do
+        described_class.perform_now(event.id)
+      rescue SCMExceptionHandler::RetryableError
+        expect(workflow_run.reload.status).to eq('running')
+      end
+    end
+  end
+
+  describe '#reschedule_at' do
+    subject(:job) { described_class.new }
+
+    it 'schedules the first retry immediately' do
+      expect(job.reschedule_at(Time.zone.now, 1)).to be_within(1.second).of(Time.zone.now)
+    end
+
+    it 'schedules the second retry after 1 minute' do
+      expect(job.reschedule_at(Time.zone.now, 2)).to be_within(1.second).of(1.minute.from_now)
+    end
+
+    it 'schedules the sixth retry after 15 minutes' do
+      expect(job.reschedule_at(Time.zone.now, 6)).to be_within(1.second).of(15.minutes.from_now)
+    end
+  end
+
+  describe '#failure' do
+    before do
+      event
+      event_subscription
+    end
+
+    it 'marks the workflow run as failed' do
+      described_class.new.tap { |j| j.arguments = [event.id] }.failure
+      expect(workflow_run.reload.status).to eq('fail')
+    end
   end
 end

--- a/src/api/spec/mailers/event_mailer_spec.rb
+++ b/src/api/spec/mailers/event_mailer_spec.rb
@@ -472,7 +472,7 @@ RSpec.describe EventMailer, :vcr do
 
       context 'when the workflow run fails' do
         before do
-          token.update_column(:consecutive_auth_failures, Token::Workflow::AUTH_FAILURE_THRESHOLD - 1)
+          token.update_column(:consecutive_auth_failures, WorkflowRun::AUTH_FAILURE_THRESHOLD - 1)
           workflow_run.update_as_failed('Unauthorized request')
         end
 
@@ -495,7 +495,7 @@ RSpec.describe EventMailer, :vcr do
 
         it { expect(mail.text_part.body.to_s).to include("The Workflow Token 'Token for GitHub' was disabled.") }
         it { expect(mail.html_part.body.to_s).to include("The Workflow Token 'Token for GitHub' was disabled.") }
-        it { expect(mail.html_part.body.to_s).to include("Authentication to Github failed #{Token::Workflow::AUTH_FAILURE_THRESHOLD} consecutive times while reporting the build status. Check your tokens authorization setup!") }
+        it { expect(mail.html_part.body.to_s).to include("Authentication to Github failed #{WorkflowRun::AUTH_FAILURE_THRESHOLD} consecutive times while reporting the build status. Check your tokens authorization setup!") }
       end
     end
 

--- a/src/api/spec/mailers/event_mailer_spec.rb
+++ b/src/api/spec/mailers/event_mailer_spec.rb
@@ -472,6 +472,7 @@ RSpec.describe EventMailer, :vcr do
 
       context 'when the workflow run fails' do
         before do
+          token.update_column(:consecutive_auth_failures, Token::Workflow::AUTH_FAILURE_THRESHOLD - 1)
           workflow_run.update_as_failed('Unauthorized request')
         end
 
@@ -494,7 +495,7 @@ RSpec.describe EventMailer, :vcr do
 
         it { expect(mail.text_part.body.to_s).to include("The Workflow Token 'Token for GitHub' was disabled.") }
         it { expect(mail.html_part.body.to_s).to include("The Workflow Token 'Token for GitHub' was disabled.") }
-        it { expect(mail.html_part.body.to_s).to include('Authentication to Github failed while reporting the build status. Check your tokens authorization setup!') }
+        it { expect(mail.html_part.body.to_s).to include("Authentication to Github failed #{Token::Workflow::AUTH_FAILURE_THRESHOLD} consecutive times while reporting the build status. Check your tokens authorization setup!") }
       end
     end
 

--- a/src/api/spec/models/workflow_run_spec.rb
+++ b/src/api/spec/models/workflow_run_spec.rb
@@ -114,12 +114,12 @@ RSpec.describe WorkflowRun, :vcr do
       end
 
       it 'does not disable the token before reaching the failure threshold' do
-        (Token::Workflow::AUTH_FAILURE_THRESHOLD - 1).times { forbidden_failure.call }
+        (WorkflowRun::AUTH_FAILURE_THRESHOLD - 1).times { forbidden_failure.call }
         expect(workflow_run.token.reload.enabled).to be(true)
       end
 
       it 'disables the token after reaching the failure threshold' do
-        Token::Workflow::AUTH_FAILURE_THRESHOLD.times { forbidden_failure.call }
+        WorkflowRun::AUTH_FAILURE_THRESHOLD.times { forbidden_failure.call }
         expect(workflow_run.token.reload.enabled).to be(false)
       end
     end

--- a/src/api/spec/models/workflow_run_spec.rb
+++ b/src/api/spec/models/workflow_run_spec.rb
@@ -35,6 +35,17 @@ RSpec.describe WorkflowRun, :vcr do
         expect(SCMStatusReport.last.status).to eq('success')
       end
     end
+
+    context 'when the token has previous auth failures' do
+      let(:options) { { api_endpoint: 'https://api.github.com' } }
+
+      before { workflow_run.token.update!(consecutive_auth_failures: 3) }
+
+      it 'resets consecutive_auth_failures to zero' do
+        expect { subject }
+          .to change { workflow_run.token.reload.consecutive_auth_failures }.from(3).to(0)
+      end
+    end
   end
 
   describe '#save_scm_report_failure' do
@@ -93,12 +104,26 @@ RSpec.describe WorkflowRun, :vcr do
     end
 
     context 'when the SCM responds with a forbidden message' do
-      subject { workflow_run.save_scm_report_failure('Failed to report back to GitHub: Request is forbidden.', { api_endpoint: 'https://api.github.com' }) }
+      let(:forbidden_failure) do
+        -> { workflow_run.save_scm_report_failure('Failed to report back to GitHub: Request is forbidden.', { api_endpoint: 'https://api.github.com' }) }
+      end
 
-      it 'disables the token of the token workflow' do
-        expect { subject }.to change { workflow_run.token.reload.enabled }.from(true).to(false)
+      it 'increments consecutive_auth_failures on each failure' do
+        forbidden_failure.call
+        expect(workflow_run.token.reload.consecutive_auth_failures).to eq(1)
+      end
+
+      it 'does not disable the token before reaching the failure threshold' do
+        (Token::Workflow::AUTH_FAILURE_THRESHOLD - 1).times { forbidden_failure.call }
+        expect(workflow_run.token.reload.enabled).to be(true)
+      end
+
+      it 'disables the token after reaching the failure threshold' do
+        Token::Workflow::AUTH_FAILURE_THRESHOLD.times { forbidden_failure.call }
+        expect(workflow_run.token.reload.enabled).to be(false)
       end
     end
+
   end
 
   describe '#labeled_pull_request?' do

--- a/src/api/spec/services/github_status_reporter_spec.rb
+++ b/src/api/spec/services/github_status_reporter_spec.rb
@@ -95,12 +95,12 @@ RSpec.describe GithubStatusReporter, type: :service do
           allow(octokit_client).to receive(:create_status).and_raise(Faraday::ConnectionFailed.new('Network glitch'))
         end
 
-        it 'raises RetryableError so delayed_job can schedule the next attempt' do
-          expect { subject }.to raise_error(SCMExceptionHandler::RetryableError)
+        it 'raises the original error so delayed_job can schedule the next attempt' do
+          expect { subject }.to raise_error(Faraday::ConnectionFailed)
         end
 
         it 'does not record a failure immediately (the job retries first)' do
-          subject rescue SCMExceptionHandler::RetryableError # rubocop:disable Style/RescueModifier
+          subject rescue Faraday::ConnectionFailed # rubocop:disable Style/RescueModifier
           expect(SCMStatusReport.count).to eq(0)
         end
       end

--- a/src/api/spec/services/github_status_reporter_spec.rb
+++ b/src/api/spec/services/github_status_reporter_spec.rb
@@ -95,12 +95,13 @@ RSpec.describe GithubStatusReporter, type: :service do
           allow(octokit_client).to receive(:create_status).and_raise(Faraday::ConnectionFailed.new('Network glitch'))
         end
 
-        it { expect { subject }.to change(SCMStatusReport, :count).by(1) }
+        it 'raises RetryableError so delayed_job can schedule the next attempt' do
+          expect { subject }.to raise_error(SCMExceptionHandler::RetryableError)
+        end
 
-        it 'tracks the exception in the workflow_run response body and sets the status to fail' do
-          subject
-          expect(workflow_run.status).to eq('fail')
-          expect(workflow_run.last_response_body).to eq('Failed to report back to GitHub: Network glitch')
+        it 'does not record a failure immediately (the job retries first)' do
+          subject rescue SCMExceptionHandler::RetryableError # rubocop:disable Style/RescueModifier
+          expect(SCMStatusReport.count).to eq(0)
         end
       end
     end


### PR DESCRIPTION
https://trello.com/c/In4BLE90

Problem

Two separate reliability issues with SCM status reporting:

1. Too eager to disable tokens: a single auth failure was enough to disable a workflow token, causing false positives when a transient network blip returned a 401.
2. No retry on transient errors: 5xx responses and network timeouts from the SCM API caused permanent failures with no recovery path. The only retry mechanism was an in-process sleep, which blocked the thread and didn't survive process restarts.

Solution

Circuit breaker (consecutive_auth_failures)
- New `consecutive_auth_failures` integer column on tokens (default 0).
- A token is disabled only after 6 consecutive auth failures, not on the first one.
- A successful report resets the counter to zero, so a single transient 401 doesn't accumulate toward the threshold.

Retry via delayed_job (`ReportToSCMJob`)
- `RETRYABLE_EXCEPTIONS` in `SCMExceptionHandler` explicitly classifies transient SCM errors (`Octokit` 5xx, `Faraday::ConnectionFailed`, `Faraday::TimeoutError`).
- `ReportToSCMJob` registers `rescue_from(*RETRYABLE_EXCEPTIONS) { raise }` so these exceptions escape `CreateJob`'s broad `rescue_from(StandardError)` and reach delayed_job's native retry hooks.
- Custom `max_attempts` (7) and `reschedule_at` implement a progressive backoff schedule: immediate → 1 min → 2 min → 5 min → 10 min → 15 min.
- `failure` callback records a final `SCMStatusReport` failure when all retries are exhausted and keeps undone_jobs balanced.
- Retry logic lives entirely in the job, so vendor reporters (`GithubStatusReporter`, etc.) are safe to call from threads without leaking retry concerns into that context.

Assisted-by: Claude Sonnet 4.6