### PR TITLE
Update brakeman to ignore Rails 7.2.3.1 EOL

### DIFF
--- a/src/api/config/brakeman.ignore
+++ b/src/api/config/brakeman.ignore
@@ -122,25 +122,6 @@
       "note": ""
     },
     {
-      "warning_type": "Unmaintained Dependency",
-      "warning_code": 122,
-      "fingerprint": "21ab0fe00fdd5899ffc405cff75aadb91b805ee996a614f7e27b08a287e9062d",
-      "check_name": "EOLRails",
-      "message": "Support for Rails 7.2.3.1 ends on 2026-08-09",
-      "file": "Gemfile.lock",
-      "line": 391,
-      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
-      "code": null,
-      "render_path": null,
-      "location": null,
-      "user_input": null,
-      "confidence": "Weak",
-      "cwe_id": [
-        1104
-      ],
-      "note": ""
-    },
-    {
       "warning_type": "SQL Injection",
       "warning_code": 0,
       "fingerprint": "23288c7e9dea90dd0d6a14268bf929de5b7651f16e9c2233776751400dda5d11",
@@ -452,6 +433,25 @@
       "note": ""
     },
     {
+      "warning_type": "Unmaintained Dependency",
+      "warning_code": 122,
+      "fingerprint": "98b26f60d776fd41ee6f088c833725145be9aac2d7c5b33780241c273622db42",
+      "check_name": "EOLRails",
+      "message": "Support for Rails 7.2.3.1 ends on 2026-08-09",
+      "file": "Gemfile.lock",
+      "line": 388,
+      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
+      "code": null,
+      "render_path": null,
+      "location": null,
+      "user_input": null,
+      "confidence": "Medium",
+      "cwe_id": [
+        1104
+      ],
+      "note": ""
+    },
+    {
       "warning_type": "SQL Injection",
       "warning_code": 0,
       "fingerprint": "ad49cd1c1746b547be303b03640568525232c39d97d6e256a9f5d6edfc7350e0",
@@ -606,7 +606,7 @@
       "check_name": "RegexDoS",
       "message": "Model attribute used in regular expression",
       "file": "app/jobs/update_released_binaries_job.rb",
-      "line": 98,
+      "line": 100,
       "link": "https://brakemanscanner.org/docs/warning_types/denial_of_service/",
       "code": "/^#{Package.striping_multibuild_suffix(backend_binary[\"package\"])}:/",
       "render_path": null,


### PR DESCRIPTION
`confidence` upgraded from `Weak` to `Medium`

Update performed following https://github.com/openSUSE/open-build-service/wiki/Brakeman

Rails upgrade to 8.0 is WIP, meanwhile we want to silent the alert
