### PR TITLE
Fix rename of user association to creator in status message model

### DIFF
--- a/src/api/app/views/webui/feeds/news.rss.builder
+++ b/src/api/app/views/webui/feeds/news.rss.builder
@@ -8,7 +8,7 @@ xml.rss version: '2.0' do
       xml.item do
         xml.title message.message
         xml.pubDate message.created_at
-        xml.author message.user
+        xml.author message.creator
         xml.link url_for only_path: false, controller: 'main', action: 'index'
       end
     end


### PR DESCRIPTION
This was left over from https://github.com/openSUSE/open-build-service/pull/19948