### PR TITLE
Add data migration to remove orphaned workflow run notifications

### DIFF
--- a/src/api/db/data/20260624131158_remove_notifications_with_missing_workflow_run.rb
+++ b/src/api/db/data/20260624131158_remove_notifications_with_missing_workflow_run.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class RemoveNotificationsWithMissingWorkflowRun < ActiveRecord::Migration[7.2]
+  def up
+    workflow_run_notifications = Notification.where(notifiable_type: 'WorkflowRun')
+    orphaned_workflow_run_notifications = workflow_run_notifications.where.not(notifiable_id: WorkflowRun.select(:id))
+    orphaned_workflow_run_notifications.destroy_all
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/src/api/db/data_schema.rb
+++ b/src/api/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 2026_06_22_102402)
+DataMigrate::Data.define(version: 2026_06_24_131158)


### PR DESCRIPTION
In https://github.com/openSUSE/open-build-service/pull/19850 we removed workflow_run records for branch delete events. The data migration used "delete_all", therefore the callback to remove the associated notification hasn't been executed and left behind orphaned notifications.
We need to remove those in another data migration now.

Fixes #19860
