### PR TITLE
Remove redundant permission check in BuildController

### DIFF
--- a/src/api/app/controllers/build_controller.rb
+++ b/src/api/app/controllers/build_controller.rb
@@ -56,12 +56,9 @@ class BuildController < ApplicationController
         [params[:package]].flatten.each do |pack_name|
           pkg = Package.find_by_project_and_name(prj.name, Package.multibuild_flavor(pack_name))
           if pkg.nil?
-            allowed = permissions.project_change?(prj)
-            unless allowed
-              render_error status: 403, errorcode: 'execute_cmd_no_permission',
-                           message: "No permission to execute command on package #{pack_name} in project #{prj.name}"
-              return
-            end
+            render_error status: 403, errorcode: 'execute_cmd_no_permission',
+                         message: "No permission to execute command on package #{pack_name} in project #{prj.name}"
+            return
           else
             allowed = permissions.package_change?(pkg)
             unless allowed


### PR DESCRIPTION
In `BuildController`, when handling a POST build command the project permission check `permissions.project_change?(prj)` is evaluated up front and stored in `allowed` (see the top of the action). The per-package loop is only reached when `allowed` is already `false`.

For a package name with no local `Package` object (`pkg.nil?`), the old code re-ran `permissions.project_change?(prj)` — the exact same check that already returned `false` — before rendering the permission error. That branch could never grant access, so the re-check was dead code.

This PR removes the duplicated check and renders the `execute_cmd_no_permission` error directly. Pure simplification, **no behavior change**.

Extracted from the larger PR #16545 ("setrelease improvements"), which is being split into smaller, independently reviewable PRs.