### PR TITLE
Retry on scm failures

### DIFF
--- a/src/api/app/jobs/report_to_scm_job.rb
+++ b/src/api/app/jobs/report_to_scm_job.rb
@@ -3,6 +3,21 @@ class ReportToSCMJob < ApplicationJob
 
   ALLOWED_EVENTS = ['Event::BuildFail', 'Event::BuildSuccess', 'Event::RequestStatechange'].freeze
 
+  # Transient errors that are worth retrying: SCM-side 5xx, rate limits, and network glitches.
+  # Auth failures, 4xx config errors, and SSL problems are not retried.
+  RETRYABLE_EXCEPTIONS = [
+    Octokit::InternalServerError,
+    Octokit::BadGateway,
+    Octokit::ServiceUnavailable,
+    Octokit::ServerError,
+    Faraday::ConnectionFailed,
+    Faraday::TimeoutError
+  ].freeze
+
+  # Progressive time before retrying the job in case of retryable exceptions
+  RETRY_WAIT_TIMES = { 1 => 0, 2 => 1.minute, 3 => 2.minutes, 4 => 5.minutes, 5 => 10.minutes }.freeze
+  retry_on(*RETRYABLE_EXCEPTIONS, wait: ->(executions) { RETRY_WAIT_TIMES.fetch(executions) }, attempts: 6)
+
   queue_as :scm
 
   def perform(event_id: nil, workflow_run: nil, event_type: nil, initial_report: false, event_payload: nil)

--- a/src/api/app/services/github_status_reporter.rb
+++ b/src/api/app/services/github_status_reporter.rb
@@ -35,7 +35,7 @@ class GithubStatusReporter < SCMExceptionHandler
     (@workflow_run.presence&.save_scm_report_failure("Failed to report back to GitHub: #{e.message}", request_context))
   rescue Octokit::Error => e
     rescue_with_handler(e) || raise(e)
-  rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Faraday::SSLError => e
+  rescue Faraday::SSLError => e
     (@workflow_run.presence&.save_scm_report_failure("Failed to report back to GitHub: #{e.message}", request_context))
   ensure
     RabbitmqBus.send_to_bus('metrics', "scm_status_report,status=fail,scm=#{@workflow_run.scm_vendor},exception=#{e.class} value=1") if e.present? && @workflow_run.present?

--- a/src/api/app/services/scm_exception_handler.rb
+++ b/src/api/app/services/scm_exception_handler.rb
@@ -23,12 +23,7 @@ class SCMExceptionHandler
               Octokit::UnverifiedEmail,
               Octokit::InvalidRepository,
               Octokit::PathDiffTooLarge,
-              Octokit::UnprocessableEntity,
-              Octokit::InternalServerError,       # 500
-              Octokit::NotImplemented,            # 501
-              Octokit::BadGateway,                # 502
-              Octokit::ServiceUnavailable,        # 503
-              Octokit::ServerError do |exception| # 500..599
+              Octokit::UnprocessableEntity do |exception|
     log_to_workflow_run(exception, 'GitHub') if @workflow_run.present?
   end
 

--- a/src/api/spec/services/github_status_reporter_spec.rb
+++ b/src/api/spec/services/github_status_reporter_spec.rb
@@ -88,21 +88,6 @@ RSpec.describe GithubStatusReporter, type: :service do
           expect(workflow_run.last_response_body).to eq('Failed to report back to GitHub: Sorry. Your account is suspended.')
         end
       end
-
-      context 'there is a network glitch' do
-        before do
-          allow(Octokit::Client).to receive(:new).and_return(octokit_client)
-          allow(octokit_client).to receive(:create_status).and_raise(Faraday::ConnectionFailed.new('Network glitch'))
-        end
-
-        it { expect { subject }.to change(SCMStatusReport, :count).by(1) }
-
-        it 'tracks the exception in the workflow_run response body and sets the status to fail' do
-          subject
-          expect(workflow_run.status).to eq('fail')
-          expect(workflow_run.last_response_body).to eq('Failed to report back to GitHub: Network glitch')
-        end
-      end
     end
 
     context 'when sending a report back to GitHub' do


### PR DESCRIPTION
https://trello.com/c/In4BLE90

Implementation to consume [retry_on](https://api.rubyonrails.org/v7.2/classes/ActiveJob/Exceptions/ClassMethods.html#method-i-retry_on) callbacks for `ActiveJob` classes. We want to retry on SCM transient failures before disabling the token after the first error.