### PR TITLE
Reduce timeout for fqhn from 600 to 30 sec in appliance setup

### DIFF
--- a/dist/setup-appliance.sh
+++ b/dist/setup-appliance.sh
@@ -155,7 +155,7 @@ function get_hostname {
   if [[ $1 && $BOOTSTRAP_TEST_MODE == 1 ]];then
     FQHOSTNAME=$1
   else
-    TIMEOUT=600
+    TIMEOUT=30
     while [ -z "$FQHOSTNAME" -o "$FQHOSTNAME" = "localhost" ];do
       FQHOSTNAME=`hostname -f 2>/dev/null`
       TIMEOUT=$(($TIMEOUT-1))


### PR DESCRIPTION
Copied over from https://github.com/openSUSE/open-build-service/pull/7843

When setting up an appliance e.g. with virt-manager, you only get a login prompt after setup-appliance.sh has finished (if kernelcmdline="... console=ttyS0 ...") This patch reduces the timeout from 600 sec to 30 sec to avoid the impression, the appliance is dead or the boot process is stuck.
