### PR TITLE
Revert "UI: Show away/dead/down worker states on monitor page"

### DIFF
--- a/src/api/app/assets/javascripts/webui/monitor.js
+++ b/src/api/app/assets/javascripts/webui/monitor.js
@@ -125,23 +125,10 @@ function processProgressBar(id, item)
     }
   }
   else {
-    var state = item["state"] || "idle";
-    el_text.html(state);
+    el_text.html("idle");
+    ctrl.css("width", "0%");
+    ctrl.css("aria-valuenow", 0)
     el_text.attr("href", "#");
-    ctrl.removeClass('text-bg-success text-bg-warning text-bg-danger');
-
-    if (state == 'dead' || state == 'down') {
-      ctrl.css("width", "100%");
-      ctrl.attr("aria-valuenow", 100);
-      ctrl.addClass('text-bg-danger');
-    } else if (state == 'away') {
-      ctrl.css("width", "100%");
-      ctrl.attr("aria-valuenow", 100);
-      ctrl.addClass('text-bg-warning');
-    } else {
-      ctrl.css("width", "0%");
-      ctrl.attr("aria-valuenow", 0);
-    }
   }
 }
 

--- a/src/api/app/services/monitor_controller_service/building_information_updater.rb
+++ b/src/api/app/services/monitor_controller_service/building_information_updater.rb
@@ -19,10 +19,7 @@ module MonitorControllerService
     end
 
     def initialize_workers
-      @workers = {}
-      %w[idle away dead down].each do |state|
-        @workers.merge!(worker_status.elements(state).to_h { |b| [worker_id(b), { 'state' => state }] })
-      end
+      @workers = worker_status.elements('idle').to_h { |b| [worker_id(b), {}] }
     end
 
     def update_workers

--- a/src/api/spec/jobs/status_history_rescaler_job_spec.rb
+++ b/src/api/spec/jobs/status_history_rescaler_job_spec.rb
@@ -6,8 +6,7 @@ RSpec.describe StatusHistoryRescalerJob do
   describe '#rescale' do
     context 'newer than 2 hours records' do
       before do
-        base_time = Time.now.utc
-        5.times { |i| StatusHistory.create(time: (base_time - i.seconds).to_i, key: 'busy_x86_64', value: i * 10) }
+        5.times { |i| StatusHistory.create(time: (Time.now.utc - i.seconds).to_i, key: 'busy_x86_64', value: i * 10) }
 
         StatusHistoryRescalerJob.perform_now
       end

--- a/src/api/spec/services/monitor_controller_service/building_information_updater_spec.rb
+++ b/src/api/spec/services/monitor_controller_service/building_information_updater_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe MonitorControllerService::BuildingInformationUpdater do
 
     it { expect(subject).not_to be_empty }
     it { expect(subject).to have_key('build01_1') }
-    it { expect(subject['build01_1']).to eq({ 'state' => 'idle' }) }
+    it { expect(subject['build01_1']).to be_empty }
     it { expect(subject).to have_key('build01_2') }
     it { expect(subject['build01_2']).to have_key('delta') }
     it { expect(subject['build01_2']['delta']).to eq('100') }


### PR DESCRIPTION
Reverts openSUSE/open-build-service#19916

See https://github.com/openSUSE/open-build-service/pull/19916#issuecomment-4925526476

Reopens #2488
