### PR TITLE
Ignore branch deletion push webhooks

### DIFF
--- a/src/api/app/models/concerns/workflow_run_payload.rb
+++ b/src/api/app/models/concerns/workflow_run_payload.rb
@@ -2,6 +2,8 @@
 module WorkflowRunPayload
   extend ActiveSupport::Concern
 
+  DELETED_COMMIT_SHA = '0000000000000000000000000000000000000000'.freeze
+
   SOURCE_NAME_PAYLOAD_MAPPING = {
     'pull_request' => %w[pull_request number],
     'Merge Request Hook' => %w[object_attributes iid],
@@ -31,6 +33,10 @@ module WorkflowRunPayload
 
   def push_event?
     github_push_event? || gitlab_push_event? || gitea_push_event?
+  end
+
+  def branch_deletion_push_event?
+    push_event? && payload[:after] == DELETED_COMMIT_SHA
   end
 
   def tag_push_event?

--- a/src/api/app/models/workflow_run.rb
+++ b/src/api/app/models/workflow_run.rb
@@ -40,6 +40,7 @@ class WorkflowRun < ApplicationRecord
     scm_vendor == 'gitlab' && hook_event == 'Merge Request Hook'
   }
   validate :validate_payload_is_json
+  validate :ignore_branch_deletion_push_event
 
   belongs_to :token, class_name: 'Token::Workflow', optional: true
   has_many :artifacts, class_name: 'WorkflowArtifactsPerStep', dependent: :destroy
@@ -169,6 +170,12 @@ class WorkflowRun < ApplicationRecord
     JSON.parse(request_payload)
   rescue JSON::ParserError
     errors.add(:request_payload, 'can not be parsed as JSON')
+  end
+
+  def ignore_branch_deletion_push_event
+    return unless branch_deletion_push_event?
+
+    errors.add(:hook_event, 'ignored branch deletion push event')
   end
 
   def set_attributes_from_payload


### PR DESCRIPTION
- Ignore branch deletion push webhooks where the `after` SHA is all `0`.
- Avoid triggering workflow execution for deleted branches