### PR TITLE
Hide the download repository link when no published URL exists

### DIFF
--- a/src/api/app/components/download_repository_link_component.html.haml
+++ b/src/api/app/components/download_repository_link_component.html.haml
@@ -1,4 +1,4 @@
-- if @published_repository_exist
+- if @download_area_url
   %li.list-inline-item
     = link_to(@download_area_url, title: 'Go to download repository') do
       %i.fas.fa-download

--- a/src/api/app/components/download_repository_link_component.rb
+++ b/src/api/app/components/download_repository_link_component.rb
@@ -7,15 +7,16 @@ class DownloadRepositoryLinkComponent < ApplicationComponent
     download_url = configuration['download_url']
     return unless download_url
 
-    @download_area_url = published_repository_url(project: project, repository: repository)
+    return unless published_repository?(project: project, repository: repository)
+
+    @download_area_url = "#{download_url}/#{project.to_s.gsub(/:/, ':/')}/#{repository}"
   end
 
   private
 
-  def published_repository_url(project:, repository:)
-    xml = Xmlhash.parse(Backend::Api::Published.download_url_for_repository(project.to_s, repository.to_s))
-    xml.elements('url').last.to_s.presence
+  def published_repository?(project:, repository:)
+    Backend::Api::Published.published_repository_exist?(project.to_s, repository.to_s)
   rescue Backend::NotFoundError
-    nil
+    false
   end
 end

--- a/src/api/app/components/download_repository_link_component.rb
+++ b/src/api/app/components/download_repository_link_component.rb
@@ -1,14 +1,21 @@
 class DownloadRepositoryLinkComponent < ApplicationComponent
-  attr_reader :published_repository_exist, :download_area_url
+  attr_reader :download_area_url
 
   def initialize(project:, repository:, configuration:)
     super()
 
-    @published_repository_exist = false
     download_url = configuration['download_url']
     return unless download_url
 
-    @published_repository_exist = Backend::Api::Published.published_repository_exist?(project.to_s, repository.to_s)
-    @download_area_url = "#{download_url}/#{project.to_s.gsub(':', ':/')}/#{repository}"
+    @download_area_url = published_repository_url(project: project, repository: repository)
+  end
+
+  private
+
+  def published_repository_url(project:, repository:)
+    xml = Xmlhash.parse(Backend::Api::Published.download_url_for_repository(project.to_s, repository.to_s))
+    xml.elements('url').last.to_s.presence
+  rescue Backend::NotFoundError
+    nil
   end
 end

--- a/src/api/app/components/download_repository_link_component.rb
+++ b/src/api/app/components/download_repository_link_component.rb
@@ -5,17 +5,15 @@ class DownloadRepositoryLinkComponent < ApplicationComponent
     super()
 
     download_url = configuration['download_url']
-    return unless download_url
-
-    return unless published_repository?(project: project, repository: repository)
-
-    @download_area_url = "#{download_url}/#{project.to_s.gsub(/:/, ':/')}/#{repository}"
+    @download_area_url = if download_url && published_repository?(project.to_s, repository.to_s)
+      "#{download_url}/#{project.to_s.gsub(/:/, ':/')}/#{repository}"
+    end
   end
 
   private
 
-  def published_repository?(project:, repository:)
-    Backend::Api::Published.published_repository_exist?(project.to_s, repository.to_s)
+  def published_repository?(project_name, repository_name)
+    Backend::Api::Published.published_repository_exist?(project_name, repository_name)
   rescue Backend::NotFoundError
     false
   end

--- a/src/api/spec/components/download_repository_link_component_spec.rb
+++ b/src/api/spec/components/download_repository_link_component_spec.rb
@@ -22,8 +22,7 @@ RSpec.describe DownloadRepositoryLinkComponent, type: :component do
       render_inline(described_class.new(project: project, repository: repository, configuration: configuration))
     end
 
-    it 'renders the fallback text instead of a broken link' do
-      expect(rendered_content).to have_text('There are no published packages')
+    it 'renders nothing and hides the link' do
       expect(rendered_content).to have_no_link('Go to download repository')
     end
   end
@@ -35,8 +34,7 @@ RSpec.describe DownloadRepositoryLinkComponent, type: :component do
       render_inline(described_class.new(project: project, repository: repository, configuration: configuration))
     end
 
-    it 'renders the fallback text instead of a broken link' do
-      expect(rendered_content).to have_text('There are no published packages')
+    it 'renders nothing and hides the link' do
       expect(rendered_content).to have_no_link('Go to download repository')
     end
   end

--- a/src/api/spec/components/download_repository_link_component_spec.rb
+++ b/src/api/spec/components/download_repository_link_component_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe DownloadRepositoryLinkComponent, type: :component do
   let(:project) { create(:project, name: 'home:Admin') }
   let(:repository) { create(:repository, project: project, name: 'images') }
-  let(:configuration) { { 'download_url' => 'https://download.opensuse.org/repositories' } }
+  let(:app_configuration) { { 'download_url' => 'https://download.opensuse.org/repositories' } }
 
   def mock_published_repository_exist(return_value: nil, raise_error: nil)
     if raise_error
@@ -21,7 +21,7 @@ RSpec.describe DownloadRepositoryLinkComponent, type: :component do
     before do
       mock_published_repository_exist(return_value: true)
 
-      render_inline(described_class.new(project: project, repository: repository, configuration: configuration))
+      render_inline(described_class.new(project: project, repository: repository, configuration: app_configuration))
     end
 
     it 'renders the download repository link' do
@@ -37,7 +37,7 @@ RSpec.describe DownloadRepositoryLinkComponent, type: :component do
     before do
       mock_published_repository_exist(return_value: false)
 
-      render_inline(described_class.new(project: project, repository: repository, configuration: configuration))
+      render_inline(described_class.new(project: project, repository: repository, configuration: app_configuration))
     end
 
     include_examples 'hides the download link'
@@ -47,7 +47,7 @@ RSpec.describe DownloadRepositoryLinkComponent, type: :component do
     before do
       mock_published_repository_exist(raise_error: Backend::NotFoundError)
 
-      render_inline(described_class.new(project: project, repository: repository, configuration: configuration))
+      render_inline(described_class.new(project: project, repository: repository, configuration: app_configuration))
     end
 
     include_examples 'hides the download link'

--- a/src/api/spec/components/download_repository_link_component_spec.rb
+++ b/src/api/spec/components/download_repository_link_component_spec.rb
@@ -3,9 +3,23 @@ RSpec.describe DownloadRepositoryLinkComponent, type: :component do
   let(:repository) { create(:repository, project: project, name: 'images') }
   let(:configuration) { { 'download_url' => 'https://download.opensuse.org/repositories' } }
 
+  def mock_published_repository_exist(return_value: nil, raise_error: nil)
+    if raise_error
+      allow(Backend::Api::Published).to receive(:published_repository_exist?).and_raise(raise_error)
+    else
+      allow(Backend::Api::Published).to receive(:published_repository_exist?).and_return(return_value)
+    end
+  end
+
+  shared_examples 'hides the download link' do
+    it 'renders nothing and hides the link' do
+      expect(rendered_content).to have_no_link('Go to download repository')
+    end
+  end
+
   context 'when published artifacts exist for the repository' do
     before do
-      allow(Backend::Api::Published).to receive(:published_repository_exist?).with(project.to_s, repository.to_s).and_return(true)
+      mock_published_repository_exist(return_value: true)
 
       render_inline(described_class.new(project: project, repository: repository, configuration: configuration))
     end
@@ -13,29 +27,29 @@ RSpec.describe DownloadRepositoryLinkComponent, type: :component do
     it 'renders the download repository link' do
       expect(rendered_content).to have_link('Go to download repository', href: 'https://download.opensuse.org/repositories/home:/Admin/images')
     end
+
+    it 'calls the backend with the correct project and repository names' do
+      expect(Backend::Api::Published).to have_received(:published_repository_exist?).with('home:Admin', 'images')
+    end
   end
 
   context 'when no published artifacts exist for the repository' do
     before do
-      allow(Backend::Api::Published).to receive(:published_repository_exist?).with(project.to_s, repository.to_s).and_return(false)
+      mock_published_repository_exist(return_value: false)
 
       render_inline(described_class.new(project: project, repository: repository, configuration: configuration))
     end
 
-    it 'renders nothing and hides the link' do
-      expect(rendered_content).to have_no_link('Go to download repository')
-    end
+    include_examples 'hides the download link'
   end
 
   context 'when the published repository is missing' do
     before do
-      allow(Backend::Api::Published).to receive(:published_repository_exist?).with(project.to_s, repository.to_s).and_raise(Backend::NotFoundError)
+      mock_published_repository_exist(raise_error: Backend::NotFoundError)
 
       render_inline(described_class.new(project: project, repository: repository, configuration: configuration))
     end
 
-    it 'renders nothing and hides the link' do
-      expect(rendered_content).to have_no_link('Go to download repository')
-    end
+    include_examples 'hides the download link'
   end
 end

--- a/src/api/spec/components/download_repository_link_component_spec.rb
+++ b/src/api/spec/components/download_repository_link_component_spec.rb
@@ -1,15 +1,11 @@
 RSpec.describe DownloadRepositoryLinkComponent, type: :component do
   let(:project) { create(:project, name: 'home:Admin') }
   let(:repository) { create(:repository, project: project, name: 'images') }
-  let(:configuration) { { 'download_url' => 'https://download.opensuse.org' } }
+  let(:configuration) { { 'download_url' => 'https://download.opensuse.org/repositories' } }
 
-  context 'when the backend returns a published repository URL' do
+  context 'when published artifacts exist for the repository' do
     before do
-      allow(Backend::Api::Published).to receive(:download_url_for_repository).with(project.to_s, repository.to_s).and_return(<<~XML)
-        <directory>
-          <url>https://download.opensuse.org/repositories/home:/Admin/images</url>
-        </directory>
-      XML
+      allow(Backend::Api::Published).to receive(:published_repository_exist?).with(project.to_s, repository.to_s).and_return(true)
 
       render_inline(described_class.new(project: project, repository: repository, configuration: configuration))
     end
@@ -19,9 +15,9 @@ RSpec.describe DownloadRepositoryLinkComponent, type: :component do
     end
   end
 
-  context 'when the backend does not return a published repository URL' do
+  context 'when no published artifacts exist for the repository' do
     before do
-      allow(Backend::Api::Published).to receive(:download_url_for_repository).with(project.to_s, repository.to_s).and_return('<directory/>')
+      allow(Backend::Api::Published).to receive(:published_repository_exist?).with(project.to_s, repository.to_s).and_return(false)
 
       render_inline(described_class.new(project: project, repository: repository, configuration: configuration))
     end
@@ -34,7 +30,7 @@ RSpec.describe DownloadRepositoryLinkComponent, type: :component do
 
   context 'when the published repository is missing' do
     before do
-      allow(Backend::Api::Published).to receive(:download_url_for_repository).with(project.to_s, repository.to_s).and_raise(Backend::NotFoundError)
+      allow(Backend::Api::Published).to receive(:published_repository_exist?).with(project.to_s, repository.to_s).and_raise(Backend::NotFoundError)
 
       render_inline(described_class.new(project: project, repository: repository, configuration: configuration))
     end

--- a/src/api/spec/components/download_repository_link_component_spec.rb
+++ b/src/api/spec/components/download_repository_link_component_spec.rb
@@ -1,0 +1,47 @@
+RSpec.describe DownloadRepositoryLinkComponent, type: :component do
+  let(:project) { create(:project, name: 'home:Admin') }
+  let(:repository) { create(:repository, project: project, name: 'images') }
+  let(:configuration) { { 'download_url' => 'https://download.opensuse.org' } }
+
+  context 'when the backend returns a published repository URL' do
+    before do
+      allow(Backend::Api::Published).to receive(:download_url_for_repository).with(project.to_s, repository.to_s).and_return(<<~XML)
+        <directory>
+          <url>https://download.opensuse.org/repositories/home:/Admin/images</url>
+        </directory>
+      XML
+
+      render_inline(described_class.new(project: project, repository: repository, configuration: configuration))
+    end
+
+    it 'renders the download repository link' do
+      expect(rendered_content).to have_link('Go to download repository', href: 'https://download.opensuse.org/repositories/home:/Admin/images')
+    end
+  end
+
+  context 'when the backend does not return a published repository URL' do
+    before do
+      allow(Backend::Api::Published).to receive(:download_url_for_repository).with(project.to_s, repository.to_s).and_return('<directory/>')
+
+      render_inline(described_class.new(project: project, repository: repository, configuration: configuration))
+    end
+
+    it 'renders the fallback text instead of a broken link' do
+      expect(rendered_content).to have_text('There are no published packages')
+      expect(rendered_content).to have_no_link('Go to download repository')
+    end
+  end
+
+  context 'when the published repository is missing' do
+    before do
+      allow(Backend::Api::Published).to receive(:download_url_for_repository).with(project.to_s, repository.to_s).and_raise(Backend::NotFoundError)
+
+      render_inline(described_class.new(project: project, repository: repository, configuration: configuration))
+    end
+
+    it 'renders the fallback text instead of a broken link' do
+      expect(rendered_content).to have_text('There are no published packages')
+      expect(rendered_content).to have_no_link('Go to download repository')
+    end
+  end
+end

--- a/src/api/spec/components/previews/download_repository_link_component_preview.rb
+++ b/src/api/spec/components/previews/download_repository_link_component_preview.rb
@@ -4,8 +4,8 @@ class DownloadRepositoryLinkComponentPreview < ViewComponent::Preview
     view_component = DownloadRepositoryLinkComponent.new(project: Project.new(name: 'home:Admin'),
                                                          repository: Repository.new(name: 'openSUSE_Tumbleweed'),
                                                          configuration: { 'download_url' => 'https://download.opensuse.org' })
-    # Just to make sure that the link is displayed, since the repository won't be published if the project and repository don't exist.
-    view_component.instance_variable_set(:@published_repository_exist, true)
+    # Ensure the link is displayed since the repository won't be published if the project and repository don't exist.
+    view_component.instance_variable_set(:@download_area_url, 'https://download.opensuse.org/repositories/home:/Admin/openSUSE_Tumbleweed')
 
     render(view_component)
   end


### PR DESCRIPTION
## Summary
- render the "Go to download repository" link only when the backend returns an actual published repository URL
- keep the existing fallback text when no published URL is available
- add a component spec for the published, empty, and missing repository cases

## Issue
Fixes #18716

## Notes
This keeps the maintainer note in mind by avoiding a blanket "publishing disabled" check and instead using the published repository URL returned by the backend.