### PR TITLE
Move config.active_job.queue_adapter into environments

### DIFF
--- a/src/api/config/application.rb
+++ b/src/api/config/application.rb
@@ -35,9 +35,6 @@ module OBSApi
     # Enable rails version 7.0 defaults
     config.load_defaults 7.0
 
-    # required since rails 4.2
-    config.active_job.queue_adapter = :delayed_job
-
     config.action_controller.perform_caching = true
 
     config.action_controller.action_on_unpermitted_parameters = :raise

--- a/src/api/config/environments/development.rb
+++ b/src/api/config/environments/development.rb
@@ -75,6 +75,9 @@ Rails.application.configure do
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]
 
+  # Use DelayedJob gem as queuing backend for Active Job
+  config.active_job.queue_adapter = :delayed_job
+
   # Highlight code that enqueued background job in logs.
   config.active_job.verbose_enqueue_logs = true
 

--- a/src/api/config/environments/production.rb
+++ b/src/api/config/environments/production.rb
@@ -56,8 +56,8 @@ Rails.application.configure do
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 
-  # Use a real queuing backend for Active Job (and separate queues per environment).
-  # config.active_job.queue_adapter     = :resque
+  # Use DelayedJob gem as qeuing backend for Active Job
+  config.active_job.queue_adapter = :delayed_job
   # config.active_job.queue_name_prefix = "obs_api_production"
 
   # see http://guides.rubyonrails.org/action_mailer_basics.html#example-action-mailer-configuration


### PR DESCRIPTION
This differs between environments and we don't need it during boot.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
