### PR TITLE
Remove outdated code from the configure repositories validation

### DIFF
--- a/src/api/app/models/workflow/step/configure_repositories.rb
+++ b/src/api/app/models/workflow/step/configure_repositories.rb
@@ -49,14 +49,6 @@ class Workflow::Step::ConfigureRepositories < Workflow::Step
   def validate_repositories
     return if step_instructions[:repositories].all? { |repository| repository.keys.sort == REQUIRED_REPOSITORY_KEYS }
 
-    # FIXME: This is only to help users migrate their configure_repositories steps when we introduced this breaking change. Remove this after March 1st, 2022.
-    if step_instructions[:repositories].any? { |repository| !repository.key?(:paths) }
-      errors.add(:base,
-                 "configure_repositories step: Repository paths are now set under the 'paths' key. Refer to " \
-                 'https://openbuildservice.org/help/manuals/obs-user-guide/cha-obs-scm-ci-workflow-integration' \
-                 '#sec-obs-obs-scm-ci-workflow-integration-obs-workflows-steps-configure-repositories-architectures-for-a-project for an example')
-    end
-
     required_repository_keys_sentence ||= REQUIRED_REPOSITORY_KEYS.map { |key| "'#{key}'" }.to_sentence
     errors.add(:base, "configure_repositories step: All repositories must have the #{required_repository_keys_sentence} keys")
   end

--- a/src/api/spec/models/workflow/step/configure_repositories_spec.rb
+++ b/src/api/spec/models/workflow/step/configure_repositories_spec.rb
@@ -104,12 +104,6 @@ RSpec.describe Workflow::Step::ConfigureRepositories do
         # This will be fixed once we remove the temporary error message helping users migrate their configure_repositories steps
         it 'is not valid' do
           expect(subject).not_to be_valid
-          expect(subject.errors.full_messages).to eq(["configure_repositories step: Repository paths are now set under the 'paths' key. Refer to " \
-                                                      'https://openbuildservice.org/help/manuals/obs-user-guide/cha-obs-scm-ci-workflow-integration' \
-                                                      '#sec-obs-obs-scm-ci-workflow-integration-obs-workflows-steps-configure-repositories-architectures-for-a-project ' \
-                                                      'for an example',
-                                                      "configure_repositories step: All repositories must have the 'architectures', 'name', and 'paths' keys",
-                                                      "configure_repositories step: All repository paths must have the 'target_project' and 'target_repository' keys"])
         end
         # rubocop:enable RSpec/ExampleLength
       end


### PR DESCRIPTION
This was useful during the migration. I think we're past that migration window so this is not needed anymore.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
