### PR TITLE
Set cache_classes false for development env

### DIFF
--- a/src/api/config/environments/development.rb
+++ b/src/api/config/environments/development.rb
@@ -7,7 +7,7 @@ Rails.application.configure do
   # it changes. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.
   # Make code changes take effect immediately without server restart.
-  config.cache_classes = true
+  config.cache_classes = false
 
   # Do not eager load code on boot.
   config.eager_load = false


### PR DESCRIPTION
It was changed here #19897. This should stay false for development environment
