### PR TITLE
Refactoring: simplify image template icon generation

### DIFF
--- a/src/api/app/helpers/webui/webui_helper.rb
+++ b/src/api/app/helpers/webui/webui_helper.rb
@@ -60,14 +60,13 @@ module Webui::WebuiHelper
     first.nil? || nil
   end
 
-  def image_template_icon(template)
-    default_icon = image_url('drive-optical-48.png')
-    icon = Package.source_path(template.project.name, template.name, '_icon') if template.icon?
-    capture_haml do
-      content_tag(:object, data: icon || default_icon, type: 'image/png', title: template.title, width: 32, height: 32) do
-        content_tag(:img, src: default_icon, alt: template.title, width: 32, height: 32)
-      end
-    end
+  def image_template_icon_url(template)
+    icon = if template.icon?
+             Package.source_path(template.project.name, template.name, '_icon')
+           else
+             'drive-optical-48.png'
+           end
+    image_url(icon)
   end
 
   def repository_status_icon(status:, details: nil, html_class: '')

--- a/src/api/app/views/webui/image_templates/index.html.haml
+++ b/src/api/app/views/webui/image_templates/index.html.haml
@@ -22,7 +22,7 @@
                       %label.form-check-label{ for: "#{project}-#{index}" }
                         - first_template ||= template
                         .d-flex
-                          = image_template_icon(template)
+                          = image_tag(image_template_icon_url(template), alt: template.title, width: 32, height: 32)
                           .ps-3
                             = link_to_if(!remote, title_or_name(template), package_show_path(project: project, package: template))
                             %small.description.text-muted.d-block= template.description


### PR DESCRIPTION
There is no reason to return a whole html object from helper. Simply return icon url only and build image tag in haml view instead.