### PR TITLE
Add link_project_step to SCM/CI integration

### DIFF
--- a/src/api/app/models/concerns/project_links.rb
+++ b/src/api/app/models/concerns/project_links.rb
@@ -30,6 +30,26 @@ module ProjectLinks
     end
   end
 
+  def add_project_link(project_name_to_link_against:)
+    # The position is handled automatically by acts_as_list on LinkedProject,
+    # which appends new links to the bottom of the list.
+    if Project.remote_project?(project_name_to_link_against)
+      linking_to.find_or_create_by(linked_remote_project_name: project_name_to_link_against)
+    else
+      project_to_link_against = Project.find_by_name(project_name_to_link_against)
+      linking_to.find_or_create_by(linked_db_project: project_to_link_against)
+    end
+  end
+
+  def remove_project_link(linked_project_name:)
+    if Project.remote_project?(linked_project_name)
+      linking_to.destroy_by(linked_remote_project_name: linked_project_name)
+    else
+      linked_project = Project.find_by_name(linked_project_name)
+      linking_to.destroy_by(linked_db_project: linked_project)
+    end
+  end
+
   def expand_linking_to
     expand_all_projects.map(&:id)
   end

--- a/src/api/app/models/linked_project.rb
+++ b/src/api/app/models/linked_project.rb
@@ -2,6 +2,8 @@ class LinkedProject < ApplicationRecord
   belongs_to :project, foreign_key: :db_project_id
   belongs_to :linked_db_project, class_name: 'Project', optional: true
 
+  acts_as_list scope: [:db_project_id]
+
   validates :linked_db_project, presence: true, unless: -> { linked_remote_project_name.present? }
   validates :linked_remote_project_name, presence: true, unless: -> { linked_db_project.present? }
   validates :linked_remote_project_name, length: { maximum: 255 }

--- a/src/api/app/models/workflow/step/link_project.rb
+++ b/src/api/app/models/workflow/step/link_project.rb
@@ -1,0 +1,39 @@
+class Workflow::Step::LinkProject < Workflow::Step
+
+  REQUIRED_KEYS = %i[project project_to_link_against].freeze
+
+  validate :validate_existence_of_projects
+
+  def call
+    return unless valid?
+
+    case
+    when workflow_run.closed_merged_pull_request?, workflow_run.unlabeled_pull_request?
+      @project.remove_project_link(linked_project_name: project_name_to_link_against)
+    when workflow_run.new_pull_request?, workflow_run.reopened_pull_request?, workflow_run.push_event?, workflow_run.tag_push_event?, workflow_run.labeled_pull_request?
+      @project.add_project_link(project_name_to_link_against: project_name_to_link_against)
+    end
+  end
+
+  private
+
+  def project_name
+    step_instructions[:project]
+  end
+
+  def project_name_to_link_against
+    step_instructions[:project_to_link_against]
+  end
+
+  def validate_existence_of_projects
+    return if project_name.blank? || project_name_to_link_against.blank?
+
+    @project = Project.find_by_name(project_name)
+    errors.add(:base, "The project '#{project_name}' does not exist.") if @project.blank?
+
+    # exists_by_name handles both local and remote (interconnect) projects
+    return if Project.exists_by_name(project_name_to_link_against)
+
+    errors.add(:base, "The project '#{project_name_to_link_against}' does not exist.")
+  end
+end


### PR DESCRIPTION
## Step Configuration

The step needs two parameters:
- `source_project`: Where the link pulls the binaries and packages from.
- `target_project`: Where the link puts the binaries and packages to.

This would look like this:
```yaml
workflow:
  steps:
    - link_project:
        source_project: openSUSE:Factory
        target_project: home:dandoni:branches:openSUSE_Factory_link
```