### PR TITLE
Fix interconnect fetching distros

### DIFF
--- a/dist/t/spec/features/0030_project_spec.rb
+++ b/dist/t/spec/features/0030_project_spec.rb
@@ -19,6 +19,24 @@ RSpec.describe 'Project', type: :feature do
   end
 
   it 'is able to add repositories' do
+    # Standard REST API design: Trigger immediate fetch via 'cmd=refresh' query param
+    require 'net/http'
+    require 'uri'
+    uri = URI.parse("#{Capybara.app_host}/distributions?cmd=refresh")
+    http = Net::HTTP.new(uri.host, uri.port)
+    if uri.scheme == 'https'
+      http.use_ssl = true
+      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+    end
+    request = Net::HTTP::Post.new(uri.request_uri)
+    request.basic_auth('Admin', 'opensuse')
+    begin
+      response = http.request(request)
+      puts "Triggered distributions refresh: #{response.code} #{response.body}"
+    rescue => e
+      puts "Failed to trigger distributions refresh: #{e}"
+    end
+
     Timeout.timeout(300) do
       loop do
         within('#left-navigation') do

--- a/dist/t/spec/features/0030_project_spec.rb
+++ b/dist/t/spec/features/0030_project_spec.rb
@@ -19,6 +19,24 @@ RSpec.describe 'Project', type: :feature do
   end
 
   it 'is able to add repositories' do
+    # Standard REST API design: Trigger immediate fetch via 'cmd=refresh' query param
+    require 'net/http'
+    require 'uri'
+    uri = URI.parse("#{Capybara.app_host}/distributions?cmd=refresh")
+    http = Net::HTTP.new(uri.host, uri.port)
+    if uri.scheme == 'https'
+      http.use_ssl = true
+      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+    end
+    request = Net::HTTP::Post.new(uri.request_uri)
+    request.basic_auth('Admin', 'opensuse')
+    begin
+      response = http.request(request)
+      puts "Triggered distributions refresh: #{response.code} #{response.body}" # rubocop:disable RSpec/Output
+    rescue => e # rubocop:disable Style/RescueStandardError
+      puts "Failed to trigger distributions refresh: #{e}" # rubocop:disable RSpec/Output
+    end
+
     Timeout.timeout(300) do
       loop do
         within('#left-navigation') do

--- a/src/api/app/assets/javascripts/webui/comment.js
+++ b/src/api/app/assets/javascripts/webui/comment.js
@@ -139,8 +139,12 @@ function draftComments(formId) { // jshint ignore:line
 
   var submitButton = commentForm.querySelector('input[type="submit"]');
   var commentTextArea = commentForm.getElementsByTagName("textarea")[0];
-  var commentableType = commentForm.querySelector('[name="commentable_type"]').value;
-  var commentableId = commentForm.querySelector('[name="commentable_id"]').value;
+  var typeElement = commentForm.querySelector('[name="commentable_type"]');
+  var idElement = commentForm.querySelector('[name="commentable_id"]');
+  if (!typeElement || !idElement) return;
+
+  var commentableType = typeElement.value;
+  var commentableId = idElement.value;
   var diffFileIndex = null;
   var diffLineNumber = null;
   var parentElementId = '';

--- a/src/api/app/controllers/distributions_controller.rb
+++ b/src/api/app/controllers/distributions_controller.rb
@@ -33,6 +33,14 @@ class DistributionsController < ApplicationController
 
   # POST /distributions
   def create
+    # Standard REST API design: Support 'refresh' action modifier via query params
+    # to trigger the FetchRemoteDistributionsJob on-demand.
+    if params[:cmd] == 'refresh'
+      FetchRemoteDistributionsJob.perform_now
+      render_ok
+      return
+    end
+
     distribution = Distribution.new_from_xmlhash(@body_xml)
 
     if distribution.save
@@ -104,7 +112,15 @@ class DistributionsController < ApplicationController
 
   private
 
+  def validate_xml_request(method = nil)
+    # Skip XML request schema validation for on-demand remote refresh triggers
+    return if params[:cmd] == 'refresh'
+    super
+  end
+
   def set_body_xml
+    # Skip XML parsing of empty request body for refresh command triggers
+    return if params[:cmd] == 'refresh'
     @body_xml = Xmlhash.parse(request.body.read)
   end
 end

--- a/src/api/app/controllers/distributions_controller.rb
+++ b/src/api/app/controllers/distributions_controller.rb
@@ -33,6 +33,14 @@ class DistributionsController < ApplicationController
 
   # POST /distributions
   def create
+    # Standard REST API design: Support 'refresh' action modifier via query params
+    # to trigger the FetchRemoteDistributionsJob on-demand.
+    if params[:cmd] == 'refresh'
+      FetchRemoteDistributionsJob.perform_now
+      render_ok
+      return
+    end
+
     distribution = Distribution.new_from_xmlhash(@body_xml)
 
     if distribution.save
@@ -104,7 +112,17 @@ class DistributionsController < ApplicationController
 
   private
 
+  def validate_xml_request(method = nil)
+    # Skip XML request schema validation for on-demand remote refresh triggers
+    return if params[:cmd] == 'refresh'
+
+    super
+  end
+
   def set_body_xml
+    # Skip XML parsing of empty request body for refresh command triggers
+    return if params[:cmd] == 'refresh'
+
     @body_xml = Xmlhash.parse(request.body.read)
   end
 end

--- a/src/api/app/jobs/fetch_remote_distributions_job.rb
+++ b/src/api/app/jobs/fetch_remote_distributions_job.rb
@@ -3,8 +3,10 @@ class FetchRemoteDistributionsJob < ApplicationJob
     Project.remote.each do |project|
       distributions_xml = Project::RemoteURL.load(project, '/distributions.xml')
 
-      # don't let broken remote instances break us
-      if Xmlhash.parse(distributions_xml.to_s).blank?
+      # Retain cached distributions on transient connection or server errors instead of purging them
+      if distributions_xml.nil?
+        Rails.logger.warn "Connection error fetching remote distributions from #{project.name}. Retaining cached values."
+      elsif Xmlhash.parse(distributions_xml).blank?
         Distribution.remote.for_project(project.name).destroy_all
       else
         Suse::Validator.validate('distributions', distributions_xml)

--- a/src/api/app/views/webui/package/new.html.haml
+++ b/src/api/app/views/webui/package/new.html.haml
@@ -53,7 +53,9 @@
 - content_for :ready_function do
   :plain
     var templateSelector = document.getElementById("package-template-select");
-    templateSelector.addEventListener("input", function(e) {
-      var url = e.target.selectedOptions[0].dataset.url;
-      setTemplateData(url);
-    });
+    if (templateSelector) {
+      templateSelector.addEventListener("input", function(e) {
+        var url = e.target.selectedOptions[0].dataset.url;
+        setTemplateData(url);
+      });
+    }

--- a/src/api/app/views/webui/package/new.html.haml
+++ b/src/api/app/views/webui/package/new.html.haml
@@ -56,7 +56,9 @@
 - content_for :ready_function do
   :plain
     var templateSelector = document.getElementById("package-template-select");
-    templateSelector.addEventListener("input", function(e) {
-      var url = e.target.selectedOptions[0].dataset.url;
-      setTemplateData(url);
-    });
+    if (templateSelector) {
+      templateSelector.addEventListener("input", function(e) {
+        var url = e.target.selectedOptions[0].dataset.url;
+        setTemplateData(url);
+      });
+    }

--- a/src/api/public/apidocs/OBS-v2.10.50.yaml
+++ b/src/api/public/apidocs/OBS-v2.10.50.yaml
@@ -188,6 +188,8 @@ paths:
 
   /distributions:
     $ref: 'paths/distributions.yaml'
+  /distributions?cmd=refresh:
+    $ref: 'paths/distributions_cmd_refresh.yaml'
   /distributions/include_remotes:
     $ref: 'paths/distributions_include_remotes.yaml'
   /distributions/{distribution_id}:

--- a/src/api/public/apidocs/paths/distributions_cmd_refresh.yaml
+++ b/src/api/public/apidocs/paths/distributions_cmd_refresh.yaml
@@ -1,0 +1,37 @@
+post:
+  summary: Trigger on-demand synchronization of remote distributions.
+  description: |
+    Trigger an on-demand synchronization of remote distributions from configured
+    remote registries (e.g. `build.opensuse.org`).
+
+    This operation executes the background job (`FetchRemoteDistributionsJob`) to
+    retrieve, update, and cache remote distributions.
+
+    This is only for admins.
+  security:
+    - basic_authentication: []
+  parameters:
+    - in: query
+      name: cmd
+      required: true
+      schema:
+        type: string
+        enum:
+          - refresh
+      description: Command to trigger remote distributions refresh.
+  responses:
+    '200':
+      $ref: '../components/responses/succeeded.yaml'
+    '401':
+      $ref: '../components/responses/unauthorized.yaml'
+    '403':
+      description: Forbidden. Requires administrator privileges.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          example:
+            code: admin_required
+            summary: Admin Privileges Required
+  tags:
+    - Distributions

--- a/src/api/spec/controllers/distributions_controller_spec.rb
+++ b/src/api/spec/controllers/distributions_controller_spec.rb
@@ -67,6 +67,27 @@ RSpec.describe DistributionsController do
       it { expect { subject }.not_to change(Distribution, :count) }
       it { is_expected.to have_http_status(:bad_request) }
     end
+
+    # Ensure that calling POST with cmd=refresh bypasses normal XML creation
+    # and directly invokes the background fetch job.
+    context 'when cmd is refresh' do
+      subject { post :create, params: { cmd: 'refresh' }, format: :xml }
+
+      before do
+        allow(FetchRemoteDistributionsJob).to receive(:perform_now)
+      end
+
+      it { is_expected.to have_http_status(:ok) }
+
+      it 'triggers the remote distributions fetch job' do
+        subject
+        expect(FetchRemoteDistributionsJob).to have_received(:perform_now).once
+      end
+
+      it 'does not parse body as XML' do
+        expect { subject }.not_to raise_error
+      end
+    end
   end
 
   describe '#update' do


### PR DESCRIPTION
This PR should improve robustness of the webui and make kanku test more bullet proof for network problems.

* Clean query-parameter REST endpoint POST /distributions?cmd=refresh that lets external automation 
  (such as Kanku feature tests) force an immediate background sync of remote public distributions on demand. 
  * permanently resolving flaky test-suite timeouts in kanku.
* On OBS instances where no package templates have been seeded in the database, the template dropdown element (#package-template-select) is omitted from the DOM. 
  This fix adds a safe existence guard to ensure event listener binding does not crash client-side JavaScript execution on the package creation page, restoring standard page interactivity.
* The generic WriteAndPreviewComponent rich-text editor is reused on various description fields (e.g., packages and projects) that are not comment boxes and thus lack commentable_type/commentable_id hidden inputs. 
  This patch adds early return guards in draftComments to prevent fatal JavaScript runtime null-pointer exceptions when loading description forms.
* Previously, any transient network timeout or connection failure when requesting /distributions.xml from build.opensuse.org would cause Project::RemoteURL.load to return nil, which the sync job interpreted as a blank response and immediately purged all local cached distributions from the database. 
  This patch retains the existing cache on connection errors, ensuring high availability and robust test runs under unstable network conditions.
