### PR TITLE
Fix backlog link for users in beta

### DIFF
--- a/src/api/app/views/webui/staging/workflows/_infos.html.haml
+++ b/src/api/app/views/webui/staging/workflows/_infos.html.haml
@@ -10,7 +10,10 @@
       %dt Empty projects:
       %dd= render 'empty_projects_list', projects: empty_projects, staging_workflow: staging_workflow
 
-      %dt= link_to('Backlog:', group_path(staging_workflow.managers_group, anchor: 'reviews-in'))
+      - if Flipper.enabled?(:request_index, User.session)
+        %dt= link_to('Backlog:', group_requests_path(staging_workflow.managers_group))
+      - else
+        %dt= link_to('Backlog:', group_path(staging_workflow.managers_group, anchor: 'reviews-in'))
       %dd= render 'requests_list', requests: unassigned_requests, more_requests: more_unassigned_requests
 
       - if Flipper.enabled?(:request_index, User.session)


### PR DESCRIPTION
When the user is not logged in or not being part of the beta program or not having the `request_index` feature flag, the `Backlog` link under the `Infos` section of the staging workflow page (for example, this one: https://build.opensuse.org/staging_workflows/openSUSE:Factory) points to the `Incoming Reviews` tab of the `Groups page` (for example: https://build.opensuse.org/groups/factory-staging#reviews-in).

But when the user is logged in and being part of the beta and has the `request_index` flag, it should be redirected to the `Groups Requests` instead (e.g: https://build.opensuse.org/groups/factory-staging/requests).

This pr fixes that last use case.

Fixes #17614
