### PR TITLE
Data migration in batches for reviews_count

### DIFF
--- a/src/api/db/data/20260723180842_prefill_reviews_count_values.rb
+++ b/src/api/db/data/20260723180842_prefill_reviews_count_values.rb
@@ -3,8 +3,12 @@
 class PrefillReviewsCountValues < ActiveRecord::Migration[7.2]
   def up
     # rubocop:disable Rails/SkipsModelValidations
-    Review.group(:bs_request_id).select(:bs_request_id, 'COUNT(id) as reviews_count').each do |review|
-      review.bs_request.update_columns(reviews_count: review.reviews_count)
+    BsRequest.in_batches do |batch|
+      ids = batch.pluck(:id)
+      counts = Review.where(bs_request_id: ids).group(:bs_request_id).count # Returns a hash with key-values like request_id => number_of_reviews
+      counts.each do |bs_request_id, count|
+        BsRequest.where(id: bs_request_id).update_all(reviews_count: count)
+      end
     end
     # rubocop:enable Rails/SkipsModelValidations
   end


### PR DESCRIPTION
Correct previously added data migration before it runs in other instances.
We better loop over millions of reviews in batches.

NOTE: The change won't affect build.o.o since that migration was already applied there. 
You can check db/data_schema.rb or the latest values on the table data_migrations. Rails will only run versions which are newer and those that don't appear in the table.
