### PR TITLE
Fix description of API parameter for token update

### DIFF
--- a/src/api/public/apidocs/paths/person_login_token_id.yaml
+++ b/src/api/public/apidocs/paths/person_login_token_id.yaml
@@ -16,7 +16,7 @@ put:
       schema:
         type: string
       required: true
-      description: Id of the token to be removed.
+      description: Id of the token to be updated.
       example: 3
   requestBody:
     description: |


### PR DESCRIPTION
It looks like the description was copied from the DELETE endpoint.

