### PR TITLE
Fix: Rename user association to creator in StatusMessage model

### DIFF
--- a/src/api/.database_consistency.todo.yml
+++ b/src/api/.database_consistency.todo.yml
@@ -1950,7 +1950,7 @@ StatusMessage:
   severity:
     ColumnPresenceChecker:
       enabled: false
-  user:
+  creator:
     ColumnPresenceChecker:
       enabled: false
     ForeignKeyChecker:

--- a/src/api/app/components/status_message_component.html.haml
+++ b/src/api/app/components/status_message_component.html.haml
@@ -3,7 +3,7 @@
     .col-auto.pe-1
       %i.fa.fa-lg.fa-fw{ helpers.icon_for_severity(@status_message.severity) }
     .col.ps-1
-      = helpers.user_with_realname_and_icon(@status_message.user, short: true)
+      = helpers.user_with_realname_and_icon(@status_message.creator, short: true)
       wrote
       %u
         = render TimeComponent.new(time: @status_message.created_at)

--- a/src/api/app/controllers/announcements_controller.rb
+++ b/src/api/app/controllers/announcements_controller.rb
@@ -59,6 +59,6 @@ class AnnouncementsController < ApplicationController
     xml = Nokogiri::XML(request.raw_post, &:strict)
     title = xml.xpath('//announcement/title').text
     content = xml.xpath('//announcement/content').text
-    { message: "#{title} #{content}", severity: 'announcement', user: User.session }
+    { message: "#{title} #{content}", severity: 'announcement', creator: User.session }
   end
 end

--- a/src/api/app/controllers/status_messages_controller.rb
+++ b/src/api/app/controllers/status_messages_controller.rb
@@ -14,7 +14,7 @@ class StatusMessagesController < ApplicationController
   def create
     xml_body = Xmlhash.parse(request.raw_post)
     @status_message = StatusMessage.new(xml_body.slice('message', 'severity', 'scope'))
-    @status_message.user = User.find_by(login: xml_body['user']) || User.session
+    @status_message.creator = User.find_by(login: xml_body['user']) || User.session
 
     authorize @status_message
 
@@ -31,7 +31,7 @@ class StatusMessagesController < ApplicationController
 
     xml_body = Xmlhash.parse(request.raw_post)
     @status_message.assign_attributes(xml_body.slice('message', 'severity', 'scope'))
-    @status_message.user = User.find_by(login: xml_body['user']) || User.session
+    @status_message.creator = User.find_by(login: xml_body['user']) || User.session
 
     if @status_message.save
       render :show

--- a/src/api/app/controllers/status_messages_controller.rb
+++ b/src/api/app/controllers/status_messages_controller.rb
@@ -5,7 +5,7 @@ class StatusMessagesController < ApplicationController
   validate_action create: { method: :post, request: :status_message, response: :status_message }
 
   def index
-    @status_messages = StatusMessage.limit(params[:limit]).order(created_at: :desc).includes(:user)
+    @status_messages = StatusMessage.limit(params[:limit]).order(created_at: :desc).includes(:creator)
     @count = @status_messages.size
   end
 

--- a/src/api/app/controllers/webui/feeds_controller.rb
+++ b/src/api/app/controllers/webui/feeds_controller.rb
@@ -6,7 +6,7 @@ class Webui::FeedsController < Webui::WebuiController
   before_action :set_timerange, only: [:commits]
 
   def news
-    @news = StatusMessage.order(created_at: :desc).for_current_user.includes(:user).limit(5)
+    @news = StatusMessage.order(created_at: :desc).for_current_user.includes(:creator).limit(5)
   end
 
   def latest_updates

--- a/src/api/app/controllers/webui/main_controller.rb
+++ b/src/api/app/controllers/webui/main_controller.rb
@@ -4,7 +4,7 @@ class Webui::MainController < Webui::WebuiController
   skip_before_action :check_anonymous_access, only: :index
 
   def index
-    @status_messages = StatusMessage.order(created_at: :desc).for_current_user.includes(:user).limit(4)
+    @status_messages = StatusMessage.order(created_at: :desc).for_current_user.includes(:creator).limit(4)
     @workerstatus = Rails.cache.fetch('workerstatus_hash', expires_in: 10.minutes) do
       Xmlhash.parse(WorkerStatus.hidden.to_xml)
     end

--- a/src/api/app/controllers/webui/status_messages_controller.rb
+++ b/src/api/app/controllers/webui/status_messages_controller.rb
@@ -83,7 +83,7 @@ class Webui::StatusMessagesController < Webui::WebuiController
   end
 
   def status_message_params
-    params.require(:status_message).permit(:message, :severity, :communication_scope).merge(user: User.session)
+    params.require(:status_message).permit(:message, :severity, :communication_scope).merge(creator: User.session)
   end
 
   def index_params

--- a/src/api/app/controllers/webui/status_messages_controller.rb
+++ b/src/api/app/controllers/webui/status_messages_controller.rb
@@ -6,7 +6,7 @@ class Webui::StatusMessagesController < Webui::WebuiController
 
   def index
     @severity, @communication_scope, @page = index_params.values_at(:severity, :communication_scope, :page)
-    @status_messages = StatusMessage.order(created_at: :desc).includes(:user).for_severity(@severity).for_communication_scope(@communication_scope).page(@page)
+    @status_messages = StatusMessage.order(created_at: :desc).includes(:creator).for_severity(@severity).for_communication_scope(@communication_scope).page(@page)
 
     respond_to do |format|
       format.html

--- a/src/api/app/models/status_message.rb
+++ b/src/api/app/models/status_message.rb
@@ -1,5 +1,5 @@
 class StatusMessage < ApplicationRecord
-  belongs_to :user # TODO: rename as creator
+  belongs_to :creator, class_name: 'User', foreign_key: 'user_id'
   has_many :status_message_acknowledgements, dependent: :destroy
   has_many :users, through: :status_message_acknowledgements
 

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -24,7 +24,7 @@ class User < ApplicationRecord
   has_many :relationships, inverse_of: :user, dependent: :destroy
 
   has_many :comments, dependent: :destroy, inverse_of: :user
-  has_many :status_messages
+  has_many :status_messages, foreign_key: 'user_id', inverse_of: :creator
   has_many :tokens, class_name: 'Token', dependent: :destroy, inverse_of: :executor, foreign_key: :executor_id
 
   has_and_belongs_to_many :shared_workflow_tokens,

--- a/src/api/app/views/status_messages/_status_message.xml.builder
+++ b/src/api/app/views/status_messages/_status_message.xml.builder
@@ -1,6 +1,6 @@
 builder.status_message(id: status_message.id) do |m|
   m.message status_message.message
-  m.user status_message.user.login
+  m.user status_message.creator.login
   m.severity status_message.severity
   m.scope status_message.communication_scope
   m.created_at status_message.created_at

--- a/src/api/spec/controllers/status_messages_controller_spec.rb
+++ b/src/api/spec/controllers/status_messages_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe StatusMessagesController do
   end
 
   describe 'GET #show' do
-    let!(:status_message) { create(:status_message, user: user) }
+    let!(:status_message) { create(:status_message, creator: user) }
 
     before { get :show, params: { id: status_message.id }, format: :xml }
 
@@ -68,7 +68,7 @@ RSpec.describe StatusMessagesController do
       XML
     end
     let(:admin) { create(:admin_user) }
-    let!(:status_message) { create(:status_message, user: user) }
+    let!(:status_message) { create(:status_message, creator: user) }
 
     before do
       login admin
@@ -81,7 +81,7 @@ RSpec.describe StatusMessagesController do
   describe '#destroy' do
     subject { delete :destroy, params: { id: status_message.id }, format: :xml }
 
-    let!(:status_message) { create(:status_message, user: user) }
+    let!(:status_message) { create(:status_message, creator: user) }
     let(:admin) { create(:admin_user) }
 
     before do

--- a/src/api/spec/controllers/webui/feeds_controller_spec.rb
+++ b/src/api/spec/controllers/webui/feeds_controller_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Webui::FeedsController, :vcr do
         before do
           (1..5).each do |n|
             # Make sure created_at timestamps differ
-            travel_to(n.seconds.ago) { create(:status_message, message: "message #{n}", user: admin_user) }
+            travel_to(n.seconds.ago) { create(:status_message, message: "message #{n}", creator: admin_user) }
           end
 
           get :news, params: { project: project, format: 'rss' }

--- a/src/api/spec/controllers/webui/status_messages_controller_spec.rb
+++ b/src/api/spec/controllers/webui/status_messages_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Webui::StatusMessagesController do
 
       post :create, params: { status_message: { message: 'Some message', severity: 'green' } }
       expect(response).to redirect_to(news_items_path)
-      message = StatusMessage.where(user: admin_user, message: 'Some message', severity: 'green')
+      message = StatusMessage.where(creator: admin_user, message: 'Some message', severity: 'green')
       expect(message).to exist
     end
 
@@ -44,7 +44,7 @@ RSpec.describe Webui::StatusMessagesController do
       it 'is not authorized to create a status message' do
         expect(response).to redirect_to(root_path)
         expect(flash[:error]).to eq('Requires staff privileges')
-        message = StatusMessage.where(user: admin_user, message: 'Some message', severity: 'green')
+        message = StatusMessage.where(creator: admin_user, message: 'Some message', severity: 'green')
         expect(message).not_to exist
       end
     end

--- a/src/api/spec/controllers/webui/status_messages_controller_spec.rb
+++ b/src/api/spec/controllers/webui/status_messages_controller_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Webui::StatusMessagesController do
   end
 
   describe 'DELETE destroy' do
-    let!(:message) { create(:status_message, user: admin_user) }
+    let!(:message) { create(:status_message, creator: admin_user) }
 
     it { is_expected.to use_after_action(:verify_authorized) }
 
@@ -111,7 +111,7 @@ RSpec.describe Webui::StatusMessagesController do
   end
 
   describe 'POST acknowledge' do
-    let(:message) { create(:status_message, user: admin_user) }
+    let(:message) { create(:status_message, creator: admin_user) }
 
     it { is_expected.to use_after_action(:verify_authorized) }
 
@@ -140,7 +140,7 @@ RSpec.describe Webui::StatusMessagesController do
     end
 
     context 'when the news item is already acknowledged' do
-      let(:message) { create(:status_message, user: admin_user, users: [admin_user]) }
+      let(:message) { create(:status_message, creator: admin_user, users: [admin_user]) }
 
       before do
         login(admin_user)

--- a/src/api/spec/factories/status_message.rb
+++ b/src/api/spec/factories/status_message.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     message { Faker::Lorem.paragraph }
     severity { :green }
     communication_scope { 'all_users' }
-    user
+    association :creator, factory: :user
 
     trait :admins_only do
       communication_scope { 'admin_users' }

--- a/src/api/spec/features/webui/main_page_spec.rb
+++ b/src/api/spec/features/webui/main_page_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'OBS main page', :js, :vcr do
     it 'shows the latest four status messages' do
       (1..5).each do |n|
         # Make sure created_at timestamps differ
-        travel_to((5 - n).seconds.ago) { create(:status_message, message: "message #{n}", user: admin_user) }
+        travel_to((5 - n).seconds.ago) { create(:status_message, message: "message #{n}", creator: admin_user) }
       end
 
       visit root_path


### PR DESCRIPTION
Fixes #19947

This renames the `user` association to `creator` in the `StatusMessage` model to resolve the confusion with the `users` association (which tracks acknowledgements). It updates all references to `status_message.user` across the codebase and specs.