### PR TITLE
Only disable SCM workflow tokens on initial auth failures

### DIFF
--- a/src/api/app/models/workflow_run.rb
+++ b/src/api/app/models/workflow_run.rb
@@ -71,7 +71,7 @@ class WorkflowRun < ApplicationRecord
   }
 
   # Marks the workflow run as failed and records the relevant debug information in response_body
-  def update_as_failed(message)
+  def update_as_failed(message, disable_token: false)
     update(response_body: message, status: 'fail')
 
     #
@@ -84,6 +84,7 @@ class WorkflowRun < ApplicationRecord
     # "Failed to report back to GitHub: Unauthorized request. Please check your credentials again."
     # "Failed to report back to GitHub: Request is forbidden."
 
+    return unless disable_token
     return unless message.include?('Unauthorized request') || /Request (is )?forbidden/.match?(message)
 
     token.update(enabled: false, reason: "Authentication to #{scm_vendor.titleize} failed while reporting the build status. Check your tokens authorization setup!")
@@ -91,8 +92,8 @@ class WorkflowRun < ApplicationRecord
 
   # Stores debug info to help figure out what went wrong when trying to save a Status in the SCM.
   # Marks the workflow run as failed also.
-  def save_scm_report_failure(message, options)
-    update_as_failed(message)
+  def save_scm_report_failure(message, options, disable_token: false)
+    update_as_failed(message, disable_token: disable_token)
     scm_status_reports.create(response_body: message,
                               request_parameters: JSON.generate(options.slice(*PERMITTED_OPTIONS)),
                               status: 'fail') # set SCMStatusReport status

--- a/src/api/app/services/gitea_status_reporter.rb
+++ b/src/api/app/services/gitea_status_reporter.rb
@@ -2,7 +2,7 @@ class GiteaStatusReporter < SCMExceptionHandler
   attr_accessor :state, :initial_report, :event_type
 
   def initialize(event_payload, event_subscription_payload, scm_token, state, workflow_run = nil, event_type = nil, initial_report: false)
-    super(event_payload, event_subscription_payload, scm_token, workflow_run)
+    super(event_payload, event_subscription_payload, scm_token, workflow_run, initial_report: initial_report)
 
     @state = state
     @initial_report = initial_report

--- a/src/api/app/services/github_status_reporter.rb
+++ b/src/api/app/services/github_status_reporter.rb
@@ -2,7 +2,7 @@ class GithubStatusReporter < SCMExceptionHandler
   attr_accessor :state, :initial_report, :event_type
 
   def initialize(event_payload, event_subscription_payload, scm_token, state, workflow_run = nil, event_type = nil, initial_report: false)
-    super(event_payload, event_subscription_payload, scm_token, workflow_run)
+    super(event_payload, event_subscription_payload, scm_token, workflow_run, initial_report: initial_report)
 
     @state = state
     @initial_report = initial_report

--- a/src/api/app/services/gitlab_status_reporter.rb
+++ b/src/api/app/services/gitlab_status_reporter.rb
@@ -2,7 +2,7 @@ class GitlabStatusReporter < SCMExceptionHandler
   attr_accessor :state, :initial_report, :event_type
 
   def initialize(event_payload, event_subscription_payload, scm_token, state, workflow_run = nil, event_type = nil, initial_report: false)
-    super(event_payload, event_subscription_payload, scm_token, workflow_run)
+    super(event_payload, event_subscription_payload, scm_token, workflow_run, initial_report: initial_report)
 
     @state = translate_state(state)
     @initial_report = initial_report

--- a/src/api/app/services/scm_exception_handler.rb
+++ b/src/api/app/services/scm_exception_handler.rb
@@ -48,11 +48,12 @@ class SCMExceptionHandler
     log_to_workflow_run(exception, 'Gitea') if @workflow_run.present?
   end
 
-  def initialize(event_payload, event_subscription_payload, scm_token, workflow_run = nil)
+  def initialize(event_payload, event_subscription_payload, scm_token, workflow_run = nil, initial_report: false)
     @event_payload = event_payload.deep_symbolize_keys
     @event_subscription_payload = event_subscription_payload.deep_symbolize_keys
     @scm_token = scm_token
     @workflow_run = workflow_run
+    @initial_report = initial_report
   end
 
   private
@@ -77,6 +78,7 @@ class SCMExceptionHandler
                                             # GitLab
                                             project_id: @event_subscription_payload[:project_id],
                                             path_with_namespace: @event_subscription_payload[:path_with_namespace]
-                                          })
+                                          },
+                                          disable_token: @initial_report)
   end
 end

--- a/src/api/spec/mailers/event_mailer_spec.rb
+++ b/src/api/spec/mailers/event_mailer_spec.rb
@@ -472,7 +472,7 @@ RSpec.describe EventMailer, :vcr do
 
       context 'when the workflow run fails' do
         before do
-          workflow_run.update_as_failed('Unauthorized request')
+          workflow_run.update_as_failed('Unauthorized request', disable_token: true)
         end
 
         it 'gets delivered' do

--- a/src/api/spec/models/workflow_run_spec.rb
+++ b/src/api/spec/models/workflow_run_spec.rb
@@ -92,8 +92,20 @@ RSpec.describe WorkflowRun, :vcr do
       end
     end
 
-    context 'when the SCM responds with a forbidden message' do
+    context 'when the SCM responds with a forbidden message during a follow-up report' do
       subject { workflow_run.save_scm_report_failure('Failed to report back to GitHub: Request is forbidden.', { api_endpoint: 'https://api.github.com' }) }
+
+      it 'does not disable the token of the token workflow' do
+        expect { subject }.not_to(change { workflow_run.token.reload.enabled })
+      end
+    end
+
+    context 'when the SCM responds with a forbidden message during the initial report' do
+      subject do
+        workflow_run.save_scm_report_failure('Failed to report back to GitHub: Request is forbidden.',
+                                             { api_endpoint: 'https://api.github.com' },
+                                             disable_token: true)
+      end
 
       it 'disables the token of the token workflow' do
         expect { subject }.to change { workflow_run.token.reload.enabled }.from(true).to(false)

--- a/src/api/spec/services/github_status_reporter_spec.rb
+++ b/src/api/spec/services/github_status_reporter_spec.rb
@@ -88,6 +88,30 @@ RSpec.describe GithubStatusReporter, type: :service do
           expect(workflow_run.last_response_body).to eq('Failed to report back to GitHub: Sorry. Your account is suspended.')
         end
       end
+
+      context 'when GitHub rejects a follow-up report' do
+        before do
+          allow(Octokit::Client).to receive(:new).and_return(octokit_client)
+          allow(octokit_client).to receive(:create_status).and_raise(Octokit::Forbidden)
+        end
+
+        it 'keeps the token enabled' do
+          expect { subject }.not_to(change { workflow_run.token.reload.enabled })
+        end
+      end
+
+      context 'when GitHub rejects the initial report' do
+        let(:scm_status_reporter) { GithubStatusReporter.new(event_payload, event_subscription_payload, token, state, workflow_run, initial_report: true) }
+
+        before do
+          allow(Octokit::Client).to receive(:new).and_return(octokit_client)
+          allow(octokit_client).to receive(:create_status).and_raise(Octokit::Forbidden)
+        end
+
+        it 'disables the token' do
+          expect { subject }.to change { workflow_run.token.reload.enabled }.from(true).to(false)
+        end
+      end
     end
 
     context 'when sending a report back to GitHub' do


### PR DESCRIPTION
## Summary
- only disable workflow tokens for authorization failures during the initial SCM status report
- keep recording follow-up SCM report failures without switching the token off
- cover the initial and follow-up paths in the workflow run and GitHub reporter specs

Fixes #19819
