### PR TITLE
UI: Show away/dead/down worker states on monitor page

### DIFF
--- a/src/api/app/assets/javascripts/webui/monitor.js
+++ b/src/api/app/assets/javascripts/webui/monitor.js
@@ -125,10 +125,23 @@ function processProgressBar(id, item)
     }
   }
   else {
-    el_text.html("idle");
-    ctrl.css("width", "0%");
-    ctrl.css("aria-valuenow", 0)
+    var state = item["state"] || "idle";
+    el_text.html(state);
     el_text.attr("href", "#");
+    ctrl.removeClass('text-bg-success text-bg-warning text-bg-danger');
+
+    if (state == 'dead' || state == 'down') {
+      ctrl.css("width", "100%");
+      ctrl.attr("aria-valuenow", 100);
+      ctrl.addClass('text-bg-danger');
+    } else if (state == 'away') {
+      ctrl.css("width", "100%");
+      ctrl.attr("aria-valuenow", 100);
+      ctrl.addClass('text-bg-warning');
+    } else {
+      ctrl.css("width", "0%");
+      ctrl.attr("aria-valuenow", 0);
+    }
   }
 }
 

--- a/src/api/app/services/monitor_controller_service/building_information_updater.rb
+++ b/src/api/app/services/monitor_controller_service/building_information_updater.rb
@@ -19,7 +19,10 @@ module MonitorControllerService
     end
 
     def initialize_workers
-      @workers = worker_status.elements('idle').to_h { |b| [worker_id(b), {}] }
+      @workers = {}
+      %w[idle away dead down].each do |state|
+        @workers.merge!(worker_status.elements(state).to_h { |b| [worker_id(b), { 'state' => state }] })
+      end
     end
 
     def update_workers

--- a/src/api/spec/jobs/status_history_rescaler_job_spec.rb
+++ b/src/api/spec/jobs/status_history_rescaler_job_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe StatusHistoryRescalerJob do
   describe '#rescale' do
     context 'newer than 2 hours records' do
       before do
-        5.times { |i| StatusHistory.create(time: (Time.now.utc - i.seconds).to_i, key: 'busy_x86_64', value: i * 10) }
+        base_time = Time.now.utc
+        5.times { |i| StatusHistory.create(time: (base_time - i.seconds).to_i, key: 'busy_x86_64', value: i * 10) }
 
         StatusHistoryRescalerJob.perform_now
       end

--- a/src/api/spec/services/monitor_controller_service/building_information_updater_spec.rb
+++ b/src/api/spec/services/monitor_controller_service/building_information_updater_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe MonitorControllerService::BuildingInformationUpdater do
 
     it { expect(subject).not_to be_empty }
     it { expect(subject).to have_key('build01_1') }
-    it { expect(subject['build01_1']).to be_empty }
+    it { expect(subject['build01_1']).to eq({ 'state' => 'idle' }) }
     it { expect(subject).to have_key('build01_2') }
     it { expect(subject['build01_2']).to have_key('delta') }
     it { expect(subject['build01_2']['delta']).to eq('100') }


### PR DESCRIPTION
Fixes #2488

### What does this implement/fix?
Workers that are not building but are in `away`, `dead` or `down` states previously showed up as empty bars on the `/monitor` page. 

This PR ensures these offline statuses are properly handled and rendered.

### Changes:
1. **Frontend (Rails App):** Updated `MonitorControllerService::BuildingInformationUpdater` to include `away`, `dead`, and `down` workers in the JSON payload.
2. **Frontend (JS):** Updated `monitor.js` to intelligently handle these states. `dead` and `down` workers display a full-width red background (`text-bg-danger`), and `away` workers display a full-width yellow background (`text-bg-warning`) to increase visibility.