### PR TITLE
Refactoring: cosmetic code cleanup

### DIFF
--- a/src/api/app/controllers/webui/groups/bs_requests_controller.rb
+++ b/src/api/app/controllers/webui/groups/bs_requests_controller.rb
@@ -1,12 +1,12 @@
 module Webui
   module Groups
     class BsRequestsController < WebuiController
+      include Webui::RequestsFilter
+      include Webui::RequestsCount
+
       before_action :set_group
       before_action :redirect_legacy
       before_action :set_bs_request
-
-      include Webui::RequestsFilter
-      include Webui::RequestsCount
 
       REQUEST_METHODS = {
         'all_requests_table' => :requests,

--- a/src/api/app/controllers/webui/packages/assignments_controller.rb
+++ b/src/api/app/controllers/webui/packages/assignments_controller.rb
@@ -1,6 +1,6 @@
 module Webui
   module Packages
-    class AssignmentsController < Webui::WebuiController
+    class AssignmentsController < WebuiController
       before_action :require_login
       before_action :set_package
       before_action :set_assignee, except: :destroy

--- a/src/api/app/controllers/webui/packages/badge_controller.rb
+++ b/src/api/app/controllers/webui/packages/badge_controller.rb
@@ -1,6 +1,6 @@
 module Webui
   module Packages
-    class BadgeController < Webui::WebuiController
+    class BadgeController < WebuiController
       include ScmsyncChecker
 
       before_action :set_project

--- a/src/api/app/controllers/webui/packages/binaries_controller.rb
+++ b/src/api/app/controllers/webui/packages/binaries_controller.rb
@@ -1,6 +1,6 @@
 module Webui
   module Packages
-    class BinariesController < Webui::WebuiController
+    class BinariesController < WebuiController
       include ScmsyncChecker
 
       # TODO: Keep in sync with Build::query in backend/build/Build.pm.

--- a/src/api/app/controllers/webui/packages/branches_controller.rb
+++ b/src/api/app/controllers/webui/packages/branches_controller.rb
@@ -1,6 +1,6 @@
 module Webui
   module Packages
-    class BranchesController < Webui::WebuiController
+    class BranchesController < WebuiController
       before_action :require_login
       before_action :set_project, only: %i[new into]
       before_action :set_package, only: [:new]

--- a/src/api/app/controllers/webui/packages/bs_requests_controller.rb
+++ b/src/api/app/controllers/webui/packages/bs_requests_controller.rb
@@ -1,6 +1,6 @@
 module Webui
   module Packages
-    class BsRequestsController < Webui::WebuiController
+    class BsRequestsController < WebuiController
       include Webui::RequestsFilter
       include Webui::RequestsCount
 

--- a/src/api/app/controllers/webui/packages/build_log_controller.rb
+++ b/src/api/app/controllers/webui/packages/build_log_controller.rb
@@ -1,6 +1,6 @@
 module Webui
   module Packages
-    class BuildLogController < Webui::WebuiController
+    class BuildLogController < WebuiController
       include BuildLogSupport
       include Webui::NotificationsHandler
 

--- a/src/api/app/controllers/webui/packages/build_reason_controller.rb
+++ b/src/api/app/controllers/webui/packages/build_reason_controller.rb
@@ -1,6 +1,6 @@
 module Webui
   module Packages
-    class BuildReasonController < Webui::WebuiController
+    class BuildReasonController < WebuiController
       include ScmsyncChecker
 
       before_action :set_project

--- a/src/api/app/controllers/webui/packages/files_controller.rb
+++ b/src/api/app/controllers/webui/packages/files_controller.rb
@@ -1,6 +1,6 @@
 module Webui
   module Packages
-    class FilesController < Webui::WebuiController
+    class FilesController < WebuiController
       include Webui::PackageHelper
       include ScmsyncChecker
 

--- a/src/api/app/controllers/webui/packages/job_history_controller.rb
+++ b/src/api/app/controllers/webui/packages/job_history_controller.rb
@@ -1,6 +1,6 @@
 module Webui
   module Packages
-    class JobHistoryController < Webui::WebuiController
+    class JobHistoryController < WebuiController
       include ScmsyncChecker
 
       before_action :set_project

--- a/src/api/app/controllers/webui/packages/meta_controller.rb
+++ b/src/api/app/controllers/webui/packages/meta_controller.rb
@@ -1,6 +1,6 @@
 module Webui
   module Packages
-    class MetaController < Webui::WebuiController
+    class MetaController < WebuiController
       include ScmsyncChecker
 
       before_action :set_project

--- a/src/api/app/controllers/webui/packages/rpmlint_controller.rb
+++ b/src/api/app/controllers/webui/packages/rpmlint_controller.rb
@@ -1,6 +1,6 @@
 module Webui
   module Packages
-    class RpmlintController < Webui::WebuiController
+    class RpmlintController < WebuiController
       include ScmsyncChecker
 
       before_action :set_project

--- a/src/api/app/controllers/webui/packages/trigger_controller.rb
+++ b/src/api/app/controllers/webui/packages/trigger_controller.rb
@@ -1,6 +1,6 @@
 module Webui
   module Packages
-    class TriggerController < Webui::WebuiController
+    class TriggerController < WebuiController
       before_action :require_login
       before_action :set_project
       before_action :set_package

--- a/src/api/app/controllers/webui/users/bs_requests_controller.rb
+++ b/src/api/app/controllers/webui/users/bs_requests_controller.rb
@@ -1,12 +1,12 @@
 module Webui
   module Users
     class BsRequestsController < WebuiController
+      include Webui::RequestsFilter
+      include Webui::RequestsCount
+
       before_action :require_login
       before_action :redirect_legacy
       before_action :set_bs_requests
-
-      include Webui::RequestsFilter
-      include Webui::RequestsCount
 
       REQUEST_METHODS = {
         'all_requests_table' => :requests,


### PR DESCRIPTION
Cosmetic cleanup code:
- `WebUI::` prefix is redundant if the enclosing `module WebUI` is already defined
- declaration order