### PR TITLE
Fix opposite order of arguments in Package.exists_on_backend?

### DIFF
--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -501,7 +501,7 @@ class Webui::PackageController < Webui::WebuiController
     linkinfo = @package.linkinfo
 
     return unless linkinfo && linkinfo['package'] && linkinfo['project']
-    return unless Package.exists_on_backend?(linkinfo['package'], linkinfo['project'])
+    return unless Package.exists_on_backend?(linkinfo['project'], linkinfo['package'])
 
     @linkinfo = { remote_project: linkinfo['project'], package: linkinfo['package'] }
   end

--- a/src/api/app/models/bs_request_action.rb
+++ b/src/api/app/models/bs_request_action.rb
@@ -739,7 +739,7 @@ class BsRequestAction < ApplicationRecord
     sp = Package.find_by_project_and_name(source_project, source_package)
     if sp.nil?
       # either not there or read permission problem
-      if Package.exists_on_backend?(source_package, source_project)
+      if Package.exists_on_backend?(source_project, source_package)
         # user is not allowed to read the source, but when they can write
         # the target, the request creator (who must have permissions to read source)
         # wanted the target owner to review it

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -293,12 +293,12 @@ class Package < ApplicationRecord
     rescue Project::UnknownObjectError
       return false
     end
-    return opts[:allow_remote_packages] && exists_on_backend?(package, project) unless prj.is_a?(Project)
+    return opts[:allow_remote_packages] && exists_on_backend?(project, package) unless prj.is_a?(Project)
 
     prj.exists_package?(package, opts)
   end
 
-  def self.exists_on_backend?(package, project)
+  def self.exists_on_backend?(project, package)
     !Backend::Api::Sources::Package.files(project, package).nil?
   rescue Backend::Error
     false

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -780,7 +780,7 @@ class Project < ApplicationRecord
           end
     if pkg.nil?
       # local project, but package may be in a linked remote one
-      opts[:allow_remote_packages] && Package.exists_on_backend?(name, self.name)
+      opts[:allow_remote_packages] && Package.exists_on_backend?(self.name, name)
     else
       pkg.project.check_access?
     end


### PR DESCRIPTION
`Package.exists_on_backend?` was defined as `(package, project)` — the opposite order of every other `Package` lookup helper (e.g. `find_by_project_and_name`, `exists_by_project_and_name`, `get_by_project_and_name`), which all take `project` first. This inconsistency is easy to get wrong.

This PR normalizes the signature to `exists_on_backend?(project, package)` and updates all call sites.

This is a pure refactor to remove a long-standing footgun. Argument semantics are preserved at every call site, so there is **no behavior change**.

Extracted as the first, lowest-risk piece of the larger PR #16545 ("setrelease improvements"), which is being split into smaller, independently reviewable PRs.