### PR TITLE
[dist] exclude '^perl(.*)' from provides

### DIFF
--- a/dist/obs-server.spec
+++ b/dist/obs-server.spec
@@ -70,6 +70,10 @@ Url:            http://www.openbuildservice.org
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 Source0:        open-build-service-%version.tar.xz
 BuildRequires:  python3-devel
+
+# None of our perl modules are for consumption
+%define __provides_exclude ^perl\\(
+
 # make sure this is in sync with the RAILS_GEM_VERSION specified in the
 # config/environment.rb of the various applications.
 # atm the obs rails version patch above unifies that setting among the applications


### PR DESCRIPTION
None of our perl modules are for consumption

Backport from 1e8688bb749
