### PR TITLE
Cleanup production environment

### DIFF
--- a/src/api/config/environments/production.rb
+++ b/src/api/config/environments/production.rb
@@ -3,120 +3,36 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  # Use memcache for cache/session storage
-  config.cache_store = if CONFIG['memcached_host']
-                         [:mem_cache_store, CONFIG['memcached_host']]
-                       else
-                         :mem_cache_store
-                       end
-  config.session_store :cache_store
+  # Code is not reloaded between requests.
+  config.enable_reloading = false
 
-  # Include generic and useful information about system operation, but avoid logging too much
-  # information to avoid inadvertent exposure of personally identifiable information (PII).
-  config.log_level = :info
-  # Use a different logger for distributed setups
-  # config.logger        = SyslogLogger.new
-
-  # Eager load code on boot. This eager loads most of Rails and
-  # your application in memory, allowing both threaded web servers
-  # and those relying on copy on write to perform better.
-  # Rake tasks automatically ignore this option for performance.
+  # Eager load code on boot for better performance and memory savings (ignored by Rake tasks).
   config.eager_load = true
 
-  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  # config.asset_host = 'http://assets.example.com'
+  # Full error reports are disabled.
+  config.consider_all_requests_local = false
 
-  # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]
-  # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).
-  # config.require_master_key = true
+  # Turn on fragment caching in view templates.
+  config.action_controller.perform_caching = true
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.enabled = ENV.fetch("RAILS_SERVE_STATIC_FILES", false)
 
-  # Specifies the header that your server uses for sending files.
-  # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
-  # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
+  # Cache assets for far-future expiry since they are all digest stamped.
+  config.public_file_server.headers = { "cache-control" => "public, max-age=#{1.year.to_i}" }
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
 
-  # Mount Action Cable outside main process or domain.
-  # config.action_cable.mount_path = nil
-  # config.action_cable.url = 'wss://example.com/cable'
-  # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
+  # Assume all access to the app is happening through a SSL-terminating reverse proxy.
+  config.assume_ssl = CONFIG['assume_ssl']
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = CONFIG['force_ssl']
-  config.assume_ssl = CONFIG['assume_ssl']
 
-  # Prepend all log lines with the following tags.
-  config.log_tags = [:request_id]
-
-  # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
-
-  # Use DelayedJob gem as qeuing backend for Active Job
-  config.active_job.queue_adapter = :delayed_job
-  # config.active_job.queue_name_prefix = "obs_api_production"
-
-  # see http://guides.rubyonrails.org/action_mailer_basics.html#example-action-mailer-configuration
-  config.action_mailer.delivery_method = :sendmail
-  config.action_mailer.perform_caching = false
-
-  config.active_support.deprecation = :silence
-
-  # Full error reports are disabled and caching is turned on.
-  config.consider_all_requests_local       = false
-  config.action_controller.perform_caching = true
-
-  # Disable Rails's static asset server (Apache or nginx will already do this)
-  config.public_file_server.enabled = false
-
-  # Compress JavaScripts and CSS
-  config.assets.compress = true
-  # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :terser
-  # config.assets.css_compressor = :sass
-
-  # Don't fallback to assets pipeline if a precompiled asset is missed
-  config.assets.compile = false
-
-  # Generate digests for assets URLs
-  config.assets.digest = true
-
-  # Ignore bad email addresses and do not raise email delivery errors.
-  # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
-
-  # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
-  # the I18n.default_locale when a translation cannot be found).
-  config.i18n.fallbacks = true
-
-  # compress our HTML
-  config.middleware.use(Rack::Deflater)
-
-  # Send deprecation notices to registered listeners.
-  config.active_support.deprecation = :notify
-
-  # Log disallowed deprecations.
-  config.active_support.disallowed_deprecation = :log
-
-  # Tell Active Support which deprecation messages to disallow.
-  config.active_support.disallowed_deprecation_warnings = []
-
-  # Use default logging formatter so that PID and timestamp are not suppressed.
-  config.log_formatter = Logger::Formatter.new
-
-  # Use a different logger for distributed setups.
-  # require "syslog/logger"
-  # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
-
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger           = ActiveSupport::Logger.new($stdout)
-    logger.formatter = config.log_formatter
-    config.logger = ActiveSupport::TaggedLogging.new(logger)
-  end
+  # Log the current request id as a default log tag.
+  config.log_tags = [ :request_id ]
 
   # Use lograge to show the logs in one line
   config.lograge.enabled = true
@@ -135,38 +51,48 @@ Rails.application.configure do
     }
   end
 
+  # Change to "debug" to log everything (including potentially personally-identifiable information!)
+  config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")
+
+  # Don't log any deprecations.
+  config.active_support.report_deprecations = false
+
+  # Replace the default in-process memory cache store with a durable alternative.
+  config.cache_store = if CONFIG['memcached_host']
+                         [:mem_cache_store, CONFIG['memcached_host']]
+                       else
+                         :mem_cache_store
+                       end
+
+  # Store the sessions in memcached too
+  config.session_store :cache_store
+
+  # Turn off live Sprockets compilation
+  config.assets.compile = false
+  # Use terser as javascript compressor
+  # https://github.com/terser/terser
+  config.assets.js_compressor = :terser
+
+  # Use DelayedJob gem as qeuing backend for Active Job
+  config.active_job.queue_adapter = :delayed_job
+
+  # see http://guides.rubyonrails.org/action_mailer_basics.html#example-action-mailer-configuration
+  config.action_mailer.delivery_method = :sendmail
+  config.action_mailer.perform_caching = false
+
+  # compress our HTML
+  config.middleware.use(Rack::Deflater)
+
+  # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
+  # the I18n.default_locale when a translation cannot be found).
+  config.i18n.fallbacks = true
+
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  # Inserts middleware to perform automatic connection switching.
-  # The `database_selector` hash is used to pass options to the DatabaseSelector
-  # middleware. The `delay` is used to determine how long to wait after a write
-  # to send a subsequent read to the primary.
-  #
-  # The `database_resolver` class is used by the middleware to determine which
-  # database is appropriate to use based on the time delay.
-  #
-  # The `database_resolver_context` class is used by the middleware to set
-  # timestamps for the last write to the primary. The resolver uses the context
-  # class timestamps to determine how long to wait before reading from the
-  # replica.
-  #
-  # By default Rails will store a last write timestamp in the session. The
-  # DatabaseSelector middleware is designed as such you can define your own
-  # strategy for connection switching and pass that into the middleware through
-  # these configuration options.
-  # config.active_record.database_selector = { delay: 2.seconds }
-  # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
-  # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+  # Only use :id for inspections in production.
+  config.active_record.attributes_for_inspect = [ :id ]
 end
 
 # ActiveJob already logs everything we need
 Delayed::Worker.default_log_level = 'debug'
-
-# require 'memory_debugger'
-# dumps the objects after every request
-# config.middleware.insert(0, MemoryDebugger)
-
-# require 'memory_dumper'
-# dumps the full heap after next request on SIGURG
-# config.middleware.insert(0, MemoryDumper)


### PR DESCRIPTION
- Added `config.enable_reloading`, is the default in Rails 8
- Added `config.active_record.attributes_for_inspect`, it's the default in Rails 8

- Added `config.active_support.report_deprecations` which replaces
  - `config.active_support.deprecation`
  - `config.active_support.disallowed_deprecation`
  - `config.active_support.disallowed_deprecation_warnings`

Dropped
- `config.assets.compress` is `config.assets.js_compressor` since Rails 5.1...
- `config.assets.digest` is the default
- `config.log_formatter` we use lograge
- `RAILS_LOG_TO_STDOUT`, we do no use this anywhere

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
