### PR TITLE
Use select and or instead of joining arrays for bs_requests

### DIFF
--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -1328,15 +1328,14 @@ class Package < ApplicationRecord
   # Returns an ActiveRecord::Relation with all BsRequest that the package is somehow involved in
   def bs_requests
     review_ids = Review.where(package_id: id)
-                       .pluck(:bs_request_id)
+                       .select(:bs_request_id)
 
     action_ids = BsRequestAction.where(target_package_id: id)
                                 .or(BsRequestAction.where(source_package_id: id))
-                                .pluck(:bs_request_id)
+                                .select(:bs_request_id)
 
-    all_ids = (review_ids + action_ids).compact.uniq
-
-    BsRequest.left_outer_joins(:bs_request_actions, :reviews).where(id: all_ids).distinct
+    base = BsRequest.left_outer_joins(:bs_request_actions, :reviews)
+    base.where(id: review_ids).or(base.where(id: action_ids)).distinct
   end
 
   private

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -1367,15 +1367,14 @@ class Project < ApplicationRecord
   # Returns an ActiveRecord::Relation with all BsRequest that the project is somehow involved in
   def bs_requests
     review_ids = Review.where(project_id: id)
-                       .pluck(:bs_request_id)
+                       .select(:bs_request_id)
 
     action_ids = BsRequestAction.where(target_project_id: id)
                                 .or(BsRequestAction.where(source_project_id: id))
-                                .pluck(:bs_request_id)
+                                .select(:bs_request_id)
 
-    all_ids = (review_ids + action_ids).compact.uniq
-
-    BsRequest.left_outer_joins(:bs_request_actions, :reviews).where(id: all_ids).distinct
+    base = BsRequest.left_outer_joins(:bs_request_actions, :reviews)
+    base.where(id: review_ids).or(base.where(id: action_ids)).distinct
   end
 
   private


### PR DESCRIPTION
Tested on counters on Factory in production console. For smaller projects/packages, this might increase the load time by a few milliseconds, but for larger projects it saves time by avoiding doing large array merges in ruby and performing everything on db side. It also caches much better, which means that a successive load will activate a cache on db side and load in milliseconds instead of seconds like previous method.