### PR TITLE
Support package commands for scmsync projects

### DIFF
--- a/src/api/app/controllers/concerns/triggerable.rb
+++ b/src/api/app/controllers/concerns/triggerable.rb
@@ -15,6 +15,10 @@ module Triggerable
     package_find_options = @token.package_find_options if package_find_options.blank?
     # By default we operate on the package association
     @package = @token.package
+    if @project.scmsync.present?
+      @package ||= @package_name
+      return
+    end
     validate_token_package
 
     # If the token has no package, let's find one from the parameters

--- a/src/api/app/controllers/source/errors.rb
+++ b/src/api/app/controllers/source/errors.rb
@@ -81,6 +81,8 @@ module Source::Errors
     setup 403
   end
 
+  class Locked < APIError; end
+
   class NotLocked < APIError; end
 
   class ScmsyncReadOnly < APIError

--- a/src/api/app/controllers/source_package_command_controller.rb
+++ b/src/api/app/controllers/source_package_command_controller.rb
@@ -18,7 +18,7 @@ class SourcePackageCommandController < SourceController
   before_action :require_valid_package_name, only: %i[copy undelete]
   before_action :set_origin_package, only: %i[collectbuildenv copy diff]
   before_action :set_user_param
-  before_action :require_standard_package_object, except: %i[branch copy diff linkdiff servicediff undelete runservice]
+  before_action :require_standard_package_object, except: %i[branch copy diff linkdiff servicediff undelete runservice lock unlock]
   # branch: everything is authorized in BranchPackage.branch
   # diff: is a read only command
   # fork: everything is authorized in BranchPackage.branch
@@ -56,8 +56,40 @@ class SourcePackageCommandController < SourceController
     render_ok
   end
 
+  # lock a package
+  # POST /source/<project>/<package>?cmd=lock
+  def lock
+    if @project.scmsync.present?
+      # a package within a backend managed project
+      authorize @project, :update?
+      pass_to_backend(request.path_info + build_query_from_hash(params, [:cmd]))
+      return
+    end
+
+    require_standard_package_object
+    authorize @package, :update?
+
+    raise Locked, "package '#{@package.project.name}/#{@package.name}' is already locked" if @package.flags.find_by_flag_and_status('lock', 'enable')
+
+    # we should never have a lock-disable, but to be sure drop it in that case
+    @package.flags.of_type('lock').delete_all
+    @package.flags.create(flag: 'lock', status: 'enable')
+    @package.store({ comment: params[:comment] })
+
+    render_ok
+  end
+
   # POST /source/<project>/<package>?cmd=unlock
   def unlock
+    if @project.scmsync.present?
+      # a package within a backend managed project
+      authorize @project, :update?
+      params.require(:comment)
+      pass_to_backend(request.path_info + build_query_from_hash(params, [:cmd]))
+      return
+    end
+
+    require_standard_package_object
     authorize @package, :unlock?
 
     params.require(:comment)
@@ -446,6 +478,7 @@ class SourcePackageCommandController < SourceController
   def set_package
     options = { updatepatchinfo: { follow_project_links: false },
                 importchannel: { follow_project_links: false },
+                lock: { follow_project_links: false },
                 unlock: { follow_project_links: false },
                 addchannels: { follow_project_links: false },
                 addcontainers: { follow_project_links: false },

--- a/src/api/app/controllers/source_package_command_controller.rb
+++ b/src/api/app/controllers/source_package_command_controller.rb
@@ -18,6 +18,7 @@ class SourcePackageCommandController < SourceController
   before_action :require_valid_package_name, only: %i[copy undelete]
   before_action :set_origin_package, only: %i[collectbuildenv copy diff]
   before_action :set_user_param
+  before_action :require_standard_package_object, except: %i[branch copy diff linkdiff servicediff undelete runservice]
   # branch: everything is authorized in BranchPackage.branch
   # diff: is a read only command
   # fork: everything is authorized in BranchPackage.branch
@@ -181,9 +182,15 @@ class SourcePackageCommandController < SourceController
   # OBS 3.0: this should be obsoleted, we have /build/ controller for this
   # POST /source/<project>/<package>?cmd=rebuild
   def rebuild
-    authorize @package
+    # project is set to local project in remote case, but also set to readonly.
+    # however, this is not true for build results as they are modifiable
+    if @package.try(:project) == @project && !@package.readonly?
+      authorize @package, :update?
+    else
+      authorize @project, :update?
+    end
 
-    if params[:repo] && @project.repositories.find_by(name: params[:repo]).empty?
+    if params[:repo] && @project.repositories.find_by(name: params[:repo]).nil?
       render_error status: 400, errorcode: 'unknown_repository',
                    message: "Unknown repository '#{params[:repo]}'"
       return
@@ -355,7 +362,7 @@ class SourcePackageCommandController < SourceController
 
   # POST /source/<project>/<package>?cmd=runservice
   def runservice
-    authorize @package, :update?
+    authorize @package
 
     path = request.path_info
     path += build_query_from_hash(params, %i[cmd comment user])
@@ -471,6 +478,11 @@ class SourcePackageCommandController < SourceController
     return if Package.valid_name?(params[:package], allow_multibuild: params[:cmd] == 'release')
 
     raise InvalidPackageNameError, "invalid package name '#{params[:package]}'"
+  end
+
+  def require_standard_package_object
+    # must not come from foreign project or scmsync
+    raise CmdExecutionNoPermission, "Unable to operate on '#{params[:package]}'" unless @package.is_a?(Package)
   end
 
   def set_user_param

--- a/src/api/app/policies/package_policy.rb
+++ b/src/api/app/policies/package_policy.rb
@@ -24,16 +24,12 @@ class PackagePolicy < ApplicationPolicy
     user.can_modify_package?(record)
   end
 
-  def rebuild?
+  def runservice?
     if record.readonly?
       user.can_modify_project?(record.project)
     else
       user.can_modify_package?(record)
     end
-  end
-
-  def runservice?
-    rebuild?
   end
 
   def unlock?

--- a/src/api/app/policies/token/service_policy.rb
+++ b/src/api/app/policies/token/service_policy.rb
@@ -2,6 +2,11 @@ class Token::ServicePolicy < TokenPolicy
   def trigger?
     return false unless user.active?
 
-    PackagePolicy.new(user, record.object_to_authorize).update?
+    object = record.object_to_authorize
+    if object.is_a?(Project) && object.scmsync.present?
+      ProjectPolicy.new(user, object).update?
+    else
+      PackagePolicy.new(user, object).update?
+    end
   end
 end

--- a/src/api/config/routes/api.rb
+++ b/src/api/config/routes/api.rb
@@ -277,6 +277,7 @@ controller :source_package_command do
   constraints(cons) do
     post 'source/:project/:package' => :updatepatchinfo, constraints: ->(req) { req.params[:cmd] == 'updatepatchinfo' }
     post 'source/:project/:package' => :importchannel, constraints: ->(req) { req.params[:cmd] == 'importchannel' }
+    post 'source/:project/:package' => :lock, constraints: ->(req) { req.params[:cmd] == 'lock' }
     post 'source/:project/:package' => :unlock, constraints: ->(req) { req.params[:cmd] == 'unlock' }
     post 'source/:project/:package' => :addchannels, constraints: ->(req) { req.params[:cmd] == 'addchannels' }
     post 'source/:project/:package' => :addcontainers, constraints: ->(req) { req.params[:cmd] == 'addcontainers' }

--- a/src/api/public/apidocs/OBS-v2.10.50.yaml
+++ b/src/api/public/apidocs/OBS-v2.10.50.yaml
@@ -440,6 +440,8 @@ paths:
     $ref: 'paths/source_project_name_package_name_cmd_linkdiff.yaml'
   /source/{project_name}/{package_name}?cmd=linktobranch:
     $ref: 'paths/source_project_name_package_name_cmd_linktobranch.yaml'
+  /source/{project_name}/{package_name}?cmd=lock:
+    $ref: 'paths/source_project_name_package_name_cmd_lock.yaml'
   /source/{project_name}/{package_name}?cmd=mergeservice:
     $ref: 'paths/source_project_name_package_name_cmd_mergeservice.yaml'
   /source/{project_name}/{package_name}?cmd=rebuild:

--- a/src/api/public/apidocs/paths/source_project_name_package_name_cmd_lock.yaml
+++ b/src/api/public/apidocs/paths/source_project_name_package_name_cmd_lock.yaml
@@ -1,0 +1,54 @@
+post:
+  summary: Lock a package.
+  description: Lock a package (sets the `<lock><enable/></lock>` flag in the package `_meta` file).
+  security:
+    - basic_authentication: []
+  parameters:
+    - $ref: '../components/parameters/project_name.yaml'
+    - $ref: '../components/parameters/package_name.yaml'
+    - in: query
+      name: comment
+      required: false
+      schema:
+        type: string
+      description: Comment to be included in the revision history of the `_meta` file
+      example: Locking the package while reworking it
+  responses:
+    '200':
+      $ref: '../components/responses/succeeded.yaml'
+    '400':
+      description: |
+        Bad Request.
+
+        XML Schema used for body validation: [status.rng](../schema/status.rng)
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          examples:
+            Already locked:
+              value:
+                code: locked
+                summary: package 'home:Foo/hello_world' is already locked
+    '403':
+      description: Forbidden
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          example:
+            code: cmd_execution_no_permission
+            summary: no permission to modify package ruby in project home:Foo
+    '404':
+      description: Not Found
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          examples:
+            Not Found:
+              value:
+                code: unknown_package
+                summary: 'Package not found: openSUSE:Leap:15.0:Update/foo'
+  tags:
+    - Sources - Packages

--- a/src/api/script/start_test_backend
+++ b/src/api/script/start_test_backend
@@ -298,6 +298,13 @@ Backend::Connection.put('/source/BrokenPublishing/pack_broken_publish/myfile?use
 Backend::Connection.put('/source/BrokenPublishing/pack_broken_publish/package.spec?user=king',
                         File.read(Rails.root.join('test/fixtures/backend/binary/package.spec').to_s))
 
+# temporary hack until we have a full git server setup for fixtures:
+Backend::Connection.put('/source/ScmSync/package/_meta?user=king',
+                        '<package><scmsync>https://somewhere?subdir=package</scmsync></package>')
+prj = Project.find_by_name('ScmSync')
+prj.scmsync = "http://somwhere"
+prj.save
+
 # manual placing of files
 FileUtils.cp(Rails.root.join('test/fixtures/backend/source/_pubkey').to_s, "#{backend_data}/projects/BaseDistro.pkg/_pubkey")
 FileUtils.cp(Rails.root.join('test/fixtures/backend/source/_signkey').to_s, "#{backend_data}/projects/BaseDistro.pkg/_signkey")

--- a/src/api/test/fixtures/projects.yml
+++ b/src/api/test/fixtures/projects.yml
@@ -299,3 +299,13 @@ BrokenPublishing:
   updated_at: 2005-01-02 01:00:01.000000000 Z
   kind: standard
   delta: 1
+ScmSync:
+  name: ScmSync
+  title: This is a a project managed via git
+  description: standard scmsync project
+  created_at: 2005-01-02 01:00:01.000000000 Z
+  updated_at: 2005-01-02 01:00:01.000000000 Z
+# currently set in start_backend script
+#  scmsync: 'https://somewhere'
+  kind: standard
+  delta: 1

--- a/src/api/test/fixtures/relationships.yml
+++ b/src/api/test/fixtures/relationships.yml
@@ -194,3 +194,7 @@ record_48:
   role: maintainer
   group: test_group
   project: BrokenPublishing
+record_49:
+  role: maintainer
+  user: tom
+  project: ScmSync

--- a/src/api/test/fixtures/repositories.yml
+++ b/src/api/test/fixtures/repositories.yml
@@ -88,3 +88,7 @@ kde4_standard:
   id: 98
   name: kde4_standard
   project: kde4
+ScmSync_dummy:
+  id: 99
+  name: dummy
+  project: ScmSync

--- a/src/api/test/fixtures/repository_architectures.yml
+++ b/src/api/test/fixtures/repository_architectures.yml
@@ -127,3 +127,8 @@ kde4_repo_arch:
   position: 0
   id: 940713217
   architecture: s390
+ScmSync_dummy:
+  repository_id: 99
+  position: 0
+  id: 940713218
+  architecture: x86_64

--- a/src/api/test/functional/source_controller_test.rb
+++ b/src/api/test/functional/source_controller_test.rb
@@ -910,18 +910,34 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     put '/source/home:Iggy/TestLinkPack/_meta', params: doc.to_s
     assert_response :forbidden
 
-    # try to unlock without comment
-    post '/source/home:Iggy/TestLinkPack', params: { cmd: 'unlock' }
-    assert_response :bad_request
-    assert_xml_tag tag: 'status', attributes: { code: 'missing_parameter' }
     # without permissions
     login_adrian
     post '/source/home:Iggy/TestLinkPack', params: { cmd: 'unlock', comment: 'BlahFasel' }
     assert_response :forbidden
-    # do for real and cleanup
+    # use a valid user
     login_Iggy
+    # try to unlock without comment
+    post '/source/home:Iggy/TestLinkPack', params: { cmd: 'unlock' }
+    assert_response :bad_request
+    assert_xml_tag tag: 'status', attributes: { code: 'missing_parameter' }
+    # do for real and cleanup
     post '/source/home:Iggy/TestLinkPack', params: { cmd: 'unlock', comment: 'BlahFasel' }
     assert_response :success
+
+    # do if via the api command
+    login_Iggy
+    post '/source/home:Iggy/TestLinkPack', params: { cmd: 'lock' }
+    assert_response :success
+    get '/source/home:Iggy/TestLinkPack/_meta'
+    assert_response :success
+    assert_xml_tag tag: 'enable', parent: { tag: 'lock' }
+    post '/source/home:Iggy/TestLinkPack', params: { cmd: 'unlock', comment: 'BlahFasel' }
+    assert_response :success
+    get '/source/home:Iggy/TestLinkPack/_meta'
+    assert_response :success
+    assert_no_xml_tag tag: 'lock'
+
+    # cleanup
     delete '/source/home:Iggy/TestLinkPack'
     assert_response :success
   end
@@ -2401,6 +2417,57 @@ class SourceControllerTest < ActionDispatch::IntegrationTest
     delete '/source/home:tom:branches:BaseDistro2.0:LinkedUpdateProject'
     assert_response :success
     delete '/source/BaseDistro2.0:LinkedUpdateProject/pack2'
+    assert_response :success
+  end
+
+  def test_linked_project_operations_with_foreign_sources
+    # we have no write permissions in the packages of the linked project,
+    # but in our own one. So it depends on the kind of operation, if
+    # it is permitted or not.
+    login_tom
+    # listings
+    put '/source/home:tom:LINK/_meta', params: "<project name='home:tom:LINK'> <title/> <description/> <link project='BaseDistro2.0'/> <repository name='dummy'> <arch>x86_64</arch> </repository> </project>"
+    assert_response :success
+    get '/source/home:tom:LINK/pack2/_meta'
+    assert_response :success
+    assert_xml_tag(tag: 'package', attributes: { project: 'BaseDistro2.0' })
+
+    # source operations must not be allowed
+    post '/source/home:tom:LINK/pack2', params: { cmd: 'lock' }
+    assert_response :not_found
+    post '/source/home:tom:LINK/pack2', params: { cmd: 'commit' }
+    assert_response :not_found
+    post '/source/home:tom:LINK/pack2', params: { cmd: 'commitfilelist' }
+    assert_response :not_found
+
+    # binary operations need to be allowed
+    post '/source/home:tom:LINK/pack2', params: { cmd: 'rebuild', repo: 'dummy' }
+    assert_response :success
+    post '/build/home:tom:LINK', params: { cmd: 'rebuild', package: 'pack2' }
+    assert_response :success
+
+    # do it via remote project, so we don't have a database object in controller code
+    # we catch crashes here not expecting this...
+    put '/source/home:tom:LINK/_meta',
+        params: "<project name='home:tom:LINK'> <title/> <description/> <link project='RemoteInstance:BaseDistro2.0'/> <repository name='dummy'> <arch>x86_64</arch> </repository> </project>"
+    assert_response :success
+
+    # source operations must not be allowed
+    post '/source/home:tom:LINK/pack2', params: { cmd: 'lock' }
+    assert_response :not_found
+    post '/source/home:tom:LINK/pack2', params: { cmd: 'commit' }
+    assert_response :not_found
+    post '/source/home:tom:LINK/pack2', params: { cmd: 'commitfilelist' }
+    assert_response :not_found
+
+    # binary operations need to be allowed
+    post '/source/home:tom:LINK/pack2', params: { cmd: 'rebuild', repo: 'dummy' }
+    assert_response :success
+    post '/build/home:tom:LINK', params: { cmd: 'rebuild', package: 'pack2' }
+    assert_response :success
+
+    # cleanup
+    delete '/source/home:tom:LINK'
     assert_response :success
   end
 

--- a/src/api/test/functional/source_services_test.rb
+++ b/src/api/test/functional/source_services_test.rb
@@ -537,4 +537,108 @@ class SourceServicesTest < ActionDispatch::IntegrationTest
     delete '/source/home:tom/service2'
     assert_response :success
   end
+
+  def test_run_service_in_scmsync_project
+    # just temporary needed until we have a full git example in fixtures
+    prj = Project.find_by_name('ScmSync')
+    prj.scmsync = 'https://localhost'
+    prj.save # without writing to backend yet, since we need to fake a package in start_test_backend script
+
+    login_adrian
+    post '/person/adrian/token?operation=runservice'
+    assert_response :success
+    doc = REXML::Document.new(@response.body)
+    invalid_token = doc.elements['//data'].text
+    assert_equal 24, invalid_token.length
+
+    login_tom
+    post '/person/tom/token?operation=runservice'
+    assert_response :success
+    doc = REXML::Document.new(@response.body)
+    token = doc.elements['//data'].text
+    assert_equal 24, token.length
+
+    # ANONYMOUS
+    reset_auth
+
+    # with wrong token
+    post '/trigger/runservice?project=ScmSync&package=package', headers: { 'Authorization' => 'Token wrong' }
+    assert_response :not_found
+    assert_xml_tag tag: 'status', attributes: { code: 'not_found' }
+    post '/trigger/runservice?project=ScmSync&package=package', headers: { 'Authorization' => "Token #{invalid_token}" }
+    assert_response :forbidden
+
+    # with right token
+    post '/trigger/runservice?project=ScmSync&package=package', headers: { 'Authorization' => "Token #{token}" }
+    # success
+    # (old code did redirect to /source/PROJECT/cmd=runservice and returned with unknown command)
+    assert_response :success
+    # FIXME: check that additional files to git files materialized in backend once we
+    #        have a full scmsync fixture setup
+
+    # test permission checks for commands by a person without permissions
+    login_adrian
+    post '/source/ScmSync/package?cmd=rebuild'
+    assert_response :forbidden
+    post '/source/ScmSync/package?cmd=addcontainers'
+    assert_response :forbidden
+    post '/source/ScmSync/package?cmd=addchannels'
+    assert_response :forbidden
+    post '/source/ScmSync/package?cmd=enablechannel'
+    assert_response :forbidden
+    post '/source/ScmSync/package?cmd=instantiate'
+    assert_response :forbidden
+    post '/source/ScmSync/package?cmd=undelete'
+    assert_response :forbidden
+    post '/source/ScmSync/package?cmd=commit'
+    assert_response :forbidden
+    post '/source/ScmSync/package?cmd=commitfilelist'
+    assert_response :forbidden
+    post '/source/ScmSync/package?cmd=copy'
+    assert_response :forbidden
+    post '/source/ScmSync/package?cmd=deleteuploadrev'
+    assert_response :forbidden
+    post '/source/ScmSync/package?cmd=linktobranch'
+    assert_response :forbidden
+    post '/source/ScmSync/package?cmd=createSpecFileTemplate'
+    assert_response :forbidden
+    post '/source/ScmSync/package?cmd=lock'
+    assert_response :forbidden
+    post '/source/ScmSync/package?cmd=unlock&comment=revert'
+    assert_response :forbidden
+
+    login_tom
+    post '/source/ScmSync/package?cmd=lock'
+    assert_response :success
+    get '/source/ScmSync/package/_meta'
+    assert_response :success
+    assert_xml_tag tag: 'enable', parent: { tag: 'lock' }
+    post '/source/ScmSync/package?cmd=unlock&comment=revert'
+    assert_response :success
+    get '/source/ScmSync/package/_meta'
+    assert_response :success
+    assert_no_xml_tag tag: 'lock'
+
+    # no token, run directly as invalid user
+    login_adrian
+    post '/source/ScmSync/package?cmd=runservice'
+    assert_response :forbidden
+    # and as valid user
+    login_tom
+    post '/source/ScmSync/package?cmd=runservice'
+    assert_response :success
+  end
+
+  #  from test_run_service_via_token
+  #    # with right token, but wrong package
+  #    post '/trigger/runservice?project=home:tom&package=invalid', headers: { 'Authorization' => "Token #{token}" }
+  #    # token package is not matching the parameters
+  #    assert_response :bad_request
+  #    assert_match(/Token is registered for other package only/, @response.body)
+  #
+  #    # with right token, but wrong package
+  #    post '/trigger/runservice?project=home:tom&package=invalid', headers: { 'Authorization' => "Token #{token}" }
+  #    # token package is not matching the parameters
+  #    assert_response :bad_request
+  #    assert_match(/Token is registered for other package only/, @response.body)
 end


### PR DESCRIPTION
Reworks the package command permission handling and adds scmsync (backend-managed project) support for package commands.

### 1. Rework permission handling for package commands

Prepares `SourcePackageCommandController` and the related policies to authorize the right object depending on the command, which the scmsync commands below rely on.

- `require_standard_package_object` (before_action + method): guards commands that must operate on a real, local `Package`.

- `PackagePolicy`: the readonly-aware logic previously in `rebuild?` (with `runservice?` aliasing it) now lives directly in `runservice?`; `rebuild?` is dropped as it is no longer used.

- `rebuild` authorizes the package when it belongs to the current project and is modifiable, otherwise the project; also fixes the repository lookup guard (`find_by` returns a record or `nil`, so `.nil?` instead of `.empty?`).

- `runservice` authorizes via the `runservice?` policy (readonly-aware) instead of `update?`.

- `Token::ServicePolicy#trigger?` uses `ProjectPolicy` when the object to authorize is an scmsync `Project`.

### 2. Support lock/unlock of scmsync packages

Adds a `lock` package command and makes both `lock` and `unlock` work for packages in an scmsync project (request passed through to the backend, authorizing the project). For regular local packages the behaviour is unchanged.

- New `cmd=lock` route and OpenAPI documentation.
- New `Locked` error for the "already locked" case.

Deviations from the original: the backend pass-through uses `pass_to_backend` for both `lock` and `unlock` (the original called a `Backend::Api::Sources::Package.unlock` helper with three arguments against a two-argument definition), and the duplicated scmsync check in `unlock` is removed.

### 3. Handle scmsync packages in the token trigger

For a token triggered on an scmsync project there is no local `Package` DB object; take the package name from the parameters and return early, skipping the local-package validation and DB/remote lookup. Together with commit 1 this makes the object to authorize resolve to the project, authorized via `ProjectPolicy`.

Original work by Adrian Schröter, extracted from #16545.