### PR TITLE
Remove polymorphic association for notifications from group model

### DIFF
--- a/src/api/app/models/group.rb
+++ b/src/api/app/models/group.rb
@@ -11,7 +11,6 @@ class Group < ApplicationRecord
   has_many :relationships, dependent: :destroy, inverse_of: :group
   has_many :event_subscriptions, dependent: :destroy, inverse_of: :group
   has_many :reviews, dependent: :nullify
-  has_many :notifications, -> { order(created_at: :desc) }, as: :subscriber, dependent: :destroy
   has_and_belongs_to_many :created_notifications, class_name: 'Notification'
   has_and_belongs_to_many :shared_workflow_tokens,
                           class_name: 'Token::Workflow',


### PR DESCRIPTION
We don't use it. Notification always belong to a user. Filtering of web notifications that are associated to a group the user is a member of, happens through the join table `groups_notifications` and the `created_notifications` `has_and_belongs_to_many` association. Seems this is a leftover from the past.