### PR TITLE
Stub SCM report job in submit_request_step_spec

### DIFF
--- a/src/api/spec/models/workflow/step/submit_request_step_spec.rb
+++ b/src/api/spec/models/workflow/step/submit_request_step_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe Workflow::Step::SubmitRequest, :vcr do
     before do
       login(user)
       allow(Backend::Api::Sources::Package).to receive(:wait_service).and_return(true)
+      allow(ReportToSCMJob).to receive(:perform_later)
     end
 
     context 'for a newly opened PR' do
@@ -53,6 +54,9 @@ RSpec.describe Workflow::Step::SubmitRequest, :vcr do
 
       it 'creates a submit request' do
         expect { subject.call }.to(change(BsRequest.where(state: 'new'), :count).by(1))
+        expect(ReportToSCMJob).to have_received(:perform_later).with(workflow_run: workflow_run,
+                                                                     event_payload: { number: BsRequest.last.number, state: :new },
+                                                                     event_type: 'Event::RequestStatechange')
       end
 
       it 'creates an event subcription' do


### PR DESCRIPTION
## Description:

`submit_request_step_spec` started failing on `master` because it executes `ReportToSCMJob.perform_later` through the test environment's inline ActiveJob adapter. Once `ReportToSCMJob` retries `Octokit::Unauthorized`, the retry path tries to enqueue a future job and raises `NotImplementedError` inside this step spec.

This PR stubs `ReportToSCMJob.perform_later` in `spec/models/workflow/step/submit_request_step_spec.rb` and asserts the enqueue arguments in the existing submit request example. That keeps the step spec focused on submit request behavior while `ReportToSCMJob` stays covered by its own job specs.

Closes #19875.

## Checklist:

- [x] I have added focused regression coverage for this fix.
- [x] I have run focused tests and linting.

Validation:

- `bundle exec rspec spec/models/workflow/step/submit_request_step_spec.rb --seed 51462`.
- `bundle exec rspec spec/jobs/report_to_scm_job_spec.rb`.
- `bundle exec rubocop spec/models/workflow/step/submit_request_step_spec.rb`.

Focused timings runs:

- 6 sequential runs in the same frontend container.
- RSpec runtime: Average: 3.31, Min: 3.21, Max 3.39 seconds.
- Wall-clock: Average: 7.15, Min: 6.16, Max 7.63 seconds.
