### PR TITLE
Fix setting CONFIG defaults

### DIFF
--- a/src/api/config/environment.rb
+++ b/src/api/config/environment.rb
@@ -22,11 +22,10 @@ rescue StandardError
 end
 
 CONFIG['schema_location'] ||= "#{File.expand_path('public/schema')}/"
-CONFIG['global_write_through'] ||= true
+CONFIG['global_write_through'] = true if CONFIG['global_write_through'].nil?
 CONFIG['proxy_auth_mode'] ||= :off
-CONFIG['force_ssl'] ||= true
-CONFIG['assume_ssl'] ||= false
-
+CONFIG['force_ssl'] = true if CONFIG['force_ssl'].nil?
+CONFIG['assume_ssl'] = false if CONFIG['assume_ssl'].nil?
 
 # Initialize the rails application
 OBSApi::Application.initialize!


### PR DESCRIPTION
Parsing a YAML file means values are objects. So `force_ssl: false` turns `CONFIG['force_ssl']` into a false class. And then...

```ruby
irb(main):005> blah = {hans: false, franz: 'peter'}
=> {hans: false, franz: "peter"}
irb(main):006> blah[:hans] ||= 'owned'
=> "owned"
irb(main):007> blah
=> {hans: "owned", franz: "peter"}
```

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
