### PR TITLE
Disable has_many_inversing only for Comment

### DIFF
--- a/src/api/app/models/comment.rb
+++ b/src/api/app/models/comment.rb
@@ -51,6 +51,14 @@ class Comment < ApplicationRecord
     COMMENTABLE_TYPES[commentable_type_name]
   end
 
+  # FIXME: A Comment has many Comment (children).
+  # It seems we have loops in our code base / specs.
+  # Rails guards now against loops.
+  # https://github.com/rails/rails/pull/41552
+  def self.has_many_inversing
+    false
+  end
+
   def to_s
     body
   end

--- a/src/api/config/application.rb
+++ b/src/api/config/application.rb
@@ -34,8 +34,6 @@ module OBSApi
   class Application < Rails::Application
     # Enable rails version 7.0 defaults
     config.load_defaults 7.0
-    # FIXME: This is a known isue in RAILS 6.1 https://github.com/rails/rails/issues/40867
-    config.active_record.has_many_inversing = false
 
     # Configure the default encoding used in templates for Ruby 1.9.
     config.encoding = 'utf-8'

--- a/src/api/spec/controllers/webui/package_controller_spec.rb
+++ b/src/api/spec/controllers/webui/package_controller_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Webui::PackageController, :vcr do
         post :remove, params: { project: target_project, package: target_package }
 
         expect(flash[:success]).to eq('Package was successfully removed.')
-        expect(target_project.packages).to be_empty
+        expect(target_project.reload.packages).to be_empty
       end
     end
 
@@ -72,7 +72,7 @@ RSpec.describe Webui::PackageController, :vcr do
       it { expect(flash[:success]).to eq('Package was successfully removed.') }
 
       it 'deletes the package' do
-        expect(user.home_project.packages).to be_empty
+        expect(user.home_project.reload.packages).to be_empty
       end
     end
 
@@ -97,7 +97,7 @@ RSpec.describe Webui::PackageController, :vcr do
 
         it 'deletes the package' do
           expect(flash[:success]).to eq('Package was successfully removed.')
-          expect(user.home_project.packages).to be_empty
+          expect(user.home_project.reload.packages).to be_empty
         end
       end
     end

--- a/src/api/spec/features/webui/repositories_spec.rb
+++ b/src/api/spec/features/webui/repositories_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe 'Repositories', :js do
       end
 
       expect(page).to have_text 'Successfully removed repository'
-      expect(project_with_dod_repo.repositories).to be_empty
+      expect(project_with_dod_repo.reload.repositories).to be_empty
     end
 
     it 'edit download repositories' do


### PR DESCRIPTION
Instead of disabling it application wide. Comment is the only model that references itself.