### PR TITLE
Extend configure repository step to accept rebuild and linkedbuild attributes

### DIFF
--- a/src/api/app/models/repository.rb
+++ b/src/api/app/models/repository.rb
@@ -41,8 +41,8 @@ class Repository < ApplicationRecord
   # Keep in sync with src/backend/BSVerify.pm
   validates :name, format: { with: %r{\A[^_:/\000-\037][^:/\000-\037]*\Z},
                              message: "must not start with '_' or contain any of these characters ':/'" }
-  validates :rebuild, inclusion: { in: %w(transitive direct local) }, allow_blank: true
-  validates :linkedbuild, inclusion: { in: %w(off localdep all alldirect alldirect_or_localdep) }, allow_blank: true
+  validates :rebuild, inclusion: { in: %w(transitive direct local), message: "'%{value}' is not a valid rebuild option" }, allow_blank: true
+  validates :linkedbuild, inclusion: { in: %w(off localdep all alldirect alldirect_or_localdep), message: "'%{value}' is not a valid linkedbuild option" }, allow_blank: true
 
   # never used in production, but existed for quite some time...
   self.ignored_columns += ['hostsystem_id']

--- a/src/api/app/models/workflow/step/configure_repositories.rb
+++ b/src/api/app/models/workflow/step/configure_repositories.rb
@@ -20,6 +20,8 @@ class Workflow::Step::ConfigureRepositories < Workflow::Step
 
     step_instructions[:repositories].each do |repository_instructions|
       configured_repository = Repository.includes(:architectures).find_or_create_by(name: repository_instructions[:name], project: target_project)
+      configured_repository.update!(rebuild: repository_instructions[:rebuild],
+                                    linkedbuild: repository_instructions[:linkedbuild])
 
       repository_instructions[:paths].each do |repository_path|
         target_repository = Repository.find_by_project_and_name(repository_path[:target_project], repository_path[:target_repository])
@@ -46,11 +48,19 @@ class Workflow::Step::ConfigureRepositories < Workflow::Step
     step_instructions[:project]
   end
 
+  # Validate each repository definition
+  # Each repository definition must have, at least, the following keys:
+  # - architectures
+  # - name
+  # - paths
+  # Optionally it can have
+  # - rebuild: with the following valid values: direct, local
+  # - linkedbuild: with the following valid values: all, localdep, alldirect, alldirect_or_localdep, off
   def validate_repositories
-    return if step_instructions[:repositories].all? { |repository| repository.keys.sort == REQUIRED_REPOSITORY_KEYS }
-
-    required_repository_keys_sentence ||= REQUIRED_REPOSITORY_KEYS.map { |key| "'#{key}'" }.to_sentence
-    errors.add(:base, "configure_repositories step: All repositories must have the #{required_repository_keys_sentence} keys")
+    unless step_instructions[:repositories].all? { |repository| (REQUIRED_REPOSITORY_KEYS - repository.keys).empty? }
+      required_repository_keys_sentence ||= REQUIRED_REPOSITORY_KEYS.map { |key| "'#{key}'" }.to_sentence
+      errors.add(:base, "configure_repositories step: All repositories must have the #{required_repository_keys_sentence} keys")
+    end
   end
 
   def validate_repository_paths

--- a/src/api/spec/models/workflow/step/configure_repositories_spec.rb
+++ b/src/api/spec/models/workflow/step/configure_repositories_spec.rb
@@ -59,19 +59,17 @@ RSpec.describe Workflow::Step::ConfigureRepositories do
       end
 
       context 'and we have all the required keys in the step instructions' do
-        before do
-          subject.call
-        end
-
         let(:configured_repositories) { target_project.reload.repositories }
         let(:configured_path_elements) { configured_repositories.first.path_elements }
         let(:configured_architectures) { configured_repositories.first.architectures }
 
         it 'configures the repository with the right attributes' do
+          subject.call
           expect(configured_repositories).to contain_exactly(have_attributes(name: 'openSUSE_Tumbleweed', db_project_id: target_project.id))
         end
 
         it 'configures the path elements with the right attributes' do
+          subject.call
           expect(configured_path_elements).to contain_exactly(
             have_attributes(parent_id: configured_repositories.first.id, repository_id: path_repository1.id, position: 1, kind: 'standard'),
             have_attributes(parent_id: configured_repositories.first.id, repository_id: path_repository2.id, position: 2, kind: 'standard')
@@ -79,7 +77,159 @@ RSpec.describe Workflow::Step::ConfigureRepositories do
         end
 
         it 'overwrites previously configured architectures with those in the step instructions' do
+          subject.call
           expect(configured_architectures.map(&:name)).to eq(%w[x86_64 ppc])
+        end
+        
+        context 'and we provide the repository with a valid rebuild option' do
+          let(:step_instructions) do
+            {
+              project: 'OBS:Server:Unstable',
+              repositories:
+                [
+                  {
+                    name: 'openSUSE_Tumbleweed',
+                    paths: [
+                      { target_project: 'openSUSE:Factory', target_repository: 'snapshot' },
+                      { target_project: 'openSUSE:Leap:15.4', target_repository: 'standard' }
+                    ],
+                    architectures: %w[
+                      x86_64
+                      ppc
+                    ],
+                    rebuild: 'direct'
+                  }
+                ]
+            }
+          end
+
+          it 'configures the repository with that option' do
+            subject.call
+            expect(subject).to be_valid
+            expect(configured_repositories.first.rebuild).to eql('direct')
+          end
+        end
+        
+        context 'but we provide the repository with an invalid rebuild option' do
+          let(:step_instructions) do
+            {
+              project: 'OBS:Server:Unstable',
+              repositories:
+                [
+                  {
+                    name: 'openSUSE_Tumbleweed',
+                    paths: [
+                      { target_project: 'openSUSE:Factory', target_repository: 'snapshot' },
+                      { target_project: 'openSUSE:Leap:15.4', target_repository: 'standard' }
+                    ],
+                    architectures: %w[
+                      x86_64
+                      ppc
+                    ],
+                    rebuild: 'invalid'
+                  }
+                ]
+            }
+          end
+
+          it 'does not configure the repository with that option' do
+            expect { subject.call }.to raise_error(ActiveRecord::RecordInvalid)
+          end
+        end
+
+        context 'and we provide the repository with a valid linkedbuild option' do
+          let(:step_instructions) do
+            {
+              project: 'OBS:Server:Unstable',
+              repositories:
+                [
+                  {
+                    name: 'openSUSE_Tumbleweed',
+                    paths: [
+                      { target_project: 'openSUSE:Factory', target_repository: 'snapshot' },
+                      { target_project: 'openSUSE:Leap:15.4', target_repository: 'standard' }
+                    ],
+                    architectures: %w[
+                      x86_64
+                      ppc
+                    ],
+                    linkedbuild: 'all'
+                  }
+                ]
+            }
+          end
+
+          it 'configures the repository with that option' do
+            subject.call
+            expect(subject).to be_valid
+            expect(configured_repositories.first.linkedbuild).to eql('all')
+          end
+        end
+
+        context 'but we provide the repository with an invalid linkedbuild option' do
+          let(:step_instructions) do
+            {
+              project: 'OBS:Server:Unstable',
+              repositories:
+                [
+                  {
+                    name: 'openSUSE_Tumbleweed',
+                    paths: [
+                      { target_project: 'openSUSE:Factory', target_repository: 'snapshot' },
+                      { target_project: 'openSUSE:Leap:15.4', target_repository: 'standard' }
+                    ],
+                    architectures: %w[
+                      x86_64
+                      ppc
+                    ],
+                    linkedbuild: 'invalid'
+                  }
+                ]
+            }
+          end
+
+          it 'does not configure the repository with that option' do
+            expect { subject.call }.to raise_error(ActiveRecord::RecordInvalid)
+          end
+        end
+
+        context 'and the repository already exists' do
+          before do
+            create(:repository, name: 'a_repo', project: target_project, rebuild: 'direct', linkedbuild: 'off')
+          end
+
+          let(:step_instructions) do
+            {
+              project: 'OBS:Server:Unstable',
+              repositories:
+                [
+                  {
+                    name: 'a_repo',
+                    paths: [
+                      { target_project: 'openSUSE:Factory', target_repository: 'snapshot' },
+                      { target_project: 'openSUSE:Leap:15.4', target_repository: 'standard' }
+                    ],
+                    architectures: %w[
+                      x86_64
+                      ppc
+                    ],
+                    rebuild: 'local',
+                    linkedbuild: 'all'
+                  }
+                ]
+            }
+          end
+
+          it 'is valid' do
+            subject.call
+            expect(subject).to be_valid
+          end
+
+          it 'updates the existing repository attributes' do
+            expect { subject.call }.to_not change(Repository, :count)
+            expect(configured_repositories.first.rebuild).to eql('local')
+            expect(configured_repositories.first.linkedbuild).to eql('all')
+          end
         end
       end
 


### PR DESCRIPTION
This options are needed for the future Link Project workflow step.