### PR TITLE
Call SCMStatusReporter async

### DIFF
--- a/src/api/app/jobs/concerns/event_undone_jobs_callback.rb
+++ b/src/api/app/jobs/concerns/event_undone_jobs_callback.rb
@@ -3,12 +3,11 @@ module EventUndoneJobsCallback
   extend ActiveSupport::Concern
 
   included do
-    attr_reader :event_id
-
     after_perform do |job|
-      next unless job.event_id
+      event_id = job.arguments.first[:event_id]
+      next unless event_id
 
-      event = Event::Base.find(job.event_id)
+      event = Event::Base.find(event_id)
 
       event.with_lock do
         event.mark_job_done!

--- a/src/api/app/jobs/concerns/event_undone_jobs_callback.rb
+++ b/src/api/app/jobs/concerns/event_undone_jobs_callback.rb
@@ -3,9 +3,12 @@ module EventUndoneJobsCallback
   extend ActiveSupport::Concern
 
   included do
+    attr_reader :event_id
+
     after_perform do |job|
-      event_id = job.arguments.first
-      event = Event::Base.find(event_id)
+      next unless job.event_id
+
+      event = Event::Base.find(job.event_id)
 
       event.with_lock do
         event.mark_job_done!

--- a/src/api/app/jobs/report_to_scm_job.rb
+++ b/src/api/app/jobs/report_to_scm_job.rb
@@ -6,7 +6,6 @@ class ReportToSCMJob < ApplicationJob
   queue_as :scm
 
   def perform(event_id: nil, workflow_run: nil, event_type: nil, initial_report: false, event_payload: nil)
-    @event_id = event_id
     if event_id
       report_event(event_id)
     else

--- a/src/api/app/jobs/report_to_scm_job.rb
+++ b/src/api/app/jobs/report_to_scm_job.rb
@@ -5,7 +5,18 @@ class ReportToSCMJob < ApplicationJob
 
   queue_as :scm
 
-  def perform(event_id)
+  def perform(event_id: nil, workflow_run: nil, event_type: nil, initial_report: false, event_payload: nil)
+    @event_id = event_id
+    if event_id
+      report_event(event_id)
+    else
+      report_direct(workflow_run, event_type: event_type, initial_report: initial_report, event_payload: event_payload)
+    end
+  end
+
+  private
+
+  def report_event(event_id)
     event = Event::Base.find(event_id)
     return unless event
     return unless event.undone_jobs.positive?
@@ -21,7 +32,14 @@ class ReportToSCMJob < ApplicationJob
     end
   end
 
-  private
+  def report_direct(workflow_run, event_type:, initial_report:, event_payload:)
+    SCMStatusReporter.new(event_payload: event_payload || workflow_run.payload,
+                          event_subscription_payload: workflow_run.payload,
+                          scm_token: workflow_run.token.scm_token,
+                          workflow_run: workflow_run,
+                          event_type: event_type,
+                          initial_report: initial_report).call
+  end
 
   def matched_event_subscription(event:)
     subscriptions = EventSubscription.joins(:token).where(channel: :scm).where(eventtype: event.eventtype).where(token: { enabled: true })

--- a/src/api/app/jobs/update_backend_infos_job.rb
+++ b/src/api/app/jobs/update_backend_infos_job.rb
@@ -2,6 +2,7 @@ class UpdateBackendInfosJob < ApplicationJob
   include EventUndoneJobsCallback
 
   def perform(event_id)
+    @event_id = event_id
     event = Event::Base.find(event_id)
     payload = event.payload
     package = Package.find_by_project_and_name(payload['project'], payload['package'])

--- a/src/api/app/jobs/update_backend_infos_job.rb
+++ b/src/api/app/jobs/update_backend_infos_job.rb
@@ -1,8 +1,7 @@
 class UpdateBackendInfosJob < ApplicationJob
   include EventUndoneJobsCallback
 
-  def perform(event_id)
-    @event_id = event_id
+  def perform(event_id:)
     event = Event::Base.find(event_id)
     payload = event.payload
     package = Package.find_by_project_and_name(payload['project'], payload['package'])

--- a/src/api/app/jobs/update_released_binaries_job.rb
+++ b/src/api/app/jobs/update_released_binaries_job.rb
@@ -5,6 +5,7 @@ class UpdateReleasedBinariesJob < ApplicationJob
   queue_as :releasetracking
 
   def perform(event_id)
+    @event_id = event_id
     event = Event::Base.find(event_id)
 
     repository = Repository.find_by_project_and_name(event.payload['project'], event.payload['repo'])

--- a/src/api/app/jobs/update_released_binaries_job.rb
+++ b/src/api/app/jobs/update_released_binaries_job.rb
@@ -4,8 +4,7 @@ class UpdateReleasedBinariesJob < ApplicationJob
 
   queue_as :releasetracking
 
-  def perform(event_id)
-    @event_id = event_id
+  def perform(event_id:)
     event = Event::Base.find(event_id)
 
     repository = Repository.find_by_project_and_name(event.payload['project'], event.payload['repo'])

--- a/src/api/app/models/concerns/report_to_scm_callback.rb
+++ b/src/api/app/models/concerns/report_to_scm_callback.rb
@@ -5,7 +5,7 @@ module ReportToScmCallback
   end
 
   def report_to_scm
-    ReportToSCMJob.perform_later(id)
+    ReportToSCMJob.perform_later(event_id: id)
     self.update_columns(undone_jobs: 1)
   end
 end

--- a/src/api/app/models/concerns/update_backend_infos_callback.rb
+++ b/src/api/app/models/concerns/update_backend_infos_callback.rb
@@ -5,7 +5,7 @@ module UpdateBackendInfosCallback
   end
 
   def update_backend_infos
-    UpdateBackendInfosJob.perform_later(id)
+    UpdateBackendInfosJob.perform_later(event_id: id)
     self.update_columns(undone_jobs: 1)
   end
 end

--- a/src/api/app/models/event/packtrack.rb
+++ b/src/api/app/models/event/packtrack.rb
@@ -12,7 +12,7 @@ module Event
     private
 
     def update_released_binaries
-      UpdateReleasedBinariesJob.perform_later(id)
+      UpdateReleasedBinariesJob.perform_later(event_id: id)
       self.update_columns(undone_jobs: 1)
     end
   end

--- a/src/api/app/models/token/workflow.rb
+++ b/src/api/app/models/token/workflow.rb
@@ -34,10 +34,9 @@ class Token::Workflow < Token
     # FIXME: This makes little sense, wherever we use response_url, just use api_endpoint...
     workflow_run.update(response_url: workflow_run.api_endpoint)
 
-    # We return early with a ping event, since it doesn't make sense to perform payload checks with it, just respond
+    # In a ping event we just return early after the validation and the initial report to SCM
     if workflow_run.ping_event?
-      SCMStatusReporter.new(event_payload: workflow_run.payload, event_subscription_payload: workflow_run.payload, scm_token: scm_token, workflow_run: workflow_run, event_type: 'success',
-                            initial_report: true).call
+      ReportToSCMJob.perform_later(workflow_run: workflow_run, event_type: 'success', initial_report: true)
       return []
     end
     yaml_file = Workflows::YAMLDownloader.new(workflow_run, token: self).call
@@ -45,15 +44,15 @@ class Token::Workflow < Token
 
     return validation_errors unless validation_errors.none?
 
-    # This is just an initial generic report to give a feedback asap. Initial status pending
-    SCMStatusReporter.new(event_payload: workflow_run.payload, event_subscription_payload: workflow_run.payload, scm_token: scm_token, workflow_run: workflow_run, initial_report: true).call
+    # Initial report with status set to pending
+    ReportToSCMJob.perform_later(workflow_run: workflow_run, initial_report: true)
     @workflows.each do |workflow|
       return workflow.errors.full_messages if workflow.invalid?(:call)
 
       workflow.call
     end
-    SCMStatusReporter.new(event_payload: workflow_run.payload, event_subscription_payload: workflow_run.payload, scm_token: scm_token, workflow_run: workflow_run, event_type: 'success',
-                          initial_report: true).call
+    # Final status report
+    ReportToSCMJob.perform_later(workflow_run: workflow_run, event_type: 'success', initial_report: true)
     # Always returning validation errors to report them back to the SCM in order to help users debug their workflows
     validation_errors
   rescue Octokit::Unauthorized, Gitlab::Error::Unauthorized

--- a/src/api/app/models/workflow/step/submit_request.rb
+++ b/src/api/app/models/workflow/step/submit_request.rb
@@ -42,11 +42,9 @@ class Workflow::Step::SubmitRequest < Workflow::Step
     @bs_request.save!
 
     Workflows::ScmEventSubscriptionCreator.new(token, workflow_run, @bs_request).call
-    SCMStatusReporter.new(event_payload: { number: @bs_request.number, state: @bs_request.state },
-                          event_subscription_payload: workflow_run.payload,
-                          scm_token: @token.scm_token,
-                          workflow_run: workflow_run,
-                          event_type: 'Event::RequestStatechange').call
+    ReportToSCMJob.perform_later(workflow_run: workflow_run,
+                                 event_payload: { number: @bs_request.number, state: @bs_request.state },
+                                 event_type: 'Event::RequestStatechange')
     @bs_request
   end
 

--- a/src/api/spec/jobs/report_to_scm_job_spec.rb
+++ b/src/api/spec/jobs/report_to_scm_job_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe ReportToSCMJob do
   end
 
   describe '#perform' do
-    subject { described_class.perform_now(event.id) }
+    subject { described_class.perform_now(event_id: event.id) }
 
     context 'happy path' do
       before do

--- a/src/api/spec/models/token/workflow_spec.rb
+++ b/src/api/spec/models/token/workflow_spec.rb
@@ -1,4 +1,5 @@
 RSpec.describe Token::Workflow do
+  include ActiveJob::TestHelper
   let(:token_user) { create(:confirmed_user, :with_home, login: 'Iggy') }
   let(:workflow_token) { create(:workflow_token, executor: token_user) }
 
@@ -48,7 +49,7 @@ RSpec.describe Token::Workflow do
         allow(Workflows::YAMLToWorkflowsService).to receive(:new).with(yaml_file: yaml_file, token: workflow_token,
                                                                        workflow_run: workflow_run).and_return(yaml_to_workflows_service)
         allow(yaml_to_workflows_service).to receive(:call).and_return(workflows)
-        allow(SCMStatusReporter).to receive(:new).and_return(proc { true })
+        allow(ReportToSCMJob).to receive(:perform_later)
       end
 
       it 'returns no validation errors' do
@@ -59,7 +60,7 @@ RSpec.describe Token::Workflow do
 
       it 'sends the initial report twice' do
         subject
-        expect(SCMStatusReporter).to have_received(:new).twice
+        expect(ReportToSCMJob).to have_received(:perform_later).twice
       end
     end
 
@@ -112,7 +113,7 @@ RSpec.describe Token::Workflow do
       before do
         # Skipping call since it's tested in the Workflow model
         allow(workflow).to receive(:call).and_return(true)
-        allow(SCMStatusReporter).to receive(:new).and_return(proc { true })
+        allow(ReportToSCMJob).to receive(:perform_later)
       end
 
       it 'returns before checking for validation errors' do
@@ -123,7 +124,7 @@ RSpec.describe Token::Workflow do
 
       it 'returns early with one report' do
         subject
-        expect(SCMStatusReporter).to have_received(:new).once
+        expect(ReportToSCMJob).to have_received(:perform_later).once
       end
     end
 
@@ -208,7 +209,7 @@ RSpec.describe Token::Workflow do
       end
 
       it 'returns no validation errors' do
-        expect { subject }.to change(SCMStatusReport, :count).by(2)
+        expect { perform_enqueued_jobs { subject } }.to change(SCMStatusReport, :count).by(2)
       end
     end
 
@@ -248,7 +249,7 @@ RSpec.describe Token::Workflow do
       end
 
       it 'returns no validation errors' do
-        expect { subject }.not_to(change(SCMStatusReport, :count))
+        expect { perform_enqueued_jobs { subject } }.not_to(change(SCMStatusReport, :count))
       end
     end
   end


### PR DESCRIPTION
Do not call `SCMStatusReporter` in a sync way, wrap in `ReportToSCMJob` instead.