### PR TITLE
Use TimeComponent to render time data

### DIFF
--- a/src/api/app/views/webui/packages/job_history/index.html.haml
+++ b/src/api/app/views/webui/packages/job_history/index.html.haml
@@ -28,7 +28,7 @@
             %td
               = jobhistory.ready_time
             %td
-              = time_tag(Time.zone.at(jobhistory.ready_time))
+              = render TimeComponent.new(time: Time.zone.at(jobhistory.ready_time))
             %td
               - if jobhistory.reason == 'source change'
                 = link_to(jobhistory.reason, package_rdiff_path(project: @project.name,


### PR DESCRIPTION
PS: the `TimeComponent` still has the raw date value in the `tooltip` attribute.


## Before
<img width="1253" height="266" alt="image" src="https://github.com/user-attachments/assets/228a9d19-9d0f-4e53-8087-3cf92b249c16" />

## After
<img width="1185" height="234" alt="image" src="https://github.com/user-attachments/assets/ab59f986-4507-4e94-960f-86c9d5e686b2" />
