### PR TITLE
Bump bundler version for openqa tests

### DIFF
--- a/dist/t/Gemfile.lock
+++ b/dist/t/Gemfile.lock
@@ -50,4 +50,4 @@ DEPENDENCIES
   rspec-expectations
 
 BUNDLED WITH
-   2.1.4
+   2.6.7


### PR DESCRIPTION
Leap 16.0 comes with a newer ruby version which does not ship `DidYouMean::SPELL_CHECKERS` anymore (got deprecated long time ago). Attempting to bundle with bundler 2.1.4 ends up throwing an error. We need to use the newer bundler version shipped by the system ruby...