### PR TITLE
Review count sorting

### DIFF
--- a/src/api/app/controllers/concerns/webui/requests_filter.rb
+++ b/src/api/app/controllers/concerns/webui/requests_filter.rb
@@ -8,7 +8,9 @@ module Webui::RequestsFilter # rubocop:disable Metrics/ModuleLength
     SortBy.new(name: 'Newest to Oldest', value: 'newest', sql: 'number DESC'),
     SortBy.new(name: 'Oldest to Newest', value: 'oldest', sql: 'number'),
     SortBy.new(name: 'Most Comments', value: 'most_comments', sql: 'comments_count DESC'),
-    SortBy.new(name: 'Least Comments', value: 'least_comments', sql: 'comments_count')
+    SortBy.new(name: 'Least Comments', value: 'least_comments', sql: 'comments_count'),
+    SortBy.new(name: 'Most Reviews', value: 'most_reviews', sql: 'reviews_count DESC'),
+    SortBy.new(name: 'Least Reviews', value: 'least_reviews', sql: 'reviews_count')
   ].freeze
 
   def filter_requests

--- a/src/api/app/models/bs_request.rb
+++ b/src/api/app/models/bs_request.rb
@@ -1304,6 +1304,7 @@ end
 #  description        :text(65535)
 #  number             :integer          uniquely indexed
 #  priority           :string           default("moderate")
+#  reviews_count      :integer          default(0), not null, indexed
 #  state              :string(255)      indexed
 #  status             :integer          indexed
 #  superseded_by      :integer          indexed
@@ -1318,6 +1319,7 @@ end
 #  index_bs_requests_on_created_at          (created_at)
 #  index_bs_requests_on_creator             (creator)
 #  index_bs_requests_on_number              (number) UNIQUE
+#  index_bs_requests_on_reviews_count       (reviews_count)
 #  index_bs_requests_on_staging_project_id  (staging_project_id)
 #  index_bs_requests_on_state               (state)
 #  index_bs_requests_on_status              (status)

--- a/src/api/app/models/review.rb
+++ b/src/api/app/models/review.rb
@@ -7,7 +7,7 @@ class Review < ApplicationRecord
 
   VALID_REVIEW_STATES = %i[new declined accepted superseded obsoleted].freeze
 
-  belongs_to :bs_request, touch: true, optional: true
+  belongs_to :bs_request, touch: true, counter_cache: true, optional: true
   has_many :history_elements, -> { order(:created_at) }, class_name: 'HistoryElement::Review', foreign_key: :op_object_id
   has_many :history_elements_assigned, class_name: 'HistoryElement::ReviewAssigned', foreign_key: :op_object_id
   has_many :notifications, as: :notifiable, dependent: :delete_all

--- a/src/api/db/data/20260723180842_prefill_reviews_count_values.rb
+++ b/src/api/db/data/20260723180842_prefill_reviews_count_values.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class PrefillReviewsCountValues < ActiveRecord::Migration[7.2]
+  def up
+    # rubocop:disable Rails/SkipsModelValidations
+    Review.group(:bs_request_id).select(:bs_request_id, 'COUNT(id) as reviews_count').each do |review|
+      review.bs_request.update_columns(reviews_count: review.reviews_count)
+    end
+    # rubocop:enable Rails/SkipsModelValidations
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/src/api/db/data_schema.rb
+++ b/src/api/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 2026_07_23_130859)
+DataMigrate::Data.define(version: 2026_07_23_180842)

--- a/src/api/db/migrate/20260723180842_add_reviews_count_to_bs_requests.rb
+++ b/src/api/db/migrate/20260723180842_add_reviews_count_to_bs_requests.rb
@@ -1,0 +1,6 @@
+class AddReviewsCountToBsRequests < ActiveRecord::Migration[7.2]
+  def change
+    add_column :bs_requests, :reviews_count, :integer, default: 0, null: false
+    add_index :bs_requests, :reviews_count
+  end
+end

--- a/src/api/db/schema.rb
+++ b/src/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_05_15_101229) do
+ActiveRecord::Schema[7.2].define(version: 2026_07_23_180842) do
   create_table "active_storage_attachments", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -282,10 +282,12 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_15_101229) do
     t.integer "staging_project_id"
     t.integer "status"
     t.integer "comments_count", default: 0, null: false
+    t.integer "reviews_count", default: 0, null: false
     t.index ["comments_count"], name: "index_bs_requests_on_comments_count"
     t.index ["created_at"], name: "index_bs_requests_on_created_at"
     t.index ["creator"], name: "index_bs_requests_on_creator"
     t.index ["number"], name: "index_bs_requests_on_number", unique: true
+    t.index ["reviews_count"], name: "index_bs_requests_on_reviews_count"
     t.index ["staging_project_id"], name: "index_bs_requests_on_staging_project_id"
     t.index ["state"], name: "index_bs_requests_on_state"
     t.index ["status"], name: "index_bs_requests_on_status"

--- a/src/api/spec/db/data/prefill_reviews_count_values_spec.rb
+++ b/src/api/spec/db/data/prefill_reviews_count_values_spec.rb
@@ -1,0 +1,18 @@
+require Rails.root.join('db/data/20260723180842_prefill_reviews_count_values.rb')
+
+RSpec.describe PrefillReviewsCountValues, type: :migration do
+  describe 'up' do
+    subject { PrefillReviewsCountValues.new.up }
+
+    let(:bs_request) { create(:bs_request_with_submit_action) }
+
+    before do
+      create_list(:user_review, 3, bs_request: bs_request)
+      bs_request.update_columns(reviews_count: 0)
+    end
+
+    it 'sets reviews_count to the actual number of reviews' do
+      expect { subject }.to change { bs_request.reload.reviews_count }.from(0).to(3)
+    end
+  end
+end


### PR DESCRIPTION
The same way we can sort the requests by number of comments, we can now sort them by number of reviews.

<img width="1047" height="763" alt="Screenshot 2026-07-24 at 11-47-55 My Requests - Open Build Service" src="https://github.com/user-attachments/assets/02d0a455-53fd-4ed3-b128-6488d5414def" />
