### PR TITLE
Refactoring: explicit pattern to serve response

### DIFF
--- a/src/api/app/controllers/webui/packages/bs_requests_controller.rb
+++ b/src/api/app/controllers/webui/packages/bs_requests_controller.rb
@@ -10,19 +10,18 @@ module Webui
       before_action :set_bs_requests
 
       def index
-        if Flipper.enabled?(:request_index, User.session)
-          # FIXME: Once we roll out filter_requests should become a before_action
-          filter_requests
-          @bs_requests = @bs_requests.page(params[:page])
+        respond_to do |format|
+          format.html do
+            filter_requests
+            @bs_requests = @bs_requests.page(params[:page])
+            @url = packages_requests_path(@project, @package)
+          end
+          format.json do
+            parsed_params = BsRequest::DataTable::ParamsParserWithStateAndType.new(params).parsed_params
+            requests_query = BsRequest::DataTable::FindForPackageQuery.new(@project, @package, parsed_params)
+            @requests_data_table = BsRequest::DataTable::Table.new(requests_query, params[:draw])
 
-          @url = packages_requests_path(@project, @package)
-        else
-          parsed_params = BsRequest::DataTable::ParamsParserWithStateAndType.new(params).parsed_params
-          requests_query = BsRequest::DataTable::FindForPackageQuery.new(@project, @package, parsed_params)
-          @requests_data_table = BsRequest::DataTable::Table.new(requests_query, params[:draw])
-
-          respond_to do |format|
-            format.json { render 'webui/shared/bs_requests/index' }
+            render 'webui/shared/bs_requests/index'
           end
         end
       end

--- a/src/api/app/controllers/webui/projects/bs_requests_controller.rb
+++ b/src/api/app/controllers/webui/projects/bs_requests_controller.rb
@@ -9,17 +9,17 @@ module Webui
       before_action :set_bs_requests
 
       def index
-        if Flipper.enabled?(:request_index, User.session)
-          # FIXME: Once we roll out filter_requests should become a before_action
-          filter_requests
-          @bs_requests = @bs_requests.page(params[:page])
-        else
-          parsed_params = BsRequest::DataTable::ParamsParserWithStateAndType.new(params).parsed_params
-          requests_query = BsRequest::DataTable::FindForProjectQuery.new(@project, parsed_params)
-          @requests_data_table = BsRequest::DataTable::Table.new(requests_query, params[:draw])
+        respond_to do |format|
+          format.html do
+            filter_requests
+            @bs_requests = @bs_requests.page(params[:page])
+          end
+          format.json do
+            parsed_params = BsRequest::DataTable::ParamsParserWithStateAndType.new(params).parsed_params
+            requests_query = BsRequest::DataTable::FindForProjectQuery.new(@project, parsed_params)
+            @requests_data_table = BsRequest::DataTable::Table.new(requests_query, params[:draw])
 
-          respond_to do |format|
-            format.json { render 'webui/shared/bs_requests/index' }
+            render 'webui/shared/bs_requests/index'
           end
         end
       end


### PR DESCRIPTION
Align the `index` pattern for all the four */bs_requests_controller.rb:
- [users](https://github.com/openSUSE/open-build-service/blob/master/src/api/app/controllers/webui/users/bs_requests_controller.rb#L19-L35) - already in the target shape
- [groups](https://github.com/openSUSE/open-build-service/blob/master/src/api/app/controllers/webui/groups/bs_requests_controller.rb#L17-L32) - already in the target shape
- projects - current PR changes
- packages - current PR changes
