### PR TITLE
[backend] fix dieing workers on build job discards

### DIFF
--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -214,9 +214,11 @@ sub cleanup_job {
       };
       print "\n";
   } elsif ($vm && -d $buildroot) {
-     rm_rf("$buildroot/.build-srcdir");
-     rm_rf("$buildroot/.build.packages");
-     rm_rf("$buildroot/.mount/.build.packages");
+     # not using rm_rf since we may get called while another process works inside
+     # we must not fail, when the directory stays
+     BSUtil::cleandir("$buildroot/.build-srcdir");
+     BSUtil::cleandir("$buildroot/.build.packages");
+     BSUtil::cleandir("$buildroot/.mount/.build.packages");
   }
 }
 


### PR DESCRIPTION
The cleanup introduced in b1feb6763f16cfe580a96d4f53d6d11ff646ab60 can die, when another jobs keeps running and makes it impossible to remove the directories.

Therefore we just clean the directories as much as possible, but accept if the directories remaind here

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
