### PR TITLE
Load Rails 7.2 defaults

### DIFF
--- a/src/api/app/models/concerns/status_checkable.rb
+++ b/src/api/app/models/concerns/status_checkable.rb
@@ -2,7 +2,7 @@ module StatusCheckable
   extend ActiveSupport::Concern
 
   included do
-    serialize :required_checks, type: Array
+    serialize :required_checks, type: Array, coder: YAML
     has_many :status_reports, as: :checkable, class_name: 'Status::Report', dependent: :destroy
   end
 end

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -31,7 +31,7 @@ class Project < ApplicationRecord
   after_rollback :reset_cache
   after_rollback :discard_cache
 
-  serialize :required_checks, type: Array
+  serialize :required_checks, type: Array, coder: YAML
 
   attr_accessor :commit_opts, :commit_user
 

--- a/src/api/config/application.rb
+++ b/src/api/config/application.rb
@@ -33,7 +33,7 @@ end
 module OBSApi
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 7.0
+    config.load_defaults 7.2
 
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.

--- a/src/api/spec/helpers/webui/markdown_helper_spec.rb
+++ b/src/api/spec/helpers/webui/markdown_helper_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Webui::MarkdownHelper do
 
     it 'does not crash due to invalid URIs' do
       expect(render_as_markdown("anbox[400000+22d000]\r\n(the number)")).to eq(
-        "<p>anbox<a href=\"the%20number\" rel=\"nofollow\">400000+22d000</a></p>\n"
+        "<p>anbox<a href=\"the number\" rel=\"nofollow\">400000+22d000</a></p>\n"
       )
     end
 

--- a/src/api/test/functional/attributes_test.rb
+++ b/src/api/test/functional/attributes_test.rb
@@ -1,5 +1,4 @@
 require File.expand_path(File.dirname(__FILE__) + '/..') + '/test_helper'
-require 'source_controller'
 
 class AttributeControllerTest < ActionDispatch::IntegrationTest
   fixtures :all

--- a/src/api/test/functional/branch_publish_flag_test.rb
+++ b/src/api/test/functional/branch_publish_flag_test.rb
@@ -1,5 +1,4 @@
 require File.expand_path(File.dirname(__FILE__) + '/..') + '/test_helper'
-require 'source_controller'
 
 class BranchPublishFlagTest < ActionDispatch::IntegrationTest
   fixtures :all

--- a/src/api/test/functional/channel_maintenance_test.rb
+++ b/src/api/test/functional/channel_maintenance_test.rb
@@ -1,7 +1,6 @@
 # rubocop:disable Metrics/AbcSize
 # rubocop:disable Metrics/MethodLength
 require File.expand_path(File.dirname(__FILE__) + '/..') + '/test_helper'
-require 'source_controller'
 
 class ChannelMaintenanceTests < ActionDispatch::IntegrationTest
   fixtures :all

--- a/src/api/test/functional/interconnect_test.rb
+++ b/src/api/test/functional/interconnect_test.rb
@@ -1,5 +1,4 @@
 require File.expand_path(File.dirname(__FILE__) + '/..') + '/test_helper'
-require 'source_controller'
 
 class InterConnectTests < ActionDispatch::IntegrationTest
   fixtures :all

--- a/src/api/test/functional/kgraft_maintenance_test.rb
+++ b/src/api/test/functional/kgraft_maintenance_test.rb
@@ -2,7 +2,6 @@
 # rubocop:disable Metrics/MethodLength
 
 require File.expand_path(File.dirname(__FILE__) + '/..') + '/test_helper'
-require 'source_controller'
 
 class MaintenanceTests < ActionDispatch::IntegrationTest
   fixtures :all

--- a/src/api/test/functional/maintenance_test.rb
+++ b/src/api/test/functional/maintenance_test.rb
@@ -2,7 +2,6 @@
 # rubocop:disable Metrics/MethodLength
 # rubocop:disable Metrics/ClassLength
 require_relative '../test_helper'
-require 'source_controller'
 
 class MaintenanceTests < ActionDispatch::IntegrationTest
   fixtures :all

--- a/src/api/test/functional/product_test.rb
+++ b/src/api/test/functional/product_test.rb
@@ -1,5 +1,4 @@
 require File.expand_path(File.dirname(__FILE__) + '/..') + '/test_helper'
-require 'source_controller'
 
 # 'ProductTests' (ending in 's') here. 'ProductTest' is already used in unit/product_test.rb
 class ProductTests < ActionDispatch::IntegrationTest

--- a/src/api/test/functional/public_controller_test.rb
+++ b/src/api/test/functional/public_controller_test.rb
@@ -1,5 +1,4 @@
 require File.expand_path(File.dirname(__FILE__) + '/..') + '/test_helper'
-require 'public_controller'
 
 class PublicControllerTest < ActionDispatch::IntegrationTest
   fixtures :all

--- a/src/api/test/functional/read_permission_test.rb
+++ b/src/api/test/functional/read_permission_test.rb
@@ -1,5 +1,4 @@
 require File.expand_path(File.dirname(__FILE__) + '/..') + '/test_helper'
-require 'source_controller'
 
 class ReadPermissionTest < ActionDispatch::IntegrationTest
   fixtures :all

--- a/src/api/test/functional/release_management_test.rb
+++ b/src/api/test/functional/release_management_test.rb
@@ -1,5 +1,4 @@
 require File.expand_path(File.dirname(__FILE__) + '/..') + '/test_helper'
-require 'source_controller'
 
 class ReleaseManagementTests < ActionDispatch::IntegrationTest
   fixtures :all

--- a/src/api/test/functional/request_controller_test.rb
+++ b/src/api/test/functional/request_controller_test.rb
@@ -1,6 +1,5 @@
 # rubocop:disable Metrics/ClassLength
 require File.expand_path(File.dirname(__FILE__) + '/..') + '/test_helper'
-require 'request_controller'
 
 class RequestControllerTest < ActionDispatch::IntegrationTest
   fixtures :all

--- a/src/api/test/functional/source_controller_test.rb
+++ b/src/api/test/functional/source_controller_test.rb
@@ -1,6 +1,5 @@
 # rubocop:disable Metrics/ClassLength
 require File.expand_path(File.dirname(__FILE__) + '/..') + '/test_helper'
-require 'source_controller'
 
 class SourceControllerTest < ActionDispatch::IntegrationTest
   fixtures :all

--- a/src/api/test/functional/source_services_test.rb
+++ b/src/api/test/functional/source_services_test.rb
@@ -1,5 +1,4 @@
 require File.expand_path(File.dirname(__FILE__) + '/..') + '/test_helper'
-require 'source_controller'
 
 class SourceServicesTest < ActionDispatch::IntegrationTest
   fixtures :all

--- a/src/api/test/functional/zzz_post_consistency_test.rb
+++ b/src/api/test/functional/zzz_post_consistency_test.rb
@@ -1,7 +1,6 @@
 require File.expand_path(File.dirname(__FILE__) + '/..') + '/test_consistency_helper'
 
 class ZZZPostConsistency < ActionDispatch::IntegrationTest
-  require 'source_controller'
   fixtures :all
 
   def setup

--- a/src/api/test/test_consistency_helper.rb
+++ b/src/api/test/test_consistency_helper.rb
@@ -1,5 +1,4 @@
 require_relative 'test_helper'
-require 'source_controller'
 
 #
 # code which is supposed to be run at multiple stages during the test suite run


### PR DESCRIPTION
This was skipped since the Rails 7.1 update. This changes it and fixes the fallout of it...