### PR TITLE
fix: constrain image templates label width to prevent overlap

### DIFF
--- a/src/api/app/views/webui/image_templates/index.html.haml
+++ b/src/api/app/views/webui/image_templates/index.html.haml
@@ -19,7 +19,7 @@
                     .form-check
                       %input{ name: 'image', type: 'radio', class: 'image_template form-check-input', id: "#{project}-#{index}",
                               checked: check_first(first_template), data: { project: project, package: template } }
-                      %label.form-check-label{ for: "#{project}-#{index}" }
+                      %label.form-check-label.w-100{ for: "#{project}-#{index}" }
                         - first_template ||= template
                         .d-flex
                           = image_template_icon(template)


### PR DESCRIPTION
## What does this PR do?

This PR fixes an issue on the `/image_templates` page where long text in the image template labels overflows its grid column, causing it to overlap with adjacent image templates and preventing users from clicking/selecting them.

By adding Bootstrap's `.w-100` utility class to the `form-check-label` element, the label's width is constrained to its parent container, forcing the text to properly wrap and preventing the overlap.

Fixes #16428