### PR TITLE
Drop frontend host settings from CONFIG

### DIFF
--- a/dist/functions.setup-appliance.sh
+++ b/dist/functions.setup-appliance.sh
@@ -226,18 +226,6 @@ function generate_proposed_dnsnames {
   PROPOSED_DNS_NAMES=$rv
 }
 ###############################################################################
-function adjust_api_config {
-
-      echo "Adjust configuration for this hostname"
-      # use local host to avoid SSL verification between webui and api
-
-      api_options_yml=$apidir/config/options.yml
-      sed -i 's,^frontend_host: .*,frontend_host: "localhost",' $api_options_yml
-      sed -i 's,^frontend_port: .*,frontend_port: 443,' $api_options_yml
-      sed -i 's,^frontend_protocol: .*,frontend_protocol: "'"https"'",' $api_options_yml
-
-}
-###############################################################################
 function adapt_worker_jobs {
   #changed IP means also that leftover jobs are invalid - cope with that
   echo "Adapting present worker jobs"

--- a/dist/setup-appliance.sh
+++ b/dist/setup-appliance.sh
@@ -109,7 +109,6 @@ fi
 
 if [[ $DETECTED_HOSTNAME_CHANGE == 1 ]];then
   adapt_worker_jobs
-  adjust_api_config
 fi
 
 echo "$FQHOSTNAME" > $backenddir/.oldfqhostname

--- a/src/api/config/environments/development.rb
+++ b/src/api/config/environments/development.rb
@@ -123,9 +123,6 @@ end
 
 CONFIG['response_schema_validation'] = true
 
-CONFIG['frontend_host'] = 'localhost'
-CONFIG['frontend_protocol'] = 'http'
-
 # Display fake sponsors above the footer on every page
 CONFIG['sponsors'] = [
   ActiveSupport::HashWithIndifferentAccess.new(

--- a/src/api/config/environments/test.rb
+++ b/src/api/config/environments/test.rb
@@ -94,10 +94,6 @@ CONFIG['source_url'] = "http://#{CONFIG['source_host']}:#{CONFIG['source_port']}
 # we set this to true
 CONFIG['global_write_through'] = false
 
-CONFIG['frontend_host'] = 'localhost'
-CONFIG['frontend_port'] = 3203
-CONFIG['frontend_protocol'] = 'http'
-
 if ENV['RUNNING_MINITEST']
   CONFIG['source_host'] = 'localhost'
   CONFIG['source_port'] = '3200'

--- a/src/api/config/options.yml.example
+++ b/src/api/config/options.yml.example
@@ -22,11 +22,6 @@ default: &default
   #source_protocol: https
   #source_protocol_ssl_verification: false
 
-  # api access to this instance
-  frontend_host: localhost
-  frontend_port: 443
-  frontend_protocol: https
-
   ### Public Access Configuration
   # Configure if this OBS is allowing people to browse it's content anonymously or not.
   # Disabling this also disables the interconnect feature.


### PR DESCRIPTION
This isn't used anymore since we dropped PackageControllerService::URLGenerator in '22 0cc097a827c11815870355932357296139315905
