### PR TITLE
Fix UI flicker in attribute type description on page load

### DIFF
--- a/src/api/app/assets/javascripts/webui/attributes.js
+++ b/src/api/app/assets/javascripts/webui/attributes.js
@@ -1,7 +1,4 @@
 $(document).ready(function() {
-  // TODO: Edge case - When a user is already on the page and does a refresh, the description flickers as it appears. Find a way to fix this...
-  $('#attribute_type-description-' + $('#attrib_attrib_type_id option:selected').val()).removeClass('d-none');
-
   $('#attrib_attrib_type_id').change(function() {
     $("[id^='attribute_type-description-']:visible").addClass('d-none');
     $('#attribute_type-description-' + $(this).val()).removeClass('d-none');

--- a/src/api/app/views/webui/attribute/new.html.haml
+++ b/src/api/app/views/webui/attribute/new.html.haml
@@ -16,7 +16,8 @@
           = form.collection_select(:attrib_type_id, @attribute_types, :id, :fullname, {}, class: 'form-control form-select')
         .col-form-label.col-12.col-md
           - @attribute_types.each do |attribute_type|
-            %p.d-none{ id: "attribute_type-description-#{attribute_type.id}" }
+            - is_selected = attribute_type.id == (@attribute.attrib_type_id || @attribute_types.first&.id)
+            %p{ id: "attribute_type-description-#{attribute_type.id}", class: ('d-none' unless is_selected) }
               = attribute_type.description.presence || 'Sorry, this attribute has no description'
       = link_to('Back', index_attribs_path, class: 'btn btn-outline-secondary', role: 'button')
       = form.submit('Add', class: 'btn btn-primary')


### PR DESCRIPTION
Fixes #19945

This renders the correct visibility state directly in the ERB view (omitting the d-none class for the option that is selected by default), rather than relying on jQuery to unhide the description on page load. This prevents the browser from rendering the hidden state first before the JavaScript executes.