### PR TITLE
Change config.action_dispatch.show_exceptions to :none

### DIFF
--- a/src/api/config/environments/test.rb
+++ b/src/api/config/environments/test.rb
@@ -29,7 +29,7 @@ Rails.application.configure do
   }
 
   # Raise exceptions instead of rendering exception templates.
-  # config.action_dispatch.show_exceptions = :none
+  config.action_dispatch.show_exceptions = :none
 
   # Store uploaded files on the local file system in a temporary directory.
   config.active_storage.service = :test
@@ -72,9 +72,6 @@ Rails.application.configure do
     Bullet.bullet_logger = true
     Bullet.raise = false # raise an error if n+1 query occurs
   end
-
-  # TODO: This shouldn't be needed when we switch to RSpec completely
-  config.action_dispatch.rescue_responses['ActionController::InvalidAuthenticityToken'] = 950
 
   config.active_job.queue_adapter = :inline
   # Access to rack session for feature specs

--- a/src/api/spec/support/vcr.rb
+++ b/src/api/spec/support/vcr.rb
@@ -4,7 +4,7 @@ require 'webmock/rspec'
 VCR.configure do |config|
   config.cassette_library_dir = 'spec/cassettes'
   config.hook_into :webmock
-  config.default_cassette_options = { record: :once }
+  config.default_cassette_options = { record: :once, allow_playback_repeats: true }
   config.allow_http_connections_when_no_cassette = true
   config.configure_rspec_metadata!
   # config.debug_logger = File.open(Rails.root.join('log', 'vcr.log'), 'w')


### PR DESCRIPTION
Change `config.action_dispatch.show_exceptions` to not swallow all exceptions during the request cycle.

This also surfaced the need to enable `allow_playback_repeats` in VCR because we frequently do something like this in specs:

```
visit /package/show/home:someproject/somepackage
click_link('Remove Whatever')
expect(page).to have_text("Removed Whatever")
visit /package/show/home:someproject/somepackage
expect(page).to have_no_link('Whatever')
```

Where both visits fire the exact same backend requests but the first visit already played back the cassette. And by default VCR does not allow a single HTTP interaction to be played back multiple times

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
