### PR TITLE
Remove password from ActiveSupport::ParameterFilter

### DIFF
--- a/src/api/config/initializers/filter_parameter_logging.rb
+++ b/src/api/config/initializers/filter_parameter_logging.rb
@@ -1,7 +1,9 @@
 # Be sure to restart your server when you modify this file.
 
-# Configure parameters to be filtered from the log file. Use this to limit dissemination of
-# sensitive information. See the ActiveSupport::ParameterFilter documentation for supported
-# notations and behaviors.
+# Configure parameters to be partially matched (e.g. passw matches password) and filtered from the log file.
+# Use this to limit dissemination of sensitive information.
+# See the ActiveSupport::ParameterFilter documentation for supported notations and behaviors.
 # FIXME: `string` is a column from the Tokens table, this column should be renamed.
-Rails.application.config.filter_parameters += %i[password passw secret token _key crypt salt certificate otp ssn scm_token string api_key :cvv :cvc]
+Rails.application.config.filter_parameters += [
+  :passw, :email, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn, :cvv, :cvc, :string, :scm_token, :api_key
+]


### PR DESCRIPTION
It's already covered with `:passw` as the generated comment explains.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
