### PR TITLE
Drop config.action_controller.perform_caching

### DIFF
--- a/src/api/config/application.rb
+++ b/src/api/config/application.rb
@@ -35,8 +35,6 @@ module OBSApi
     # Enable rails version 7.0 defaults
     config.load_defaults 7.0
 
-    config.action_controller.perform_caching = true
-
     config.action_controller.action_on_unpermitted_parameters = :raise
 
     config.assets.configure do |env|


### PR DESCRIPTION
It's set in all environments...

```
➜  api git:(master) ✗ ack action_controller.perform_caching config
config/application.rb
38:    config.action_controller.perform_caching = true

config/environments/stage.rb
13:config.action_controller.perform_caching = true

config/environments/test.rb
28:  config.action_controller.perform_caching = false

config/environments/development.rb
41:  config.action_controller.perform_caching = true

config/environments/production.rb
71:  config.action_controller.perform_caching = true
```

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
