### PR TITLE
docs: Fix Markdown formatting warnings (MD022, MD040)

### DIFF
--- a/dist/t/README.md
+++ b/dist/t/README.md
@@ -1,4 +1,5 @@
 # Open Build Service Appliance QA Suite
+
 This is a test suite based on perl's [prove](http://perldoc.perl.org/prove.html),
 and [RSpec](http://rspec.info/). We are testing the following:
 
@@ -7,13 +8,14 @@ and [RSpec](http://rspec.info/). We are testing the following:
 * Building a simple package works
 
 ## Running the suite
+
 This test suite runs [automatically](https://github.com/os-autoinst/os-autoinst-distri-obs)
 against new appliances that got built from
 our [OBS:Server:Unstable](https://build.opensuse.org/project/show/OBS:Server:Unstable)
 on [openQA](https://openqa.opensuse.org/).
 
-
 ## QA for package updates
+
 Additionally our [test instance](https://build-test.opensuse.org/) rebuilds all packages in
 [OBS:Server:Unstable](https://build.opensuse.org/project/show/OBS:Server:Unstable) and
 it's publisher is calling "zypper up" to update itself.

--- a/docs/dev/GUIDE.md
+++ b/docs/dev/GUIDE.md
@@ -1,11 +1,13 @@
 # Development Style Guide
+
 This development guide tries to show you how we style the code of OBS.
 
 ## Models
+
 All the **ActiveRecord::Base** models should use the same structure to be easy to follow for everyone. We have
 overwritten the template for model, so you can just use Rails::Generators like that:
 
-  ```
+  ```bash
   rails generate model Dog
   ```
 
@@ -16,13 +18,13 @@ For a better comprehension [here](model_template_example.rb) you have an example
 All the Controllers should use the same structure to be easy to follow for everyone. We have
 overwritten the template for controllers too, so you can just use Rails::Generators like that:
 
-  ```
+  ```bash
   rails generate scaffold_controller Webui::Dog
   ```
 
 Have in mind that namespaced controllers that uses non-namespaced models should be created as follows:
 
-  ```
+  ```bash
   rails generate scaffold_controller Webui::Dog --model-name=Dog
   ```
 


### PR DESCRIPTION
While reviewing the developer documentation, I noticed several Markdown formatting violations that throw warnings in strict Markdown parsers (specifically `MD022/blanks-around-headings` and `MD040/fenced-code-language`). 

This PR:
- Adds missing blank lines around headings in the Developer Style Guide (`GUIDE.md`) and QA Suite (`README.md`).
- Adds language identifiers (`bash`) to the fenced code blocks for proper syntax highlighting.

This ensures the documentation renders perfectly across all parsers and improves readability.

Fixes #19930