### PR TITLE
[backend] BSContar: revert oci-archive preference for now

### DIFF
--- a/src/backend/BSContar.pm
+++ b/src/backend/BSContar.pm
@@ -302,8 +302,8 @@ sub get_manifest_oci_tar {
 
 sub get_manifest {
   my ($tar) = @_;
-  return get_manifest_oci_tar($tar) if $tar->{'index.json'} && $tar->{'oci-layout'};
   my $manifest_ent = $tar->{'manifest.json'};
+  return get_manifest_oci_tar($tar) if !$manifest_ent && $tar->{'index.json'} && $tar->{'oci-layout'};
   die("no manifest.json file found\n") unless $manifest_ent;
   my $manifest_json = BSTar::extract($manifest_ent->{'file'}, $manifest_ent);
   my $manifest = JSON::XS::decode_json($manifest_json);


### PR DESCRIPTION
New docker versions add oci files to the generated tar archives. The index.json oci index points to another(!) oci-index that contains both the container image and a slsa provenance file.

Revert oci-archive preference until we can deal with docker's way of writing it.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
