### PR TITLE
UI: Show away/dead/down worker states as badges on monitor page

### DIFF
--- a/src/api/app/assets/javascripts/webui/monitor.js
+++ b/src/api/app/assets/javascripts/webui/monitor.js
@@ -97,12 +97,14 @@ function processProgressBar(id, item)
   var delta = item["delta"];
 
   var container = $('#p' + id);
+  var host = container.data('host');
   var el_text = container.find(".monitorpb_text");
   var ctrl = container.find(".progress-bar");
 
   var logfileinfo = $("#worker-display option:selected").val();
 
   if (delta) {
+    container.removeClass('d-none');
     el_text.text(item[logfileinfo]);
     ctrl.css("width", delta + "%").attr("aria-valuenow", delta);
     if (item["hidden"]) {
@@ -127,12 +129,11 @@ function processProgressBar(id, item)
       ctrl.addClass("text-bg-danger");
       ctrl.removeClass('text-bg-success text-bg-warning');
     }
+    return null;
   }
   else {
-    el_text.html("idle");
-    ctrl.css("width", "0%");
-    ctrl.css("aria-valuenow", 0)
-    el_text.attr("href", "#");
+    container.addClass('d-none');
+    return { host: host, status: item["state"] || "idle" };
   }
 }
 
@@ -143,9 +144,35 @@ function updateProgressBar()
   var monitorPath=$('#workers').data('monitorPath');
 
   $.getJSON(monitorPath, function(json) {
+    var hostStates = {};
     $.each(json, function(i,item) {
-            processProgressBar(i, item);
+            var state = processProgressBar(i, item);
+            if (state && state.host && state.status) {
+              if (!hostStates[state.host]) {
+                hostStates[state.host] = { idle: 0, away: 0, dead: 0, down: 0 };
+              }
+              if (hostStates[state.host][state.status] !== undefined) {
+                hostStates[state.host][state.status]++;
+              }
+            }
     });
+
+    $('.builderbox').each(function() {
+      var host = $(this).data('host');
+      var states = hostStates[host] || { idle: 0, away: 0, dead: 0, down: 0 };
+      
+      $.each(['idle', 'away', 'dead', 'down'], function(index, state) {
+        var badge = $(this).find('.' + state + '-badge');
+        var count = states[state] || 0;
+        badge.text(state + ': ' + count);
+        if (count > 0) {
+          badge.removeClass('d-none');
+        } else {
+          badge.addClass('d-none');
+        }
+      }.bind(this));
+    });
+
     $("#workers-updating").fadeOut(1200);
   });
 }

--- a/src/api/app/controllers/webui/monitor_controller.rb
+++ b/src/api/app/controllers/webui/monitor_controller.rb
@@ -22,14 +22,16 @@ class Webui::MonitorController < Webui::WebuiController
       workers_list = []
       %w[idle building away down dead].each do |state|
         @workerstatus.elements(state) do |b|
-          workers_list << [b['workerid'], b['hostarch']]
+          workers_list << [b['workerid'], b['hostarch'], state]
         end
       end
-      workers_list.each do |bid, barch|
+      workers_list.each do |bid, barch, state|
         hostname, subid = bid.tr(':', '/').split('/')
         id = bid.gsub(%r{[:./]}, '_')
         workers[hostname] ||= {}
         workers[hostname]['_arch'] = barch
+        workers[hostname]['_states'] ||= { 'idle' => 0, 'away' => 0, 'dead' => 0, 'down' => 0 }
+        workers[hostname]['_states'][state] += 1 if workers[hostname]['_states'].key?(state)
         workers[hostname][subid] = id
       end
       @workers_sorted = {}

--- a/src/api/app/services/monitor_controller_service/building_information_updater.rb
+++ b/src/api/app/services/monitor_controller_service/building_information_updater.rb
@@ -19,7 +19,10 @@ module MonitorControllerService
     end
 
     def initialize_workers
-      @workers = worker_status.elements('idle').to_h { |b| [worker_id(b), {}] }
+      @workers = {}
+      %w[idle away dead down].each do |state|
+        @workers.merge!(worker_status.elements(state).to_h { |b| [worker_id(b), { 'state' => state }] })
+      end
     end
 
     def update_workers

--- a/src/api/app/services/monitor_controller_service/building_information_updater.rb
+++ b/src/api/app/services/monitor_controller_service/building_information_updater.rb
@@ -21,12 +21,16 @@ module MonitorControllerService
     def initialize_workers
       @workers = {}
       %w[idle away dead down].each do |state|
-        @workers.merge!(worker_status.elements(state).to_h { |b| [worker_id(b), { 'state' => state }] })
+        (worker_status.elements(state) || []).each do |b|
+          @workers[worker_id(b)] = { 'state' => state }
+        end
       end
     end
 
     def update_workers
-      @workers.merge!(@worker_status.elements('building').to_h { |b| [worker_id(b), workers_hash(b, calculate_delta(b['starttime'].to_i))] })
+      (@worker_status.elements('building') || []).each do |b|
+        @workers[worker_id(b)] = workers_hash(b, calculate_delta(b['starttime'].to_i))
+      end
     end
 
     def workers_hash(b, delta)

--- a/src/api/app/services/monitor_controller_service/building_information_updater.rb
+++ b/src/api/app/services/monitor_controller_service/building_information_updater.rb
@@ -19,11 +19,18 @@ module MonitorControllerService
     end
 
     def initialize_workers
-      @workers = worker_status.elements('idle').to_h { |b| [worker_id(b), {}] }
+      @workers = {}
+      %w[idle away dead down].each do |state|
+        (worker_status.elements(state) || []).each do |b|
+          @workers[worker_id(b)] = { 'state' => state }
+        end
+      end
     end
 
     def update_workers
-      @workers.merge!(@worker_status.elements('building').to_h { |b| [worker_id(b), workers_hash(b, calculate_delta(b['starttime'].to_i))] })
+      (@worker_status.elements('building') || []).each do |b|
+        @workers[worker_id(b)] = workers_hash(b, calculate_delta(b['starttime'].to_i))
+      end
     end
 
     def workers_hash(b, delta)

--- a/src/api/app/views/webui/monitor/_workers_table.html.haml
+++ b/src/api/app/views/webui/monitor/_workers_table.html.haml
@@ -26,13 +26,14 @@
       %ul.monitorboxrow.list-unstyled.overflow-hidden.m-3
         %li.builderbox.float-start{ data: { host: name } }
           %span.fw-bold #{name} (#{hash['_arch']})
+          - states = hash['_states'] || { 'idle' => 0, 'away' => 0, 'dead' => 0, 'down' => 0 }
           .worker-badges.mt-1.mb-1
-            %span.badge.text-bg-secondary.idle-badge.d-none idle: 0
-            %span.badge.text-bg-warning.away-badge.d-none away: 0
-            %span.badge.text-bg-danger.dead-badge.d-none dead: 0
-            %span.badge.text-bg-danger.down-badge.d-none down: 0
+            %span.badge.text-bg-secondary.idle-badge{ class: states['idle'] > 0 ? '' : 'd-none' } idle: #{states['idle']}
+            %span.badge.text-bg-warning.away-badge{ class: states['away'] > 0 ? '' : 'd-none' } away: #{states['away']}
+            %span.badge.text-bg-danger.dead-badge{ class: states['dead'] > 0 ? '' : 'd-none' } dead: #{states['dead']}
+            %span.badge.text-bg-danger.down-badge{ class: states['down'] > 0 ? '' : 'd-none' } down: #{states['down']}
           - hash.each do |subid, id|
-            - if subid != '_arch'
+            - if subid != '_arch' && subid != '_states'
               .monitorpb.worker-progress.d-none.position-relative.mt-1{ id: "p#{id}", data: { host: name } }
                 .progress
                   .progress-bar.progress-bar-striped{ 'aria-valuemax' => '100', 'aria-valuemin' => '0',

--- a/src/api/app/views/webui/monitor/_workers_table.html.haml
+++ b/src/api/app/views/webui/monitor/_workers_table.html.haml
@@ -24,11 +24,17 @@
   .d-flex.flex-wrap
     - workers_sorted.each do |name, hash|
       %ul.monitorboxrow.list-unstyled.overflow-hidden.m-3
-        %li.builderbox.float-start
+        %li.builderbox.float-start{ data: { host: name } }
           %span.fw-bold #{name} (#{hash['_arch']})
+          - states = hash['_states'] || { 'idle' => 0, 'away' => 0, 'dead' => 0, 'down' => 0 }
+          .worker-badges.mt-1.mb-1
+            %span.badge.text-bg-secondary.idle-badge{ class: states['idle'] > 0 ? '' : 'd-none' } idle: #{states['idle']}
+            %span.badge.text-bg-warning.away-badge{ class: states['away'] > 0 ? '' : 'd-none' } away: #{states['away']}
+            %span.badge.text-bg-danger.dead-badge{ class: states['dead'] > 0 ? '' : 'd-none' } dead: #{states['dead']}
+            %span.badge.text-bg-danger.down-badge{ class: states['down'] > 0 ? '' : 'd-none' } down: #{states['down']}
           - hash.each do |subid, id|
-            - if subid != '_arch'
-              .monitorpb.position-relative.mt-1{ id: "p#{id}" }
+            - if subid != '_arch' && subid != '_states'
+              .monitorpb.worker-progress.d-none.position-relative.mt-1{ id: "p#{id}", data: { host: name } }
                 .progress
                   .progress-bar.progress-bar-striped{ 'aria-valuemax' => '100', 'aria-valuemin' => '0',
                                                       'role' => 'progressbar' }

--- a/src/api/app/views/webui/monitor/_workers_table.html.haml
+++ b/src/api/app/views/webui/monitor/_workers_table.html.haml
@@ -24,11 +24,16 @@
   .d-flex.flex-wrap
     - workers_sorted.each do |name, hash|
       %ul.monitorboxrow.list-unstyled.overflow-hidden.m-3
-        %li.builderbox.float-start
+        %li.builderbox.float-start{ data: { host: name } }
           %span.fw-bold #{name} (#{hash['_arch']})
+          .worker-badges.mt-1.mb-1
+            %span.badge.text-bg-secondary.idle-badge.d-none idle: 0
+            %span.badge.text-bg-warning.away-badge.d-none away: 0
+            %span.badge.text-bg-danger.dead-badge.d-none dead: 0
+            %span.badge.text-bg-danger.down-badge.d-none down: 0
           - hash.each do |subid, id|
             - if subid != '_arch'
-              .monitorpb.position-relative.mt-1{ id: "p#{id}" }
+              .monitorpb.worker-progress.d-none.position-relative.mt-1{ id: "p#{id}", data: { host: name } }
                 .progress
                   .progress-bar.progress-bar-striped{ 'aria-valuemax' => '100', 'aria-valuemin' => '0',
                                                       'role' => 'progressbar' }

--- a/src/api/spec/services/monitor_controller_service/building_information_updater_spec.rb
+++ b/src/api/spec/services/monitor_controller_service/building_information_updater_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe MonitorControllerService::BuildingInformationUpdater do
 
     it { expect(subject).not_to be_empty }
     it { expect(subject).to have_key('build01_1') }
-    it { expect(subject['build01_1']).to be_empty }
+    it { expect(subject['build01_1']).to eq({ 'state' => 'idle' }) }
     it { expect(subject).to have_key('build01_2') }
     it { expect(subject['build01_2']).to have_key('delta') }
     it { expect(subject['build01_2']['delta']).to eq('100') }

--- a/src/api/spec/services/monitor_controller_service/building_information_updater_spec.rb
+++ b/src/api/spec/services/monitor_controller_service/building_information_updater_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe MonitorControllerService::BuildingInformationUpdater do
 
     it { expect(subject).not_to be_empty }
     it { expect(subject).to have_key('build01_1') }
-    it { expect(subject['build01_1']).to be_empty }
+    it { expect(subject['build01_1']).to eq({ 'state' => 'idle' }) }
     it { expect(subject).to have_key('build01_2') }
     it { expect(subject['build01_2']).to have_key('delta') }
     it { expect(subject['build01_2']['delta']).to eq('100') }


### PR DESCRIPTION
Re-implements the feature to track idle/away/dead/down worker states on the monitor page (fixes #2488).

As suggested by @hennevogel in the review of the reverted PR #19916, this implementation aggregates the non-building states (idle, away, dead, down) into individual badges per worker host. 

Empty progress bars for non-building workers are now hidden by default, making the UI lighter and ensuring that active jobs are not pushed down. The javascript polling dynamically updates these badge counts as states change.

### Screenshots

**Before**
<img width="800" alt="Before: Empty progress bars" src="https://raw.githubusercontent.com/pranavchoudhary-tech/open-build-service/pr-screenshots/pr_screenshots/monitor_worker_badges_before.png">

**After**
<img width="800" alt="After: Badges for idle, away, dead, down" src="https://raw.githubusercontent.com/pranavchoudhary-tech/open-build-service/pr-screenshots/pr_screenshots/monitor_worker_badges.png">
