### PR TITLE
Switch back the job execution configuration for test

### DIFF
--- a/src/api/config/environments/test.rb
+++ b/src/api/config/environments/test.rb
@@ -78,7 +78,7 @@ OBSApi::Application.configure do
   # TODO: This shouldn't be needed when we switch to RSpec completely
   config.action_dispatch.rescue_responses['ActionController::InvalidAuthenticityToken'] = 950
 
-  config.active_job.queue_adapter = :inline
+  config.active_job.queue_adapter = :test
   # Access to rack session for feature specs
   config.middleware.use RackSessionAccess::Middleware
 end


### PR DESCRIPTION
`config.active_job.queue_adapter` set to `:inline` executes the jobs synchronously.
In the test environment there is litle reason to execute the jobs. Ideally we should tests the jobs in isolation and in the rest of the test suite just ensure the the job was queued. It makes the test suite faster and remove side effects.

This should fix the spec errors in [master branch](https://app.circleci.com/pipelines/github/openSUSE/open-build-service/31606/workflows/c948f2e0-8ab7-45ff-9162-5c370abbb024/jobs/297706).

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
