### PR TITLE
Fix 7.1 framework defaults

### DIFF
--- a/src/api/app/controllers/configurations_controller.rb
+++ b/src/api/app/controllers/configurations_controller.rb
@@ -1,5 +1,3 @@
-require 'configuration'
-
 class ConfigurationsController < ApplicationController
   # Site-specific configuration is insensitive information, no login needed therefore
   before_action :require_admin, only: [:update]

--- a/src/api/app/models/bs_request_action/differ.rb
+++ b/src/api/app/models/bs_request_action/differ.rb
@@ -1,5 +1,3 @@
-require 'bs_request_action/differ/for_source'
-
 # this overwrites the sourcediff function for submit requests and maintenance
 class BsRequestAction
   module Differ

--- a/src/api/app/models/concerns/pretty_nested_errors.rb
+++ b/src/api/app/models/concerns/pretty_nested_errors.rb
@@ -1,4 +1,3 @@
-require 'pretty_nested_errors/key_and_messages_parser'
 #  PrettyNestedErrors
 #
 #  Groups errors for nested resources on a model by a lambda for each nested resource.
@@ -85,7 +84,7 @@ module PrettyNestedErrors
     @nested_error_messages = {}
     errors.messages.each do |key, messages|
       @nested_error_messages =
-        KeyAndMessagesParser.new(self, key, messages, @nested_error_messages, self.nested_error_groupings).parse
+        PrettyNestedErrors::KeyAndMessagesParser.new(self, key, messages, @nested_error_messages, self.nested_error_groupings).parse
     end
     @nested_error_messages
   end

--- a/src/api/app/models/concerns/status_checkable.rb
+++ b/src/api/app/models/concerns/status_checkable.rb
@@ -2,7 +2,7 @@ module StatusCheckable
   extend ActiveSupport::Concern
 
   included do
-    serialize :required_checks, type: Array
+    serialize :required_checks, type: Array, coder: JSON
     has_many :status_reports, as: :checkable, class_name: 'Status::Report', dependent: :destroy
   end
 end

--- a/src/api/app/models/kiwi/image.rb
+++ b/src/api/app/models/kiwi/image.rb
@@ -1,5 +1,3 @@
-require 'pretty_nested_errors'
-
 module Kiwi
   class Image < ApplicationRecord
     #### Includes and extends

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -31,7 +31,7 @@ class Project < ApplicationRecord
   after_rollback :reset_cache
   after_rollback :discard_cache
 
-  serialize :required_checks, type: Array
+  serialize :required_checks, type: Array, coder: JSON
 
   attr_accessor :commit_opts, :commit_user
 

--- a/src/api/spec/lib/pretty_nested_errors_spec.rb
+++ b/src/api/spec/lib/pretty_nested_errors_spec.rb
@@ -1,5 +1,3 @@
-require 'pretty_nested_errors'
-
 class Bicycle < ApplicationRecord
   include PrettyNestedErrors
 


### PR DESCRIPTION
This has not happen during the update from Rails 7.0 to 7.1...

7.1 no longer adds autoloaded paths into `$LOAD_PATH` this means that you won't be able to manually require files that are managed by the autoloader, which you shouldn't do anyway.

In 7.1 ActiveRecord serialization, the coder is not optional anymore.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
