### PR TITLE
Add missing Group Requests counter

### DIFF
--- a/src/api/app/views/webui/groups/bs_requests/index.html.haml
+++ b/src/api/app/views/webui/groups/bs_requests/index.html.haml
@@ -11,6 +11,8 @@
       %li.nav-item
         %a.nav-link.active
           Group Requests
+          %span.badge.text-bg-primary
+            = @bs_requests.size
   .card-body
     .tab-content
       .tab-pane.active


### PR DESCRIPTION
Open one of the groups under Configuration > Manage Groups and click on the [Group Requests tab](http://localhost:3000/groups/group_1/requests).

The counter was missing but now it's displayed.
<img width="1477" height="185" alt="Screenshot 2026-07-24 at 12-25-25 Requests for group_1 - Open Build Service" src="https://github.com/user-attachments/assets/8f37959d-97d3-45f9-b537-715f582c7b46" />
