### PR TITLE
Orphan branches will not keep failed workflow runs

### DIFF
--- a/src/api/app/controllers/trigger_workflow_controller.rb
+++ b/src/api/app/controllers/trigger_workflow_controller.rb
@@ -72,6 +72,10 @@ class TriggerWorkflowController < ApplicationController
       end
     # We always want to return 200 in the request. Because a lot of things in `Workflow`` can go wrong outside this request cycle.
     # People need to have a look at their `WorkflowRun` to see how `Workflow` went.
+    rescue Token::Errors::NonExistentWorkflowsFile
+      branch = @workflow_run.target_branch
+      @workflow_run.destroy
+      render_ok(data: { info: "There is no workflow configuration file in branch '#{branch}'." })
     rescue APIError => e
       @workflow_run.update_as_failed(render_error(status: e.status, errorcode: e.errorcode, message: e.message))
     rescue Pundit::NotAuthorizedError => e

--- a/src/api/spec/controllers/trigger_workflow_controller_spec.rb
+++ b/src/api/spec/controllers/trigger_workflow_controller_spec.rb
@@ -35,16 +35,12 @@ RSpec.describe TriggerWorkflowController do
         post :create, body: github_payload
       end
 
-      it { expect(response).to have_http_status(:not_found) }
+      it { expect(response).to have_http_status(:ok) }
+      it { expect(WorkflowRun.count).to eq(0) }
 
-      it "displays a user-friendly error message in the response's body" do
-        expect(response.body).to include("<status code=\"non_existent_workflows_file\">\n  " \
-                                         "<summary>.obs/workflows.yml could not be downloaded from the SCM branch/commit master: Octokit::NotFound</summary>\n</status>\n")
+      it 'returns an informative message with the branch name without leaving a WorkflowRun behind' do
+        expect(response.body).to include("There is no workflow configuration file in branch 'master'.")
       end
-
-      it { expect(WorkflowRun.count).to eq(1) }
-      it { expect(WorkflowRun.last.status).to eq('fail') }
-      it { expect(response.body).to include(WorkflowRun.last.response_body) }
     end
 
     context 'token different type' do


### PR DESCRIPTION
Orphan/disconnected branches (like gh-pages) don't have .obs/workflows.yml.
So far, OBS tried to download the file, failed, and stored a failed WorkflowRun.
This polluted the  WorkflowRun list and some users added fake workflow.yml files just to make the errors go away.

With this PR I propose the most simple solution possible based on the existing code.
When Token::Errors::NonExistentWorkflowsFile is raised, the WorkflowRun is **destroyed** and the **SCM webhook** receives a 200 OK with an **informative message** instead of a 404 error response.

```
<status code="ok">
  <summary>Ok</summary>
  <data name="info">There is no workflow configuration file in branch 'gh-pages'.</data>
</status>
```

In the future we can work on an improvement: not creating the WorkflowRun at all.
That will require downloading the YAML file upfront (so will be downloaded twice) or a bigger refactoring.

I believe this is enough to begin with.

Assisted-by: Claude:claude-sonnet-4-6