### PR TITLE
Fix crash when toggling distributions

### DIFF
--- a/src/api/app/controllers/webui/distributions_controller.rb
+++ b/src/api/app/controllers/webui/distributions_controller.rb
@@ -45,7 +45,7 @@ class Webui::DistributionsController < Webui::WebuiController
   end
 
   def destroy_repository
-    repository = @project.repositories.find_by(name: @distribution.reponame)
+    repository = Repository.find_by_project_and_path(@project, @distribution_repository).first
     @project.repositories.delete(repository)
     if @project.valid?
       @project.store(comment: "Removed #{repository.name} repository")

--- a/src/api/spec/controllers/webui/distributions_controller_spec.rb
+++ b/src/api/spec/controllers/webui/distributions_controller_spec.rb
@@ -66,5 +66,21 @@ RSpec.describe Webui::DistributionsController do
         expect(user.home_project.reload.repositories.where(name: distribution.reponame)).to be_any
       end
     end
+
+    context 'when the repository linking the distribution has a custom name' do
+      let!(:repository) do
+        create(:repository, project: user.home_project, name: 'custom_name',
+                            path_elements: [create(:path_element, link: Repository.find_by_project_and_name!(distribution.project, distribution.repository))])
+      end
+
+      before do
+        login user
+        get :toggle, params: { project_name: user.home_project_name, distribution: distribution }, xhr: true
+      end
+
+      it 'removes the repository regardless of its name' do
+        expect(user.home_project.reload.repositories.where(name: 'custom_name')).not_to be_any
+      end
+    end
   end
 end


### PR DESCRIPTION
 Fixes #19696
 
Toggling a distribution crashed when the project's repository had a "custom name" (set via osc or the meta XML), because destroy_repository looked it up by distribution.reponame, got nil, and called delete(nil).

Example of XML:

```
<repository name="my_custom_name">   <!-- instead of openSUSE_Leap_15.6 -->
  <path project="openSUSE:Leap:15.6" repository="standard"/>
  <arch>x86_64</arch>
</repository>
```

The [method distribution?](https://github.com/openSUSE/open-build-service/blob/84daa36b2f53608d2882a6b123ac309f9ff409a4/src/api/app/controllers/webui/distributions_controller.rb#L26) checks presence using path elements, but destroy_repository fetched the repository in a different way, using find_by and reponame.

To fix this, we make use of the existing `find_by_project_and_path`.

Assisted-by: Claude:claude-sonnet-4-6