### PR TITLE
Drop toggleBuildInfo and use toggleCollapsibleTooltip instead

### DIFF
--- a/src/api/app/assets/javascripts/webui/buildresult.js
+++ b/src/api/app/assets/javascripts/webui/buildresult.js
@@ -1,4 +1,4 @@
-/* exported updateRpmlintResult, updateBuildResult, updateArchDisplay, toggleBuildInfo */
+/* exported updateRpmlintResult, updateBuildResult, updateArchDisplay */
 /* global initializePopovers */
 
 // TODO: replace with the content of
@@ -74,22 +74,5 @@ function updateRpmlintDisplay(index) {
     success: function (data) {
       $('#rpmlint_display_' + index).html(data);
     }
-  });
-}
-
-// TODO: Stop using toggleBuildInfo in favor of the generic toggleCollapsibleTooltip
-function toggleBuildInfo() {
-  $('.toggle-build-info').on('click', function(){
-    var replaceTitle = $(this).attr('title') === 'Click to keep it open' ? 'Click to close it' : 'Click to keep it open';
-    var infoContainer = $(this).parents('.toggle-build-info-parent').next();
-    $(infoContainer).toggleClass('collapsed');
-    $(infoContainer).removeClass('hover');
-    $('.toggle-build-info').attr('title', replaceTitle);
-  });
-  $('.toggle-build-info').on('mouseover', function(){
-    $(this).parents('.toggle-build-info-parent').next().addClass('hover');
-  });
-  $('.toggle-build-info').on('mouseout', function(){
-    $(this).parents('.toggle-build-info-parent').next().removeClass('hover');
   });
 }

--- a/src/api/app/assets/javascripts/webui/collapsible_tooltip.js
+++ b/src/api/app/assets/javascripts/webui/collapsible_tooltip.js
@@ -1,17 +1,15 @@
-/* exported toggleCollapsibleTooltip */
+$(document).on('click', '.collapsible-tooltip', function(){
+  var replaceTitle = $(this).attr('title') === 'Click to keep it open' ? 'Click to close it' : 'Click to keep it open';
+  var infoContainer = $(this).parents('.collapsible-tooltip-parent').next();
+  $(infoContainer).toggleClass('collapsed');
+  $(infoContainer).removeClass('hover');
+  $(this).attr('title', replaceTitle);
+});
 
-function toggleCollapsibleTooltip() {
-  $('.collapsible-tooltip').on('click', function(){
-    var replaceTitle = $(this).attr('title') === 'Click to keep it open' ? 'Click to close it' : 'Click to keep it open';
-    var infoContainer = $(this).parents('.collapsible-tooltip-parent').next();
-    $(infoContainer).toggleClass('collapsed');
-    $(infoContainer).removeClass('hover');
-    $(this).attr('title', replaceTitle);
-  });
-  $('.collapsible-tooltip').on('mouseover', function(){
-    $(this).parents('.collapsible-tooltip-parent').next().addClass('hover');
-  });
-  $('.collapsible-tooltip').on('mouseout', function(){
-    $(this).parents('.collapsible-tooltip-parent').next().removeClass('hover');
-  });
-}
+$(document).on('mouseover', '.collapsible-tooltip', function(){
+  $(this).parents('.collapsible-tooltip-parent').next().addClass('hover');
+});
+
+$(document).on('mouseout', '.collapsible-tooltip', function(){
+  $(this).parents('.collapsible-tooltip-parent').next().removeClass('hover');
+});

--- a/src/api/app/assets/stylesheets/webui/build-results.scss
+++ b/src/api/app/assets/stylesheets/webui/build-results.scss
@@ -40,9 +40,6 @@
   z-index: 900;
 }
 
-.toggle-build-info { cursor: pointer; }
-.toggle-build-info-parent { z-index: 2; }
-
 .build-info {
   @extend .d-flex;
   @extend .flex-column;

--- a/src/api/app/components/buildresult_status_link_component.html.haml
+++ b/src/api/app/components/buildresult_status_link_component.html.haml
@@ -2,4 +2,4 @@
   = link_to(@build_status, package_live_build_log_path(project: @project_name, package: @package_name, repository: @repository_name,
                                                        arch: @architecture_name), rel: 'nofollow', class: css_class)
 - else
-  %span{ id: span_id, class: "#{css_class} toggle-build-info", title: 'Click to keep it open' }= @build_status
+  %span{ id: span_id, class: "#{css_class} collapsible-tooltip", title: 'Click to keep it open' }= @build_status

--- a/src/api/app/components/watchlist_component.html.haml
+++ b/src/api/app/components/watchlist_component.html.haml
@@ -24,6 +24,3 @@
   = render WatchedItemsListComponent.new(items: projects, class_name: 'Project', current_object: @current_object)
   = render WatchedItemsListComponent.new(items: packages, class_name: 'Package', current_object: @current_object)
   = render WatchedItemsListComponent.new(items: bs_requests, class_name: 'BsRequest', current_object: @current_object)
-
-:javascript
-  toggleCollapsibleTooltip();

--- a/src/api/app/views/webui/package/_buildstatus.html.haml
+++ b/src/api/app/views/webui/package/_buildstatus.html.haml
@@ -38,8 +38,8 @@
                 %i.fas.fa-clock.text-warning{ title: 'This result is outdated' }
               %span.ms-1
                 = result.architecture
-            .build-state.toggle-build-info-parent
-              %i.fa.fa-question-circle.text-info.px-2.ps-lg-1.toggle-build-info{ title: 'Click to keep it open' }
+            .build-state.collapsible-tooltip-parent
+              %i.fa.fa-question-circle.text-info.px-2.ps-lg-1.collapsible-tooltip{ title: 'Click to keep it open' }
               = render(BuildresultStatusLinkComponent.new(repository_name: result.repository, architecture_name: result.architecture,
                                                           project_name: project.name, package_name: package,
                                                           build_status: result.code, build_details: result.details))
@@ -65,4 +65,4 @@
       %strong excluded/disabled
 
 :javascript
-  toggleBuildInfo();
+  toggleCollapsibleTooltip();

--- a/src/api/app/views/webui/package/_buildstatus.html.haml
+++ b/src/api/app/views/webui/package/_buildstatus.html.haml
@@ -63,6 +63,3 @@
     - else
       All the results have state
       %strong excluded/disabled
-
-:javascript
-  toggleCollapsibleTooltip();

--- a/src/api/app/views/webui/project/_buildstatus.html.haml
+++ b/src/api/app/views/webui/project/_buildstatus.html.haml
@@ -50,8 +50,8 @@
 
               .build-state.d-flex.flex-column
                 - build_result.summary.each do |status_count|
-                  .toggle-build-info-parent.text-nowrap
-                    %i.fa.fa-question-circle.text-info.px-2.ps-lg-1.toggle-build-info{ title: 'Click to keep it open' }
+                  .collapsible-tooltip-parent.text-nowrap
+                    %i.fa.fa-question-circle.text-info.px-2.ps-lg-1.collapsible-tooltip{ title: 'Click to keep it open' }
                     = link_to("#{status_count.code}: #{status_count.count}",
                       { action: :monitor,
                         "#{valid_xml_id("repo_#{repository}")}": 1,
@@ -68,4 +68,4 @@
                         %span.ps-1= repository_info(build_result.state)
 
 :javascript
-  toggleBuildInfo();
+  toggleCollapsibleTooltip();

--- a/src/api/app/views/webui/project/_buildstatus.html.haml
+++ b/src/api/app/views/webui/project/_buildstatus.html.haml
@@ -66,6 +66,3 @@
                       %div
                         = repository_status_icon(status: build_result.state)
                         %span.ps-1= repository_info(build_result.state)
-
-:javascript
-  toggleCollapsibleTooltip();

--- a/src/api/spec/components/buildresult_status_link_component_spec.rb
+++ b/src/api/spec/components/buildresult_status_link_component_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe BuildresultStatusLinkComponent, type: :component do
     let(:build_details) { 'Some details about the build' }
 
     it 'renders a span tag with text-warning style and build status scheduled' do
-      expect(rendered_content).to have_css('span.text-warning.toggle-build-info',
+      expect(rendered_content).to have_css('span.text-warning.collapsible-tooltip',
                                            id: "id-#{package_name}_#{repository_name}_#{architecture_name}",
                                            text: 'scheduled')
     end
@@ -26,7 +26,7 @@ RSpec.describe BuildresultStatusLinkComponent, type: :component do
     let(:build_status) { 'blocked' }
 
     it 'renders a span tag with the correct id and class' do
-      expect(rendered_content).to have_css("span.build-state-#{build_status}.toggle-build-info",
+      expect(rendered_content).to have_css("span.build-state-#{build_status}.collapsible-tooltip",
                                            id: "id-#{package_name}_#{repository_name}_#{architecture_name}",
                                            text: build_status.to_s)
     end


### PR DESCRIPTION
## How to test:
- open any project/package page where there is at least one build result
- look for the `?` icon next to the build result: hover to see the tooltip on and off, click on it to make the tooltip visible, click again to close back the tooltip
- open a request page, add it to the watchlist, open the watchlist sidebar
- look for the `?` icon next to the request item in the watchlist: hover to see the tooltip on and off, click on it to make the tooltip visible, click again to close back the tooltip (same as described before in the project/package page for build results)

Assisted-By: Anthropic:Claude Sonnet 4.6