### PR TITLE
Make token call parameters simpler

### DIFF
--- a/src/api/app/controllers/trigger_workflow_controller.rb
+++ b/src/api/app/controllers/trigger_workflow_controller.rb
@@ -61,7 +61,7 @@ class TriggerWorkflowController < ApplicationController
 
   def call_token
     @token.executor.run_as do
-      validation_errors = @token.call(workflow_run: @workflow_run)
+      validation_errors = @token.call(@workflow_run)
 
       unless @workflow_run.status == 'fail' # The SCMStatusReporter might already set the status to 'fail', lets not overwrite it
         if validation_errors.none?

--- a/src/api/app/models/token/workflow.rb
+++ b/src/api/app/models/token/workflow.rb
@@ -29,9 +29,8 @@ class Token::Workflow < Token
 
   after_save :state_change_event, if: :enabled_previously_changed?
 
-  def call(options)
+  def call(workflow_run)
     set_triggered_at
-    workflow_run = options[:workflow_run]
     # FIXME: This makes little sense, wherever we use response_url, just use api_endpoint...
     workflow_run.update(response_url: workflow_run.api_endpoint)
 

--- a/src/api/spec/models/token/workflow_spec.rb
+++ b/src/api/spec/models/token/workflow_spec.rb
@@ -14,14 +14,14 @@ RSpec.describe Token::Workflow do
 
       it "changes the token's triggered_at field and raises an error with a helpful message" do
         expect do
-          workflow_token.call({ workflow_run: workflow_run })
+          workflow_token.call(workflow_run)
         end.to change(workflow_token, :triggered_at).and(raise_error(Token::Errors::SCMTokenInvalid, 'Your SCM token secret is not properly set in your OBS workflow token.' \
                                                                                                      "\nCheck #{described_class::AUTHENTICATION_DOCUMENTATION_LINK}"))
       end
     end
 
     context 'without validation errors' do
-      subject { workflow_token.call(workflow_run: workflow_run) }
+      subject { workflow_token.call(workflow_run) }
 
       let(:workflow_run) do
         create(:workflow_run, token: workflow_token, scm_vendor: scm_vendor, hook_event: hook_event,
@@ -64,7 +64,7 @@ RSpec.describe Token::Workflow do
     end
 
     context 'with validation errors' do
-      subject { workflow_token.call(workflow_run: workflow_run) }
+      subject { workflow_token.call(workflow_run) }
 
       let(:workflow_run) do
         create(:workflow_run, token: workflow_token, scm_vendor: scm_vendor, hook_event: hook_event,
@@ -94,7 +94,7 @@ RSpec.describe Token::Workflow do
     end
 
     context 'with a ping event' do
-      subject { workflow_token.call(workflow_run: workflow_run) }
+      subject { workflow_token.call(workflow_run) }
 
       let(:workflow_run) do
         create(:workflow_run, token: workflow_token, scm_vendor: scm_vendor, hook_event: hook_event,
@@ -174,7 +174,7 @@ RSpec.describe Token::Workflow do
     end
 
     context 'when processing a reportable event' do
-      subject { workflow_token.call(workflow_run: workflow_run) }
+      subject { workflow_token.call(workflow_run) }
 
       let(:scm_vendor) { 'github' }
       let(:hook_event) { 'pull_request' }
@@ -213,7 +213,7 @@ RSpec.describe Token::Workflow do
     end
 
     context 'when processing a non-reportable event' do
-      subject { workflow_token.call(workflow_run: workflow_run) }
+      subject { workflow_token.call(workflow_run) }
 
       let(:scm_vendor) { 'github' }
       let(:hook_event) { 'pull_request' }


### PR DESCRIPTION
We only have one parameter, so there is just only one way of passing it. There is no need for named parameters.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
