### PR TITLE
Bugfix: de-group when filter_search_text on top of filter_labels

### DIFF
--- a/src/api/app/controllers/concerns/webui/requests_filter.rb
+++ b/src/api/app/controllers/concerns/webui/requests_filter.rb
@@ -127,7 +127,10 @@ module Webui::RequestsFilter # rubocop:disable Metrics/ModuleLength
     search_for_ids_options = { per_page: TEXT_SEARCH_MAX_RESULTS }
 
     if BsRequest.search_count(@selected_filter['search']) > TEXT_SEARCH_MAX_RESULTS
-      if @bs_requests.limit(TEXT_SEARCH_MAX_RESULTS + 1).count > TEXT_SEARCH_MAX_RESULTS
+      # De-group before counting: filter_labels may have added a GROUP BY, and calling
+      # .count on a grouped relation returns a Hash ({id => count}), which raises when
+      # compared against an Integer. unscope(:group) keeps this an Integer count.
+      if @bs_requests.unscope(:group).limit(TEXT_SEARCH_MAX_RESULTS + 1).count > TEXT_SEARCH_MAX_RESULTS
         flash.now[:error] = 'Your text search pattern matches too many results. Please, try again with a more restrictive search pattern.'
         @bs_requests = BsRequest.none
 

--- a/src/api/spec/controllers/webui/users/bs_requests_controller_spec.rb
+++ b/src/api/spec/controllers/webui/users/bs_requests_controller_spec.rb
@@ -197,6 +197,19 @@ RSpec.describe Webui::Users::BsRequestsController do
 
         it { expect(assigns[:bs_requests]).to contain_exactly(incoming_request) }
       end
+
+      context 'and the labels and search parameters are used together', :thinking_sphinx do
+        let(:context_params) { { labels: [label.label_template.name], search: 'incoming' } }
+
+        before do
+          # filter_labels adds a GROUP BY; filter_search_text must not blow up counting it
+          allow(BsRequest).to receive(:search_count).and_return(Webui::RequestsFilter::TEXT_SEARCH_MAX_RESULTS + 1)
+        end
+
+        it 'does not raise when counting the grouped relation' do
+          expect(response).to have_http_status(:success)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/openSUSE/open-build-service/issues/20096

De-group before counting: `filter_labels` may have added a `GROUP BY`, and calling `.count` on a grouped relation returns a `Hash ({id => count})`, which raises when compared against an `Integer`. `unscope(:group)` keeps this an `Integer` count.

