### PR TITLE
Pin `connection_pool` gem to version < 3.0

### DIFF
--- a/src/api/Gemfile
+++ b/src/api/Gemfile
@@ -132,6 +132,10 @@ gem 'next_rails'
 # Result object pattern gem
 gem "resonad"
 
+# Pin connection_pool, newer version is not compatible with Rails < 8.0
+# see https://github.com/rails/rails/pull/56294
+gem "connection_pool", "< 3.0"
+
 group :development, :production do
   # to have the delayed job daemon
   gem 'daemons'

--- a/src/api/Gemfile.lock
+++ b/src/api/Gemfile.lock
@@ -635,6 +635,7 @@ DEPENDENCIES
   clockwork
   cocoon
   coderay
+  connection_pool (< 3.0)
   daemons
   dalli
   data_migrate


### PR DESCRIPTION
There is a breaking change in versions >= 3.0. A fix was introduced in Rails >= 8.0. We have to first update to Rails 8.0 in order to update connection_pool.

Right now we have to always exclude indirect updates of it from depfu PR's, lets pin the version until the update of Rails is performed. 
