### PR TITLE
Skip workflow processing for events from branches not in the token's allowlist

### DIFF
--- a/src/api/.database_consistency.todo.yml
+++ b/src/api/.database_consistency.todo.yml
@@ -1991,6 +1991,9 @@ Token:
   workflow_configuration_path:
     LengthConstraintChecker:
       enabled: false
+  allowed_branches:
+    LengthConstraintChecker:
+      enabled: false
   workflow_configuration_url:
     LengthConstraintChecker:
       enabled: false

--- a/src/api/app/components/token_card_component.html.haml
+++ b/src/api/app/components/token_card_component.html.haml
@@ -9,6 +9,9 @@
       = token_package_link
   %p.card-text
     Runs as: #{link_to(@token.executor.login, user_path(@token.executor))}
+  - if @token.is_a?(Token::Workflow)
+    %p.card-text
+      Allowed branches: #{@token.allowed_branches.present? ? @token.allowed_branches.join(', ') : 'all'}
   - if @token.triggered_at.present?
     %p.card-text
       Last trigger on #{@token.triggered_at}

--- a/src/api/app/controllers/webui/users/tokens_controller.rb
+++ b/src/api/app/controllers/webui/users/tokens_controller.rb
@@ -85,16 +85,27 @@ class Webui::Users::TokensController < Webui::WebuiController
 
   def set_parameters
     @params = params.except(:project_name, :package_name).require(:token).except(:string_readonly)
-                    .permit(:type, :description, :scm_token, :workflow_configuration_path, :workflow_configuration_url).tap do |token_parameters|
+                    .permit(:type, :description, :scm_token, :workflow_configuration_path, :workflow_configuration_url, :allowed_branches).tap do |token_parameters|
       token_parameters.require(:type)
     end
-    @params = @params.except(:scm_token, :workflow_configuration_path, :workflow_configuration_url) unless @params[:type] == 'workflow'
+    @params = @params.except(:scm_token, :workflow_configuration_path, :workflow_configuration_url, :allowed_branches) unless @params[:type] == 'workflow'
+    @params = @params.merge(allowed_branches: parse_allowed_branches(@params[:allowed_branches])) if @params[:type] == 'workflow'
     @extra_params = params.slice(:project_name, :package_name).permit!
   end
 
   def update_parameters
-    params.require(:token).except(:string_readonly).permit(:description, :enabled, :scm_token, :workflow_configuration_path, :workflow_configuration_url)
-          .reject! { |k, v| k == 'scm_token' && (@token.type != 'Token::Workflow' || v.empty?) }
+    permitted = params.require(:token).except(:string_readonly)
+                      .permit(:description, :enabled, :scm_token, :workflow_configuration_path, :workflow_configuration_url, :allowed_branches)
+                      .reject! { |k, v| k == 'scm_token' && (@token.type != 'Token::Workflow' || v.empty?) }
+    return permitted unless @token.is_a?(Token::Workflow) && permitted.key?(:allowed_branches)
+
+    permitted.merge(allowed_branches: parse_allowed_branches(permitted[:allowed_branches]))
+  end
+
+  def parse_allowed_branches(value)
+    return nil if value.nil?
+
+    value.to_s.split(',').map(&:strip).reject(&:empty?).presence
   end
 
   def set_package

--- a/src/api/app/models/token.rb
+++ b/src/api/app/models/token.rb
@@ -92,6 +92,7 @@ end
 # Table name: tokens
 #
 #  id                          :integer          not null, primary key
+#  allowed_branches            :text(65535)
 #  description                 :string(64)       default("")
 #  enabled                     :boolean          default(TRUE), not null, indexed
 #  scm_token                   :string(255)      indexed

--- a/src/api/app/models/token/rebuild.rb
+++ b/src/api/app/models/token/rebuild.rb
@@ -23,6 +23,7 @@ end
 # Table name: tokens
 #
 #  id                          :integer          not null, primary key
+#  allowed_branches            :text(65535)
 #  description                 :string(64)       default("")
 #  enabled                     :boolean          default(TRUE), not null, indexed
 #  scm_token                   :string(255)      indexed

--- a/src/api/app/models/token/release.rb
+++ b/src/api/app/models/token/release.rb
@@ -63,6 +63,7 @@ end
 # Table name: tokens
 #
 #  id                          :integer          not null, primary key
+#  allowed_branches            :text(65535)
 #  description                 :string(64)       default("")
 #  enabled                     :boolean          default(TRUE), not null, indexed
 #  scm_token                   :string(255)      indexed

--- a/src/api/app/models/token/service.rb
+++ b/src/api/app/models/token/service.rb
@@ -16,6 +16,7 @@ end
 # Table name: tokens
 #
 #  id                          :integer          not null, primary key
+#  allowed_branches            :text(65535)
 #  description                 :string(64)       default("")
 #  enabled                     :boolean          default(TRUE), not null, indexed
 #  scm_token                   :string(255)      indexed

--- a/src/api/app/models/token/workflow.rb
+++ b/src/api/app/models/token/workflow.rb
@@ -42,6 +42,9 @@ class Token::Workflow < Token
       ReportToSCMJob.perform_later(workflow_run: workflow_run, event_type: 'success', initial_report: true)
       return []
     end
+
+    return [] unless branch_allowed?(workflow_run)
+
     yaml_file = Workflows::YAMLDownloader.new(workflow_run, token: self).call
     @workflows = Workflows::YAMLToWorkflowsService.new(yaml_file: yaml_file, token: self, workflow_run: workflow_run).call
 
@@ -110,6 +113,13 @@ class Token::Workflow < Token
     return if allowed_branches.is_a?(Array) && allowed_branches.all? { |b| b.is_a?(String) }
 
     errors.add(:allowed_branches, 'must be a comma-separated list of branch names')
+  end
+
+  def branch_allowed?(workflow_run)
+    return true if workflow_run.generic_event_type == 'tag_push'
+    return true if allowed_branches.blank?
+
+    allowed_branches.include?(workflow_run.target_branch.to_s)
   end
 end
 

--- a/src/api/app/models/token/workflow.rb
+++ b/src/api/app/models/token/workflow.rb
@@ -98,6 +98,7 @@ end
 # Table name: tokens
 #
 #  id                          :integer          not null, primary key
+#  allowed_branches            :text(65535)
 #  description                 :string(64)       default("")
 #  enabled                     :boolean          default(TRUE), not null, indexed
 #  scm_token                   :string(255)      indexed

--- a/src/api/app/models/token/workflow.rb
+++ b/src/api/app/models/token/workflow.rb
@@ -21,11 +21,14 @@ class Token::Workflow < Token
 
   attr_writer :reason
 
+  serialize :allowed_branches, coder: JSON
+
   validates :scm_token, presence: true
   # Either a url referring to the worklflow configuration file or a filepath to the config inside the
   # SCM repository has to be provided
   validates :workflow_configuration_path, presence: true, unless: -> { workflow_configuration_url.present? }
   validates :workflow_configuration_url, presence: true, unless: -> { workflow_configuration_path.present? }
+  validate :allowed_branches_valid, if: -> { allowed_branches.present? }
 
   after_save :state_change_event, if: :enabled_previously_changed?
 
@@ -74,6 +77,16 @@ class Token::Workflow < Token
     [users, groups&.map(&:users)&.flatten].flatten.compact.uniq
   end
 
+  def allowed_branches=(value)
+    super(
+      case value
+      when String then value.split(',').map(&:strip).reject(&:empty?).presence
+      when Array  then value.map { |b| b.is_a?(String) ? b.strip : b }.reject { |b| b == '' }.presence
+      else             value.presence
+      end
+    )
+  end
+
   private
 
   def validation_errors
@@ -90,6 +103,13 @@ class Token::Workflow < Token
 
   def state_change_event
     Event::TokenStateChange.create(id: workflow_runs.last&.id, token_id: id, reason: @reason, enabled: enabled)
+  end
+
+  def allowed_branches_valid
+    # At this point the value is formated as an array or nil after calling allowed_branches=(value)
+    return if allowed_branches.is_a?(Array) && allowed_branches.all? { |b| b.is_a?(String) }
+
+    errors.add(:allowed_branches, 'must be a comma-separated list of branch names')
   end
 end
 

--- a/src/api/app/views/webui/users/tokens/edit.html.haml
+++ b/src/api/app/views/webui/users/tokens/edit.html.haml
@@ -64,6 +64,13 @@
                                                                 placeholder: 'Eg: https://example.com/.my_subdir/my_workflows_file.yml')
                   .form-text.text-muted
                     When the URL is given, the path will be ignored. The URL should be accessible for the OBS instance.
+                .mb-3#allowed-branches-group
+                  = f.label(:allowed_branches, 'Allowed Branches:')
+                  .input-group
+                    = f.text_field(:allowed_branches, value: @token.allowed_branches&.join(', '), class: 'form-control',
+                                                      placeholder: 'Eg: main, master, develop')
+                  .form-text.text-muted
+                    Optional: comma-separated list of branch names that trigger the workflow. Leave empty to allow all branches.
           .actions
             = link_to('Cancel', tokens_path, title: 'Cancel', class: 'btn btn-outline-secondary px-4 me-3 mt-3 mt-sm-0')
             = f.submit('Update', class: 'btn btn-primary px-4 mt-3 mt-sm-0')

--- a/src/api/app/views/webui/users/tokens/new.html.haml
+++ b/src/api/app/views/webui/users/tokens/new.html.haml
@@ -60,6 +60,11 @@
                                                               placeholder: 'Eg: https://example.com/.my_subdir/my_workflows_file.yml')
                 .form-text.text-muted
                   When the URL is given, the path will be ignored. The URL should be accessible for the OBS instance.
+              .mb-3
+                = f.label(:allowed_branches, 'Allowed Branches:')
+                = f.text_field(:allowed_branches, class: 'form-control', placeholder: 'Eg: main, master, develop')
+                .form-text.text-muted
+                  Optional: comma-separated list of branch names that trigger the workflow. Leave empty to allow all branches.
           .actions
             = link_to('Cancel', tokens_path, title: 'Cancel', class: 'btn btn-outline-secondary px-4 me-3 mt-3 mt-sm-0')
             = f.submit('Create', class: 'btn btn-primary px-4 mt-3 mt-sm-0')

--- a/src/api/app/views/webui/users/tokens/show.html.haml
+++ b/src/api/app/views/webui/users/tokens/show.html.haml
@@ -84,6 +84,18 @@
           .row
             .col
               .mb-3
+                %label.fw-bold
+                  Allowed Branches:
+                %span
+                  - if @token.allowed_branches.present?
+                    = @token.allowed_branches.join(', ')
+                  - else
+                    %small.fst-italic.text-muted
+                      All branches
+
+          .row
+            .col
+              .mb-3
                 %label.col-form-label.me-2.fw-bold
                   Token trigger url:
                 .input-group

--- a/src/api/db/migrate/20260629144500_add_allowed_branches_to_tokens.rb
+++ b/src/api/db/migrate/20260629144500_add_allowed_branches_to_tokens.rb
@@ -1,0 +1,5 @@
+class AddAllowedBranchesToTokens < ActiveRecord::Migration[7.2]
+  def change
+    add_column :tokens, :allowed_branches, :text
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_05_15_101229) do
+ActiveRecord::Schema[7.2].define(version: 2026_06_29_144500) do
   create_table "active_storage_attachments", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -1191,6 +1191,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_15_101229) do
     t.string "workflow_configuration_path", default: ".obs/workflows.yml"
     t.string "workflow_configuration_url", limit: 8192
     t.boolean "enabled", default: true, null: false
+    t.text "allowed_branches"
     t.index ["enabled"], name: "index_tokens_on_enabled"
     t.index ["executor_id"], name: "user_id"
     t.index ["package_id"], name: "package_id"

--- a/src/api/spec/controllers/webui/users/tokens_controller_spec.rb
+++ b/src/api/spec/controllers/webui/users/tokens_controller_spec.rb
@@ -100,6 +100,13 @@ RSpec.describe Webui::Users::TokensController do
 
         it { expect { subject }.not_to change(Token, :count) }
       end
+
+      context 'with allowed_branches as a comma-separated string' do
+        let(:form_parameters) { { token: { type: 'workflow', scm_token: 'test_SCM_token_string', allowed_branches: 'main, master' } } }
+
+        it { expect { subject }.to change(Token, :count).from(0).to(1) }
+        it { expect { subject }.to change { Token::Workflow.last&.allowed_branches }.to(['main', 'master']) }
+      end
     end
   end
 
@@ -116,6 +123,20 @@ RSpec.describe Webui::Users::TokensController do
       it { expect { subject }.to change { token.reload.scm_token }.from('something').to('something_else') }
       it { expect { subject }.to change { token.reload.description }.from('').to('My first token') }
       it { expect { subject }.to change { token.reload.enabled }.from(true).to(false) }
+    end
+
+    context 'updates allowed_branches of a workflow token' do
+      let(:token) { create(:workflow_token, executor: user, scm_token: 'something') }
+      let(:update_parameters) { { id: token.id, token: { allowed_branches: 'main, master' } } }
+
+      it { expect { subject }.to change { token.reload.allowed_branches }.from(nil).to(['main', 'master']) }
+    end
+
+    context 'clears allowed_branches when an empty string is submitted' do
+      let(:token) { create(:workflow_token, executor: user, scm_token: 'something', allowed_branches: ['main']) }
+      let(:update_parameters) { { id: token.id, token: { allowed_branches: '' } } }
+
+      it { expect { subject }.to change { token.reload.allowed_branches }.from(['main']).to(nil) }
     end
 
     context 'updates the token string of a token belonging to the logged-in user' do

--- a/src/api/spec/models/token/workflow_spec.rb
+++ b/src/api/spec/models/token/workflow_spec.rb
@@ -254,6 +254,18 @@ RSpec.describe Token::Workflow do
     end
   end
 
+  describe '#allowed_branches=' do
+    it { expect(build(:workflow_token, allowed_branches: [])).to have_attributes(allowed_branches: nil) }
+    it { expect(build(:workflow_token, allowed_branches: [''])).to have_attributes(allowed_branches: nil) }
+  end
+
+  describe '#allowed_branches_valid' do
+    it { expect(build(:workflow_token, allowed_branches: nil)).to be_valid }
+    it { expect(build(:workflow_token, allowed_branches: 'main')).to be_valid }
+    it { expect(build(:workflow_token, allowed_branches: ['main', 'master'])).to be_valid }
+    it { expect(build(:workflow_token, allowed_branches: [1, 'main'])).not_to be_valid }
+  end
+
   describe 'token sharing' do
     let(:other_user) { create(:confirmed_user, :with_home, login: 'Peter') }
 

--- a/src/api/spec/models/token/workflow_spec.rb
+++ b/src/api/spec/models/token/workflow_spec.rb
@@ -128,6 +128,68 @@ RSpec.describe Token::Workflow do
       end
     end
 
+    context 'with allowed_branches filter' do
+      subject { workflow_token.call(workflow_run) }
+
+      let(:yaml_downloader) { instance_double(Workflows::YAMLDownloader) }
+      let(:yaml_file) { file_fixture('workflows.yml') }
+      let(:yaml_to_workflows_service) { instance_double(Workflows::YAMLToWorkflowsService) }
+      let(:workflow_run) do
+        create(:workflow_run, token: workflow_token, scm_vendor: 'github', hook_event: 'pull_request',
+                              request_payload: file_fixture('request_payload_github_pull_request_opened.json').read)
+      end
+
+      before do
+        allow(Workflows::YAMLDownloader).to receive(:new).and_return(yaml_downloader)
+        allow(yaml_downloader).to receive(:call).and_return(yaml_file)
+        allow(ReportToSCMJob).to receive(:perform_later)
+        allow(Workflows::YAMLToWorkflowsService).to receive(:new).and_return(yaml_to_workflows_service)
+        allow(yaml_to_workflows_service).to receive(:call).and_return([])
+      end
+
+      context 'when the branch is in the allowed list' do
+        # The request payload (fixture) has master as target_branch
+        let(:workflow_token) { create(:workflow_token, executor: token_user, allowed_branches: ['master']) }
+
+        it 'proceeds to download the YAML' do
+          subject
+          expect(yaml_downloader).to have_received(:call)
+        end
+      end
+
+      context 'when the branch is not in the allowed list' do
+        let(:workflow_token) { create(:workflow_token, executor: token_user, allowed_branches: ['gh-pages']) }
+
+        before do
+          allow(yaml_downloader).to receive(:call)
+        end
+
+        it 'returns early without downloading the YAML' do
+          expect(subject).to eq([])
+          expect(yaml_downloader).not_to have_received(:call)
+        end
+      end
+
+      context 'when allowed_branches is nil (all branches allowed)' do
+        let(:workflow_token) { create(:workflow_token, executor: token_user, allowed_branches: nil) }
+
+        it 'proceeds to download the YAML' do
+          subject
+          expect(yaml_downloader).to have_received(:call)
+        end
+      end
+
+      context 'when the event is a tag push (filter never applies)' do
+        let(:workflow_token) { create(:workflow_token, executor: token_user, allowed_branches: ['gh-pages']) }
+        let(:workflow_run) { create(:workflow_run, :tag_push, token: workflow_token) }
+
+        it 'proceeds to download the YAML regardless of allowed_branches' do
+          subject
+          expect(yaml_downloader).to have_received(:call)
+        end
+      end
+    end
+
     context 'validates presence of either workflow configuration path or url' do
       let(:workflow_run) do
         create(:workflow_run, token: workflow_token, scm_vendor: 'github', hook_event: 'pull_request',


### PR DESCRIPTION
Some repositories might contain many branches, some of them don't need SCM/CI integration at all. But once the SCM generates a webhook, OBS tries to find the configuration YAML file on that branch, ending up on an error because there is none. People is doing a workaround: adding a fake configuration YAML file to the branches they don't want to integrate.

I'm introducing a new feature that allows the user to set which branches they want to integrate (empty/nil means all of them). They will be specified on the Workflow Token itself, so they can be checked before even attempting to download the YAML file.

This PR is a follow-up of #19902 and includes the logic that checks if the incoming webhook was raised from a branch which is allowed, otherwise OBS won't go further.

Assisted-by: Claude:claude-sonnet-4-6