### PR TITLE
Retry with longer wait on GitHub TooManyRequests

### DIFF
--- a/src/api/app/jobs/report_to_scm_job.rb
+++ b/src/api/app/jobs/report_to_scm_job.rb
@@ -19,6 +19,9 @@ class ReportToSCMJob < ApplicationJob
   RETRY_WAIT_TIMES = { 1 => 0, 2 => 1.minute, 3 => 2.minutes, 4 => 5.minutes, 5 => 10.minutes }.freeze
   retry_on(*RETRYABLE_EXCEPTIONS, wait: ->(executions) { RETRY_WAIT_TIMES.fetch(executions) }, attempts: 6)
 
+  RETRY_LONG_WAIT_TIMES = { 1 => 1.minute, 2 => 5.minutes, 3 => 10.minutes, 4 => 15.minutes, 5 => 30.minutes }.freeze
+  retry_on(Octokit::TooManyRequests, wait: ->(executions) { RETRY_LONG_WAIT_TIMES.fetch(executions) }, attempts: 6)
+
   queue_as :scm
 
   def perform(event_id: nil, workflow_run: nil, event_type: nil, initial_report: false, event_payload: nil)


### PR DESCRIPTION
Retry on [`TooManyRequests`](https://octokit.github.io/octokit.rb/Octokit/TooManyRequests.html) GitHub exception. Wait a bit longer than the default, especially do not _retry right away without waiting_ because, if the limit has been reached, better to wait a bit more to thin down the amount of requests.