### PR TITLE
Retry_on transient GitLab errors for ReportToSCMJob

### DIFF
--- a/src/api/app/jobs/report_to_scm_job.rb
+++ b/src/api/app/jobs/report_to_scm_job.rb
@@ -6,18 +6,18 @@ class ReportToSCMJob < ApplicationJob
   # Transient errors that are worth retrying: SCM-side 5xx, rate limits, network glitches and auth failures.
   # 4xx config errors, and SSL problems are not retried.
   RETRYABLE_EXCEPTIONS = [
+    Faraday::ConnectionFailed,
+    Faraday::TimeoutError,
     Gitlab::Error::BadGateway,
     Gitlab::Error::ConnectionTimedOut,
     Gitlab::Error::InternalServerError,
     Gitlab::Error::ServiceUnavailable,
     Gitlab::Error::Unauthorized,
-    Octokit::InternalServerError,
     Octokit::BadGateway,
-    Octokit::ServiceUnavailable,
+    Octokit::InternalServerError,
     Octokit::ServerError,
-    Octokit::Unauthorized,
-    Faraday::ConnectionFailed,
-    Faraday::TimeoutError
+    Octokit::ServiceUnavailable,
+    Octokit::Unauthorized
   ].freeze
   # Transient errors that are worth retrying, but with longer wait times
   RETRYABLE_LONG_WAIT_EXCEPTIONS = [Gitlab::Error::TooManyRequests, Octokit::TooManyRequests].freeze

--- a/src/api/app/jobs/report_to_scm_job.rb
+++ b/src/api/app/jobs/report_to_scm_job.rb
@@ -19,13 +19,15 @@ class ReportToSCMJob < ApplicationJob
     Faraday::ConnectionFailed,
     Faraday::TimeoutError
   ].freeze
+  # Transient errors that are worth retrying, but with longer wait times
+  RETRYABLE_LONG_WAIT_EXCEPTIONS = [Gitlab::Error::TooManyRequests, Octokit::TooManyRequests].freeze
 
   # Progressive time before retrying the job in case of retryable exceptions
   RETRY_WAIT_TIMES = { 1 => 0, 2 => 1.minute, 3 => 2.minutes, 4 => 5.minutes, 5 => 10.minutes }.freeze
   retry_on(*RETRYABLE_EXCEPTIONS, wait: ->(executions) { RETRY_WAIT_TIMES.fetch(executions) }, attempts: 6)
 
   RETRY_LONG_WAIT_TIMES = { 1 => 1.minute, 2 => 5.minutes, 3 => 10.minutes, 4 => 15.minutes, 5 => 30.minutes }.freeze
-  retry_on([Gitlab::Error::TooManyRequests, Octokit::TooManyRequests], wait: ->(executions) { RETRY_LONG_WAIT_TIMES.fetch(executions) }, attempts: 6)
+  retry_on(*RETRYABLE_LONG_WAIT_EXCEPTIONS, wait: ->(executions) { RETRY_LONG_WAIT_TIMES.fetch(executions) }, attempts: 6)
 
   queue_as :scm
 

--- a/src/api/app/jobs/report_to_scm_job.rb
+++ b/src/api/app/jobs/report_to_scm_job.rb
@@ -3,8 +3,8 @@ class ReportToSCMJob < ApplicationJob
 
   ALLOWED_EVENTS = ['Event::BuildFail', 'Event::BuildSuccess', 'Event::RequestStatechange'].freeze
 
-  # Transient errors that are worth retrying: SCM-side 5xx, rate limits, and network glitches.
-  # Auth failures, 4xx config errors, and SSL problems are not retried.
+  # Transient errors that are worth retrying: SCM-side 5xx, rate limits, network glitches and auth failures.
+  # 4xx config errors, and SSL problems are not retried.
   RETRYABLE_EXCEPTIONS = [
     Octokit::InternalServerError,
     Octokit::BadGateway,

--- a/src/api/app/jobs/report_to_scm_job.rb
+++ b/src/api/app/jobs/report_to_scm_job.rb
@@ -6,6 +6,11 @@ class ReportToSCMJob < ApplicationJob
   # Transient errors that are worth retrying: SCM-side 5xx, rate limits, network glitches and auth failures.
   # 4xx config errors, and SSL problems are not retried.
   RETRYABLE_EXCEPTIONS = [
+    Gitlab::Error::BadGateway,
+    Gitlab::Error::ConnectionTimedOut,
+    Gitlab::Error::InternalServerError,
+    Gitlab::Error::ServiceUnavailable,
+    Gitlab::Error::Unauthorized,
     Octokit::InternalServerError,
     Octokit::BadGateway,
     Octokit::ServiceUnavailable,
@@ -20,7 +25,7 @@ class ReportToSCMJob < ApplicationJob
   retry_on(*RETRYABLE_EXCEPTIONS, wait: ->(executions) { RETRY_WAIT_TIMES.fetch(executions) }, attempts: 6)
 
   RETRY_LONG_WAIT_TIMES = { 1 => 1.minute, 2 => 5.minutes, 3 => 10.minutes, 4 => 15.minutes, 5 => 30.minutes }.freeze
-  retry_on(Octokit::TooManyRequests, wait: ->(executions) { RETRY_LONG_WAIT_TIMES.fetch(executions) }, attempts: 6)
+  retry_on([Gitlab::Error::TooManyRequests, Octokit::TooManyRequests], wait: ->(executions) { RETRY_LONG_WAIT_TIMES.fetch(executions) }, attempts: 6)
 
   queue_as :scm
 

--- a/src/api/app/services/scm_exception_handler.rb
+++ b/src/api/app/services/scm_exception_handler.rb
@@ -26,16 +26,11 @@ class SCMExceptionHandler
     log_to_workflow_run(exception, 'GitHub') if @workflow_run.present?
   end
 
-  rescue_from Gitlab::Error::BadGateway,
-              Gitlab::Error::BadRequest,
+  rescue_from Gitlab::Error::BadRequest,
               Gitlab::Error::Conflict,
               Gitlab::Error::Forbidden,
-              Gitlab::Error::InternalServerError,
               Gitlab::Error::MissingCredentials,
               Gitlab::Error::NotFound,
-              Gitlab::Error::ServiceUnavailable,
-              Gitlab::Error::TooManyRequests,
-              Gitlab::Error::Unauthorized,
               OpenSSL::SSL::SSLError do |exception|
     log_to_workflow_run(exception, 'GitLab') if @workflow_run.present?
   end


### PR DESCRIPTION
Following `ReportToSCMJob`'s `retry_on` pattern for GitHub, this PR contains the same for [GitLab errors](https://www.rubydoc.info/gems/gitlab/Gitlab/Error):

- Network errors
- Authentication errors
- Server errors
- API rate limiting erros