### PR TITLE
Refactoring: carve out view-content from models

### DIFF
--- a/src/api/app/components/bs_request_history_element_component.html.haml
+++ b/src/api/app/components/bs_request_history_element_component.html.haml
@@ -18,7 +18,7 @@
             = element.action_target
         = user_action_suffix
       - elsif element.instance_of?(HistoryElement::RequestAccepted) && pending_reviews?
-        #{element.user_action} and dismissed pending reviews
+        #{user_action} and dismissed pending reviews
       - else
         = user_action
       - if element.is_a?(HistoryElement::Review) && element.review && !element.review.for_user?

--- a/src/api/app/components/bs_request_history_element_component.html.haml
+++ b/src/api/app/components/bs_request_history_element_component.html.haml
@@ -10,17 +10,17 @@
         superseded this request with
         = link_to("request ##{element.description_extension}", request_show_path(element.description_extension))
       - elsif element.instance_of?(HistoryElement::RequestReviewAdded) && element.review
-        = element.user_action_prefix
+        = user_action_prefix
         %strong
           - if element.review_by_staging_project?
             = link_to element.action_target, project_show_path(element.action_target)
           - else
             = element.action_target
-        = element.user_action_suffix
+        = user_action_suffix
       - elsif element.instance_of?(HistoryElement::RequestAccepted) && pending_reviews?
         #{element.user_action} and dismissed pending reviews
       - else
-        = element.user_action
+        = user_action
       - if element.is_a?(HistoryElement::Review) && element.review && !element.review.for_user?
         for
         - if element.review.for_group?

--- a/src/api/app/components/bs_request_history_element_component.rb
+++ b/src/api/app/components/bs_request_history_element_component.rb
@@ -12,6 +12,18 @@ class BsRequestHistoryElementComponent < ApplicationComponent
     @request_reviews_for_non_staging_projects = request_reviews_for_non_staging_projects
   end
 
+  def user_action
+    helpers.history_element_user_action(element)
+  end
+
+  def user_action_prefix
+    element.review_by_staging_project? ? 'set' : 'added'
+  end
+
+  def user_action_suffix
+    element.review_by_staging_project? ? 'as a staging project' : 'as a reviewer'
+  end
+
   private
 
   def icon

--- a/src/api/app/helpers/webui/request_helper.rb
+++ b/src/api/app/helpers/webui/request_helper.rb
@@ -216,6 +216,32 @@ module Webui::RequestHelper
     "(#{package.latest_local_version.version})"
   end
 
+  def history_element_user_action(element)
+    case element
+    when HistoryElement::ReviewAccepted
+      element.staged_review? ? 'staged request' : 'accepted review'
+    when HistoryElement::ReviewDeclined            then 'declined review'
+    when HistoryElement::ReviewAssigned            then 'assigned review'
+    when HistoryElement::ReviewObsoleted           then 'obsoleted review'
+    when HistoryElement::ReviewReopened            then 'reopened review'
+    when HistoryElement::RequestAccepted           then 'accepted request'
+    when HistoryElement::RequestDeclined           then 'declined request'
+    when HistoryElement::RequestRevoked            then 'revoked request'
+    when HistoryElement::RequestReopened           then 'reopened request'
+    when HistoryElement::RequestDeleted            then 'deleted request'
+    when HistoryElement::RequestSuperseded         then 'superseded request'
+    when HistoryElement::RequestAllReviewsApproved then 'accepted last open review'
+    when HistoryElement::RequestPriorityChange     then "changed priority to #{element.description_extension}"
+    when HistoryElement::RequestSetIncident        then "moved maintenance target to #{element.description_extension}"
+    when HistoryElement::RequestReviewAdded
+      return 'added a reviewer' unless element.review
+
+      prefix = element.review_by_staging_project? ? 'set' : 'added'
+      suffix = element.review_by_staging_project? ? 'as a staging project' : 'as a reviewer'
+      "#{prefix} #{element.action_target} #{suffix}"
+    end
+  end
+
   private
 
   def action_type_icon(type)

--- a/src/api/app/models/history_element/request_accepted.rb
+++ b/src/api/app/models/history_element/request_accepted.rb
@@ -8,9 +8,6 @@ module HistoryElement
       'Request got accepted'
     end
 
-    def user_action
-      'accepted request'
-    end
   end
 end
 

--- a/src/api/app/models/history_element/request_all_reviews_approved.rb
+++ b/src/api/app/models/history_element/request_all_reviews_approved.rb
@@ -8,9 +8,6 @@ module HistoryElement
       'Request got reviewed'
     end
 
-    def user_action
-      'accepted last open review'
-    end
   end
 end
 

--- a/src/api/app/models/history_element/request_declined.rb
+++ b/src/api/app/models/history_element/request_declined.rb
@@ -8,9 +8,6 @@ module HistoryElement
       'Request got declined'
     end
 
-    def user_action
-      'declined request'
-    end
   end
 end
 

--- a/src/api/app/models/history_element/request_deleted.rb
+++ b/src/api/app/models/history_element/request_deleted.rb
@@ -8,9 +8,6 @@ module HistoryElement
       'Request was deleted'
     end
 
-    def user_action
-      'deleted request'
-    end
   end
 end
 

--- a/src/api/app/models/history_element/request_priority_change.rb
+++ b/src/api/app/models/history_element/request_priority_change.rb
@@ -8,9 +8,6 @@ module HistoryElement
       "Request got a new priority: #{description_extension}"
     end
 
-    def user_action
-      "changed priority to #{description_extension}"
-    end
   end
 end
 

--- a/src/api/app/models/history_element/request_reopened.rb
+++ b/src/api/app/models/history_element/request_reopened.rb
@@ -8,9 +8,6 @@ module HistoryElement
       'Request got reopened'
     end
 
-    def user_action
-      'reopened request'
-    end
   end
 end
 

--- a/src/api/app/models/history_element/request_review_added.rb
+++ b/src/api/app/models/history_element/request_review_added.rb
@@ -4,26 +4,8 @@ module HistoryElement
       'Request got a new review request'
     end
 
-    def user_action
-      return 'added a reviewer' unless review
-
-      "#{user_action_prefix} #{action_target} #{user_action_suffix}"
-    end
-
-    def user_action_prefix
-      return 'set' if review_by_staging_project?
-
-      'added'
-    end
-
     def action_target
       review.reviewed_by
-    end
-
-    def user_action_suffix
-      return 'as a staging project' if review_by_staging_project?
-
-      'as a reviewer'
     end
 
     # self.description_extension is review id, but it's not present in old history elements

--- a/src/api/app/models/history_element/request_revoked.rb
+++ b/src/api/app/models/history_element/request_revoked.rb
@@ -8,9 +8,6 @@ module HistoryElement
       'Request got revoked'
     end
 
-    def user_action
-      'revoked request'
-    end
   end
 end
 

--- a/src/api/app/models/history_element/request_set_incident.rb
+++ b/src/api/app/models/history_element/request_set_incident.rb
@@ -8,9 +8,6 @@ module HistoryElement
       "Maintenance target got moved to project #{description_extension}"
     end
 
-    def user_action
-      "moved maintenance target to #{description_extension}"
-    end
   end
 end
 

--- a/src/api/app/models/history_element/request_superseded.rb
+++ b/src/api/app/models/history_element/request_superseded.rb
@@ -10,9 +10,6 @@ module HistoryElement
       desc
     end
 
-    def user_action
-      'superseded request'
-    end
   end
 end
 

--- a/src/api/app/models/history_element/review_accepted.rb
+++ b/src/api/app/models/history_element/review_accepted.rb
@@ -4,12 +4,11 @@ module HistoryElement
       'Review got accepted'
     end
 
-    def user_action
-      # We check if the accepted review was created when the request was staged in a staging workflow. In this case, the review
-      # will also be for the managers group of that staging workflow.
-      return 'staged request' if review.for_group? && request.staged_request? && review.by_group == request.staging_project.staging_workflow.managers_group.title
-
-      'accepted review'
+    # True when the accepted review was created because the request was staged in a staging workflow —
+    # in that case the review also belongs to the staging workflow's managers group.
+    def staged_review?
+      review.for_group? && request.staged_request? &&
+        review.by_group == request.staging_project.staging_workflow.managers_group.title
     end
   end
 end

--- a/src/api/app/models/history_element/review_assigned.rb
+++ b/src/api/app/models/history_element/review_assigned.rb
@@ -4,9 +4,6 @@ module HistoryElement
       'Review got assigned'
     end
 
-    def user_action
-      'assigned review'
-    end
   end
 end
 

--- a/src/api/app/models/history_element/review_declined.rb
+++ b/src/api/app/models/history_element/review_declined.rb
@@ -4,9 +4,6 @@ module HistoryElement
       'Review got declined'
     end
 
-    def user_action
-      'declined review'
-    end
   end
 end
 

--- a/src/api/app/models/history_element/review_obsoleted.rb
+++ b/src/api/app/models/history_element/review_obsoleted.rb
@@ -4,9 +4,6 @@ module HistoryElement
       'Review got obsoleted'
     end
 
-    def user_action
-      'obsoleted review'
-    end
   end
 end
 

--- a/src/api/app/models/history_element/review_reopened.rb
+++ b/src/api/app/models/history_element/review_reopened.rb
@@ -4,9 +4,6 @@ module HistoryElement
       'Review got reopened'
     end
 
-    def user_action
-      'reopened review'
-    end
   end
 end
 

--- a/src/api/app/views/webui/request/_request_history_element.html.haml
+++ b/src/api/app/views/webui/request/_request_history_element.html.haml
@@ -6,9 +6,9 @@
     %p
       = link_to(element.user, user_path(element.user))
       - if element.instance_of?(HistoryElement::RequestSuperseded)
-        = link_to(element.user_action, request_show_path(element.description_extension))
+        = link_to(history_element_user_action(element), request_show_path(element.description_extension))
       - else
-        = element.user_action
+        = history_element_user_action(element)
       = link_to("#status-history-#{element.id}", title: I18n.l(element.created_at.utc), name: "status-history-#{element.id}") do
         = render TimeComponent.new(time: element.created_at)
 

--- a/src/api/spec/models/history_element_spec.rb
+++ b/src/api/spec/models/history_element_spec.rb
@@ -8,4 +8,26 @@ RSpec.describe HistoryElement do
       expect(HistoryElement::RequestDeleted.new.description).to eq('Request was deleted')
     end
   end
+
+  describe 'HistoryElement::ReviewAccepted' do
+    describe '#staged_review?' do
+      subject(:element) { create(:history_element_request_review_accepted_with_review_by_group) }
+
+      context 'when the request is not staged' do
+        it { is_expected.not_to be_staged_review }
+      end
+
+      context 'when the review is for the staging workflow managers group' do
+        let(:managers_group) { instance_double(Group, title: 'managers') }
+        let(:staging_workflow) { instance_double(Staging::Workflow, managers_group: managers_group) }
+        let(:staging_project) { instance_double(Project, staging_workflow: staging_workflow) }
+        let(:review) { instance_double(Review, for_group?: true, by_group: 'managers') }
+        let(:request) { instance_double(BsRequest, staged_request?: true, staging_project: staging_project) }
+
+        before { allow(element).to receive_messages(review: review, request: request) }
+
+        it { is_expected.to be_staged_review }
+      end
+    end
+  end
 end


### PR DESCRIPTION
Model should not include display/view content. Extracting it from models and moving into ViewComponent/helper.

Assisted-By: Anthropic:Claude Sonnet 4.6