### PR TITLE
Adapt DisallowNullForGroupIdInGroupsUsers migration

### DIFF
--- a/src/api/db/migrate/20171102110929_disallow_null_for_group_id_in_groups_users.rb
+++ b/src/api/db/migrate/20171102110929_disallow_null_for_group_id_in_groups_users.rb
@@ -1,7 +1,7 @@
 class DisallowNullForGroupIdInGroupsUsers < ActiveRecord::Migration[5.1]
   def up
     # Remove all dangling groups users that got created since 18680d611347d312
-    GroupsUser.where(group_id: nil).destroy_all
+    safety_assured { execute 'DELETE FROM groups_users WHERE group_id IS NULL' }
     change_column :groups_users, :group_id, :integer, null: false, default: 0, before: :user_id
   end
 


### PR DESCRIPTION
By using `GroupsUser.where(group_id: nil).destroy_all` we are instantiating each object before removing it and therefore running callbacks and validations.

With some [recent changes](https://github.com/openSUSE/open-build-service/pull/20093/changes#diff-68f8fe7c77c9eee248c6b3d8e882f02c3f6ccd4153c5a55fae8b72bf772a9b8bR5), we are validating the user_id of the User model. But, at this point in the migration sequence (2017), the biography column does not yet exist in the users table (added in 2020), so it validates a User instance and fails.

<img width="1280" height="136" alt="Screenshot 2026-07-30 at 17-14-16 migrations_tests (304794) - openSUSE_open-build-service" src="https://github.com/user-attachments/assets/b0a10926-787d-4f3d-88f3-23193ace3fa5" />

The screenshot is taken from CircleCi on master.

Replacing destroy_all by ~delete_all~ the equivalent raw SQL stops running callbacks but also instantiating the objects and validating.

