### PR TITLE
Orphan / disconnected branches end up on Skipped WorkflowRun

### DIFF
--- a/src/api/app/controllers/trigger_workflow_controller.rb
+++ b/src/api/app/controllers/trigger_workflow_controller.rb
@@ -63,7 +63,7 @@ class TriggerWorkflowController < ApplicationController
     @token.executor.run_as do
       validation_errors = @token.call(@workflow_run)
 
-      unless @workflow_run.status == 'fail' # The SCMStatusReporter might already set the status to 'fail', lets not overwrite it
+      unless @workflow_run.fail? || @workflow_run.skipped? # Do not overwrite a status already set during token#call
         if validation_errors.none?
           @workflow_run.update(status: 'success', response_body: render_ok)
         else

--- a/src/api/app/models/token/workflow.rb
+++ b/src/api/app/models/token/workflow.rb
@@ -40,7 +40,14 @@ class Token::Workflow < Token
       return []
     end
     yaml_file = Workflows::YAMLDownloader.new(workflow_run, token: self).call
-    raise Token::Errors::NonExistentWorkflowsFile, yaml_file.error if yaml_file.failure?
+    if yaml_file.failure?
+      if yaml_file.error == :not_found
+        workflow_run.update(status: :skipped,
+                            response_body: "No workflow configuration found on branch '#{workflow_run.target_branch}'. Skipping.")
+        return []
+      end
+      raise Token::Errors::NonExistentWorkflowsFile, yaml_file.error
+    end
 
     @workflows = Workflows::YAMLToWorkflowsService.new(yaml_file: yaml_file.value, token: self, workflow_run: workflow_run).call
 

--- a/src/api/app/models/workflow_run.rb
+++ b/src/api/app/models/workflow_run.rb
@@ -67,7 +67,8 @@ class WorkflowRun < ApplicationRecord
   enum :status, {
     running: 0,
     success: 1,
-    fail: 2
+    fail: 2,
+    skipped: 3
   }
 
   # Marks the workflow run as failed and records the relevant debug information in response_body

--- a/src/api/app/services/workflows/yaml_downloader.rb
+++ b/src/api/app/services/workflows/yaml_downloader.rb
@@ -39,9 +39,9 @@ module Workflows
         content = client.content(@workflow_run.target_repository_full_name, path: "/#{@token.workflow_configuration_path}", ref: @workflow_run.target_branch)[:content]
       rescue Octokit::InvalidRepository => e
         return Resonad.Failure(e.message)
-      rescue Octokit::NotFound => e
+      rescue Octokit::NotFound
         # 'target_branch' can contain a commit sha (when tag push) instead of a branch name
-        return Resonad.Failure("#{@token.workflow_configuration_path} could not be downloaded from the SCM branch/commit #{@workflow_run.target_branch}: #{e.message}")
+        return Resonad.Failure(:not_found)
       end
       Resonad.Success(create_temp_file(Base64.decode64(content)))
     end
@@ -51,8 +51,8 @@ module Workflows
       begin
         gitlab_client = Gitlab.client(endpoint: "#{@workflow_run.api_endpoint}/api/v4", private_token: @token.scm_token)
         gitlab_file = gitlab_client.file_contents(@workflow_run.gitlab_project_id, @token.workflow_configuration_path, @workflow_run.target_branch)
-      rescue Gitlab::Error::NotFound => e
-        return Resonad.Failure(e.message)
+      rescue Gitlab::Error::NotFound
+        return Resonad.Failure(:not_found)
       end
       Resonad.Success(create_temp_file(gitlab_file))
     end
@@ -66,6 +66,10 @@ module Workflows
 
     def download_from_url(url)
       Resonad.Success(Down.download(url, max_size: MAX_FILE_SIZE))
+    rescue Down::NotFound => e
+      return Resonad.Failure("#{@token.workflow_configuration_url} could not be downloaded.\n#{e.message}") if @token.workflow_configuration_url.present?
+
+      Resonad.Failure(:not_found)
     rescue Down::Error => e
       return Resonad.Failure("#{@token.workflow_configuration_url} could not be downloaded.\n#{e.message}") if @token.workflow_configuration_url.present?
 

--- a/src/api/spec/models/token/workflow_spec.rb
+++ b/src/api/spec/models/token/workflow_spec.rb
@@ -4,10 +4,42 @@ RSpec.describe Token::Workflow do
   let(:workflow_token) { create(:workflow_token, executor: token_user) }
 
   describe '#call' do
-    context 'with wrong SCM token' do
-      let(:yaml_downloader) { instance_double(Workflows::YAMLDownloader) }
-      let(:workflow_run) { create(:workflow_run, token: workflow_token, response_url: 'https://example.com') }
+    let(:yaml_downloader) { instance_double(Workflows::YAMLDownloader) }
+    let(:workflow_run) { create(:workflow_run, token: workflow_token, response_url: 'https://example.com') }
 
+    context 'when the workflow configuration file is not found on the branch' do
+      before do
+        allow(Workflows::YAMLDownloader).to receive(:new).and_return(yaml_downloader)
+        allow(yaml_downloader).to receive(:call).and_return(Resonad.Failure(:not_found))
+      end
+
+      it 'marks the workflow_run as skipped' do
+        workflow_token.call(workflow_run)
+        expect(workflow_run.reload.skipped?).to be(true)
+      end
+
+      it 'stores a descriptive message in response_body' do
+        workflow_token.call(workflow_run)
+        expect(workflow_run.reload.response_body).to include("No workflow configuration found on branch '#{workflow_run.target_branch}'")
+      end
+
+      it 'does not return other errors' do
+        expect(workflow_token.call(workflow_run)).to eq([])
+      end
+    end
+
+    context 'when the workflow configuration file cannot be downloaded due to another error' do
+      before do
+        allow(Workflows::YAMLDownloader).to receive(:new).and_return(yaml_downloader)
+        allow(yaml_downloader).to receive(:call).and_return(Resonad.Failure('connection refused'))
+      end
+
+      it 'raises NonExistentWorkflowsFile' do
+        expect { workflow_token.call(workflow_run) }.to raise_error(Token::Errors::NonExistentWorkflowsFile, 'connection refused')
+      end
+    end
+
+    context 'with wrong SCM token' do
       before do
         allow(Workflows::YAMLDownloader).to receive(:new).and_return(yaml_downloader)
         allow(yaml_downloader).to receive(:call).and_raise(Octokit::Unauthorized)

--- a/src/api/spec/services/workflows/yaml_downloader_spec.rb
+++ b/src/api/spec/services/workflows/yaml_downloader_spec.rb
@@ -85,6 +85,48 @@ RSpec.describe Workflows::YAMLDownloader, type: :service do
       end
     end
 
+    context 'when the file is not found on the branch' do
+      context 'github' do
+        let(:scm_vendor) { 'github' }
+        let(:hook_event) { 'push' }
+        let(:request_payload) { file_fixture('request_payload_gitea_push.json').read }
+        let(:octokit_client) { instance_double(Octokit::Client) }
+
+        before do
+          allow(Octokit::Client).to receive(:new).and_return(octokit_client)
+          allow(octokit_client).to receive(:content).and_raise(Octokit::NotFound)
+        end
+
+        it { expect(yaml_downloader.call.error).to eq(:not_found) }
+      end
+
+      context 'gitlab' do
+        let(:gitlab_client) { instance_spy(Gitlab::Client) }
+        let(:scm_vendor) { 'gitlab' }
+        let(:hook_event) { 'Push Hook' }
+        let(:request_payload) { file_fixture('request_payload_gitlab_push.json').read }
+
+        before do
+          allow(Gitlab).to receive(:client).and_return(gitlab_client)
+          allow(gitlab_client).to receive(:file_contents).and_raise(Gitlab::Error::NotFound.new(double.as_null_object))
+        end
+
+        it { expect(yaml_downloader.call.error).to eq(:not_found) }
+      end
+
+      context 'gitea' do
+        let(:scm_vendor) { 'gitea' }
+        let(:hook_event) { 'push' }
+        let(:request_payload) { file_fixture('request_payload_gitea_push.json').read }
+
+        before do
+          allow(Down).to receive(:download).and_raise(Down::NotFound, 'Not Found')
+        end
+
+        it { expect(yaml_downloader.call.error).to eq(:not_found) }
+      end
+    end
+
     context 'given workflow_configuration_url' do
       before do
         workflow_token.workflow_configuration_url = 'https://example.com/subdir/config_file.yml'


### PR DESCRIPTION
Orphan/disconnected branches (like gh-pages) don't have .obs/workflows.yml.
So far, OBS tried to download the file, failed, and stored a failed WorkflowRun.
This polluted the  WorkflowRun list and some users added fake workflow.yml files just to make the errors go away.

With these changes, if the workflow configuration file is not found on the branch (HTTP 404) it is considered an orphan branch and the WorkflowRun is marked as `skipped` instead of `fail, with a message like:_No workflow configuration found on branch 'gh-pages'. Skipping._

Any other download error (connection failure, bad credentials, etc.) still results in fail as before — so real problems are still visible.