### PR TITLE
Fix the release request changes page when source package is gone

### DIFF
--- a/src/api/app/views/webui/request/_binary_changes.html.haml
+++ b/src/api/app/views/webui/request/_binary_changes.html.haml
@@ -8,7 +8,7 @@
       - release_targets.each do |release_target|
         %li.list-group-item
           Copy binaries of
-          - if action.source_package_object.multibuild_flavors.present?
+          - if action.source_package_object&.multibuild_flavors.present?
             = safe_join(action.source_package_object.multibuild_flavors.map { |f| link_to("#{action.source_package}:#{f}",
                         project_package_repository_binaries_path(project_name: action.source_project, package_name: "#{action.source_package}:#{f}",
                         repository_name: release_target.repository.name)) }, ', ')


### PR DESCRIPTION
Check if the source_package_object is present before checking for the multibuild flavors. When the source package is deleted, the source_package_object is gone

Fixes #19991

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
