### PR TITLE
Fix Project.restore crash when dependent project/repository is missing

### DIFF
--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -734,13 +734,13 @@ class Package < ApplicationRecord
     pkg
   end
 
-  def update_from_xml(xmlhash, ignore_lock = nil)
+  def update_from_xml(xmlhash, ignore_lock = nil, ignore_missing_links: false)
     check_write_access!(ignore_lock)
 
     Package.transaction do
       assign_attributes_from_from_xml(xmlhash)
 
-      assign_devel_package_from_xml(xmlhash)
+      assign_devel_package_from_xml(xmlhash, ignore_missing_links)
 
       # just for cycle detection
       resolve_devel_package
@@ -767,7 +767,7 @@ class Package < ApplicationRecord
     self.scmsync = xmlhash.value('scmsync')
   end
 
-  def assign_devel_package_from_xml(xmlhash)
+  def assign_devel_package_from_xml(xmlhash, ignore_missing_links)
     #--- devel project/package ---#
     devel = xmlhash['devel']
     self.develpackage = nil
@@ -775,10 +775,14 @@ class Package < ApplicationRecord
 
     devel_project_name = devel['project'] || xmlhash['project']
     devel_project = Project.find_by_name(devel_project_name)
+    
+    return if !devel_project && ignore_missing_links
     raise SaveError, "project '#{devel_project_name}' does not exist" unless devel_project
 
     devel_package_name = devel['package'] || xmlhash['name']
     devel_package = devel_project.packages.find_by_name(devel_package_name)
+    
+    return if !devel_package && ignore_missing_links
     raise SaveError, "package '#{devel_package_name}' does not exist in project '#{devel_project_name}'" unless devel_package
 
     self.develpackage = devel_package

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -733,13 +733,13 @@ class Package < ApplicationRecord
     pkg
   end
 
-  def update_from_xml(xmlhash, ignore_lock = nil)
+  def update_from_xml(xmlhash, ignore_lock = nil, ignore_missing_links: false)
     check_write_access!(ignore_lock)
 
     Package.transaction do
       assign_attributes_from_from_xml(xmlhash)
 
-      assign_devel_package_from_xml(xmlhash)
+      assign_devel_package_from_xml(xmlhash, ignore_missing_links: ignore_missing_links)
 
       # just for cycle detection
       resolve_devel_package
@@ -766,7 +766,7 @@ class Package < ApplicationRecord
     self.scmsync = xmlhash.value('scmsync')
   end
 
-  def assign_devel_package_from_xml(xmlhash)
+  def assign_devel_package_from_xml(xmlhash, ignore_missing_links: false)
     #--- devel project/package ---#
     devel = xmlhash['devel']
     self.develpackage = nil
@@ -774,10 +774,14 @@ class Package < ApplicationRecord
 
     devel_project_name = devel['project'] || xmlhash['project']
     devel_project = Project.find_by_name(devel_project_name)
+
+    return if !devel_project && ignore_missing_links
     raise SaveError, "project '#{devel_project_name}' does not exist" unless devel_project
 
     devel_package_name = devel['package'] || xmlhash['name']
     devel_package = devel_project.packages.find_by_name(devel_package_name)
+
+    return if !devel_package && ignore_missing_links
     raise SaveError, "package '#{devel_package_name}' does not exist in project '#{devel_project_name}'" unless devel_package
 
     self.develpackage = devel_package

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -767,7 +767,7 @@ class Package < ApplicationRecord
     self.scmsync = xmlhash.value('scmsync')
   end
 
-  def assign_devel_package_from_xml(xmlhash, ignore_missing_links)
+  def assign_devel_package_from_xml(xmlhash, ignore_missing_links = false)
     #--- devel project/package ---#
     devel = xmlhash['devel']
     self.develpackage = nil

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -155,7 +155,7 @@ class Project < ApplicationRecord
       project = Project.new(name: project_name)
 
       Project.transaction do
-        project.update_from_xml!(Xmlhash.parse(project.meta.content))
+        project.update_from_xml!(Xmlhash.parse(project.meta.content), nil, ignore_missing_links: true)
         project.store
 
         # restore all package meta data objects in DB
@@ -168,7 +168,7 @@ class Project < ApplicationRecord
           package_meta = Xmlhash.parse(package.meta.content)
 
           Package.transaction do
-            package.update_from_xml(package_meta)
+            package.update_from_xml(package_meta, nil, ignore_missing_links: true)
             package.store
           end
         end
@@ -665,8 +665,8 @@ class Project < ApplicationRecord
     errors.none?
   end
 
-  def update_from_xml!(xmlhash, force = nil)
-    Project::UpdateFromXmlCommand.new(self).run(xmlhash, force)
+  def update_from_xml!(xmlhash, force = nil, ignore_missing_links: false)
+    Project::UpdateFromXmlCommand.new(self).run(xmlhash, force, ignore_missing_links: ignore_missing_links)
   end
 
   def update_from_xml(xmlhash, force = nil)

--- a/src/api/app/models/project/update_from_xml_command.rb
+++ b/src/api/app/models/project/update_from_xml_command.rb
@@ -134,7 +134,7 @@ class Project
       project.maintained_projects.delete(olds.values)
     end
 
-    def update_repositories(xmlhash, force, ignore_missing_links)
+    def update_repositories(xmlhash, force, ignore_missing_links = false)
       fill_repo_cache
 
       xmlhash.elements('repository') do |repo_xml_hash|
@@ -196,7 +196,7 @@ class Project
       @repocache.delete(xml_hash['name'])
     end
 
-    def update_path_elements(current_repo, xml_hash, ignore_missing_links)
+    def update_path_elements(current_repo, xml_hash, ignore_missing_links = false)
       # destroy all current pathelements
       current_repo.path_elements.destroy_all
       return unless xml_hash['path'] || xml_hash['hostsystem']

--- a/src/api/app/models/project/update_from_xml_command.rb
+++ b/src/api/app/models/project/update_from_xml_command.rb
@@ -8,7 +8,7 @@ class Project
       @project = project
     end
 
-    def run(xmlhash, force = nil)
+    def run(xmlhash, force = nil, ignore_missing_links: false)
       project.check_write_access!
 
       # check for raising read access permissions, which can't get ensured atm
@@ -45,7 +45,7 @@ class Project
       update_maintained_prjs_from_xml(xmlhash)
       project.update_relationships_from_xml(xmlhash)
 
-      update_repositories(xmlhash, force)
+      update_repositories(xmlhash, force, ignore_missing_links)
 
       return if project.scmsync.blank?
 
@@ -134,11 +134,11 @@ class Project
       project.maintained_projects.delete(olds.values)
     end
 
-    def update_repositories(xmlhash, force)
+    def update_repositories(xmlhash, force, ignore_missing_links)
       fill_repo_cache
 
       xmlhash.elements('repository') do |repo_xml_hash|
-        update_repository_without_path_element(repo_xml_hash)
+        update_repository_without_path_element(repo_xml_hash, ignore_missing_links)
       end
       # Some repositories might be refered by path elements before they appear in the
       # xml tree. Thus we have 2 iterations. First one goes through all repository
@@ -147,7 +147,7 @@ class Project
       # repository uses another one, eg. importing an existing config from elsewhere.
       xmlhash.elements('repository') do |repo|
         current_repo = project.repositories.find_by_name(repo['name'])
-        update_path_elements(current_repo, repo)
+        update_path_elements(current_repo, repo, ignore_missing_links)
       end
 
       # delete remaining repositories in @repocache
@@ -177,7 +177,7 @@ class Project
       end
     end
 
-    def update_repository_without_path_element(xml_hash)
+    def update_repository_without_path_element(xml_hash, ignore_missing_links)
       current_repo = @repocache[xml_hash['name']]
       unless current_repo
         Rails.logger.debug { "adding repository '#{xml_hash['name']}'" }
@@ -186,7 +186,7 @@ class Project
       Rails.logger.debug { "modifying repository '#{xml_hash['name']}'" }
 
       update_repository_flags(current_repo, xml_hash)
-      update_release_targets(current_repo, xml_hash)
+      update_release_targets(current_repo, xml_hash, ignore_missing_links)
       current_repo.save! if current_repo.changed?
       update_repository_architectures(current_repo, xml_hash)
       update_download_repositories(current_repo, xml_hash)
@@ -196,7 +196,7 @@ class Project
       @repocache.delete(xml_hash['name'])
     end
 
-    def update_path_elements(current_repo, xml_hash)
+    def update_path_elements(current_repo, xml_hash, ignore_missing_links)
       # destroy all current pathelements
       current_repo.path_elements.destroy_all
       return unless xml_hash['path'] || xml_hash['hostsystem']
@@ -206,6 +206,8 @@ class Project
       xml_hash.elements('hostsystem') do |hostsystem|
         host_repo = Repository.find_by_project_and_name(hostsystem['project'], hostsystem['repository'])
         raise SaveError, 'Using same repository as hostsystem element is not allowed' if hostsystem['project'] == project.name && hostsystem['repository'] == xml_hash['name']
+        
+        next if !host_repo && ignore_missing_links
         raise SaveError, "Unknown hostsystem repository '#{hostsystem['project']}/#{hostsystem['repository']}'" unless host_repo
 
         current_repo.path_elements.new(link: host_repo, position: position, kind: :hostsystem)
@@ -217,6 +219,8 @@ class Project
       xml_hash.elements('path') do |path|
         link_repo = Repository.find_by_project_and_name(path['project'], path['repository'])
         raise SaveError, 'Using same repository as path element is not allowed' if path['project'] == project.name && path['repository'] == xml_hash['name']
+        
+        next if !link_repo && ignore_missing_links
         raise SaveError, "Cannot find repository '#{path['project']}/#{path['repository']}'" unless link_repo
 
         current_repo.path_elements.new(link: link_repo, position: position)
@@ -239,7 +243,7 @@ class Project
       current_repo.linkedbuild = xml_hash['linkedbuild']
     end
 
-    def update_release_targets(current_repo, xml_hash)
+    def update_release_targets(current_repo, xml_hash, ignore_missing_links)
       # destroy all current releasetargets
       current_repo.release_targets.destroy_all
 
@@ -249,14 +253,17 @@ class Project
         repository = release_target['repository']
         trigger    = release_target['trigger']
 
+        next if !project && ignore_missing_links
         raise SaveError, "Project '#{release_target['project']}' does not exist." unless project
 
         raise SaveError, 'Using same repository as release target element is not allowed' if release_target['project'] == self.project.name && repository == xml_hash['name']
 
+        next if project.defines_remote_instance? && ignore_missing_links
         raise SaveError, "Can not use remote repository as release target '#{project}/#{repository}'" if project.defines_remote_instance?
 
         target_repo = Repository.find_by_project_and_name(project.name, repository)
 
+        next if !target_repo && ignore_missing_links
         raise SaveError, "Unknown target repository '#{project}/#{repository}'" unless target_repo
 
         current_repo.release_targets.new(target_repository: target_repo, trigger: trigger)

--- a/src/api/app/models/project/update_from_xml_command.rb
+++ b/src/api/app/models/project/update_from_xml_command.rb
@@ -8,7 +8,7 @@ class Project
       @project = project
     end
 
-    def run(xmlhash, force = nil)
+    def run(xmlhash, force = nil, ignore_missing_links: false)
       project.check_write_access!
 
       # check for raising read access permissions, which can't get ensured atm
@@ -45,7 +45,7 @@ class Project
       update_maintained_prjs_from_xml(xmlhash)
       project.update_relationships_from_xml(xmlhash)
 
-      update_repositories(xmlhash, force)
+      update_repositories(xmlhash, force, ignore_missing_links: ignore_missing_links)
 
       return if project.scmsync.blank?
 
@@ -133,11 +133,11 @@ class Project
       project.maintained_projects.delete(olds.values)
     end
 
-    def update_repositories(xmlhash, force)
+    def update_repositories(xmlhash, force, ignore_missing_links: false)
       fill_repo_cache
 
       xmlhash.elements('repository') do |repo_xml_hash|
-        update_repository_without_path_element(repo_xml_hash)
+        update_repository_without_path_element(repo_xml_hash, ignore_missing_links: ignore_missing_links)
       end
       # Some repositories might be refered by path elements before they appear in the
       # xml tree. Thus we have 2 iterations. First one goes through all repository
@@ -146,7 +146,7 @@ class Project
       # repository uses another one, eg. importing an existing config from elsewhere.
       xmlhash.elements('repository') do |repo|
         current_repo = project.repositories.find_by_name(repo['name'])
-        update_path_elements(current_repo, repo)
+        update_path_elements(current_repo, repo, ignore_missing_links: ignore_missing_links)
       end
 
       # delete remaining repositories in @repocache
@@ -176,7 +176,7 @@ class Project
       end
     end
 
-    def update_repository_without_path_element(xml_hash)
+    def update_repository_without_path_element(xml_hash, ignore_missing_links: false)
       current_repo = @repocache[xml_hash['name']]
       unless current_repo
         Rails.logger.debug { "adding repository '#{xml_hash['name']}'" }
@@ -185,7 +185,7 @@ class Project
       Rails.logger.debug { "modifying repository '#{xml_hash['name']}'" }
 
       update_repository_flags(current_repo, xml_hash)
-      update_release_targets(current_repo, xml_hash)
+      update_release_targets(current_repo, xml_hash, ignore_missing_links: ignore_missing_links)
       current_repo.save! if current_repo.changed?
       update_repository_architectures(current_repo, xml_hash)
       update_download_repositories(current_repo, xml_hash)
@@ -195,7 +195,7 @@ class Project
       @repocache.delete(xml_hash['name'])
     end
 
-    def update_path_elements(current_repo, xml_hash)
+    def update_path_elements(current_repo, xml_hash, ignore_missing_links: false)
       # destroy all current pathelements
       current_repo.path_elements.destroy_all
       return unless xml_hash['path'] || xml_hash['hostsystem']
@@ -205,6 +205,7 @@ class Project
       xml_hash.elements('hostsystem') do |hostsystem|
         host_repo = Repository.find_by_project_and_name(hostsystem['project'], hostsystem['repository'])
         raise SaveError, 'Using same repository as hostsystem element is not allowed' if hostsystem['project'] == project.name && hostsystem['repository'] == xml_hash['name']
+        next if !host_repo && ignore_missing_links
         raise SaveError, "Unknown hostsystem repository '#{hostsystem['project']}/#{hostsystem['repository']}'" unless host_repo
 
         current_repo.path_elements.new(link: host_repo, position: position, kind: :hostsystem)
@@ -216,6 +217,8 @@ class Project
       xml_hash.elements('path') do |path|
         link_repo = Repository.find_by_project_and_name(path['project'], path['repository'])
         raise SaveError, 'Using same repository as path element is not allowed' if path['project'] == project.name && path['repository'] == xml_hash['name']
+
+        next if !link_repo && ignore_missing_links
         raise SaveError, "Cannot find repository '#{path['project']}/#{path['repository']}'" unless link_repo
 
         current_repo.path_elements.new(link: link_repo, position: position)
@@ -238,7 +241,7 @@ class Project
       current_repo.linkedbuild = xml_hash['linkedbuild']
     end
 
-    def update_release_targets(current_repo, xml_hash)
+    def update_release_targets(current_repo, xml_hash, ignore_missing_links: false)
       # destroy all current releasetargets
       current_repo.release_targets.destroy_all
 
@@ -248,14 +251,17 @@ class Project
         repository = release_target['repository']
         trigger    = release_target['trigger']
 
+        next if !project && ignore_missing_links
         raise SaveError, "Project '#{release_target['project']}' does not exist." unless project
 
         raise SaveError, 'Using same repository as release target element is not allowed' if release_target['project'] == self.project.name && repository == xml_hash['name']
 
+        next if project.defines_remote_instance? && ignore_missing_links
         raise SaveError, "Can not use remote repository as release target '#{project}/#{repository}'" if project.defines_remote_instance?
 
         target_repo = Repository.find_by_project_and_name(project.name, repository)
 
+        next if !target_repo && ignore_missing_links
         raise SaveError, "Unknown target repository '#{project}/#{repository}'" unless target_repo
 
         current_repo.release_targets.new(target_repository: target_repo, trigger: trigger)


### PR DESCRIPTION
Fixes #12710. This PR adds an `ignore_missing_links` option during `Project.restore` to gracefully skip over repositories or package dependencies that were permanently deleted while the project was in a deleted state.