### PR TITLE
Fix WorkflowArtifactsPerStep double-encoded artifacts

### DIFF
--- a/src/api/app/components/workflow_artifacts_per_step_component.rb
+++ b/src/api/app/components/workflow_artifacts_per_step_component.rb
@@ -12,7 +12,7 @@ class WorkflowArtifactsPerStepComponent < ApplicationComponent
   end
 
   def call
-    parsed_artifacts = JSON.parse(artifacts).deep_symbolize_keys
+    parsed_artifacts = (artifacts.is_a?(Hash) ? artifacts : JSON.parse(artifacts)).deep_symbolize_keys
 
     case step
     when 'Workflow::Step::BranchPackageStep'

--- a/src/api/app/services/workflows/artifacts_collector.rb
+++ b/src/api/app/services/workflows/artifacts_collector.rb
@@ -31,7 +31,7 @@ module Workflows
                       target_project: @step.target_project_name
                     }
                   end
-      WorkflowArtifactsPerStep.find_or_create_by(workflow_run_id: @workflow_run_id, step: @step.class.name, artifacts: artifacts.to_json) if artifacts
+      WorkflowArtifactsPerStep.find_or_create_by(workflow_run_id: @workflow_run_id, step: @step.class.name, artifacts: artifacts) if artifacts
     end
   end
 end

--- a/src/api/db/data/20260723130859_fix_double_encoded_workflow_artifacts.rb
+++ b/src/api/db/data/20260723130859_fix_double_encoded_workflow_artifacts.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class FixDoubleEncodedWorkflowArtifacts < ActiveRecord::Migration[7.2]
+  def up
+    WorkflowArtifactsPerStep.find_each do |record|
+      # AR's serialize :artifacts, coder: JSON decodes one level on read.
+      # A double-encoded record yields a String instead of a Hash after that decode.
+      next unless record.artifacts.is_a?(String)
+
+      # record.artifacts is the inner JSON string (one level already decoded by AR).
+      # Parse it into a Hash, re-encode as JSON, and write directly via raw SQL.
+      # update_columns still goes through the AR type layer for text columns, which
+      # would double-encode again, so we use raw SQL to write the value verbatim.
+      conn = WorkflowArtifactsPerStep.connection
+      single_encoded = JSON.parse(record.artifacts).to_json
+      conn.execute("UPDATE workflow_artifacts_per_steps SET artifacts = #{conn.quote(single_encoded)} WHERE id = #{record.id}")
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/src/api/db/data_schema.rb
+++ b/src/api/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 2026_06_24_131158)
+DataMigrate::Data.define(version: 2026_07_23_130859)

--- a/src/api/lib/tasks/data_backfill.rake
+++ b/src/api/lib/tasks/data_backfill.rake
@@ -32,5 +32,6 @@ namespace :data do
         data_migration[:version] == 20_250_131_143_734
       end.present?
     end
+
   end
 end

--- a/src/api/spec/components/workflow_artifacts_per_step_component_spec.rb
+++ b/src/api/spec/components/workflow_artifacts_per_step_component_spec.rb
@@ -1,0 +1,34 @@
+RSpec.describe WorkflowArtifactsPerStepComponent, type: :component do
+  let(:workflow_run) { create(:workflow_run) }
+
+  let(:record) do
+    build(:workflow_artifacts_per_step_rebuild_package,
+          workflow_run: workflow_run,
+          source_project_name: 'home:foo',
+          source_package_name: 'bar')
+  end
+
+  context 'when artifacts is a Hash (correctly serialized record)' do
+    before do
+      allow(record).to receive(:artifacts).and_return(
+        { 'project' => 'home:foo', 'package' => 'bar' }
+      )
+      render_inline(described_class.new(artifacts_per_step: record))
+    end
+
+    it { expect(rendered_content).to have_text('home:foo') }
+    it { expect(rendered_content).to have_text('bar') }
+  end
+
+  context 'when artifacts is a String (legacy double-encoded record)' do
+    before do
+      allow(record).to receive(:artifacts).and_return(
+        { project: 'home:foo', package: 'bar' }.to_json
+      )
+      render_inline(described_class.new(artifacts_per_step: record))
+    end
+
+    it { expect(rendered_content).to have_text('home:foo') }
+    it { expect(rendered_content).to have_text('bar') }
+  end
+end

--- a/src/api/spec/db/data/fix_double_encoded_workflow_artifacts_spec.rb
+++ b/src/api/spec/db/data/fix_double_encoded_workflow_artifacts_spec.rb
@@ -1,0 +1,35 @@
+require Rails.root.join('db/data/20260723130859_fix_double_encoded_workflow_artifacts.rb')
+
+RSpec.describe FixDoubleEncodedWorkflowArtifacts, type: :migration do
+  describe '#up' do
+    let(:workflow_run) { create(:workflow_run) }
+    let(:record) { create(:workflow_artifacts_per_step, workflow_run: workflow_run) }
+
+    context 'when artifacts is double-encoded (legacy record)' do
+      before do
+        # Simulate a legacy double-encoded record by writing the value directly
+        # via raw SQL, bypassing ActiveRecord's serialize layer.
+        conn = WorkflowArtifactsPerStep.connection
+        double_encoded = { source_project: 'home:foo', source_package: 'bar',
+                           target_project: 'home:foo:target', target_package: 'bar' }.to_json.to_json
+        conn.execute("UPDATE workflow_artifacts_per_steps SET artifacts = #{conn.quote(double_encoded)} WHERE id = #{record.id}")
+      end
+
+      it 'fixes the record so artifacts is deserialized as a Hash' do
+        described_class.new.up
+        expect(record.reload.artifacts).to be_a(Hash)
+      end
+
+      it 'preserves the artifacts content' do
+        described_class.new.up
+        expect(record.reload.artifacts).to include('source_project' => 'home:foo', 'source_package' => 'bar')
+      end
+    end
+
+    context 'when artifacts is already correctly encoded' do
+      it 'leaves the record unchanged' do
+        expect { described_class.new.up }.not_to(change { record.reload.artifacts })
+      end
+    end
+  end
+end

--- a/src/api/spec/factories/workflow_artifacts_per_step.rb
+++ b/src/api/spec/factories/workflow_artifacts_per_step.rb
@@ -20,7 +20,7 @@ FactoryBot.define do
       workflow_artifacts_per_step.artifacts = { source_project: evaluator.source_project_name,
                                                 source_package: evaluator.source_package_name,
                                                 target_project: evaluator.target_project_name,
-                                                target_package: evaluator.target_package_name }.to_json
+                                                target_package: evaluator.target_package_name }
     end
 
     factory :workflow_artifacts_per_step_link_package do
@@ -30,7 +30,7 @@ FactoryBot.define do
         workflow_artifacts_per_step.artifacts = { source_project: evaluator.source_project_name,
                                                   source_package: evaluator.source_package_name,
                                                   target_project: evaluator.target_project_name,
-                                                  target_package: evaluator.target_package_name }.to_json
+                                                  target_package: evaluator.target_package_name }
       end
     end
     factory :workflow_artifacts_per_step_rebuild_package do
@@ -38,7 +38,7 @@ FactoryBot.define do
 
       before(:create) do |workflow_artifacts_per_step, evaluator|
         workflow_artifacts_per_step.artifacts = { project: evaluator.source_project_name,
-                                                  package: evaluator.source_package_name }.to_json
+                                                  package: evaluator.source_package_name }
       end
     end
     factory :workflow_artifacts_per_step_trigger_services do
@@ -46,7 +46,7 @@ FactoryBot.define do
 
       before(:create) do |workflow_artifacts_per_step, evaluator|
         workflow_artifacts_per_step.artifacts = { project: evaluator.source_project_name,
-                                                  package: evaluator.source_package_name }.to_json
+                                                  package: evaluator.source_package_name }
       end
     end
     factory :workflow_artifacts_per_step_config_repositories do
@@ -66,7 +66,7 @@ FactoryBot.define do
               architectures: ['x86_64']
             }
           ]
-        }.to_json
+        }
       end
     end
     factory :workflow_artifacts_per_step_set_flags do
@@ -81,7 +81,7 @@ FactoryBot.define do
               repository: 'openSUSE_Tumbleweed',
               architecture: 'x86_64' }
           ]
-        }.to_json
+        }
       end
     end
   end

--- a/src/api/spec/services/workflows/artifacts_collector_spec.rb
+++ b/src/api/spec/services/workflows/artifacts_collector_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Workflows::ArtifactsCollector, type: :service do
 
         it do
           subject.call
-          expect(WorkflowArtifactsPerStep.last.artifacts).to eq(artifacts.to_json)
+          expect(WorkflowArtifactsPerStep.last.artifacts).to eq(artifacts.stringify_keys)
           expect(WorkflowArtifactsPerStep.last.step).to eq('Workflow::Step::BranchPackageStep')
         end
       end
@@ -59,7 +59,7 @@ RSpec.describe Workflows::ArtifactsCollector, type: :service do
 
         it do
           subject.call
-          expect(WorkflowArtifactsPerStep.last.artifacts).to eq(artifacts.to_json)
+          expect(WorkflowArtifactsPerStep.last.artifacts).to eq(artifacts.stringify_keys)
           expect(WorkflowArtifactsPerStep.last.step).to eq('Workflow::Step::BranchPackageStep')
         end
       end
@@ -82,7 +82,7 @@ RSpec.describe Workflows::ArtifactsCollector, type: :service do
 
         it do
           subject.call
-          expect(WorkflowArtifactsPerStep.last.artifacts).to eq(artifacts.to_json)
+          expect(WorkflowArtifactsPerStep.last.artifacts).to eq(artifacts.stringify_keys)
           expect(WorkflowArtifactsPerStep.last.step).to eq('Workflow::Step::BranchPackageStep')
         end
       end
@@ -121,7 +121,7 @@ RSpec.describe Workflows::ArtifactsCollector, type: :service do
 
         it do
           subject.call
-          expect(WorkflowArtifactsPerStep.last.artifacts).to eq(artifacts.to_json)
+          expect(WorkflowArtifactsPerStep.last.artifacts).to eq(artifacts.stringify_keys)
           expect(WorkflowArtifactsPerStep.last.step).to eq('Workflow::Step::LinkPackageStep')
         end
       end
@@ -144,7 +144,7 @@ RSpec.describe Workflows::ArtifactsCollector, type: :service do
 
         it do
           subject.call
-          expect(WorkflowArtifactsPerStep.last.artifacts).to eq(artifacts.to_json)
+          expect(WorkflowArtifactsPerStep.last.artifacts).to eq(artifacts.stringify_keys)
           expect(WorkflowArtifactsPerStep.last.step).to eq('Workflow::Step::LinkPackageStep')
         end
       end
@@ -167,7 +167,7 @@ RSpec.describe Workflows::ArtifactsCollector, type: :service do
 
         it do
           subject.call
-          expect(WorkflowArtifactsPerStep.last.artifacts).to eq(artifacts.to_json)
+          expect(WorkflowArtifactsPerStep.last.artifacts).to eq(artifacts.stringify_keys)
           expect(WorkflowArtifactsPerStep.last.step).to eq('Workflow::Step::LinkPackageStep')
         end
       end
@@ -196,7 +196,7 @@ RSpec.describe Workflows::ArtifactsCollector, type: :service do
 
       it do
         subject.call
-        expect(WorkflowArtifactsPerStep.last.artifacts).to eq(artifacts.to_json)
+        expect(WorkflowArtifactsPerStep.last.artifacts).to eq(artifacts.stringify_keys)
         expect(WorkflowArtifactsPerStep.last.step).to eq('Workflow::Step::RebuildPackage')
       end
     end
@@ -224,7 +224,7 @@ RSpec.describe Workflows::ArtifactsCollector, type: :service do
 
       it do
         subject.call
-        expect(WorkflowArtifactsPerStep.last.artifacts).to eq(artifacts.to_json)
+        expect(WorkflowArtifactsPerStep.last.artifacts).to eq(artifacts.stringify_keys)
         expect(WorkflowArtifactsPerStep.last.step).to eq('Workflow::Step::TriggerServices')
       end
     end
@@ -283,7 +283,7 @@ RSpec.describe Workflows::ArtifactsCollector, type: :service do
 
       it do
         subject.call
-        expect(WorkflowArtifactsPerStep.last.artifacts).to eq(artifacts.to_json)
+        expect(WorkflowArtifactsPerStep.last.artifacts).to eq(artifacts.deep_stringify_keys)
         expect(WorkflowArtifactsPerStep.last.step).to eq('Workflow::Step::ConfigureRepositories')
       end
     end
@@ -312,7 +312,7 @@ RSpec.describe Workflows::ArtifactsCollector, type: :service do
 
       it do
         subject.call
-        expect(WorkflowArtifactsPerStep.last.artifacts).to eq(artifacts.to_json)
+        expect(WorkflowArtifactsPerStep.last.artifacts).to eq(artifacts.deep_stringify_keys)
         expect(WorkflowArtifactsPerStep.last.step).to eq('Workflow::Step::SetFlags')
       end
     end


### PR DESCRIPTION
`WorkflowArtifactsPerStep` declares `serialize :artifacts, coder: JSON`, so ActiveRecord handles JSON encoding on write and decoding on read.

Both `Workflows::ArtifactsCollector` and the FactoryBot factory were calling `.to_json` on the Hash before assigning it, causing the value to be encoded twice. The database stored a JSON string whose content was itself a JSON string.

On read, ActiveRecord decoded one level and returned a `String` instead of a `Hash`, leading to inconsistent behaviour across the codebase.

This PR adds:
- A data migration to fix the wrongfully double-encoded records.
- A change in the model to understand both the wrong and the fixed records while the data migration finishes.

## Follow-up

A separate PR will remove the code to understand both record shapes, and the specs to prove the fix.

Assisted-by: OpenCode:claude-sonnet-4-6@default