### PR TITLE
Handle deleted group reviews in request overview avatars

### DIFF
--- a/src/api/app/components/bs_request_overview_avatars_component.rb
+++ b/src/api/app/components/bs_request_overview_avatars_component.rb
@@ -22,7 +22,7 @@ class BsRequestOverviewAvatarsComponent < ApplicationComponent
   end
 
   def group_avatar_objects
-    [@review.group.users, @review.group].flatten
+    [@review.group&.users, @review.group].flatten.compact
   end
 
   def package_avatar_objects

--- a/src/api/spec/components/bs_request_overview_avatars_component_spec.rb
+++ b/src/api/spec/components/bs_request_overview_avatars_component_spec.rb
@@ -1,4 +1,21 @@
 RSpec.describe BsRequestOverviewAvatarsComponent, type: :component do
+  describe '#group_avatar_objects' do
+    let(:user) { create(:confirmed_user, login: 'King') }
+    let(:group) { create(:group) }
+    let(:bs_request) { create(:bs_request_with_submit_action, creator: user) }
+    let(:review) do
+      create(:review, by_group: group.title, bs_request: bs_request).tap do |created_review|
+        group.destroy!
+        created_review.reload
+      end
+    end
+
+    it 'does not render avatars for a deleted group' do
+      expect { render_inline(described_class.new(review)) }.not_to raise_error
+      expect(rendered_content).to have_no_css('img')
+    end
+  end
+
   describe '#package_avatar_objects' do
     let(:user) { create(:confirmed_user, login: 'King') }
     let(:bs_request) { create(:bs_request_with_submit_action, creator: user) }


### PR DESCRIPTION
## Description:

Request review overview can render group reviews whose group has already been deleted.

`BsRequestOverviewAvatarsComponent` currently assumes `review.group` always exists and raises `NoMethodError` when it tries to read `users` from a missing group.

This PR updates the group avatar lookup to return no avatars when the review group no longer exists instead of raising during rendering.

It also adds focused component regression coverage for the deleted-group case.

## Checklist:

- [x] I have run focused tests in the frontend docker container.
- [x] I have run linting for the changed files in the frontend docker container.