### PR TITLE
Do not link hidden monitor workers to build logs

### DIFF
--- a/src/api/app/assets/javascripts/webui/monitor.js
+++ b/src/api/app/assets/javascripts/webui/monitor.js
@@ -105,7 +105,7 @@ function processProgressBar(id, item)
   if (delta) {
     el_text.text(item[logfileinfo]);
     ctrl.css("width", delta + "%").attr("aria-valuenow", delta);
-    if (item["project"] === '---' || item["package"] === '---' || item["repository"] === '---') {
+    if (item["hidden"]) {
       el_text.removeAttr("href");
     } else {
       var url = $('#workers').data('buildLogPath');

--- a/src/api/app/assets/javascripts/webui/monitor.js
+++ b/src/api/app/assets/javascripts/webui/monitor.js
@@ -105,13 +105,17 @@ function processProgressBar(id, item)
   if (delta) {
     el_text.text(item[logfileinfo]);
     ctrl.css("width", delta + "%").attr("aria-valuenow", delta);
-    var url = $('#workers').data('buildLogPath');
-    url = url.replace('ARCH', item["arch"]);
-    url = url.replace('PROJECT', item["project"]);
-    url = url.replace('PACKAGE', item["package"]);
-    url = url.replace('REPOSITORY', item["repository"]);
+    if (item["project"] === '---' || item["package"] === '---' || item["repository"] === '---') {
+      el_text.removeAttr("href");
+    } else {
+      var url = $('#workers').data('buildLogPath');
+      url = url.replace('ARCH', item["arch"]);
+      url = url.replace('PROJECT', item["project"]);
+      url = url.replace('PACKAGE', item["package"]);
+      url = url.replace('REPOSITORY', item["repository"]);
 
-    el_text.attr("href", url);
+      el_text.attr("href", url);
+    }
 
     if (delta <= 50) {
       ctrl.addClass("text-bg-success");

--- a/src/api/app/models/worker_status.rb
+++ b/src/api/app/models/worker_status.rb
@@ -25,6 +25,7 @@ class WorkerStatus
     end
 
     def hide_project_information(prj)
+      prj['hidden'] = 'true'
       %w[project repository package].each { |k| prj[k] = '---' }
     end
 

--- a/src/api/app/services/monitor_controller_service/building_information_updater.rb
+++ b/src/api/app/services/monitor_controller_service/building_information_updater.rb
@@ -27,7 +27,7 @@ module MonitorControllerService
     end
 
     def workers_hash(b, delta)
-      b.slice('project', 'repository', 'package', 'arch', 'starttime').merge('delta' => delta.to_s)
+      b.slice('project', 'repository', 'package', 'arch', 'starttime', 'hidden').merge('delta' => delta.to_s)
     end
 
     def calculate_delta(starttime)

--- a/src/api/spec/features/webui/monitor_spec.rb
+++ b/src/api/spec/features/webui/monitor_spec.rb
@@ -1,0 +1,28 @@
+require 'browser_helper'
+require 'webmock/rspec'
+
+RSpec.describe 'Monitor', :js, :vcr do
+  let(:xml_response) do
+    <<~XML
+      <workerstatus clients="2">
+        <building workerid="build01/3" hostarch="i586" project="home:Iggy" repository="10.2" package="TestPack" arch="i586" starttime="#{30.minutes.ago.to_i}" />
+        <building workerid="build01/4" hostarch="i586" project="HiddenProject" repository="nada" package="pack" arch="i586" starttime="#{1.hour.ago.to_i}" />
+      </workerstatus>
+    XML
+  end
+
+  before do
+    create(:project, name: 'home:Iggy')
+    stub_request(:get, "#{CONFIG['source_url']}/build/_workerstatus").and_return(body: xml_response)
+  end
+
+  it 'does not link hidden workers to broken build logs' do
+    visit monitor_path
+
+    visible_worker = find('#pbuild01_3 .monitorpb_text', text: 'TestPack')
+    expect(visible_worker[:href]).to match(%r{/package/live_build_log/home(?::|%3A)Iggy/TestPack/10\.2/i586\z})
+
+    hidden_worker = find('#pbuild01_4 .monitorpb_text', text: '---')
+    expect(hidden_worker[:href]).to be_nil
+  end
+end

--- a/src/api/spec/models/worker_status_spec.rb
+++ b/src/api/spec/models/worker_status_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe WorkerStatus do
       end
 
       it { expect(subject['building']['project']).to eq(project.name) }
+      it { expect(subject['building']['hidden']).to be_nil }
     end
 
     context 'XPATH filter matches more projects' do
@@ -45,6 +46,7 @@ RSpec.describe WorkerStatus do
       end
 
       it { expect(subject['building']['project']).to eq('---') }
+      it { expect(subject['building']['hidden']).to eq('true') }
     end
 
     context 'project name is hidden' do
@@ -69,6 +71,7 @@ RSpec.describe WorkerStatus do
 
       it { expect(subject['building'].count).to eq(4) }
       it { expect(subject['building'].pluck('project')).to all(eq('---')) }
+      it { expect(subject['building'].pluck('hidden')).to all(eq('true')) }
     end
   end
 

--- a/src/api/spec/services/monitor_controller_service/building_information_updater_spec.rb
+++ b/src/api/spec/services/monitor_controller_service/building_information_updater_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe MonitorControllerService::BuildingInformationUpdater do
             <idle workerid="build01/1" hostarch="x86_64"/>
             <building workerid="build01/2" hostarch="i586" project="BinaryprotectedProject" repository="nada" package="bdpack" arch="i586" starttime="0" />
             <building workerid="build01/3" hostarch="i586" project="SourceprotectedProject" repository="repo" package="pack" arch="i586" starttime="#{(Time.now - 30.minutes).to_i}" />
-            <building workerid="build01/4" hostarch="i586" project="HiddenProject" repository="nada" package="pack" arch="i586" starttime="#{(Time.now - 1.hour).to_i}" />
+            <building workerid="build01/4" hostarch="i586" project="---" repository="---" package="---" arch="i586" starttime="#{(Time.now - 1.hour).to_i}" hidden="true" />
             <waiting arch="i586" jobs="1" />
             <waiting arch="x86_64" jobs="0" />
             <blocked arch="i586" jobs="1" />
@@ -51,5 +51,6 @@ RSpec.describe MonitorControllerService::BuildingInformationUpdater do
     it { expect(subject['build01_3']['delta']).to eq('48') }
     it { expect(subject['build01_4']).to have_key('delta') }
     it { expect(subject['build01_4']['delta']).to eq('66') }
+    it { expect(subject['build01_4']['hidden']).to eq('true') }
   end
 end


### PR DESCRIPTION
## Description:

Issue #19380 reports that hidden workers on the Monitor page are rendered as `---`, but the JavaScript still attaches a `live_build_log` link to those hidden rows.

This PR marks hidden worker entries when `WorkerStatus.hidden` masks project, repository, and package values. The monitor worker JSON carries that `hidden` flag, and the frontend uses it to avoid adding a build-log link for hidden workers.

Visible workers keep the existing build-log link behavior.

It also adds regression coverage for hidden worker flagging, JSON transport, and browser rendering.

Closes #19380.

## Validation:

1. Prepare the OBS Docker development environment.
2. Run the focused tests:

```bash
docker compose run --rm frontend bundle exec rspec spec/models/worker_status_spec.rb spec/services/monitor_controller_service/building_information_updater_spec.rb spec/features/webui/monitor_spec.rb --format documentation
```

Expected result:

```text
21 examples, 0 failures
```

The focused tests verify that hidden workers get an explicit `hidden` flag, that the monitor JSON includes the flag, and that the browser DOM has no `href` for the hidden worker while visible workers still link to their build logs.

## Checklist:

- [x] I have run focused tests in the OBS frontend container using `bundle exec rspec spec/models/worker_status_spec.rb spec/services/monitor_controller_service/building_information_updater_spec.rb spec/features/webui/monitor_spec.rb --format documentation`.
- [x] I have run linting in the OBS frontend container using `bundle exec rake dev:lint:all`.