### PR TITLE
Expose scmsync attribute in the UI

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -129,6 +129,8 @@ class Webui::PackageController < Webui::WebuiController
     respond_to do |format|
       format.js do
         if @package.update(package_details_params)
+          set_linkinfo
+          @failures = 0
           flash.now[:success] = 'Package was successfully updated.'
         else
           flash.now[:error] = 'Failed to update the package.'

--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -428,7 +428,7 @@ class Webui::PackageController < Webui::WebuiController
   end
 
   def package_params
-    params.require(:package).permit(:name, :title, :description)
+    params.require(:package).permit(:name, :title, :description, :scmsync)
   end
 
   def package_details_params
@@ -443,7 +443,8 @@ class Webui::PackageController < Webui::WebuiController
               :description,
               :url,
               :report_bug_url,
-              :anitya_ignore)
+              :anitya_ignore,
+              :scmsync)
   end
 
   def set_file_details

--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -447,7 +447,8 @@ class Webui::ProjectController < Webui::WebuiController
       :disable_publishing,
       :url,
       :report_bug_url,
-      :anitya_distribution_name
+      :anitya_distribution_name,
+      :scmsync
     )
   end
 

--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -126,6 +126,7 @@ class Webui::ProjectController < Webui::WebuiController
       format.js do
         if @project.update(project_params)
           @project.store
+          load_project_info
           flash.now[:success] = 'Project was successfully updated.'
         else
           flash.now[:error] = 'Failed to update the project.'

--- a/src/api/app/views/webui/package/_edit.html.haml
+++ b/src/api/app/views/webui/package/_edit.html.haml
@@ -9,6 +9,9 @@
   .mb-3
     = form.label(:url, 'URL:')
     = form.text_field(:url, class: 'form-control')
+  .mb-3
+    = form.label(:scmsync, 'SCM Sync URL:')
+    = form.text_field(:scmsync, class: 'form-control', placeholder: 'e.g. https://github.com/org/repo.git')
   - if feature_enabled?('foster_collaboration')
     .mb-3
       = form.label(:report_bug_url, 'Report Bug URL:')

--- a/src/api/app/views/webui/package/new.html.haml
+++ b/src/api/app/views/webui/package/new.html.haml
@@ -34,6 +34,9 @@
                 = f.text_field(:title, size: 80, class: 'form-control', placeholder: 'Enter Title')
                 %label.form-text.template-description#description-title
               .mb-3
+                = f.label(:scmsync, 'SCM Sync URL')
+                = f.text_field(:scmsync, size: 80, class: 'form-control', placeholder: 'e.g. https://github.com/org/repo.git')
+              .mb-3
                 = f.label(:description)
                 = render WriteAndPreviewComponent.new(form: f, preview_message_url: package_preview_description_path,
                                                       message_body_param: 'package[description]',

--- a/src/api/app/views/webui/package/update.js.haml
+++ b/src/api/app/views/webui/package/update.js.haml
@@ -14,6 +14,13 @@ resetFormValidation();
       $('#package-title').html("#{escape_javascript(@package.title.presence || @package.name)}");
       $('.action-report-bug').html("#{escape_javascript(render(partial: 'webui/package/show_actions/bugzilla_owner',
                                                                locals: { url: @package.report_bug_or_bugzilla_url }))}");
+      $('.side_links').replaceWith("#{escape_javascript(render(partial: 'webui/package/side_links',
+                                                               locals: { devel_package: @package.develpackage,
+                                                                         failures: @failures,
+                                                                         linkinfo: @linkinfo,
+                                                                         revision: @revision,
+                                                                         project: @project,
+                                                                         package: @package }))}");
       setCollapsible();
       $('.in-place-editing,.action-report-bug').animate({ opacity: 1 }, 400, function() {
         $('#flash').html("#{escape_javascript(render(layout: false, partial: 'layouts/webui/flash', object: flash))}");

--- a/src/api/app/views/webui/project/_edit.html.haml
+++ b/src/api/app/views/webui/project/_edit.html.haml
@@ -7,6 +7,9 @@
   .mb-3
     = form.label(:url, 'URL:')
     = form.text_field(:url, class: 'form-control')
+  .mb-3
+    = form.label(:scmsync, 'SCM Sync URL:')
+    = form.text_field(:scmsync, class: 'form-control', placeholder: 'e.g. https://github.com/org/repo.git')
   - if feature_enabled?('foster_collaboration')
     .mb-3
       = form.label(:report_bug_url, 'Report Bug URL:')

--- a/src/api/app/views/webui/project/_edit_project_dialog.html.haml
+++ b/src/api/app/views/webui/project/_edit_project_dialog.html.haml
@@ -15,5 +15,8 @@
           .mb-3
             = form.label(:url, 'URL:')
             = form.text_field(:url, class: 'form-control')
+          .mb-3
+            = form.label(:scmsync, 'SCM Sync URL:')
+            = form.text_field(:scmsync, class: 'form-control', placeholder: 'e.g. https://github.com/org/repo.git')
         .modal-footer
           = render partial: 'webui/shared/dialog_action_buttons', locals: { submit_tag_text: 'Update' }

--- a/src/api/app/views/webui/project/_form.html.haml
+++ b/src/api/app/views/webui/project/_form.html.haml
@@ -15,6 +15,9 @@
   = form.label(:title, 'Title:')
   = form.text_field(:title, class: 'form-control')
 .mb-3
+  = form.label(:scmsync, 'SCM Sync URL:')
+  = form.text_field(:scmsync, class: 'form-control', placeholder: 'e.g. https://github.com/org/repo.git')
+.mb-3
   = form.label(:description, 'Description:')
   = render WriteAndPreviewComponent.new(form: form, preview_message_url: project_preview_description_path,
                                         message_body_param: 'project[description]',

--- a/src/api/app/views/webui/project/update.js.haml
+++ b/src/api/app/views/webui/project/update.js.haml
@@ -13,6 +13,19 @@ resetFormValidation();
       $('#project-title').html("#{escape_javascript(@project.title.presence || @project)}");
       $('.action-report-bug').html("#{escape_javascript(render(partial: 'webui/project/show_actions/report_bug',
                                                                locals: { url: @project.report_bug_or_bugzilla_url }))}");
+      $('.side_links').replaceWith("#{escape_javascript(render(partial: 'webui/project/side_links',
+                                                               locals: { open_maintenance_incidents: @open_maintenance_incidents,
+                                                                         project: @project,
+                                                                         maintained_projects: @maintained_projects,
+                                                                         nr_of_problem_packages: @nr_of_problem_packages,
+                                                                         open_release_requests: @open_release_requests,
+                                                                         release_targets: @release_targets,
+                                                                         requests: @requests,
+                                                                         package: @package,
+                                                                         linking_projects: @linking_projects,
+                                                                         project_maintenance_project: @project_maintenance_project,
+                                                                         incoming_requests_size: @incoming_requests_size,
+                                                                         outgoing_requests_size: @outgoing_requests_size }))}");
       setCollapsible();
       $('.in-place-editing,.action-report-bug').animate({ opacity: 1 }, 400, function() {
         $('#flash').html("#{escape_javascript(render(layout: false, partial: 'layouts/webui/flash', object: flash))}");

--- a/src/api/config/brakeman.ignore
+++ b/src/api/config/brakeman.ignore
@@ -122,6 +122,7 @@
       "note": ""
     },
     {
+
       "warning_type": "SQL Injection",
       "warning_code": 0,
       "fingerprint": "23288c7e9dea90dd0d6a14268bf929de5b7651f16e9c2233776751400dda5d11",

--- a/src/api/spec/controllers/webui/project_controller_spec.rb
+++ b/src/api/spec/controllers/webui/project_controller_spec.rb
@@ -34,6 +34,10 @@ RSpec.describe Webui::ProjectController, :vcr do
   describe 'PATCH #update' do
     let(:project) { user.home_project }
 
+    before do
+      allow_any_instance_of(Project).to receive(:number_of_build_problems).and_return(0)
+    end
+
     context 'with valid parameters' do
       before do
         login user


### PR DESCRIPTION
Fixes #19826.

This PR adds the `scmsync` attribute field to the UI when creating or editing Projects and Packages, as requested by users who frequently paste SCM Sync Git URLs. The field has been added to the relevant HAML forms and the WebUI controllers have been updated to permit the new parameter.