### PR TITLE
[backend] BuildJob/Reproduciblecheck: do not diff the slsa provenance

### DIFF
--- a/src/backend/BSSched/BuildJob/Reproduciblecheck.pm
+++ b/src/backend/BSSched/BuildJob/Reproduciblecheck.pm
@@ -294,10 +294,12 @@ sub jobfinished {
     for my $file (ls($jobdatadir)) {
       next if $file eq 'logfile' || $file eq '_statistics' || $file eq '.needcompare';
       next if $file =~ /\.obsbinlnk$/ || $file =~ /^_blob\./;
+      next if $file eq '_slsa_provenance.json' || $file eq '_slsa_provenance.config';
       rename("$jobdatadir/$file", "$jobdatadir/b_$file");
     }
     for my $file (ls($origdst)) {
       next if $file eq 'logfile' || $file eq '_statistics' || $file eq 'meta' || $file eq 'status' || $file =~ /^\./;
+      next if $file eq '_slsa_provenance.json' || $file eq '_slsa_provenance.config';
       next if $file =~ /\.obsbinlnk$/;
       if ($file =~ /^_blob\./) {
 	BSUtil::cp("$origdst/$file", "$jobdatadir/$file") unless -e "$jobdatadir/$file";

--- a/src/backend/bs_worker
+++ b/src/backend/bs_worker
@@ -3910,7 +3910,11 @@ sub dobuild {
     getbinaries($buildinfo, $pkgdir, $srcdir, $preinstallimagedata);
     undef $oldpkgdir;
     $buildinfo->{'file'} = $ptfmode ? 'ptf.spec' : 'reproduciblecheck.spec';
-    $buildinfo->{'_no_container_normalization'} = 1 if $reproduciblecheckmode;
+    if ($reproduciblecheckmode) {
+      $buildinfo->{'_no_container_normalization'} = 1;
+      $buildinfo->{'followup_slsa_provenance'} = readstr("$srcdir/_slsa_provenance.json", 1);
+      $buildinfo->{'followup_slsa_provenance_config'} = readstr("$srcdir/_slsa_provenance.config", 1);
+    }
     @meta = split("\n", readstr("$srcdir/meta"));
   } elsif ($followupmode) {
     getfollowupsources($buildinfo, $srcdir);


### PR DESCRIPTION
Also change the worker to reuse the provenance from the build in reprocheck jobs.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
