### PR TITLE
Create linked package to sync packages from the backend

### DIFF
--- a/src/api/app/controllers/build_controller.rb
+++ b/src/api/app/controllers/build_controller.rb
@@ -127,7 +127,7 @@ class BuildController < ApplicationController
     # for permission check
     pkg = Package.get_by_project_and_name(params[:project], params[:package], follow_multibuild: true)
 
-    if pkg.instance_of?(Package) && pkg.project.disabled_for?('binarydownload', params[:repository], params[:arch]) &&
+    if pkg.is_a?(Package) && pkg.project.disabled_for?('binarydownload', params[:repository], params[:arch]) &&
        !User.possibly_nobody.can_download_binaries?(pkg.project)
       render_error status: 403, errorcode: 'download_binary_no_permission',
                    message: "No permission to download binaries from package #{params[:package]}, project #{params[:project]}"

--- a/src/api/app/controllers/webui/attribute_controller.rb
+++ b/src/api/app/controllers/webui/attribute_controller.rb
@@ -92,7 +92,7 @@ class Webui::AttributeController < Webui::WebuiController
 
   def set_attribute
     @attribute = Attrib.find(params[:id])
-    if @attribute.container.instance_of?(Package)
+    if @attribute.container.is_a?(Package)
       @package = @attribute.container
       @project = @package.project
     elsif @attribute.container.instance_of?(Project)

--- a/src/api/app/jobs/reconcile_linked_package_job.rb
+++ b/src/api/app/jobs/reconcile_linked_package_job.rb
@@ -1,0 +1,39 @@
+class ReconcileLinkedPackageJob < ApplicationJob
+  queue_as :default
+
+  def perform(action:, project_name:, package_name:)
+    User.session ||= User.default_admin
+
+    project = Project.find_by(name: project_name)
+    return if project.nil? || !project.maintained_by_backend?
+
+    package_name = Package.striping_multibuild_suffix(package_name)
+
+    if action.to_s == 'delete'
+      destroy_linked_package(project, package_name)
+    else
+      upsert_linked_package(project, package_name)
+    end
+  end
+
+  private
+
+  def upsert_linked_package(project, package_name)
+    meta = Backend::Api::Sources::Package.meta(project.name, package_name)
+  rescue Backend::NotFoundError
+    destroy_linked_package(project, package_name)
+  else
+    package = project.linked_packages.find_or_initialize_by(name: package_name)
+    package.assign_attributes_from_from_xml(Xmlhash.parse(meta))
+    package.commit_opts = { no_backend_write: 1 }
+    package.save!
+  end
+
+  def destroy_linked_package(project, package_name)
+    package = project.linked_packages.find_by(name: package_name)
+    return if package.nil?
+
+    package.commit_opts = { no_backend_write: 1 }
+    package.destroy
+  end
+end

--- a/src/api/app/models/branch_package.rb
+++ b/src/api/app/models/branch_package.rb
@@ -178,7 +178,7 @@ class BranchPackage
       raise CanNotBranchPackage, "package is developed at #{p[:package].scmsync}. Fork it instead" if p[:package].try(:scmsync).present?
 
       pac = p[:package]
-      if pac.instance_of?(Package)
+      if pac.is_a?(Package)
         a = pac.find_attribute('OBS', 'RejectBranch')
         raise BranchRejected, "Branching is not allowed because: #{a.values.first.value}" if a && a.values.first
       end

--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -1173,7 +1173,7 @@ class BsRequest < ApplicationRecord
         next if reviews.any? { |a| a.by_project == r.name && a.by_package.nil? }
 
         reviews.new(by_project: r.name, state: :new)
-      elsif r.instance_of?(Package)
+      elsif r.is_a?(Package)
         next if reviews.any? { |a| a.by_project == r.project.name && a.by_package == r.name }
 
         reviews.new(by_project: r.project.name, by_package: r.name, state: :new)

--- a/src/api/app/models/bs_request_action.rb
+++ b/src/api/app/models/bs_request_action.rb
@@ -1013,7 +1013,7 @@ class BsRequestAction < ApplicationRecord
     obj.relationships.groups.where(role_id: reviewer_id).pluck(:group_id).each do |r|
       reviewers << Group.find(r)
     end
-    reviewers += find_reviewers(obj.project) if obj.instance_of?(Package) && !disable_project
+    reviewers += find_reviewers(obj.project) if obj.is_a?(Package) && !disable_project
 
     reviewers
   end

--- a/src/api/app/models/concerns/reconcile_linked_package_callback.rb
+++ b/src/api/app/models/concerns/reconcile_linked_package_callback.rb
@@ -1,0 +1,19 @@
+module ReconcileLinkedPackageCallback
+  extend ActiveSupport::Concern
+
+  included do
+    class_attribute :reconcile_linked_package_action, default: 'create'
+    after_create :reconcile_linked_package
+  end
+
+  def reconcile_linked_package
+    project = Project.find_by(name: payload['project'])
+    return unless project&.maintained_by_backend?
+
+    ReconcileLinkedPackageJob.perform_later(
+      action: reconcile_linked_package_action,
+      project_name: payload['project'],
+      package_name: payload['package']
+    )
+  end
+end

--- a/src/api/app/models/event/create_package.rb
+++ b/src/api/app/models/event/create_package.rb
@@ -1,6 +1,7 @@
 module Event
   class CreatePackage < Base
     include EventObjectPackage
+    include ReconcileLinkedPackageCallback
 
     self.message_bus_routing_key = 'package.create'
     self.description = 'Package created'

--- a/src/api/app/models/event/delete_package.rb
+++ b/src/api/app/models/event/delete_package.rb
@@ -1,8 +1,11 @@
 module Event
   class DeletePackage < Base
+    include ReconcileLinkedPackageCallback
+
     self.message_bus_routing_key = 'package.delete'
     self.description = 'Package deleted'
     payload_keys :project, :package, :sender, :comment, :requestid
+    self.reconcile_linked_package_action = 'delete'
 
     def set_payload(attribs, keys)
       attribs['comment'] = attribs['comment'][0..800] if attribs['comment'].present?

--- a/src/api/app/models/event/undelete_package.rb
+++ b/src/api/app/models/event/undelete_package.rb
@@ -2,6 +2,7 @@ module Event
   class UndeletePackage < Base
     include EventObjectPackage
     include UpdateBackendInfosCallback
+    include ReconcileLinkedPackageCallback
 
     self.message_bus_routing_key = 'package.undelete'
     self.description = 'Package undeleted'

--- a/src/api/app/models/event/update_package.rb
+++ b/src/api/app/models/event/update_package.rb
@@ -1,6 +1,7 @@
 module Event
   class UpdatePackage < Base
     include EventObjectPackage
+    include ReconcileLinkedPackageCallback
 
     self.message_bus_routing_key = 'package.update'
     self.description = 'Package meta data updated'

--- a/src/api/app/models/linked_package.rb
+++ b/src/api/app/models/linked_package.rb
@@ -1,0 +1,44 @@
+class LinkedPackage < Package
+  def backend_writable?
+    false
+  end
+end
+
+# == Schema Information
+#
+# Table name: packages
+#
+#  id              :integer          not null, primary key
+#  activity_index  :float(24)        default(100.0)
+#  anitya_ignore   :boolean          default(FALSE), not null
+#  bcntsynctag     :string(255)
+#  comments_count  :integer          default(0), not null, indexed
+#  delta           :boolean          default(TRUE), not null
+#  description     :text(65535)
+#  name            :string(200)      not null, uniquely indexed => [project_id]
+#  releasename     :string(255)
+#  report_bug_url  :string(8192)
+#  scmsync         :string(255)
+#  title           :string(255)
+#  type            :string(255)      indexed
+#  url             :string(255)
+#  created_at      :datetime
+#  updated_at      :datetime
+#  develpackage_id :integer          indexed
+#  kiwi_image_id   :integer          indexed
+#  project_id      :integer          not null, uniquely indexed => [name]
+#
+# Indexes
+#
+#  devel_package_id_index            (develpackage_id)
+#  index_packages_on_comments_count  (comments_count)
+#  index_packages_on_kiwi_image_id   (kiwi_image_id)
+#  index_packages_on_type            (type)
+#  packages_all_index                (project_id,name) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...     (kiwi_image_id => kiwi_images.id)
+#  packages_ibfk_3  (develpackage_id => packages.id)
+#  packages_ibfk_4  (project_id => projects.id)
+#

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -218,7 +218,7 @@ class Package < ApplicationRecord
   def self.get_by_project_and_name(project_name, package_name, opts = {})
     get_by_project_and_name_defaults = { use_source: true,
                                          follow_project_links: true,
-                                         follow_project_scmsync_links: false,
+                                         follow_project_scmsync_links: Flipper.enabled?(:linked_packages, User.possibly_nobody),
                                          follow_project_remote_links: false,
                                          follow_multibuild: false,
                                          follow_special_names: false,
@@ -250,8 +250,20 @@ class Package < ApplicationRecord
     if package.nil? && project.scmsync.present?
       return nil unless opts[:follow_project_scmsync_links]
 
-      package = project.linked_packages.find_by(name: package_name)
-      raise UnknownObjectError, "Package not found: #{project.name}/#{package_name}" unless package
+      if Flipper.enabled?(:linked_packages, User.possibly_nobody)
+        package = project.linked_packages.find_by(name: package_name)
+        raise UnknownObjectError, "Package not found: #{project.name}/#{package_name}" unless package
+      else
+        begin
+          package_xmlhash = Xmlhash.parse(Backend::Api::Sources::Package.meta(project.name, package_name))
+        rescue Backend::NotFoundError
+          raise UnknownObjectError, "Package not found: #{project.name}/#{package_name}"
+        else
+          package = project.packages.new(name: package_name)
+          package.assign_attributes_from_from_xml(package_xmlhash)
+          package.readonly!
+        end
+      end
     end
 
     if package.nil? && project.links_to_remote? && opts[:follow_project_links]

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -269,7 +269,7 @@ class Package < ApplicationRecord
     end
 
     raise UnknownObjectError, "Package not found: #{project.name}/#{package_name}" unless package
-    raise ReadAccessError, "#{project.name}/#{package.name}" unless package.instance_of?(Package) && package.project.check_access?
+    raise ReadAccessError, "#{project.name}/#{package.name}" unless package.is_a?(Package) && package.project.check_access?
 
     package.check_source_access! if opts[:use_source]
 

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -102,7 +102,8 @@ class Package < ApplicationRecord
   # WHERE (packages.project_id not in (0))
   # because we assumes that there are more allowed projects than forbidden ones.
   default_scope do
-    where.not(id: PackagesFinder.new.forbidden_packages)
+    scope = where.not(id: PackagesFinder.new(Package.unscoped).forbidden_packages)
+    klass == Package ? scope.where(type: nil) : scope
   end
 
   scope :for_user, ->(user_id) { joins(:relationships).where(relationships: { user_id: user_id, role_id: Role.hashed['maintainer'] }) }
@@ -129,6 +130,7 @@ class Package < ApplicationRecord
     end
   }
   validate :valid_name
+  validates :type, length: { maximum: 255 }
 
   has_one :backend_package, foreign_key: :package_id, dependent: :destroy, inverse_of: :package # rubocop:disable Rails/RedundantForeignKey
   has_many :tokens, dependent: :destroy
@@ -248,15 +250,8 @@ class Package < ApplicationRecord
     if package.nil? && project.scmsync.present?
       return nil unless opts[:follow_project_scmsync_links]
 
-      begin
-        package_xmlhash = Xmlhash.parse(Backend::Api::Sources::Package.meta(project.name, package_name))
-      rescue Backend::NotFoundError
-        raise UnknownObjectError, "Package not found: #{project.name}/#{package_name}"
-      else
-        package = project.packages.new(name: package_name)
-        package.assign_attributes_from_from_xml(package_xmlhash)
-        package.readonly!
-      end
+      package = project.linked_packages.find_by(name: package_name)
+      raise UnknownObjectError, "Package not found: #{project.name}/#{package_name}" unless package
     end
 
     if package.nil? && project.links_to_remote? && opts[:follow_project_links]
@@ -798,12 +793,17 @@ class Package < ApplicationRecord
     @commit_opts[:comment] = comment
   end
 
+  def backend_writable?
+    true
+  end
+
   def write_to_backend
     reset_cache
     raise InvalidParameterError, 'Project meta file can not be written via package model' if name == '_project'
 
     #--- write through to backend ---#
     if CONFIG['global_write_through'] && !@commit_opts[:no_backend_write]
+      raise LinkedPackageReadOnly, "#{project.name}/#{name}" unless backend_writable?
       raise ArgumentError, 'no commit_user set' unless commit_user
 
       Backend::Api::Sources::Package.write_meta(project.name, name, to_axml,
@@ -828,7 +828,7 @@ class Package < ApplicationRecord
 
     raise ArgumentError, 'no commit_user set' unless commit_user
 
-    if CONFIG['global_write_through'] && !@commit_opts[:no_backend_write]
+    if CONFIG['global_write_through'] && !@commit_opts[:no_backend_write] && backend_writable?
       begin
         Backend::Api::Sources::Package.delete(project.name, name,
                                               { user: commit_user.login, comment: commit_opts[:comment], requestid: commit_opts[:request]&.number }.compact)
@@ -837,7 +837,7 @@ class Package < ApplicationRecord
         logger.tagged('backend_sync') { logger.warn("Package #{project.name}/#{name} was already missing on backend on removal") }
       end
       logger.tagged('backend_sync') { logger.warn("Deleted Package #{project.name}/#{name}") }
-    elsif @commit_opts[:no_backend_write]
+    elsif @commit_opts[:no_backend_write] || !backend_writable?
       logger.tagged('backend_sync') { logger.warn "Not deleting Package #{project.name}/#{name}, backend_write is off " } unless @commit_opts[:project_destroy_transaction]
     else
       logger.tagged('backend_sync') { logger.warn "Not deleting Package #{project.name}/#{name}, global_write_through is off" }
@@ -1449,6 +1449,7 @@ end
 #  report_bug_url  :string(8192)
 #  scmsync         :string(255)
 #  title           :string(255)
+#  type            :string(255)      indexed
 #  url             :string(255)
 #  created_at      :datetime
 #  updated_at      :datetime
@@ -1461,6 +1462,7 @@ end
 #  devel_package_id_index            (develpackage_id)
 #  index_packages_on_comments_count  (comments_count)
 #  index_packages_on_kiwi_image_id   (kiwi_image_id)
+#  index_packages_on_type            (type)
 #  packages_all_index                (project_id,name) UNIQUE
 #
 # Foreign Keys

--- a/src/api/app/models/package/errors.rb
+++ b/src/api/app/models/package/errors.rb
@@ -36,4 +36,8 @@ module Package::Errors
   class ScmsyncReadOnly < APIError
     setup 'scmsync_read_only', 403, 'Can not change files in SCM bridged packages'
   end
+
+  class LinkedPackageReadOnly < APIError
+    setup 'linked_package_read_only', 403, 'Can not modify the backend state of a linked package'
+  end
 end

--- a/src/api/app/models/product.rb
+++ b/src/api/app/models/product.rb
@@ -6,7 +6,7 @@ class Product < ApplicationRecord
   include CanRenderModel
 
   def self.find_or_create_by_name_and_package(name, package)
-    raise Product::NotFoundError, 'Error: Package not valid.' unless package.instance_of?(Package)
+    raise Product::NotFoundError, 'Error: Package not valid.' unless package.is_a?(Package)
 
     product = find_by_name_and_package(name, package)
 

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -42,6 +42,7 @@ class Project < ApplicationRecord
     end
   end
   has_many :patchinfos, -> { with_kind('patchinfo') }, class_name: 'Package'
+  has_many :linked_packages, class_name: 'LinkedPackage', inverse_of: :project
 
   has_many :issues, through: :packages
   has_many :attribs, dependent: :destroy do
@@ -713,7 +714,7 @@ class Project < ApplicationRecord
   # when we delete ourself. No need to delete packages
   # individually on backend
   def cleanup_packages
-    packages.each do |package|
+    (packages + linked_packages).each do |package|
       package.commit_opts = { no_backend_write: 1, project_destroy_transaction: 1, request: commit_opts[:request] }
       package.destroy
     end

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -604,6 +604,10 @@ class Project < ApplicationRecord
     remoteurl.present?
   end
 
+  def maintained_by_backend?
+    scmsync.present? || defines_remote_instance?
+  end
+
   def delegates_requests?
     find_attribute('OBS', 'DelegateRequestTarget').present?
   end

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -628,7 +628,7 @@ class User < ApplicationRecord
 
   # lists packages maintained by this user and are not in maintained projects
   def involved_packages
-    Package.unscoped.for_user(id).or(Package.unscoped.for_group(group_ids)).where.not(project: involved_projects)
+    Package.unscoped.for_user(id).or(Package.unscoped.for_group(group_ids)).where.not(project: involved_projects).where(type: nil)
   end
 
   # lists reviews involving this user

--- a/src/api/app/policies/linked_package_policy.rb
+++ b/src/api/app/policies/linked_package_policy.rb
@@ -1,0 +1,17 @@
+class LinkedPackagePolicy < PackagePolicy
+  def update?
+    false
+  end
+
+  def save_meta_update?
+    false
+  end
+
+  def destroy?
+    false
+  end
+
+  def unlock?
+    false
+  end
+end

--- a/src/api/app/policies/token/service_policy.rb
+++ b/src/api/app/policies/token/service_policy.rb
@@ -1,7 +1,8 @@
 class Token::ServicePolicy < TokenPolicy
   def trigger?
     return false unless user.active?
+    return false unless record.object_to_authorize.is_a?(Package)
 
-    PackagePolicy.new(user, record.object_to_authorize).update?
+    Pundit.policy(user, record.object_to_authorize).update?
   end
 end

--- a/src/api/app/queries/packages_finder.rb
+++ b/src/api/app/queries/packages_finder.rb
@@ -50,7 +50,7 @@ class PackagesFinder
   def find_by_attribute
     <<-END_SQL
       LEFT OUTER JOIN attribs attrprj ON pack.project_id = attrprj.project_id
-      WHERE ( attr.attrib_type_id = ? or attrprj.attrib_type_id = ? )
+      WHERE pack.type IS NULL AND ( attr.attrib_type_id = ? or attrprj.attrib_type_id = ? )
     END_SQL
   end
 
@@ -65,7 +65,7 @@ class PackagesFinder
   def find_by_attribute_and_value
     <<-END_SQL
       LEFT OUTER JOIN attrib_values val ON attr.id = val.attrib_id
-      WHERE attr.attrib_type_id = ? AND val.value = ?
+      WHERE pack.type IS NULL AND attr.attrib_type_id = ? AND val.value = ?
     END_SQL
   end
 

--- a/src/api/config/initializers/flipper.rb
+++ b/src/api/config/initializers/flipper.rb
@@ -8,7 +8,8 @@ ENABLED_FEATURE_TOGGLES = [
   { name: :labels, description: 'Allow to apply labels to packages, requests and projects to improve collaboration between build service users.' },
   { name: :request_index, description: 'Redesign of listing requests' },
   { name: :canned_responses, description: 'Create messages using templates' },
-  { name: :package_version_tracking, description: 'Track the local and upstream versions of your packages' }
+  { name: :package_version_tracking, description: 'Track the local and upstream versions of your packages' },
+  { name: :linked_packages, description: 'Access packages that come from a link (e.g. scmsync-bridged projects)' }
 ].freeze
 
 Flipper.configure do

--- a/src/api/db/migrate/20260728103639_add_type_to_packages.rb
+++ b/src/api/db/migrate/20260728103639_add_type_to_packages.rb
@@ -1,0 +1,6 @@
+class AddTypeToPackages < ActiveRecord::Migration[7.2]
+  def change
+    add_column :packages, :type, :string, limit: 255, null: true, default: nil
+    add_index :packages, :type
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_07_23_180842) do
+ActiveRecord::Schema[7.2].define(version: 2026_07_28_103639) do
   create_table "active_storage_attachments", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -872,10 +872,12 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_23_180842) do
     t.string "report_bug_url", limit: 8192
     t.integer "comments_count", default: 0, null: false
     t.boolean "anitya_ignore", default: false, null: false
+    t.string "type"
     t.index ["comments_count"], name: "index_packages_on_comments_count"
     t.index ["develpackage_id"], name: "devel_package_id_index"
     t.index ["kiwi_image_id"], name: "index_packages_on_kiwi_image_id"
     t.index ["project_id", "name"], name: "packages_all_index", unique: true
+    t.index ["type"], name: "index_packages_on_type"
   end
 
   create_table "path_elements", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|

--- a/src/api/spec/factories/packages.rb
+++ b/src/api/spec/factories/packages.rb
@@ -15,6 +15,10 @@ FactoryBot.define do
       end
     end
 
+    factory :linked_package, class: 'LinkedPackage' do
+      project { association :project, scmsync: 'https://example.com/repo.git' }
+    end
+
     factory :package_with_maintainer do
       transient do
         maintainer { association :confirmed_user }

--- a/src/api/spec/jobs/reconcile_linked_package_job_spec.rb
+++ b/src/api/spec/jobs/reconcile_linked_package_job_spec.rb
@@ -1,0 +1,89 @@
+RSpec.describe ReconcileLinkedPackageJob, :vcr do
+  let(:admin) { create(:admin_user, login: 'Admin') }
+  let(:scmsync_project) { create(:project, name: 'scmsync_home', scmsync: 'https://example.com/repo.git') }
+  let(:normal_project) { create(:project, name: 'normal_home') }
+  let(:meta) do
+    %(<package name="pkg" project="#{scmsync_project.name}"><title>Linked pkg</title><description>desc</description></package>)
+  end
+
+  before do
+    admin
+    allow(Backend::Api::Sources::Package).to receive(:meta).and_return(meta)
+  end
+
+  describe 'create/update' do
+    it 'creates a LinkedPackage from the backend meta' do
+      expect do
+        described_class.perform_now(action: 'create', project_name: scmsync_project.name, package_name: 'pkg')
+      end.to change { scmsync_project.linked_packages.count }.by(1)
+
+      package = scmsync_project.linked_packages.find_by(name: 'pkg')
+      expect(package).to have_attributes(type: 'LinkedPackage', title: 'Linked pkg', description: 'desc')
+    end
+
+    it 'updates an existing linked package instead of duplicating it' do
+      create(:linked_package, name: 'pkg', project: scmsync_project, title: 'old')
+
+      expect do
+        described_class.perform_now(action: 'update', project_name: scmsync_project.name, package_name: 'pkg')
+      end.not_to change(scmsync_project.linked_packages, :count)
+
+      expect(scmsync_project.linked_packages.find_by(name: 'pkg').title).to eq('Linked pkg')
+    end
+
+    it 'strips the multibuild flavor suffix' do
+      described_class.perform_now(action: 'create', project_name: scmsync_project.name, package_name: 'pkg:flavor')
+
+      expect(scmsync_project.linked_packages.pluck(:name)).to contain_exactly('pkg')
+    end
+
+    it 'destroys a stale record when the backend meta is gone' do
+      create(:linked_package, name: 'pkg', project: scmsync_project)
+      allow(Backend::Api::Sources::Package).to receive(:meta).and_raise(Backend::NotFoundError)
+
+      described_class.perform_now(action: 'create', project_name: scmsync_project.name, package_name: 'pkg')
+
+      expect(scmsync_project.linked_packages.find_by(name: 'pkg')).to be_nil
+    end
+  end
+
+  describe 'delete' do
+    it 'destroys the linked package' do
+      create(:linked_package, name: 'pkg', project: scmsync_project)
+
+      expect do
+        described_class.perform_now(action: 'delete', project_name: scmsync_project.name, package_name: 'pkg')
+      end.to change { scmsync_project.linked_packages.count }.by(-1)
+    end
+
+    it 'is a no-op when the linked package does not exist' do
+      expect do
+        described_class.perform_now(action: 'delete', project_name: scmsync_project.name, package_name: 'missing')
+      end.not_to raise_error
+    end
+  end
+
+  describe 'guards' do
+    it 'does nothing for a normal (frontend-managed) project' do
+      expect do
+        described_class.perform_now(action: 'create', project_name: normal_project.name, package_name: 'pkg')
+      end.not_to change(LinkedPackage, :count)
+    end
+
+    it 'does nothing for an unknown project' do
+      expect do
+        described_class.perform_now(action: 'create', project_name: 'does:not:exist', package_name: 'pkg')
+      end.not_to change(LinkedPackage, :count)
+    end
+
+    # The discriminator is project.maintained_by_backend?, not scmsync specifically, so remote
+    # packages are reconciled automatically if the backend ever emits events for them.
+    it 'reconciles packages of a remote instance project' do
+      remote_project = create(:project, name: 'remote_home', remoteurl: 'https://api.example.com/public')
+
+      expect do
+        described_class.perform_now(action: 'create', project_name: remote_project.name, package_name: 'pkg')
+      end.to change { remote_project.linked_packages.count }.by(1)
+    end
+  end
+end

--- a/src/api/spec/models/concerns/reconcile_linked_package_callback_spec.rb
+++ b/src/api/spec/models/concerns/reconcile_linked_package_callback_spec.rb
@@ -1,0 +1,36 @@
+RSpec.describe ReconcileLinkedPackageCallback, :vcr do
+  let!(:scmsync_project) { create(:project, name: 'scmsync_home', scmsync: 'https://example.com/repo.git') }
+  let(:payload) { { 'project' => scmsync_project.name, 'package' => 'pkg', 'sender' => 'Admin' } }
+
+  before do
+    allow(ReconcileLinkedPackageJob).to receive(:perform_later)
+  end
+
+  shared_examples 'an upsert-reconciling event' do |event_class|
+    it "enqueues a create reconcile job for #{event_class}" do
+      event_class.create(payload)
+
+      expect(ReconcileLinkedPackageJob).to have_received(:perform_later)
+        .with(action: 'create', project_name: scmsync_project.name, package_name: 'pkg')
+    end
+  end
+
+  it_behaves_like 'an upsert-reconciling event', Event::CreatePackage
+  it_behaves_like 'an upsert-reconciling event', Event::UpdatePackage
+  it_behaves_like 'an upsert-reconciling event', Event::UndeletePackage
+
+  it 'enqueues a delete reconcile job for Event::DeletePackage' do
+    Event::DeletePackage.create(payload)
+
+    expect(ReconcileLinkedPackageJob).to have_received(:perform_later)
+      .with(action: 'delete', project_name: scmsync_project.name, package_name: 'pkg')
+  end
+
+  it 'does not enqueue a job for a normal (frontend-managed) project' do
+    normal_project = create(:project, name: 'normal_home')
+
+    Event::CreatePackage.create(payload.merge('project' => normal_project.name))
+
+    expect(ReconcileLinkedPackageJob).not_to have_received(:perform_later)
+  end
+end

--- a/src/api/spec/models/linked_package_spec.rb
+++ b/src/api/spec/models/linked_package_spec.rb
@@ -1,0 +1,132 @@
+RSpec.describe LinkedPackage, :vcr do
+  let(:user) { create(:confirmed_user, :with_home, login: 'tom') }
+  let(:home_project) { user.home_project }
+  let(:scmsync_project) { create(:project, name: 'scmsync_home', scmsync: 'https://example.com/repo.git') }
+  let!(:normal_package) { create(:package, name: 'normal', project: home_project) }
+  let!(:linked_package) { create(:linked_package, name: 'linked', project: scmsync_project) }
+
+  before do
+    login(user)
+  end
+
+  describe 'STI type' do
+    it 'stores the class name in the type column' do
+      expect(linked_package.type).to eq('LinkedPackage')
+    end
+
+    it 'leaves the type NULL for a normal package' do
+      expect(normal_package.type).to be_nil
+    end
+  end
+
+  describe 'default scope' do
+    it 'excludes linked packages from the Package scope' do
+      expect(Package.all).not_to include(linked_package)
+      expect(Package.all).to include(normal_package)
+    end
+
+    it 'only returns linked packages from the LinkedPackage scope' do
+      expect(LinkedPackage.all).to contain_exactly(linked_package)
+    end
+
+    it 'filters the base scope by NULL type' do
+      expect(Package.all.to_sql).to include('`packages`.`type` IS NULL')
+    end
+
+    it 'filters the subclass scope by its type and not by NULL type' do
+      expect(LinkedPackage.all.to_sql).to include("`packages`.`type` = 'LinkedPackage'")
+      expect(LinkedPackage.all.to_sql).not_to include('IS NULL')
+    end
+
+    it 'raises RecordNotFound when looking a linked package up via the base class' do
+      expect { Package.find(linked_package.id) }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    # Guards the `Package.unscoped` used to build the forbidden subquery: otherwise a forbidden
+    # linked package would leak into LinkedPackage.all.
+    it 'excludes forbidden linked packages from the LinkedPackage scope' do
+      forbidden_project = create(:forbidden_project, name: 'forbidden_scmsync', scmsync: 'https://example.com/secret.git')
+      # A project is only forbidden to others once it has a maintainer whitelist that excludes them.
+      create(:relationship_project_user, project: forbidden_project, user: create(:confirmed_user))
+      forbidden = create(:linked_package, name: 'secret', project: forbidden_project)
+      # forbidden_project_ids is cached; discard it so the freshly forbidden project is recomputed.
+      Relationship.discard_cache
+
+      expect(LinkedPackage.all).not_to include(forbidden)
+    end
+  end
+
+  describe 'project associations' do
+    it 'excludes linked packages from Project#packages' do
+      expect(scmsync_project.packages).not_to include(linked_package)
+    end
+
+    it 'exposes linked packages via Project#linked_packages' do
+      expect(scmsync_project.linked_packages).to contain_exactly(linked_package)
+    end
+  end
+
+  describe '#backend_writable?' do
+    it 'is false for a linked package' do
+      expect(linked_package.backend_writable?).to be(false)
+    end
+
+    it 'is true for a normal package' do
+      expect(normal_package.backend_writable?).to be(true)
+    end
+  end
+
+  describe 'backend write guard' do
+    context 'with global_write_through enabled' do
+      before { allow(CONFIG).to receive(:[]).and_call_original }
+
+      it 'refuses to write a linked package meta to the backend' do
+        allow(CONFIG).to receive(:[]).with('global_write_through').and_return(true)
+        linked_package.title = 'changed'
+
+        expect { linked_package.save! }.to raise_error(Package::Errors::LinkedPackageReadOnly)
+      end
+
+      it 'allows the reconcile path (no_backend_write) to save' do
+        allow(CONFIG).to receive(:[]).with('global_write_through').and_return(true)
+        linked_package.title = 'changed'
+        linked_package.commit_opts = { no_backend_write: 1 }
+
+        expect { linked_package.save! }.not_to raise_error
+      end
+    end
+  end
+
+  describe '.get_by_project_and_name' do
+    context 'with the linked_packages beta feature enabled' do
+      before { Flipper.enable(:linked_packages, user) }
+
+      it 'returns the persisted linked package for a scmsync project' do
+        found = described_class.get_by_project_and_name(scmsync_project.name, linked_package.name,
+                                                        use_source: false, follow_project_scmsync_links: true)
+        expect(found).to eq(linked_package)
+      end
+
+      it 'raises UnknownObjectError for a missing scmsync package' do
+        expect do
+          described_class.get_by_project_and_name(scmsync_project.name, 'does_not_exist',
+                                                  use_source: false, follow_project_scmsync_links: true)
+        end.to raise_error(Package::Errors::UnknownObjectError)
+      end
+    end
+
+    context 'without the linked_packages beta feature' do
+      before do
+        allow(Backend::Api::Sources::Package).to receive(:meta)
+          .and_return(%(<package name="#{linked_package.name}" project="#{scmsync_project.name}"><title>ephemeral</title></package>))
+      end
+
+      it 'falls back to a readonly package built from the backend meta' do
+        found = described_class.get_by_project_and_name(scmsync_project.name, linked_package.name,
+                                                        use_source: false, follow_project_scmsync_links: true)
+        expect(found).to be_readonly
+        expect(found).not_to eq(linked_package)
+      end
+    end
+  end
+end

--- a/src/api/spec/models/package_get_by_project_and_name_spec.rb
+++ b/src/api/spec/models/package_get_by_project_and_name_spec.rb
@@ -197,18 +197,34 @@ RSpec.describe Package, '#get_by_project_and_name' do
     context 'enabled' do
       let(:arguments) { { follow_project_scmsync_links: true } }
 
-      before do
-        # Mock Package.exists_on_backend?
-        allow(Backend::Api::Sources::Package).to receive(:meta).and_return(package_xml)
+      context 'with the linked_packages beta feature enabled' do
+        # scmsync packages are persisted as LinkedPackage records (reconciled from backend events).
+        let!(:linked_package) { create(:linked_package, name: package.name, project: project, title: 'hans', description: 'franz') }
+
+        before { Flipper.enable(:linked_packages) }
+
+        it 'returns the persisted linked package' do
+          expect(subject).to eq(linked_package)
+        end
+
+        it 'reads attributes from the linked package' do
+          expect(subject).to have_attributes(title: 'hans', description: 'franz')
+        end
       end
 
-      it 'returns a readonly package' do
-        expect(subject).to be_readonly
-      end
+      context 'without the linked_packages beta feature' do
+        before do
+          allow(Backend::Api::Sources::Package).to receive(:meta).and_return(package_xml)
+        end
 
-      it 'reads attributes from the backend' do
-        expect(subject.title).to eq('hans')
-        expect(subject.description).to eq('franz')
+        it 'returns a readonly package' do
+          expect(subject).to be_readonly
+        end
+
+        it 'reads attributes from the backend' do
+          expect(subject.title).to eq('hans')
+          expect(subject.description).to eq('franz')
+        end
       end
     end
 

--- a/src/api/spec/models/project_spec.rb
+++ b/src/api/spec/models/project_spec.rb
@@ -862,4 +862,10 @@ RSpec.describe Project, :vcr do
 
     it { expect(project.bs_requests).to contain_exactly(incoming_request, outgoing_request, request_with_review) }
   end
+
+  describe '#maintained_by_backend?' do
+    it { expect(create(:project, scmsync: 'https://example.com/repo.git')).to be_maintained_by_backend }
+    it { expect(create(:project, remoteurl: 'https://api.example.com/public')).to be_maintained_by_backend }
+    it { expect(create(:project)).not_to be_maintained_by_backend }
+  end
 end

--- a/src/api/spec/policies/linked_package_policy_spec.rb
+++ b/src/api/spec/policies/linked_package_policy_spec.rb
@@ -1,0 +1,32 @@
+RSpec.describe LinkedPackagePolicy do
+  subject { described_class }
+
+  let(:user) { create(:confirmed_user, :with_home) }
+  let(:scmsync_project) { create(:project, name: 'scmsync_home', scmsync: 'https://example.com/repo.git') }
+  let(:linked_package) { create(:linked_package, name: 'linked', project: scmsync_project) }
+
+  before do
+    # The user maintains the scmsync project, so permissions would pass if the package were normal.
+    create(:relationship, project: scmsync_project, user: user, role: Role.find_by_title('maintainer'))
+  end
+
+  describe 'forbidden source-modifying features' do
+    %i[update? save_meta_update? destroy? unlock?].each do |action|
+      permissions action do
+        it { is_expected.not_to permit(user, linked_package) }
+      end
+    end
+  end
+
+  describe 'allowed non-source features' do
+    # rebuild is a build-state operation and does not modify the source, so a maintainer keeps
+    # normal permissions. Frontend-only features (labels, ...) stay allowed too.
+    permissions :rebuild?, :update_labels? do
+      it { is_expected.to permit(user, linked_package) }
+    end
+  end
+
+  it 'is resolved automatically by Pundit for a LinkedPackage record' do
+    expect(Pundit.policy(user, linked_package)).to be_a(described_class)
+  end
+end


### PR DESCRIPTION
This PR was assisted by Claude Opus 4.8.

In a few cases there are packages which only exist on the backend:
* Project Link package
* Remote project link package
* scmsync project package

The intention of this model is to sync all of them from the backend into the frontend, however we only receive events for some of them, like scmsync. In the future this same code should be capable of supporting more linked packages as needed.

Access to these packages is behind a beta flag, to allow us testing and hopefully not break anything in the process.