### PR TITLE
[dist] t: chomp trailing newline from ssh key

### DIFF
--- a/dist/t/osc/0037_update_gitworkflow_package.ts
+++ b/dist/t/osc/0037_update_gitworkflow_package.ts
@@ -75,7 +75,7 @@ sub prepare_ssh {
     $key = <$fh>;
     close $fh;
   }
-
+  chomp($key);
   my $keys_param = {
     'headers' => [ 'Content-Type: application/json' ],
     'uri'     => "https://obsadmin:opensuse\@$fqhn/gitea/api/v1/user/keys",


### PR DESCRIPTION
Avoid problems when pushing ssh key to gitea like:

```
422 remote error: Unprocessable Entity (https://obsadmin:opensuse@<hostname>/gitea/api/v1/user/keys)
```
