### PR TITLE
Harden token trigger against untrusted webhook payloads

### DIFF
--- a/src/api/app/controllers/trigger/errors.rb
+++ b/src/api/app/controllers/trigger/errors.rb
@@ -17,6 +17,8 @@ module Trigger::Errors
     setup 'bad_request', 400, 'Token is setup with another project.'
   end
 
+  class InvalidProjectName < APIError; end
+
   class InvalidPackage < APIError
     setup 'bad_request', 400, 'Token is setup with another package.'
   end

--- a/src/api/app/controllers/trigger_controller.rb
+++ b/src/api/app/controllers/trigger_controller.rb
@@ -83,10 +83,16 @@ class TriggerController < ApplicationController
   end
 
   def set_project_name
+    # Don't take random content when people just use a random webhook on our
+    # route, e.g. GitLab sending its own data with an unrelated project hash.
+    raise InvalidProjectName if params[:project].present? && !params[:project].is_a?(String)
+
     @project_name = params[:project]
   end
 
   def set_package_name
+    return if params[:package].blank? || @project_name.blank?
+
     @package_name = params[:package]
   end
 end

--- a/src/api/spec/controllers/trigger_controller_spec.rb
+++ b/src/api/spec/controllers/trigger_controller_spec.rb
@@ -70,6 +70,14 @@ RSpec.describe TriggerController do
 
       it { expect(subject).to have_http_status(:success) }
     end
+
+    context 'with an untrusted project parameter that is not a string' do
+      # e.g. a random webhook (like GitLab) sending its own payload with a
+      # project hash. The controller must not treat that as a project name.
+      subject { post :rebuild, params: { project: { unrelated: 'payload' }, format: :xml } }
+
+      it { expect(subject).to have_http_status(:bad_request) }
+    end
   end
 
   describe '#release', :vcr do


### PR DESCRIPTION
The trigger route can be hit by arbitrary webhooks (e.g. GitLab) that send their own payload. If such a payload contains a `project` key that is not a plain string (e.g. a nested hash), `TriggerController#set_project_name` used to blindly take it as the project name.

This PR adds two guards:

- `set_project_name` now bails out unless `params[:project]` is a `String`.
- `set_package_name` now bails out unless there is both a `package` parameter and an already-resolved project name.

This prevents the controller from acting on random, unrelated webhook content. A regression test is added: an untrusted non-string `project` parameter must not result in a successful trigger.

Extracted from the larger PR #16545 ("setrelease improvements"), which is being split into smaller, independently reviewable PRs.

> Note: the original change also touched `Token::ServicePolicy` and the scmsync branch of the `Triggerable` concern. Those depend on a larger permission rework and are intentionally left out of this PR; they will come in a follow-up.