### PR TITLE
Render deleted review groups without links in request history

### DIFF
--- a/src/api/app/components/bs_request_history_element_component.html.haml
+++ b/src/api/app/components/bs_request_history_element_component.html.haml
@@ -25,7 +25,10 @@
         for
         - if element.review.for_group?
           group
-          = link_to(element.review.by_group, group_path(Group.find_by(title: element.review.by_group)))
+          - if (group = element.review.reviewed_by)
+            = link_to(element.review.by_group, group_path(group))
+          - else
+            = element.review.by_group
         - else
           = helpers.project_or_package_link({project: element.review.by_project, package: element.review.by_package}.compact)
       = link_to("#status-history-#{element.id}", title: l(element.created_at.utc), name: "status-history-#{element.id}") do

--- a/src/api/spec/components/bs_request_history_element_component_spec.rb
+++ b/src/api/spec/components/bs_request_history_element_component_spec.rb
@@ -76,6 +76,19 @@ RSpec.describe BsRequestHistoryElementComponent, type: :component do
       end
     end
 
+    context 'with review for deleted group' do
+      let(:element) do
+        create(:history_element_request_review_accepted_with_review_by_group, user: user).tap do |history_element|
+          Group.find_by!(title: history_element.review.by_group).destroy!
+        end
+      end
+
+      it 'renders the group name without a link' do
+        expect(rendered_content).to have_text(element.review.by_group)
+        expect(rendered_content).to have_no_link(element.review.by_group)
+      end
+    end
+
     context 'with review for project' do
       let(:element) { create(:history_element_request_review_accepted_with_review_by_project, user: user) }
 


### PR DESCRIPTION
## Description:

Request history can render review entries with `by_group` even when the referenced group no longer exists.

`BsRequestHistoryElementComponent` currently always builds a group link for those entries, which raises `ActionController::UrlGenerationError` when the group lookup returns `nil`.

This PR updates the request history component to keep the existing link for groups that still exist and render the stored group name as plain text when the group has been deleted.

It also adds focused component regression coverage for the deleted-group case.

## Checklist:

- [x] I have run focused tests in the frontend docker container.
- [x] I have run linting for the changed files in the frontend docker container.