### PR TITLE
Fix reports page when canned responses are enabled

### DIFF
--- a/src/api/app/components/write_and_preview_component.html.haml
+++ b/src/api/app/components/write_and_preview_component.html.haml
@@ -13,7 +13,6 @@
       - if Flipper.enabled?(:canned_responses, User.session) && canned_responses_enabled
         .d-flex.justify-content-end
           - user_canned_responses = User.session.canned_responses.where(decision_type: nil)
-          - request_canned_responses = bs_request.canned_responses.where(decision_type: nil)
           = render CannedResponsesDropdownComponent.new(user_canned_responses.or(request_canned_responses).order(:title))
       ~ form.text_area(text_area_attributes[:object_name], id: "#{text_area_attributes[:id_suffix]}_body",
         rows: text_area_attributes[:rows], required: text_area_attributes[:required],

--- a/src/api/app/components/write_and_preview_component.rb
+++ b/src/api/app/components/write_and_preview_component.rb
@@ -20,6 +20,12 @@ class WriteAndPreviewComponent < ApplicationComponent
 
   private
 
+  def request_canned_responses
+    return CannedResponse.none if bs_request.nil?
+
+    bs_request.canned_responses.where(decision_type: nil)
+  end
+
   def text_area_attributes_defaults
     { rows: 4, placeholder: 'Write your message here... (Markdown markup is supported)', required: true,
       object_name: :message, id_suffix: 'message' }

--- a/src/api/spec/components/write_and_preview_component_spec.rb
+++ b/src/api/spec/components/write_and_preview_component_spec.rb
@@ -1,0 +1,24 @@
+RSpec.describe WriteAndPreviewComponent, type: :component do
+  let(:form) { double('FormBuilder', text_area: 'text area') }
+
+  describe '#request_canned_responses' do
+    context 'when bs_request responds to canned_responses' do
+      let(:canned_responses) { double('CannedResponses') }
+      let(:bs_request) { double('BsRequest', canned_responses: canned_responses) }
+      let(:component) { described_class.new(form: form, preview_message_url: '/preview', message_body_param: 'body', bs_request: bs_request) }
+
+      it 'returns the bs_request canned responses' do
+        expect(canned_responses).to receive(:where).with(decision_type: nil).and_return('filtered_responses')
+        expect(component.send(:request_canned_responses)).to eq('filtered_responses')
+      end
+    end
+
+    context 'when bs_request is nil' do
+      let(:component) { described_class.new(form: form, preview_message_url: '/preview', message_body_param: 'body', bs_request: nil) }
+
+      it 'returns CannedResponse.none' do
+        expect(component.send(:request_canned_responses)).to eq(CannedResponse.none)
+      end
+    end
+  end
+end


### PR DESCRIPTION
When the canned responses feature is enabled on the reports page, calling
`bs_request.canned_responses` directly in the view causes a `NoMethodError`
when `bs_request` is `nil` (e.g. on non-request report pages).

This moves the lookup into a private `request_canned_responses` method on the
`WriteAndPreviewComponent`, with a proper nil guard, so the page renders
correctly in all contexts.

Also adds a component spec covering both the nil and non-nil cases.

Closes #19871