### PR TITLE
Make Webui::GroupsController look a bit more rails'ish

### DIFF
--- a/src/api/app/controllers/webui/groups_controller.rb
+++ b/src/api/app/controllers/webui/groups_controller.rb
@@ -1,68 +1,44 @@
 class Webui::GroupsController < Webui::WebuiController
   include Webui::NotificationsHandler
 
-  before_action :require_login, except: %i[show autocomplete]
-  after_action :verify_authorized, except: %i[show autocomplete edit update]
+  before_action :require_login, except: :show
+  before_action :require_admin, only: %i[index create new]
+  before_action :set_group, only: %i[show edit update]
+  before_action :set_members, only: :create
+  after_action :verify_authorized, except: %i[index show new autocomplete]
 
   def index
-    authorize Group.new, :index?
     @groups = Group.includes(:users).order(:title)
   end
 
   def show
-    @group = Group.includes(:users).find_by_title(params[:title])
-    unless @group
-      flash[:error] = "Group '#{params[:title]}' does not exist"
-      redirect_back_or_to({ controller: 'main', action: 'index' })
-      return
-    end
-
     @current_notification = handle_notification
   end
 
-  def new
-    authorize Group.new, :create?
-  end
+  def new; end
 
   def edit
-    @group = Group.find_by(title: params[:title])
-
-    if @group
-      authorize(@group, :update?)
-    else
-      flash[:error] = "The group doesn't exist"
-      redirect_to(groups_path)
-    end
+    authorize @group
   end
 
   def create
-    group = Group.new(title: group_params[:title])
-    authorize group, :create?
+    group = Group.new(group_params.slice(:email, :title).compact)
+    authorize group
 
-    group.transaction do
-      group.save!
-      raise ActiveRecord::RecordInvalid unless group.replace_members(group_params[:members])
+    group.users = @members
+
+    if group.save
+      redirect_to groups_path, success: "Group '#{group}' successfully created."
+    else
+      redirect_back_or_to root_path, error: "Group can't be saved: #{group.errors.full_messages.to_sentence}"
     end
-
-    flash[:success] = "Group '#{group}' successfully created."
-    redirect_to controller: :groups, action: :index
-  rescue ActiveRecord::RecordInvalid
-    redirect_back_or_to root_path, error: "Group can't be saved: #{group.errors.full_messages.to_sentence}"
   end
 
   def update
-    @group = Group.find_by(title: params[:title])
-
-    unless @group
-      flash[:error] = "The group doesn't exist"
-      redirect_to(groups_path) && return
-    end
-
-    authorize @group, :update?
+    authorize @group
 
     if @group.update(email: group_params[:email])
-      flash[:success] = 'Group email successfully updated'
-      redirect_to groups_path
+      redirect_to groups_path, success: 'Group email successfully updated'
     else
       flash[:error] = "Couldn't update group: #{@group.errors.full_messages.to_sentence}"
     end
@@ -74,6 +50,26 @@ class Webui::GroupsController < Webui::WebuiController
   end
 
   private
+
+  def set_group
+    @group = Group.includes(:users).find_by(title: params[:title])
+    return if @group
+
+    redirect_back_or_to root_path, error: "Group '#{params[:title]}' not found"
+  end
+
+  def set_members
+    @members = []
+
+    group_params[:members].split(',').uniq.each do |login|
+      user = User.active.find_by(login: login)
+      @members << user if user
+      next if user
+
+      redirect_back_or_to root_path, error: "Group can't be saved: User #{login} not found"
+      return
+    end
+  end
 
   def group_params
     params.require(:group).permit(:title, :email, :members)

--- a/src/api/app/models/group.rb
+++ b/src/api/app/models/group.rb
@@ -92,16 +92,6 @@ class Group < ApplicationRecord
     GroupsUser.find_or_create_by!(user: user, group: self)
   end
 
-  def replace_members(members)
-    new_members = members.split(',').map do |m|
-      User.not_deleted.find_by!(login: m)
-    end
-    users.replace(new_members)
-  rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotFound => e
-    errors.add(:base, e.message)
-    false
-  end
-
   def remove_user(user, user_session_login:)
     delete_user(GroupsUser, user.id, id, user_session_login: user_session_login)
   end

--- a/src/api/app/policies/group_policy.rb
+++ b/src/api/app/policies/group_policy.rb
@@ -1,8 +1,4 @@
 class GroupPolicy < ApplicationPolicy
-  def index?
-    create?
-  end
-
   def create?
     # Only admins can create new groups atm
     user.admin?
@@ -16,7 +12,7 @@ class GroupPolicy < ApplicationPolicy
     update?
   end
 
-  def display_email?
-    !user.nobody?
+  def edit?
+    update?
   end
 end

--- a/src/api/app/views/webui/groups/_group_members.html.haml
+++ b/src/api/app/views/webui/groups/_group_members.html.haml
@@ -1,5 +1,5 @@
 - write_access = policy(group).update?
-- display_group_email = policy(group).display_email? && group.email.present?
+- display_group_email = User.session.present? && group.email.present?
 
 - if group.users.empty?
   %p

--- a/src/api/spec/controllers/webui/groups_controller_spec.rb
+++ b/src/api/spec/controllers/webui/groups_controller_spec.rb
@@ -1,27 +1,43 @@
 RSpec.describe Webui::GroupsController do
   let(:group) { create(:group) }
+  let(:admin) { create(:admin_user) }
 
-  # except [:show, :tokens, :autocomplete]
-  it { is_expected.to use_before_action(:require_login) }
-  # except: [:show, :autocomplete, :tokens]
-  it { is_expected.to use_after_action(:verify_authorized) }
+  describe '#set_group' do
+    it 'redirects to root_path if group does not exist' do
+      get :show, params: { title: 'Foobar' }
+      expect(flash[:error]).to eq("Group 'Foobar' not found")
+      expect(response).to redirect_to(root_path)
+    end
+  end
 
-  describe 'GET show' do
+  describe '#set_members' do
+    before do
+      login(admin)
+
+      post :create, params: { group: { title: 'hans', members: '_nobody_' } }
+    end
+
+    it "shows a flash message with the validation error and doesn't create the group" do
+      expect(flash[:error]).to eq("Group can't be saved: User _nobody_ not found")
+      expect(Group.where(title: 'hans')).not_to exist
+    end
+  end
+
+  describe 'GET #show' do
     it 'assigns @group' do
       get :show, params: { title: group.title }
       expect(response).to have_http_status(:success)
       expect(assigns(:group)).to eq(group)
     end
-
-    it 'redirects to root_path if group does not exist' do
-      get :show, params: { title: 'Foobar' }
-      expect(flash[:error]).to eq("Group 'Foobar' does not exist")
-      expect(response).to redirect_to(root_path)
-    end
   end
 
-  describe 'GET autocomplete' do
+  describe 'GET #autocomplete' do
+    let(:user) { create(:confirmed_user) }
     let(:another_group) { create(:group, title: "#{group.title}-#{SecureRandom.hex}") }
+
+    before do
+      login(user)
+    end
 
     it 'returns list with one group for a match' do
       get :autocomplete, params: { term: group.title }
@@ -40,142 +56,53 @@ RSpec.describe Webui::GroupsController do
     end
   end
 
-  describe 'POST create' do
+  describe 'POST #create' do
     let(:title) { 'my_group' }
-    let(:users_to_add) { create_list(:user, 3).map(&:login).join(',') }
+    let(:users_to_add) { create_list(:confirmed_user, 3).map(&:login).join(',') }
 
     before do
-      login(login_as)
+      login(admin)
 
       post :create, params: { group: { title: title, members: users_to_add } }
     end
 
-    context 'as a normal user' do
-      let(:login_as) { create(:confirmed_user) }
+    context 'with valid title and valid users' do
+      it 'creates a group with members' do
+        expect(response).to redirect_to(groups_path)
+        expect(flash[:success]).to eq("Group '#{title}' successfully created.")
+        expect(Group.where(title: title)).to exist
+      end
+    end
 
-      it 'does not allow to create a group' do
-        expect(flash[:error]).to eq('Sorry, you are not authorized to create this group.')
+    context 'with an invalid title' do
+      let(:title) { 'my group' }
+
+      it "shows a flash message with the validation error and doesn't create the group" do
+        expect(flash[:error]).to eq("Group can't be saved: Title must not contain invalid characters")
         expect(Group.where(title: title)).not_to exist
-      end
-    end
-
-    context 'as an admin' do
-      let(:login_as) { create(:admin_user) }
-
-      context 'with valid title and valid users' do
-        it 'creates a group with members' do
-          expect(response).to redirect_to(groups_path)
-          expect(flash[:success]).to eq("Group '#{title}' successfully created.")
-          expect(Group.where(title: title)).to exist
-        end
-      end
-
-      context 'with an invalid title' do
-        let(:title) { 'my group' }
-
-        it "shows a flash message with the validation error and doesn't create the group" do
-          expect(flash[:error]).to eq("Group can't be saved: Title must not contain invalid characters")
-          expect(Group.where(title: title)).not_to exist
-        end
-      end
-
-      context 'with a nonexistent user' do
-        let(:users_to_add) { 'non_existent_user' }
-
-        it "shows a flash message with the validation error and doesn't create the group" do
-          expect(flash[:error]).to eq("Group can't be saved: Couldn't find User")
-          expect(Group.where(title: title)).not_to exist
-        end
-      end
-    end
-  end
-
-  describe 'GET #edit' do
-    let(:title) { group.title }
-
-    before do
-      login(login_as)
-      get :edit, params: { title: title }
-    end
-
-    context 'as a normal user' do
-      let(:login_as) { create(:confirmed_user) }
-
-      it 'does not allow to edit the group' do
-        expect(flash[:error]).to eq('Sorry, you are not authorized to update this group.')
-      end
-    end
-
-    context 'as an admin' do
-      let(:login_as) { create(:admin_user) }
-
-      it { expect(assigns(:group)).to eq(group) }
-
-      context 'which an inexistent group' do
-        let(:title) { 'no_real_title' }
-
-        it 'does not allow to edit the group' do
-          expect(flash[:error]).to eq("The group doesn't exist")
-        end
       end
     end
   end
 
   describe 'PUT #update' do
-    let(:title) { group.title }
+    let(:email) { 'example@example.com' }
 
     before do
-      login(login_as)
-      put :update, params: { title: title, group: { email: email } }
+      login(admin)
+      put :update, params: { title: group.title, group: { email: email } }
     end
 
-    context 'as a normal user' do
-      let(:login_as) { create(:confirmed_user) }
-      let(:email) { 'new_email@example.com' }
-
-      it 'does not allow to update the group' do
-        expect(flash[:error]).to eq('Sorry, you are not authorized to update this group.')
-        expect(group.reload.email).not_to eq(email)
-      end
+    it 'updates the group' do
+      expect(flash[:success]).to eq('Group email successfully updated')
+      expect(group.reload.email).to eq(email)
     end
 
-    context 'as an admin' do
-      let(:login_as) { create(:admin_user) }
+    context 'when the attribute is empty' do
+      let(:email) { nil }
 
-      context 'which an inexistent group' do
-        let(:title) { 'no_real_title' }
-        let(:email) { 'new_email@example.com' }
-
-        it 'does not allow to edit the group' do
-          expect(flash[:error]).to eq("The group doesn't exist")
-        end
-      end
-
-      context 'when the email is empty' do
-        let(:email) { nil }
-
-        it 'updates the email' do
-          expect(flash[:success]).to eq('Group email successfully updated')
-          expect(group.reload.email).to be_empty
-        end
-      end
-
-      context 'when the email is not empty' do
-        let(:email) { 'new_email@example.com' }
-
-        it 'updates the email' do
-          expect(response).to redirect_to(groups_path)
-          expect(flash[:success]).to eq('Group email successfully updated')
-          expect(group.reload.email).to eq(email)
-        end
-      end
-
-      context 'when the email have the wrong format' do
-        let(:email) { 'is_not_an_email' }
-
-        it 'is not updated' do
-          expect(flash[:error]).to eq("Couldn't update group: Email must be a valid email address")
-        end
+      it 'removes the attribute' do
+        expect(flash[:success]).to eq('Group email successfully updated')
+        expect(group.reload.email).to be_empty
       end
     end
   end

--- a/src/api/spec/models/group_spec.rb
+++ b/src/api/spec/models/group_spec.rb
@@ -8,66 +8,6 @@ RSpec.describe Group do
     it { is_expected.to validate_length_of(:title).is_at_most(100).with_message('must have less than 100 characters') }
   end
 
-  describe '#replace_members' do
-    subject! { group.replace_members(members) }
-
-    context 'no previous group users' do
-      context 'adding one valid user' do
-        let(:members) { user.login }
-
-        it 'adds one user successfully' do
-          expect(subject).to be_truthy
-          expect(group.users).to eq([user])
-        end
-      end
-
-      context 'adding two valid users' do
-        let(:members) { "#{user.login},#{another_user.login}" }
-
-        it 'adds more than one user successfully' do
-          expect(subject).to be_truthy
-          expect(group.users).to eq([user, another_user])
-        end
-      end
-
-      context 'with user _nobody_' do
-        let(:members) { '_nobody_' }
-
-        it 'does not add the user' do
-          expect(subject).to be_falsey
-          expect(group.users).to eq([])
-          expect(group.errors.full_messages).to eq(["Couldn't find User"])
-        end
-      end
-    end
-
-    context 'one previous group user' do
-      before do
-        group.users << user
-      end
-
-      context 'with an invalid user' do
-        let(:members) { 'Foobar' }
-
-        it 'errors and does not change users' do
-          expect(subject).to be_falsey
-          expect(group.users).to eq([user])
-          expect(group.errors.full_messages).to eq(["Couldn't find User"])
-        end
-      end
-
-      context 'with two users, one of them invalid' do
-        let(:members) { "#{another_user.login},Foobar" }
-
-        it 'errors and does not change users' do
-          expect(subject).to be_falsey
-          expect(group.users).to eq([user])
-          expect(group.errors.full_messages).to eq(["Couldn't find User"])
-        end
-      end
-    end
-  end
-
   describe '#involved_projects' do
     let!(:involved_project) { create(:project, maintainer: group) }
 

--- a/src/api/spec/policies/group_policy_spec.rb
+++ b/src/api/spec/policies/group_policy_spec.rb
@@ -8,24 +8,16 @@ RSpec.describe GroupPolicy do
   let(:group_member) { create(:groups_user, group: group).user }
   let(:group_maintainer) { create(:group_maintainer, group: group).user }
 
-  permissions :create?, :index? do
+  permissions :create? do
     it { is_expected.not_to permit(user, group) }
     it { is_expected.not_to permit(group_member, group) }
     it { is_expected.not_to permit(group_maintainer, group) }
     it { is_expected.to permit(admin, group) }
   end
 
-  permissions :update?, :destroy? do
+  permissions :update?, :destroy?, :edit? do
     it { is_expected.not_to permit(user, group) }
     it { is_expected.not_to permit(group_member, group) }
-    it { is_expected.to permit(group_maintainer, group) }
-    it { is_expected.to permit(admin, group) }
-  end
-
-  permissions :display_email? do
-    it { is_expected.not_to permit(anonymous_user, group) }
-    it { is_expected.to permit(user, group) }
-    it { is_expected.to permit(group_member, group) }
     it { is_expected.to permit(group_maintainer, group) }
     it { is_expected.to permit(admin, group) }
   end


### PR DESCRIPTION
- use before action to ensure admin is logged in
- use before actions to load data we need
- Use ActiveRecord to assign associations instead of (dropped) model code
    
Also stop testing Group validations and authorization in the controller spec, they are already tested in the Group / GroupPolicy spec. CI time is developer time...
