### PR TITLE
Isolate link_project target project name for push and tag_push events

### DIFF
--- a/src/api/app/models/workflow/step/link_project.rb
+++ b/src/api/app/models/workflow/step/link_project.rb
@@ -1,14 +1,13 @@
 class Workflow::Step::LinkProject < Workflow::Step
-
   REQUIRED_KEYS = %i[target_project source_project].freeze
-  
+
   def call
     return unless valid?
 
     if Project.exists_by_name(target_project_name)
       Pundit.authorize(@token.executor, target_project, :update?)
     else
-      create_target_project 
+      create_target_project
     end
 
     case
@@ -21,11 +20,22 @@ class Workflow::Step::LinkProject < Workflow::Step
 
   private
 
+  def target_project_name
+    case
+    when workflow_run.push_event?
+      "#{target_project_base_name}:#{workflow_run.commit_sha.slice(0, SHORT_COMMIT_SHA_LENGTH)}"
+    when workflow_run.tag_push_event?
+      "#{target_project_base_name}:#{workflow_run.tag_name}"
+    else
+      super
+    end
+  end
+
   # This is the project the packages are going to land into
   def target_project_base_name
     step_instructions[:target_project]
   end
-  
+
   def create_target_project
     project = Project.new(name: target_project_name, url: workflow_run.event_source_url)
     Pundit.authorize(@token.executor, project, :create?)


### PR DESCRIPTION
Append the short commit SHA (when receiving a push event) or tag name (when receiving a tag_push) to the target project name, preventing concurrent push events from interfering with each other's project links.

Assisted-by: Claude sonnet:4.6

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
