### PR TITLE
Revert specifying JSON coder on serializer

### DIFF
--- a/src/api/app/models/concerns/status_checkable.rb
+++ b/src/api/app/models/concerns/status_checkable.rb
@@ -2,7 +2,7 @@ module StatusCheckable
   extend ActiveSupport::Concern
 
   included do
-    serialize :required_checks, type: Array, coder: JSON
+    serialize :required_checks, type: Array
     has_many :status_reports, as: :checkable, class_name: 'Status::Report', dependent: :destroy
   end
 end

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -31,7 +31,7 @@ class Project < ApplicationRecord
   after_rollback :reset_cache
   after_rollback :discard_cache
 
-  serialize :required_checks, type: Array, coder: JSON
+  serialize :required_checks, type: Array
 
   attr_accessor :commit_opts, :commit_user
 


### PR DESCRIPTION
Was introduced in https://github.com/openSUSE/open-build-service/pull/20076 and cause exceptions with `lexical error: malformed number, a digit is required after the minus sign` now. Revert for now until the cause is found.

Fixes https://github.com/openSUSE/open-build-service/issues/20085
