### PR TITLE
[backend] bs_repserver: split publishing status query into a seperate function

### DIFF
--- a/src/backend/BSRPC.pm
+++ b/src/backend/BSRPC.pm
@@ -141,7 +141,7 @@ sub createreq {
   }
   $port = substr($port || ($proto eq 'http' ? ":80" : ":443"), 1);
   if ($param->{'_stripauthhost'} && $host ne $param->{'_stripauthhost'}) {
-    @xhdrs = grep {!/^authorization:/i} @xhdrs;
+    @xhdrs = grep {!/^(?:proxy-)?authorization:/i} @xhdrs;
     delete $param->{'authenticator'};
   }
   unshift @xhdrs, "Connection: close" unless $param->{'noclose'} || $param->{'keepalive'};

--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -451,7 +451,7 @@ sub create_detached_cms_signature {
 
   if (qsystem($BSConfig::sign, @signargs, '--cmssign', '--cert', "$uploaddir/publisher.$$.cert", '--cms-nocerts', '-h', 'sha512', $file)) {
     unlink("$uploaddir/publisher.$$.cert");
-    die("    cms sign failed: $?\n");
+    die("cms sign failed: $?\n");
   }
   unlink("$uploaddir/publisher.$$.cert");
 }
@@ -3778,6 +3778,17 @@ sub set_publish_retry {
   }
 }
 
+sub set_publish_error {
+  my ($req, $err) = @_;
+  my $myeventdir = $req->{'conf'}->{'eventdir'};
+  my $ev = $req->{'ev'};
+  die unless $ev->{'type'} eq 'publish';
+  my $evname = $req->{'event'};
+  $evname .= '::inprogress' if $req->{'inprogress'};
+  $ev->{'details'} = $err || 'unknown error';
+  writexml("$myeventdir/.$evname$$", "$myeventdir/$evname", $ev, $BSXML::event);
+}
+
 sub notify_state {
   my ($projid, $repoid, $state) = @_;
   BSNotify::notify('REPO_PUBLISH_STATE', { 'project' => $projid, 'repo' => $repoid, 'state' => $state });
@@ -3869,7 +3880,7 @@ sub publishevent {
     publishstats($req, $prp, $code, $starttime, $now);
     db_sync();
     BSUtil::printlog("publish failed for $prp") if $req->{'forked'};
-    return 1 if $noretry;	# this will delete the publish event
+    set_publish_error($req, $err) if $noretry;		# put noretry marker in job
     return 0;
   }
 
@@ -3939,6 +3950,9 @@ sub getevent {
     return ($req, undef, 1);
   }
   return ($req, undef, 1) if $evtype eq 'configuration';
+
+  # publish on hold
+  return undef if $evtype eq 'publish' && $req->{'ev'}->{'details'};
 
   # also don't fork if the database is not in sync
   if (@db_sync) {

--- a/src/backend/bs_repserver
+++ b/src/backend/bs_repserver
@@ -1944,19 +1944,28 @@ sub readschedulerstate {
   return $schedulerstate;
 }
 
+sub getpublisherstate {
+  my ($projid, $repoid) = @_;
+  return 'scheduled' if -e "$eventdir/publish/${projid}::$repoid";
+  return 'building' if -e "$eventdir/publish/${projid}::${repoid}::inprogress";
+  return 'succeeded';
+}
+
 sub getschedulerstate {
-  my ($projid, $repoid, $arch) = @_;
+  my ($projid, $repoid, $arch, $publisherstate) = @_;
 
   my $schedulerstate = readschedulerstate($projid, $repoid, $arch);
-  my $details = $schedulerstate->{'details'};
+  my $schedulerdetails = $schedulerstate->{'details'};
   $schedulerstate = $schedulerstate->{'code'} || 'unknown';
-  if ($schedulerstate eq 'finished' && !$details) {
-    return 'finished'     if -e "$eventdir/publish/${projid}::$repoid";
-    return 'publishing'   if -e "$eventdir/publish/${projid}::${repoid}::inprogress";
-    return 'unpublished'  if (readstr("$reporoot/$projid/$repoid/$arch/:repodone", 1) || '') =~ /^disabled/;
-    return 'published';
+  if ($publisherstate && $schedulerstate eq 'finished' && !$schedulerdetails) {
+    return 'unpublished' if (readstr("$reporoot/$projid/$repoid/$arch/:repodone", 1) || '') =~ /^disabled/;
+    my ($code, $details) = @{$publisherstate->{"$projid/$repoid"} ||= [ getpublisherstate($projid, $repoid) ]};
+    $schedulerstate = 'published' if $code eq 'succeeded';
+    $schedulerstate = 'publishing' if $code eq 'building';
+    $schedulerstate = 'publishfailed' if $code eq 'failed';
+    $schedulerdetails = $details if $details && $code eq 'failed';
   }
-  return ($schedulerstate, $details);
+  return ($schedulerstate, $schedulerdetails);
 }
 
 sub workerstatus {
@@ -3038,6 +3047,7 @@ sub getresult {
       $prpas_repro{$prpa} = undef if $repoid =~ /._reproduciblecheck$/;
     }
   }
+  my %publisherstate;
   for my $prpa (keys %prpas_repro, @$prpas) {
     if ($prpas_repro{$prpa}) {
       push @$r, delete $prpas_repro{$prpa};
@@ -3056,7 +3066,7 @@ sub getresult {
 	$ps->{'packststus'}->{$_} ||= 'unknown';
       }
     }
-    my ($schedulerstate, $schedulerdetails) = getschedulerstate($projid, $repoid, $arch);
+    my ($schedulerstate, $schedulerdetails) = getschedulerstate($projid, $repoid, $arch, \%publisherstate);
     my $sl = {'project' => $projid, 'repository' => $repoid, 'arch' => $arch, 'code' => $schedulerstate, 'state' => $schedulerstate };
     $sl->{'details'} = $schedulerdetails if defined $schedulerdetails;
     $sl->{'dirty'} = 'true' if -e "$reporoot/$prpa/:schedulerstate.dirty";

--- a/src/backend/bs_repserver
+++ b/src/backend/bs_repserver
@@ -1946,8 +1946,8 @@ sub readschedulerstate {
 
 sub getpublisherstate {
   my ($projid, $repoid) = @_;
-  return 'scheduled' if -e "$eventdir/publish/${projid}::$repoid";
   return 'building' if -e "$eventdir/publish/${projid}::${repoid}::inprogress";
+  return 'scheduled' if -e "$eventdir/publish/${projid}::$repoid";
   return 'succeeded';
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
