### PR TITLE
Increase capybara timeout to 60 seconds

### DIFF
--- a/dist/t/spec/support/capybara.rb
+++ b/dist/t/spec/support/capybara.rb
@@ -16,7 +16,7 @@ Capybara.register_driver :selenium_chrome_headless do |app|
 end
 
 Capybara.default_driver = :selenium_chrome_headless
-Capybara.default_max_wait_time = 20 # We increase this value because we depend on the load of the system and resource constraints
+Capybara.default_max_wait_time = 60 # We increase this value because we depend on the load of the system and resource constraints
 Capybara.javascript_driver = :selenium_chrome_headless
 Capybara.save_path = '/tmp/rspec_screens'
 


### PR DESCRIPTION
We are having a hard time on to get the rspec smoke tests to pass on openqa.opensuse.org without running into timeouts...

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
