### PR TITLE
Move APIError classes to app/lib/api_error

### DIFF
--- a/src/api/app/controllers/concerns/webui/manage_relationships.rb
+++ b/src/api/app/controllers/concerns/webui/manage_relationships.rb
@@ -7,7 +7,7 @@ module Webui::ManageRelationships
       Relationship::AddRole.new(main_object, Role.find_by_title!(params[:role]), check: true, user: params[:userid], group: params[:groupid]).add_role # report error on duplicate
       main_object.store
     rescue NotFoundError,
-           Relationship::AddRole::SaveError => e
+           RelationshipSaveError => e
       flash[:error] = e.to_s
       return redirect_to(custom_users_path)
     end

--- a/src/api/app/controllers/person_controller.rb
+++ b/src/api/app/controllers/person_controller.rb
@@ -154,9 +154,6 @@ class PersonController < ApplicationController
     internal_register
   end
 
-  class ErrRegisterSave < APIError
-  end
-
   def internal_register
     xml = REXML::Document.new(request.raw_post)
 

--- a/src/api/app/controllers/request_controller.rb
+++ b/src/api/app/controllers/request_controller.rb
@@ -17,14 +17,6 @@ class RequestController < ApplicationController
     @request_list = BsRequest.page(params[:page]).order(:number).pluck(:number)
   end
 
-  class RequireFilter < APIError
-    setup 404, 'This call requires at least one filter, either by user, project or package or states or types or reviewstates'
-  end
-
-  class SaveError < APIError
-    setup 'request_save_error'
-  end
-
   def render_request_collection
     # if all params are blank, something is wrong
     raise RequireFilter if %i[project package user states types reviewstates ids].all? { |f| params[f].blank? }
@@ -231,10 +223,6 @@ class RequestController < ApplicationController
   def request_command_changereviewstate
     @req.change_review_state(params[:newstate], params)
     render_ok
-  end
-
-  class MultipleMaintenanceIncidents < APIError
-    setup 404
   end
 
   def request_command_changestate

--- a/src/api/app/controllers/search_controller.rb
+++ b/src/api/app/controllers/search_controller.rb
@@ -1,10 +1,6 @@
 class SearchController < ApplicationController
   require 'xpath_engine'
 
-  class IllegalXpathError < APIError
-    setup 'illegal_xpath_error', 400
-  end
-
   def project
     search(:project, true)
   end
@@ -287,7 +283,7 @@ class SearchController < ApplicationController
 
   def find_items(what, predicate)
     XpathEngine.new.find("/#{what}[#{predicate}]")
-  rescue ArgumentError, XpathEngine::IllegalXpathError => e
+  rescue ArgumentError => e
     message = "Error found searching elements '#{what}' with xpath predicate: '#{predicate}'."
     message += "\n\nDetailed error message from parser: #{e.message}" unless e.is_a?(ArgumentError)
 

--- a/src/api/app/controllers/source/errors.rb
+++ b/src/api/app/controllers/source/errors.rb
@@ -6,9 +6,6 @@ module Source::Errors
   class InvalidProjectNameError < APIError
   end
 
-  class InvalidPackageNameError < APIError
-  end
-
   class NoPermissionForDeleted < APIError
     setup 403, 'only admins can see deleted projects'
   end
@@ -85,8 +82,6 @@ module Source::Errors
   end
 
   class NotLocked < APIError; end
-
-  class InvalidFlag < APIError; end
 
   class ScmsyncReadOnly < APIError
     setup 403

--- a/src/api/app/controllers/source_attribute_controller.rb
+++ b/src/api/app/controllers/source_attribute_controller.rb
@@ -2,17 +2,6 @@ class SourceAttributeController < SourceController
   before_action :set_request_data, only: [:update]
   before_action :find_attribute_container
 
-  class RemoteProject < APIError
-    setup 501, 'Attribute access to remote project is not yet supported'
-  end
-
-  class InvalidAttribute < APIError
-  end
-
-  class ChangeAttributeNoPermission < APIError
-    setup 403
-  end
-
   # GET
   # /source/:project/_attribute
   # /source/:project/_attribute/:attribute
@@ -102,7 +91,7 @@ class SourceAttributeController < SourceController
                                                              use_source: false)
     else
       # project
-      raise RemoteProject if Project.remote_project?(params[:project])
+      raise RemoteProjectError, 'Attribute access to remote project is not yet supported' if Project.remote_project?(params[:project])
 
       @attribute_container = Project.get_by_name(params[:project])
     end

--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -225,7 +225,7 @@ class Webui::ProjectController < Webui::WebuiController
         flash[:success] = 'Created maintenance release request ' \
                           "<a href='#{url_for(controller: 'request', action: 'show', number: req.number)}'>#{req.number}</a>"
       rescue ArchitectureOrderMissmatch,
-             Patchinfo::IncompletePatchinfo,
+             IncompletePatchinfo,
              BsRequestActionMaintenanceRelease::OpenReleaseRequests,
              BsRequestActionMaintenanceRelease::RepositoryWithoutReleaseTarget,
              BsRequestActionMaintenanceRelease::RepositoryWithoutArchitecture,

--- a/src/api/app/controllers/webui/projects/maintenance_incident_requests_controller.rb
+++ b/src/api/app/controllers/webui/projects/maintenance_incident_requests_controller.rb
@@ -34,7 +34,7 @@ module Webui
             req.save!
           end
           flash[:success] = 'Created maintenance incident request'
-        rescue MaintenanceHelper::MissingAction, BsRequestAction::UnknownProject, BsRequestAction::UnknownTargetPackage => e
+        rescue MissingAction, BsRequestAction::UnknownProject, BsRequestAction::UnknownTargetPackage => e
           flash[:error] = e.message
           redirect_back_or_to project_show_path(@project)
           return

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -56,7 +56,7 @@ class Webui::RequestController < Webui::WebuiController
       redirect_to request_show_path(@bs_request.number)
       return
     # FIXME: Use validations in the model instead of raising whenever something is wrong
-    rescue MaintenanceHelper::MissingAction
+    rescue MissingAction
       flash[:error] = 'Unable to submit, sources are unchanged'
     rescue Project::Errors::UnknownObjectError
       flash[:error] = "Unable to submit. The project '#{elide(params[:project_name])}' was not found"

--- a/src/api/app/helpers/flag_helper.rb
+++ b/src/api/app/helpers/flag_helper.rb
@@ -1,8 +1,4 @@
 module FlagHelper
-  class InvalidFlag < APIError
-    setup 'invalid_flag'
-  end
-
   TYPES = {
     'lock' => :disable,
     'build' => :enable,

--- a/src/api/app/helpers/maintenance_helper.rb
+++ b/src/api/app/helpers/maintenance_helper.rb
@@ -1,10 +1,4 @@
 module MaintenanceHelper
-  class MissingAction < APIError
-    setup 400, 'The request contains no actions. Submit requests without source changes may have skipped!'
-  end
-
-  class MultipleUpdateInfoTemplate < APIError; end
-
   def release_package(source_package, target, target_package_name, opts = {})
     filter_source_repository = opts[:repository]
     filter_architecture      = opts[:arch]

--- a/src/api/app/lib/api_error/attribute_not_set_error.rb
+++ b/src/api/app/lib/api_error/attribute_not_set_error.rb
@@ -1,0 +1,3 @@
+class AttributeNotSetError < APIError
+  setup 'attribute_not_set', 400
+end

--- a/src/api/app/lib/api_error/attribute_save_error.rb
+++ b/src/api/app/lib/api_error/attribute_save_error.rb
@@ -1,0 +1,1 @@
+class AttributeSaveError < APIError; end

--- a/src/api/app/lib/api_error/change_attribute_no_permission.rb
+++ b/src/api/app/lib/api_error/change_attribute_no_permission.rb
@@ -1,0 +1,3 @@
+class ChangeAttributeNoPermission < APIError
+  setup 403
+end

--- a/src/api/app/lib/api_error/err_register_save.rb
+++ b/src/api/app/lib/api_error/err_register_save.rb
@@ -1,0 +1,1 @@
+class ErrRegisterSave < APIError; end

--- a/src/api/app/lib/api_error/excluded_request_not_found.rb
+++ b/src/api/app/lib/api_error/excluded_request_not_found.rb
@@ -1,0 +1,3 @@
+class ExcludedRequestNotFound < APIError
+  setup 'invalid_request'
+end

--- a/src/api/app/lib/api_error/failed_to_retrieve_build_info.rb
+++ b/src/api/app/lib/api_error/failed_to_retrieve_build_info.rb
@@ -1,0 +1,3 @@
+class FailedToRetrieveBuildInfo < APIError
+  setup 404
+end

--- a/src/api/app/lib/api_error/illegal_xpath_error.rb
+++ b/src/api/app/lib/api_error/illegal_xpath_error.rb
@@ -1,0 +1,4 @@
+
+class IllegalXpathError < APIError
+  setup 'illegal_xpath_error', 400
+end

--- a/src/api/app/lib/api_error/incomplete_patchinfo.rb
+++ b/src/api/app/lib/api_error/incomplete_patchinfo.rb
@@ -1,0 +1,1 @@
+class IncompletePatchinfo < APIError; end

--- a/src/api/app/lib/api_error/invalid_attribute_error.rb
+++ b/src/api/app/lib/api_error/invalid_attribute_error.rb
@@ -1,0 +1,1 @@
+class InvalidAttributeError < APIError; end

--- a/src/api/app/lib/api_error/invalid_flag.rb
+++ b/src/api/app/lib/api_error/invalid_flag.rb
@@ -1,0 +1,1 @@
+class InvalidFlag < APIError; end

--- a/src/api/app/lib/api_error/invalid_package_name_error.rb
+++ b/src/api/app/lib/api_error/invalid_package_name_error.rb
@@ -1,0 +1,1 @@
+class InvalidPackageNameError < APIError; end

--- a/src/api/app/lib/api_error/invalid_request_format.rb
+++ b/src/api/app/lib/api_error/invalid_request_format.rb
@@ -1,0 +1,1 @@
+class InvalidRequestFormat < APIError; end

--- a/src/api/app/lib/api_error/issue_tracker_not_found_error.rb
+++ b/src/api/app/lib/api_error/issue_tracker_not_found_error.rb
@@ -1,0 +1,3 @@
+class IssueTrackerNotFoundError < APIError
+  setup 'issue_tracker_not_found', 404, 'Issue Tracker not found'
+end

--- a/src/api/app/lib/api_error/missing_action.rb
+++ b/src/api/app/lib/api_error/missing_action.rb
@@ -1,0 +1,3 @@
+class MissingAction < APIError
+  setup 400, 'The request contains no actions. Submit requests without source changes may have skipped!'
+end

--- a/src/api/app/lib/api_error/multiple_maintenance_incidents.rb
+++ b/src/api/app/lib/api_error/multiple_maintenance_incidents.rb
@@ -1,0 +1,3 @@
+class MultipleMaintenanceIncidents < APIError
+  setup 404
+end

--- a/src/api/app/lib/api_error/multiple_update_info_template.rb
+++ b/src/api/app/lib/api_error/multiple_update_info_template.rb
@@ -1,0 +1,1 @@
+class MultipleUpdateInfoTemplate < APIError; end

--- a/src/api/app/lib/api_error/no_maintenance_release_target.rb
+++ b/src/api/app/lib/api_error/no_maintenance_release_target.rb
@@ -1,0 +1,3 @@
+class NoMaintenanceReleaseTarget < APIError
+  setup 'no_maintenance_release_target'
+end

--- a/src/api/app/lib/api_error/no_repositories_found.rb
+++ b/src/api/app/lib/api_error/no_repositories_found.rb
@@ -1,0 +1,3 @@
+class NoRepositoriesFound < APIError
+  setup 404, 'No repositories build against target'
+end

--- a/src/api/app/lib/api_error/patchinfo_file_exists.rb
+++ b/src/api/app/lib/api_error/patchinfo_file_exists.rb
@@ -1,0 +1,1 @@
+class PatchinfoFileExists < APIError; end

--- a/src/api/app/lib/api_error/patchinfo_not_found.rb
+++ b/src/api/app/lib/api_error/patchinfo_not_found.rb
@@ -1,0 +1,3 @@
+class PatchinfoNotFound < APIError
+  setup 404
+end

--- a/src/api/app/lib/api_error/relationship_save_error.rb
+++ b/src/api/app/lib/api_error/relationship_save_error.rb
@@ -1,0 +1,2 @@
+class RelationshipSaveError < APIError
+end

--- a/src/api/app/lib/api_error/releasetarget_not_found.rb
+++ b/src/api/app/lib/api_error/releasetarget_not_found.rb
@@ -1,0 +1,3 @@
+class ReleasetargetNotFound < APIError
+  setup 404
+end

--- a/src/api/app/lib/api_error/request_save_error.rb
+++ b/src/api/app/lib/api_error/request_save_error.rb
@@ -1,0 +1,3 @@
+class RequestSaveError < APIError
+  setup 'request_save_error'
+end

--- a/src/api/app/lib/api_error/require_filter.rb
+++ b/src/api/app/lib/api_error/require_filter.rb
@@ -1,0 +1,3 @@
+class RequireFilter < APIError
+  setup 404, 'This call requires at least one filter, either by user, project or package or states or types or reviewstates'
+end

--- a/src/api/app/lib/api_error/review_not_found_error.rb
+++ b/src/api/app/lib/api_error/review_not_found_error.rb
@@ -1,0 +1,3 @@
+class ReviewNotFoundError < APIError
+  setup 'review_not_found', 404, 'Review not found'
+end

--- a/src/api/app/lib/api_error/unknown_attribute_type_error.rb
+++ b/src/api/app/lib/api_error/unknown_attribute_type_error.rb
@@ -1,0 +1,3 @@
+class UnknownAttributeTypeError < APIError
+  setup 'unknown_attribute_type', 404, 'Unknown Attribute Type'
+end

--- a/src/api/app/lib/routes_helper/webui_matcher.rb
+++ b/src/api/app/lib/routes_helper/webui_matcher.rb
@@ -1,8 +1,5 @@
 module RoutesHelper
   class WebuiMatcher
-    class InvalidRequestFormat < APIError
-    end
-
     def self.matches?(request)
       request.format.to_sym != :xml || formatless_path?(request)
     rescue ArgumentError => e

--- a/src/api/app/models/attrib_type.rb
+++ b/src/api/app/models/attrib_type.rb
@@ -3,13 +3,6 @@ class AttribType < ApplicationRecord
   #### Includes and extends
   #### Constants
   #### Self config
-  class UnknownAttributeTypeError < APIError
-    setup 'unknown_attribute_type', 404, 'Unknown Attribute Type'
-  end
-
-  class InvalidAttributeError < APIError
-  end
-
   #### Attributes
   #### Associations macros (Belongs to, Has one, Has many)
   belongs_to :attrib_namespace

--- a/src/api/app/models/binary_release.rb
+++ b/src/api/app/models/binary_release.rb
@@ -1,6 +1,4 @@
 class BinaryRelease < ApplicationRecord
-  class SaveError < APIError; end
-
   # These aliases are the attribute names the backend uses to represent a BinaryRelease
   # Having these makes it easier for us to transpose one into the other.
   alias_attribute :name, :binary_name

--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -129,7 +129,7 @@ class BsRequest < ApplicationRecord
   def self.new_from_xml(xml)
     hashed = Xmlhash.parse(xml)
 
-    raise SaveError, 'Failed parsing the request xml' unless hashed
+    raise RequestSaveError, 'Failed parsing the request xml' unless hashed
 
     new_from_hash(hashed)
   end
@@ -204,7 +204,7 @@ class BsRequest < ApplicationRecord
       str = hashed.value('accept_at')
       request.accept_at = Time.parse(str) if str
       hashed.delete('accept_at')
-      raise SaveError, 'Auto accept time is in the past' if request.accept_at && request.accept_at < Time.now
+      raise RequestSaveError, 'Auto accept time is in the past' if request.accept_at && request.accept_at < Time.now
 
       # we do not support to import history anymore on purpose
       # would be all fake, but means also history gets lost when
@@ -629,9 +629,9 @@ class BsRequest < ApplicationRecord
       user_review = reviews.where(by_user: reviewer.login).last
       # Set the by_group/project/package reviews to :new and destroy the user review
       if opts[:revert]
-        raise Review::NotFoundError unless user_review
+        raise ReviewNotFoundError unless user_review
         raise InvalidStateError, 'review is not in new state' unless user_review.state == :new
-        raise Review::NotFoundError, 'Not an assigned review' unless HistoryElement::ReviewAssigned.where(op_object_id: user_review.id).last
+        raise ReviewNotFoundError, 'Not an assigned review' unless HistoryElement::ReviewAssigned.where(op_object_id: user_review.id).last
 
         reassign_reviews(reviewer, opts)
 
@@ -703,7 +703,7 @@ class BsRequest < ApplicationRecord
 
       old_request_state = state
       review = find_review_for_opts(opts)
-      raise Review::NotFoundError unless review
+      raise ReviewNotFoundError unless review
 
       # Neither the state nor the reason is changing...
       return if review.state == new_review_state && review.reviewer == User.session!.login && review.reason == opts[:comment].to_s
@@ -771,7 +771,7 @@ class BsRequest < ApplicationRecord
   def setpriority(opts)
     permission_check_setpriority!
 
-    raise SaveError, "Illegal priority '#{opts[:priority]}'" unless opts[:priority].in?(VALID_REQUEST_PRIORITIES)
+    raise RequestSaveError, "Illegal priority '#{opts[:priority]}'" unless opts[:priority].in?(VALID_REQUEST_PRIORITIES)
 
     p = { request: self, user_id: User.session!.id, description_extension: "#{priority} => #{opts[:priority]}" }
     p[:comment] = opts[:comment] if opts[:comment]
@@ -925,8 +925,8 @@ class BsRequest < ApplicationRecord
     self.creator ||= User.session!.login
     self.commenter ||= User.session!.login
     # FIXME: Move permission checks to controller level
-    raise SaveError, 'Admin permissions required to set request creator to foreign user' unless self.creator == User.session!.login || User.admin_session?
-    raise SaveError, 'Admin permissions required to set request commenter to foreign user' unless self.commenter == User.session!.login || User.admin_session?
+    raise RequestSaveError, 'Admin permissions required to set request creator to foreign user' unless self.creator == User.session!.login || User.admin_session?
+    raise RequestSaveError, 'Admin permissions required to set request commenter to foreign user' unless self.commenter == User.session!.login || User.admin_session?
 
     # ensure correct initial values, no matter what has been sent to us
     self.state = :new
@@ -983,7 +983,7 @@ class BsRequest < ApplicationRecord
       newactions.concat(new_action)
     end
     # will become an empty request
-    raise MaintenanceHelper::MissingAction if newactions.empty? && oldactions.size == bs_request_actions.size
+    raise MissingAction if newactions.empty? && oldactions.size == bs_request_actions.size
 
     oldactions.each { |a| bs_request_actions.destroy(a) }
     newactions.each { |a| bs_request_actions << a }
@@ -1237,13 +1237,13 @@ class BsRequest < ApplicationRecord
   end
 
   def reassign_reviews(reviewer, opts, new_review = nil)
-    raise Review::NotFoundError unless opts[:by_group] || opts[:by_project] || opts[:by_package]
+    raise ReviewNotFoundError unless opts[:by_group] || opts[:by_project] || opts[:by_package]
 
     reviews_to_reassign = reviews.where(by_group: opts[:by_group]) if opts[:by_group]
     reviews_to_reassign = reviews.where(by_project: opts[:by_project], by_package: opts[:by_package]) if opts[:by_project] && opts[:by_package]
     reviews_to_reassign = reviews.where(by_project: opts[:by_project]) if opts[:by_project] && !opts[:by_package]
 
-    raise Review::NotFoundError unless reviews_to_reassign.any?
+    raise ReviewNotFoundError unless reviews_to_reassign.any?
 
     reviews_to_reassign.reverse_each do |review|
       if opts[:revert]

--- a/src/api/app/models/bs_request/errors.rb
+++ b/src/api/app/models/bs_request/errors.rb
@@ -15,10 +15,6 @@ module BsRequest::Errors
     setup 'under_embargo', 400
   end
 
-  class SaveError < APIError
-    setup 'request_save_error'
-  end
-
   class AddReviewNotPermitted < APIError
     setup 403
   end

--- a/src/api/app/models/bs_request_action.rb
+++ b/src/api/app/models/bs_request_action.rb
@@ -688,7 +688,7 @@ class BsRequestAction < ApplicationRecord
     # empty submission protection
     if action_type.in?(%i[submit maintenance_incident]) && target_package &&
        Package.exists_by_project_and_name(target_project, target_package, follow_project_links: false)
-      raise MaintenanceHelper::MissingAction unless contains_change?
+      raise MissingAction unless contains_change?
 
       return
     end

--- a/src/api/app/models/bs_request_action_maintenance_incident.rb
+++ b/src/api/app/models/bs_request_action_maintenance_incident.rb
@@ -3,12 +3,7 @@ class BsRequestActionMaintenanceIncident < BsRequestAction
   include BsRequestAction::Differ
 
   #### Constants
-
   #### Self config
-  class NoMaintenanceReleaseTarget < APIError
-    setup 'no_maintenance_release_target'
-  end
-
   #### Attributes
   #### Associations macros (Belongs to, Has one, Has many)
   #### Callbacks macros: before_save, after_save, etc.

--- a/src/api/app/models/concerns/has_attributes.rb
+++ b/src/api/app/models/concerns/has_attributes.rb
@@ -2,9 +2,6 @@
 module HasAttributes
   extend ActiveSupport::Concern
 
-  class AttributeSaveError < APIError
-  end
-
   def write_attributes
     return unless CONFIG['global_write_through']
 

--- a/src/api/app/models/concerns/has_relationships.rb
+++ b/src/api/app/models/concerns/has_relationships.rb
@@ -2,9 +2,6 @@
 module HasRelationships
   extend ActiveSupport::Concern
 
-  class SaveError < APIError
-  end
-
   def add_user(user, role, ignore_lock = nil)
     Relationship.add_user(self, user, role, ignore_lock)
   end
@@ -161,7 +158,7 @@ module HasRelationships
       group = Group.find_by_title(id)
       return group if group
 
-      raise SaveError, "unknown group '#{id}'"
+      raise RelationshipSaveError, "unknown group '#{id}'"
     end
   end
 
@@ -179,7 +176,7 @@ module HasRelationships
     # we keep the relationships
     xmlhash.elements(@updater.xml_element) do |node|
       role = Role.hashed[node['role']]
-      raise SaveError, "illegal role name '#{node['role']}'" unless role
+      raise RelationshipSaveError, "illegal role name '#{node['role']}'" unless role
 
       id = @updater.id(node)
       item = @updater.find!(id)

--- a/src/api/app/models/issue.rb
+++ b/src/api/app/models/issue.rb
@@ -21,7 +21,7 @@ class Issue < ApplicationRecord
     unless issue_tracker
       return if options[:nonfatal]
 
-      raise IssueTracker::NotFoundError, "Error: Issue Tracker '#{issue_tracker_name}' not found."
+      raise IssueTrackerNotFoundError, "Error: Issue Tracker '#{issue_tracker_name}' not found."
     end
 
     issue = issue_tracker.issues.find_by_name(name)

--- a/src/api/app/models/issue_tracker.rb
+++ b/src/api/app/models/issue_tracker.rb
@@ -2,11 +2,6 @@ require 'xmlrpc/client'
 
 class IssueTracker < ApplicationRecord
   has_many :issues, dependent: :destroy
-
-  class NotFoundError < APIError
-    setup 'issue_tracker_not_found', 404, 'Issue Tracker not found'
-  end
-
   validates :name, :regex, :url, :kind, presence: true
   validates :name, :regex, uniqueness: { case_sensitive: true }
   validates :kind, inclusion: { in: %w[other bugzilla cve fate trac launchpad sourceforge github jira debbugs] }

--- a/src/api/app/models/owner_search/base.rb
+++ b/src/api/app/models/owner_search/base.rb
@@ -1,9 +1,5 @@
 module OwnerSearch
   class Base
-    class AttributeNotSetError < APIError
-      setup 'attribute_not_set', 400
-    end
-
     def devel_disabled?(project = nil)
       return %w[0 false].include?(params[:devel]) if params[:devel]
 

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -539,7 +539,7 @@ class Package < ApplicationRecord
       xml.elements('issue') do |i|
         current_issues['kept'] ||= []
         current_issues['kept'] << Issue.find_or_create_by_name_and_tracker(i['id'], i['tracker'])
-      rescue IssueTracker::NotFoundError => e
+      rescue IssueTrackerNotFoundError => e
         # if the issue is invalid, we ignore it
         Rails.logger.debug e
       end

--- a/src/api/app/models/package_build_status.rb
+++ b/src/api/app/models/package_build_status.rb
@@ -1,12 +1,4 @@
 class PackageBuildStatus
-  class NoRepositoriesFound < APIError
-    setup 404, 'No repositories build against target'
-  end
-
-  class FailedToRetrieveBuildInfo < APIError
-    setup 404
-  end
-
   def initialize(pkg)
     @pkg = pkg
   end

--- a/src/api/app/models/patchinfo.rb
+++ b/src/api/app/models/patchinfo.rb
@@ -5,24 +5,6 @@
 class Patchinfo
   include ActiveModel::Model
 
-  class PatchinfoFileExists < APIError; end
-
-  class IncompletePatchinfo < APIError; end
-
-  class InvalidPackageNameError < APIError; end
-
-  class ReleasetargetNotFound < APIError
-    setup 404
-  end
-
-  class TrackerNotFound < APIError
-    setup 404
-  end
-
-  class PatchinfoNotFound < APIError
-    setup 404
-  end
-
   # FIXME: Layout and colors belong to CSS
   RATING_COLORS = {
     'low' => 'green',
@@ -95,7 +77,7 @@ class Patchinfo
     # valid tracker?
     data.elements('issue').each do |i|
       tracker = IssueTracker.find_by_name(i['tracker'])
-      raise TrackerNotFound, "Tracker #{i['tracker']} is not registered in this OBS instance" unless tracker
+      raise IssueTrackerNotFoundError, "Tracker #{i['tracker']} is not registered in this OBS instance" unless tracker
 
       issue = Issue.new(name: i['id'], issue_tracker: tracker)
       raise Issue::InvalidName, issue.errors.full_messages.to_sentence unless issue.valid?

--- a/src/api/app/models/relationship/add_role.rb
+++ b/src/api/app/models/relationship/add_role.rb
@@ -1,6 +1,4 @@
 class Relationship::AddRole
-  class SaveError < APIError; end
-
   def initialize(package_or_project, role, opts)
     self.package_or_project = package_or_project
     self.role = role
@@ -24,7 +22,7 @@ class Relationship::AddRole
 
   def duplicate?
     return false unless package_or_project.relationships.exists?(user: user, group: group, role: role)
-    raise SaveError, 'Relationship already exists' if check
+    raise RelationshipSaveError, 'Relationship already exists' if check
 
     true
   end
@@ -44,6 +42,6 @@ class Relationship::AddRole
     return unless role.global
 
     # only nonglobal roles may be set in an object
-    raise SaveError, "tried to set global role '#{role.title}' in #{package_or_project.class} '#{package_or_project.name}'"
+    raise RelationshipSaveError, "tried to set global role '#{role.title}' in #{package_or_project.class} '#{package_or_project.name}'"
   end
 end

--- a/src/api/app/models/review.rb
+++ b/src/api/app/models/review.rb
@@ -1,10 +1,6 @@
 class Review < ApplicationRecord
   include ActiveModel::Validations
 
-  class NotFoundError < APIError
-    setup 'review_not_found', 404, 'Review not found'
-  end
-
   VALID_REVIEW_STATES = %i[new declined accepted superseded obsoleted].freeze
 
   belongs_to :bs_request, touch: true, optional: true

--- a/src/api/app/models/service.rb
+++ b/src/api/app/models/service.rb
@@ -3,8 +3,6 @@ class Service
   include ActiveModel::Model
   include Package::Errors
 
-  class InvalidParameter < APIError; end
-
   attr_accessor :package
 
   # helper function
@@ -20,10 +18,10 @@ class Service
 
   def self.verify_xml!(raw_post)
     Xmlhash.parse(raw_post).elements('service').each do |s|
-      raise InvalidParameter, "service name #{s['name']} contains invalid chars" unless Service::NameValidator.new(s['name']).valid?
+      raise InvalidParameterError, "service name #{s['name']} contains invalid chars" unless Service::NameValidator.new(s['name']).valid?
 
       s.elements('param').each do |p|
-        raise InvalidParameter, "service parameter #{p['name']} contains invalid chars" unless Service::NameValidator.new(p['name']).valid?
+        raise InvalidParameterError, "service parameter #{p['name']} contains invalid chars" unless Service::NameValidator.new(p['name']).valid?
       end
     end
   end

--- a/src/api/app/models/staging/excluded_request_not_found.rb
+++ b/src/api/app/models/staging/excluded_request_not_found.rb
@@ -1,3 +1,0 @@
-class Staging::ExcludedRequestNotFound < APIError
-  setup 'invalid_request'
-end

--- a/src/api/app/models/staging/request_excluder.rb
+++ b/src/api/app/models/staging/request_excluder.rb
@@ -25,7 +25,7 @@ class Staging::RequestExcluder
     errors << "Requests with number #{non_excluded_requests.to_sentence} are not excluded" if non_excluded_requests.any?
     return self if valid?
 
-    raise Staging::ExcludedRequestNotFound, errors.to_sentence
+    raise ExcludedRequestNotFound, errors.to_sentence
   end
 
   def destroy!
@@ -33,7 +33,7 @@ class Staging::RequestExcluder
     destroy
     return if valid?
 
-    raise Staging::ExcludedRequestNotFound, errors.to_sentence
+    raise ExcludedRequestNotFound, errors.to_sentence
   end
 
   def errors

--- a/src/api/app/models/staging/staged_requests.rb
+++ b/src/api/app/models/staging/staged_requests.rb
@@ -16,7 +16,7 @@ class Staging::StagedRequests
 
     return if valid?
 
-    raise Staging::ExcludedRequestNotFound, errors.to_sentence
+    raise ExcludedRequestNotFound, errors.to_sentence
   end
 
   def destroy

--- a/src/api/app/models/unregistered_user.rb
+++ b/src/api/app/models/unregistered_user.rb
@@ -1,7 +1,4 @@
 class UnregisteredUser < User
-  class ErrRegisterSave < APIError
-  end
-
   # Raises an exception if registration is disabled for a user
   # Returns true if a user can register
   def self.can_register?

--- a/src/api/config/initializers/airbrake.rb
+++ b/src/api/config/initializers/airbrake.rb
@@ -107,7 +107,7 @@ def ignore_by_class?(notice)
                           'ActiveRecord::RecordNotFound', 'Backend::NotFoundError',
                           'CGI::Session::CookieStore::TamperedWithCookie',
                           'Interrupt', 'Net::HTTPBadResponse',
-                          'RoutesHelper::WebuiMatcher::InvalidRequestFormat']
+                          'InvalidRequestFormat']
 
   notice[:errors].pluck(:type).intersect?(exceptions_to_ignore)
 end

--- a/src/api/lib/xpath_engine.rb
+++ b/src/api/lib/xpath_engine.rb
@@ -2,8 +2,6 @@
 class XpathEngine
   require 'rexml/parsers/xpathparser'
 
-  class IllegalXpathError < ArgumentError; end
-
   def initialize
     @lexer = REXML::Parsers::XPathParser.new
 
@@ -258,21 +256,21 @@ class XpathEngine
     rescue NoMethodError
       # if the input contains a [ in random place, rexml will throw
       #  undefined method `[]' for nil:NilClass
-      raise IllegalXpathError, 'failed to parse xpath expression'
+      raise ArgumentError, 'failed to parse xpath expression'
     rescue REXML::ParseException => e
-      raise IllegalXpathError, e.message
+      raise ArgumentError, e.message
     end
     # logger.debug "starting stack: #{@stack.inspect}"
 
-    raise IllegalXpathError, 'xpath expression has to begin with root node' if @stack.shift != :document
+    raise ArgumentError, 'xpath expression has to begin with root node' if @stack.shift != :document
 
-    raise IllegalXpathError, 'xpath expression has to begin with root node' if @stack.shift != :child
+    raise ArgumentError, 'xpath expression has to begin with root node' if @stack.shift != :child
 
     @stack.shift
     @stack.shift
     tablename = @stack.shift
     @base_table = @tables[tablename]
-    raise IllegalXpathError, "unknown table #{tablename}" unless @base_table
+    raise ArgumentError, "unknown table #{tablename}" unless @base_table
 
     until @stack.empty?
       token = @stack.shift
@@ -283,16 +281,16 @@ class XpathEngine
            :namespace, :parent, :preceding, :preceding_sibling
         nil
       when :self
-        raise IllegalXpathError, "axis '#{token}' not supported"
+        raise ArgumentError, "axis '#{token}' not supported"
       when :child
-        raise IllegalXpathError, "non :qname token after :child token: #{token.inspect}" if @stack.shift != :qname
+        raise ArgumentError, "non :qname token after :child token: #{token.inspect}" if @stack.shift != :qname
 
         @stack.shift # namespace
         @stack.shift # node
       when :predicate
         parse_predicate([], @stack.shift)
       else
-        raise IllegalXpathError, "Unhandled token '#{token.inspect}'"
+        raise ArgumentError, "Unhandled token '#{token.inspect}'"
       end
     end
 
@@ -373,7 +371,7 @@ class XpathEngine
     # logger.debug "------------------ predicate ---------------"
     # logger.debug "-- pred_array: #{stack.inspect} --"
 
-    raise IllegalXpathError, 'invalid predicate' if stack.nil?
+    raise ArgumentError, 'invalid predicate' if stack.nil?
 
     until stack.empty?
       token = stack.shift
@@ -381,7 +379,7 @@ class XpathEngine
       when :function
         fname = stack.shift
         fname_int = "xpath_func_#{fname.tr('-', '_')}"
-        raise IllegalXpathError, "unknown xpath function '#{fname}'" unless respond_to?(fname_int)
+        raise ArgumentError, "unknown xpath function '#{fname}'" unless respond_to?(fname_int)
 
         __send__(fname_int, root, *stack.shift)
       when :child
@@ -405,17 +403,17 @@ class XpathEngine
         when :any
           # noop, already shifted
         else
-          raise IllegalXpathError, "unhandled token '#{t.inspect}'"
+          raise ArgumentError, "unhandled token '#{t.inspect}'"
         end
       when *@operators
         opname = token.to_s
         opname_int = "xpath_op_#{opname}"
-        raise IllegalXpathError, "unhandled xpath operator '#{opname}'" unless respond_to?(opname_int)
+        raise ArgumentError, "unhandled xpath operator '#{opname}'" unless respond_to?(opname_int)
 
         __send__(opname_int, root, *stack)
         stack = []
       else
-        raise IllegalXpathError, "illegal token X '#{token.inspect}'"
+        raise ArgumentError, "illegal token X '#{token.inspect}'"
       end
     end
 
@@ -444,7 +442,7 @@ class XpathEngine
 
         if @last_key && @attribs[table][@last_key][:split]
           tvalues = value.split(@attribs[table][@last_key][:split])
-          raise IllegalXpathError, 'attributes must be $NAMESPACE:$NAME' if tvalues.size != 2
+          raise ArgumentError, 'attributes must be $NAMESPACE:$NAME' if tvalues.size != 2
 
           @condition_values_needed.times { @condition_values << tvalues }
         else
@@ -453,14 +451,14 @@ class XpathEngine
         @last_key = nil
         return '?'
       else
-        raise IllegalXpathError, "illegal token: '#{token.inspect}'"
+        raise ArgumentError, "illegal token: '#{token.inspect}'"
       end
     end
     key = (root + a).join('/')
     # this is a wild hack - we need to save the key, so we can possibly split the next
     # literal. The real fix is to translate the xpath into SQL directly
     @last_key = key
-    raise IllegalXpathError, "unable to evaluate '#{key}' for '#{table}'" unless @attribs[table] && @attribs[table].key?(key)
+    raise ArgumentError, "unable to evaluate '#{key}' for '#{table}'" unless @attribs[table] && @attribs[table].key?(key)
     # logger.debug "-- found key: #{key} --"
     return if @attribs[table][key][:empty]
 

--- a/src/api/public/apidocs/components/responses/remote_project.yaml
+++ b/src/api/public/apidocs/components/responses/remote_project.yaml
@@ -1,0 +1,13 @@
+description: |
+  Bad request.
+
+  XML Schema used for body validation: [status.rng](../schema/status.rng)
+content:
+  application/xml; charset=utf-8:
+    schema:
+      $ref: '../schemas/api_response.yaml'
+    examples:
+      Unknown Project:
+        value:
+          code: remote_project
+          summary: "Attribute access to remote project is not yet supported"

--- a/src/api/public/apidocs/paths/source_project_name_attribute.yaml
+++ b/src/api/public/apidocs/paths/source_project_name_attribute.yaml
@@ -51,14 +51,7 @@ get:
       $ref: '../components/responses/unauthorized.yaml'
     '404':
       $ref: '../components/responses/unknown_project.yaml'
-    '501':
-      description: Not Implemented.
-      content:
-        application/xml; charset=utf-8:
-          schema:
-            $ref: '../components/schemas/api_response.yaml'
-          example:
-              code: remote_project
-              summary: Attribute access to remote project is not yet supported
+    '400':
+      $ref: '../components/responses/remote_project.yaml'
   tags:
     - Sources - Projects

--- a/src/api/public/apidocs/paths/source_project_name_package_name_attribute.yaml
+++ b/src/api/public/apidocs/paths/source_project_name_package_name_attribute.yaml
@@ -64,17 +64,8 @@ get:
       $ref: '../components/responses/unauthorized.yaml'
     '404':
       $ref: '../components/responses/unknown_project_or_package.yaml'
-    '501':
-      description: Not Implemented.
-      content:
-        application/xml; charset=utf-8:
-          schema:
-            $ref: '../components/schemas/api_response.yaml'
-          examples:
-            remoteProject:
-              value:
-                code: remote_project
-                summary: Attribute access to remote project is not yet supported
+    '400':
+      $ref: '../components/responses/remote_project.yaml'
   tags:
     - Sources - Packages
 

--- a/src/api/spec/controllers/webui/project_controller_spec.rb
+++ b/src/api/spec/controllers/webui/project_controller_spec.rb
@@ -644,7 +644,7 @@ RSpec.describe Webui::ProjectController, :vcr do
     end
 
     context 'when raises a non APIError' do
-      [Patchinfo::IncompletePatchinfo,
+      [IncompletePatchinfo,
        BsRequestAction::UnknownProject,
        BsRequestAction::BuildNotFinished,
        BsRequestActionMaintenanceRelease::RepositoryWithoutReleaseTarget,

--- a/src/api/spec/controllers/webui/projects/maintenance_incident_requests_controller_spec.rb
+++ b/src/api/spec/controllers/webui/projects/maintenance_incident_requests_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Webui::Projects::MaintenanceIncidentRequestsController do
         post :create, params: { project_name: maintenance_project, description: 'Fake description for a request' }
       end
 
-      it { expect(flash[:error]).to eq('MaintenanceHelper::MissingAction') }
+      it { expect(flash[:error]).to eq('MissingAction') }
       it { is_expected.to redirect_to(root_url) }
     end
 

--- a/src/api/spec/models/bs_request_spec.rb
+++ b/src/api/spec/models/bs_request_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe BsRequest, :vcr do
       end
 
       it 'raises exception on wrong user' do
-        expect { request.change_review_state(:accepted, by_user: someone.login) }.to raise_error(Review::NotFoundError)
+        expect { request.change_review_state(:accepted, by_user: someone.login) }.to raise_error(ReviewNotFoundError)
         expect(request.state).to be(:review)
       end
 

--- a/src/api/spec/models/relationship_spec.rb
+++ b/src/api/spec/models/relationship_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Relationship do
     context 'with a global role' do
       let(:role) { global_role }
 
-      it { expect { subject }.to raise_error(Relationship::AddRole::SaveError, /tried to set global role/) }
+      it { expect { subject }.to raise_error(RelationshipSaveError, /tried to set global role/) }
     end
 
     context 'with an already existing relationship' do
@@ -25,7 +25,7 @@ RSpec.describe Relationship do
         project.relationships.create(user: user, role: role)
       end
 
-      it { expect { subject }.to raise_error(Relationship::AddRole::SaveError, 'Relationship already exists') }
+      it { expect { subject }.to raise_error(RelationshipSaveError, 'Relationship already exists') }
     end
 
     context 'with invalid relationship data' do
@@ -65,7 +65,7 @@ RSpec.describe Relationship do
     context 'with a global role' do
       let(:role) { global_role }
 
-      it { expect { subject }.to raise_error(Relationship::AddRole::SaveError, /tried to set global role/) }
+      it { expect { subject }.to raise_error(RelationshipSaveError, /tried to set global role/) }
     end
 
     context 'with an already existing relationship' do
@@ -73,7 +73,7 @@ RSpec.describe Relationship do
         project.relationships.create(group: group, role: role)
       end
 
-      it { expect { subject }.to raise_error(Relationship::AddRole::SaveError, 'Relationship already exists') }
+      it { expect { subject }.to raise_error(RelationshipSaveError, 'Relationship already exists') }
     end
 
     context 'with invalid relationship data' do

--- a/src/api/spec/models/service_spec.rb
+++ b/src/api/spec/models/service_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Service, :vcr do
     end
 
     it { expect { Service.verify_xml!(valid_xml) }.not_to raise_error }
-    it { expect { Service.verify_xml!(invalid_xml) }.to raise_error(Service::InvalidParameter) }
+    it { expect { Service.verify_xml!(invalid_xml) }.to raise_error(InvalidParameterError) }
   end
 
   describe '#add_download_url' do

--- a/src/api/spec/models/unregistered_user_spec.rb
+++ b/src/api/spec/models/unregistered_user_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe UnregisteredUser do
       end
 
       it 'throws an exception that confirms the user registration... and creates an unconfirmed user' do
-        expect { subject }.to raise_error(UnregisteredUser::ErrRegisterSave,
+        expect { subject }.to raise_error(ErrRegisterSave,
                                           'Thank you for signing up! An admin has to confirm your account now. Please be patient.')
         expect(User.where(attributes_for_query)).to exist
       end
@@ -70,7 +70,7 @@ RSpec.describe UnregisteredUser do
       end
 
       it 'throws an exception' do
-        expect { subject }.to raise_error(UnregisteredUser::ErrRegisterSave, 'Sorry, sign up is disabled')
+        expect { subject }.to raise_error(ErrRegisterSave, 'Sorry, sign up is disabled')
         expect(User.count).to eq(user_count_before)
       end
     end

--- a/src/api/test/functional/attributes_test.rb
+++ b/src/api/test/functional/attributes_test.rb
@@ -349,7 +349,8 @@ ription</description>
 
     # via remote link
     get '/source/RemoteInstance:home:tom/_attribute/OBS:Maintained'
-    assert_response :not_implemented
+    assert_response :not_found
+    assert_xml_tag tag: 'status', attributes: { code: 'remote_project' }
 
     # via group
     login_adrian

--- a/src/api/test/functional/maintenance_test.rb
+++ b/src/api/test/functional/maintenance_test.rb
@@ -1075,7 +1075,7 @@ class MaintenanceTests < ActionDispatch::IntegrationTest
     pi.add_child('<issue id="0815" tracker="INVALID"/>') # invalid tracker
     put "/source/#{incident_project}/patchinfo/_patchinfo", params: pi.to_xml
     assert_response :not_found
-    assert_xml_tag tag: 'status', attributes: { code: 'tracker_not_found' }
+    assert_xml_tag tag: 'status', attributes: { code: 'issue_tracker_not_found' }
     # continue
     get "/source/#{incident_project}/patchinfo/_meta"
     assert_xml_tag(parent: { tag: 'build' }, tag: 'enable', attributes: { repository: nil, arch: nil })

--- a/src/api/test/unit/package_test.rb
+++ b/src/api/test/unit/package_test.rb
@@ -156,7 +156,7 @@ class PackageTest < ActiveSupport::TestCase
                                ))
     end
 
-    assert_raise(HasRelationships::SaveError) do
+    assert_raise(RelationshipSaveError) do
       @package.update_from_xml(Xmlhash.parse(
                                  "<package name='TestBack' project='home:Iggy'>
                                    <title>My Test package</title>
@@ -182,7 +182,7 @@ class PackageTest < ActiveSupport::TestCase
     @package.add_user('tom', 'maintainer')
     @package.update_from_xml(Xmlhash.parse(orig))
 
-    assert_raise(Relationship::AddRole::SaveError) do
+    assert_raise(RelationshipSaveError) do
       @package.add_user('tom', 'Admin')
     end
     assert_equal orig, @package.render_xml

--- a/src/api/test/unit/patchinfo_test.rb
+++ b/src/api/test/unit/patchinfo_test.rb
@@ -61,7 +61,7 @@ blub
                  </description>
                  <summary>Security update for someone</summary>
                </patchinfo>"
-    assert_raise(Patchinfo::TrackerNotFound) do
+    assert_raise(IssueTrackerNotFoundError) do
       Patchinfo.new.verify_data(Project.first, content)
     end
   end


### PR DESCRIPTION
There should be one place to define these, not dozens of other classes.

Also found some duplications on the way...

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
