### PR TITLE
Allow to hand over setrelease via token trigger

### DIFF
--- a/src/api/app/controllers/trigger_controller.rb
+++ b/src/api/app/controllers/trigger_controller.rb
@@ -28,7 +28,8 @@ class TriggerController < ApplicationController
     opts = { project: @project, package: @package, multibuild_flavor: @multibuild_flavor,
              repository: params[:repository] || params[:filter_source_repository],
              arch: params[:arch] || params[:architecture],
-             targetproject: params[:targetproject], targetrepository: params[:targetrepository] }.compact
+             targetproject: params[:targetproject], targetrepository: params[:targetrepository],
+             setrelease: params[:setrelease] }.compact
     @token.executor.run_as { @token.call(opts) }
 
     render_ok

--- a/src/api/app/models/token/release.rb
+++ b/src/api/app/models/token/release.rb
@@ -33,6 +33,7 @@ class Token::Release < Token
              comment: 'Releasing via trigger event' }
     opts[:multibuild_container] = options[:multibuild_flavor] if options[:multibuild_flavor].present?
     opts[:arch] = options[:arch] if options[:arch].present?
+    opts[:setrelease] = options[:setrelease] if options[:setrelease].present?
 
     if package_to_release.present?
       release_package(package_to_release,
@@ -50,7 +51,12 @@ class Token::Release < Token
 
     # releasing ...
     manual_release_targets.each do |release_target|
-      next if options[:repository].present? && options[:repository] == release_target.repository.name
+      next if options[:repository].present? && options[:repository] != release_target.repository.name
+
+      if options[:targetproject].present? && options[:targetrepository].present?
+        next if options[:targetproject] != release_target.target_repository.project.name
+        next if options[:targetrepository] != release_target.target_repository.name
+      end
 
       release_target.repository.check_valid_release_target!(release_target.target_repository, options[:arch])
       release(package_to_release, release_target.repository, release_target.target_repository, time_now, options)

--- a/src/api/public/apidocs/paths/trigger_release.yaml
+++ b/src/api/public/apidocs/paths/trigger_release.yaml
@@ -37,5 +37,14 @@ post:
       schema:
         type: string
       example: openSUSE_Factory
+    - in: query
+      name: setrelease
+      description: |
+        Defines a custom release name. This overwrites milestone definitions
+        or built-in defaults.
+        Renaming can be disabled entirely by using '-'.
+      schema:
+        type: string
+      example: '20.5'
   tags:
     - Trigger


### PR DESCRIPTION
Makes the `setrelease` parameter usable through the token trigger endpoint (`/trigger/release`), forwarding it all the way down to the backend release call. `setrelease` defines a custom release name (overriding milestone definitions or built-in defaults); renaming can be disabled entirely with `-`.

It also lands the release-target filtering change that logically belongs with this feature:

- Fix the inverted condition when filtering manual release targets: skip a target when its repository does **not** match the requested `repository` (previously it skipped the matching one, i.e. `==` where it should be `!=`).
- Honor `targetproject` / `targetrepository` when filtering manual release targets.

Fixes #16544.

This is extracted from Adrian Schröter's PR #16545. Two deliberate deviations from the original commits:

1. **Dropped an obsolete line** in `TriggerController#create` (`opts[:multibuild_flavor] = @multibuild_container if @multibuild_container.present?`). `@multibuild_container` no longer exists in the current code; the multibuild flavor is already provided through `@multibuild_flavor` in the `opts` hash.

2. **Fixed the target filtering.** The original code compared against `release_target.project.name` and `release_target.name`. `release_target` is a `ReleaseTarget`, which only defines the associations `repository` (the release **source**) and `target_repository` (the release **destination**) — it has neither `#project` nor `#name`, so the original code would raise a `NoMethodError` whenever that branch was actually reached (the original specs never hit it, because they always passed `repository` too, which takes the early-return branch in `#call`). Since `targetproject` / `targetrepository` describe the release destination, the comparison now goes through `target_repository`: `release_target.target_repository.project.name` and `release_target.target_repository.name` (symmetric with the repository filter just above, which compares against `release_target.repository.name`).