### PR TITLE
Requests filter label performance: filtering labels via IN-subquery instead of grouped join

### DIFF
--- a/src/api/app/controllers/concerns/webui/requests_filter.rb
+++ b/src/api/app/controllers/concerns/webui/requests_filter.rb
@@ -111,13 +111,22 @@ module Webui::RequestsFilter # rubocop:disable Metrics/ModuleLength
 
     return if @selected_filter['labels'].blank?
 
-    # Match bs_request records containing AT LEAST all selected labels
+    # Match bs_request records containing AT LEAST all selected labels.
+    #
+    # The "has all N labels" check is isolated in a derived subquery over the labels
+    # table rather than joining labels into @bs_requests and grouping the whole result.
+    # @bs_requests is already seeded with left_outer_joins(:bs_request_actions, :reviews)
+    # and .distinct; adding another one-to-many join plus GROUP BY/HAVING on top builds a
+    # wide cartesian intermediate and forces Kaminari's pagination count into a
+    # subquery-wrapped count. Filtering by an IN-subquery keeps the outer relation flat.
     target_labels = @selected_filter['labels']
-    @bs_requests = @bs_requests
-                   .joins(labels: :label_template)
-                   .where(label_templates: { name: target_labels })
-                   .group('bs_requests.id')
-                   .having('COUNT(DISTINCT label_templates.name) = ?', target_labels.size)
+    matching_request_ids = Label
+                           .joins(:label_template)
+                           .where(labelable_type: 'BsRequest', label_templates: { name: target_labels })
+                           .group(:labelable_id)
+                           .having('COUNT(DISTINCT label_templates.name) = ?', target_labels.size)
+                           .select(:labelable_id)
+    @bs_requests = @bs_requests.where(id: matching_request_ids)
   end
 
   def filter_search_text


### PR DESCRIPTION
filter_labels joined the labels table into @bs_requests (already seeded with left_outer_joins(:bs_request_actions, :reviews) and .distinct) and grouped the whole relation. Over multiple one-to-many joins this builds a wide cartesian intermediate, and Kaminari's pagination count on the "grouped+distinct" relation degrades into a subquery-wrapped count.

Isolate the "has all N labels" check in a derived subquery over the labels table and filter with WHERE bs_requests.id IN (...). The outer relation stays flat (no GROUP BY, no cartesian blow-up), and pagination counts a plain filtered relation.

Benchmarked in the Rails console on a seeded dataset (5k requests, each with 3 actions + 3 reviews + labels; ~50% **matching a 2-label filter**), warm run, wall-clock:

  | Operation           | OLD     | NEW     | Speedup |
  | ------------------- | ------- | ------- | ------- |
  | Load (page 1, / 25) | 0.578 s | 0.077 s | ~7.5×   |
  | Pagination count    | 0.677 s | 0.170 s | ~4×     |



_Assisted by: Claude Code - Opus 4.8_