### PR TITLE
Resolve SimpleCov deprecation warnings by defining custom profile

### DIFF
--- a/src/api/.simplecov
+++ b/src/api/.simplecov
@@ -1,15 +1,20 @@
-SimpleCov.start 'rails' do
-  add_filter '/app/indices/'
-  add_filter '/lib/templates/'
-  add_filter '/lib/memory_debugger.rb'
-  add_filter '/lib/memory_dumper.rb'
+SimpleCov.profiles.define 'obs' do
+  load_profile 'rails'
+
+  skip '/app/indices/'
+  skip '/lib/templates/'
+  skip '/lib/memory_debugger.rb'
+  skip '/lib/memory_dumper.rb'
+
   merge_timeout 3600
-  add_group 'Components', 'app/components'
-  add_group 'Datatables', 'app/datatables'
-  add_group 'Instrumentations', 'app/instrumentations'
-  add_group 'Mixins', 'app/mixins'
-  add_group 'Policies', 'app/policies'
-  add_group 'Queries', 'app/queries'
-  add_group 'Services', 'app/services'
-  add_group 'Validators', 'app/validators'
+
+  group 'Components', 'app/components'
+  group 'Datatables', 'app/datatables'
+  group 'Instrumentations', 'app/instrumentations'
+  group 'Mixins', 'app/mixins'
+  group 'Policies', 'app/policies'
+  group 'Queries', 'app/queries'
+  group 'Services', 'app/services'
+  group 'Validators', 'app/validators'
 end
+

--- a/src/api/spec/spec_helper.rb
+++ b/src/api/spec/spec_helper.rb
@@ -4,7 +4,7 @@
 
 # for generating test coverage
 require 'simplecov'
-SimpleCov.start
+SimpleCov.start 'obs'
 
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../config/environment', __dir__)

--- a/src/api/test/test_helper.rb
+++ b/src/api/test/test_helper.rb
@@ -4,6 +4,7 @@ ENV['RAILS_ENV'] = 'test'
 ENV['RUNNING_MINITEST'] = '1'
 
 require 'simplecov'
+SimpleCov.start 'obs'
 require 'builder'
 require 'minitest/reporters'
 


### PR DESCRIPTION
Remove the simplecov deprecations. 

Some where old .simplecov syntax.
Some were warnings because we were loading the simplecov framework twice, once implicitly (when using `SimpleCov.start 'rails'` in `.simplecov`) and once explicitly (another `SimpleCov.start` in the test helpers). Now, we define the profile inside `.simplecov` and then we start it explicitly from the test helpers.