### PR TITLE
Simplify set_package_name in TriggerController

### DIFF
--- a/src/api/app/controllers/trigger_controller.rb
+++ b/src/api/app/controllers/trigger_controller.rb
@@ -91,8 +91,6 @@ class TriggerController < ApplicationController
   end
 
   def set_package_name
-    return if params[:package].blank? || @project_name.blank?
-
     @package_name = params[:package]
   end
 end


### PR DESCRIPTION
Revert a superfluous change introduced in #20055.

`set_package_name` should only set the parameter; the actual project/package coherence checks live downstream in `set_project`, `set_package` and `validate_token_package`.
