### PR TITLE
Involvement filter missing

### DIFF
--- a/src/api/app/controllers/concerns/webui/requests_count.rb
+++ b/src/api/app/controllers/concerns/webui/requests_count.rb
@@ -22,8 +22,20 @@ module Webui::RequestsCount
   end
 
   def counts_for_states_and_types
-    @counts_grouped_by_state = group_and_fill(@bs_requests, :state, BsRequest::VALID_REQUEST_STATES.map(&:to_s))
-    @counts_grouped_by_type  = group_and_fill(@bs_requests, :type, FILTERABLE_BSREQUEST_TYPES)
+    involvement_filtered = involvement_filtered_requests
+    @counts_grouped_by_state = group_and_fill(involvement_filtered, :state, BsRequest::VALID_REQUEST_STATES.map(&:to_s))
+    @counts_grouped_by_type  = group_and_fill(involvement_filtered, :type, FILTERABLE_BSREQUEST_TYPES)
+  end
+
+  def involvement_filtered_requests
+    involvement = params[:involvement]&.compact_blank.presence || %w[incoming outgoing review]
+    filters = []
+    filters << incoming_query if involvement.include?('incoming')
+    filters << outgoing_query if involvement.include?('outgoing')
+    filters << review_query   if involvement.include?('review')
+    return @bs_requests unless filters.any?
+
+    @bs_requests.merge(filters.inject(:or))
   end
 
   def group_and_fill(relation, column, keys)

--- a/src/api/app/views/webui/shared/bs_requests/_requests_filter.html.haml
+++ b/src/api/app/views/webui/shared/bs_requests/_requests_filter.html.haml
@@ -267,6 +267,7 @@
 - content_for(:content_for_head, javascript_include_tag('webui/content-selector-filters'))
 -# turbo frame used to trigger the turbo stream which updates the request filter counters
 = turbo_frame_tag("request_filter_counts_processor", src: url_for(controller_path: controller_path,
-                                                                  action: 'counts', format: :turbo_stream))
+                                                                  action: 'counts', format: :turbo_stream,
+                                                                  involvement: params[:involvement]))
 
 -# haml-lint:enable ViewLength

--- a/src/api/spec/controllers/webui/users/bs_requests_controller_spec.rb
+++ b/src/api/spec/controllers/webui/users/bs_requests_controller_spec.rb
@@ -212,4 +212,50 @@ RSpec.describe Webui::Users::BsRequestsController do
       end
     end
   end
+
+  describe 'GET #counts' do
+    context 'when the user has the request_index feature flag enabled' do
+      let!(:user) { create(:confirmed_user, login: 'king') }
+      let!(:group) { create(:group) }
+      let(:target_project) { create(:project_with_package, maintainer: user) }
+      let(:target_package) { target_project.packages.first }
+
+      # Project managed by the group, not directly by the user.
+      # Requests targeting this project appear in @bs_requests (via Project.for_group)
+      # but are excluded by the involvement filter (which only checks user's direct relationships).
+      let!(:group_managed_project) do
+        create(:project_with_package).tap do |project|
+          project.relationships.create(group: group, role: Role.find_by_title('maintainer'))
+        end
+      end
+
+      # Accepted request where user is a direct maintainer of the target — appears in both the
+      # badge counter and the paginated list.
+      let!(:accepted_direct_request) do
+        create(:bs_request_with_submit_action,
+               source_package: create(:project_with_package).packages.first,
+               target_package: target_package).tap { |r| r.update_column(:state, 'accepted') }
+      end
+
+      # Accepted request targeting the group-managed project — previously inflating the badge
+      # counter because it was in @bs_requests, but not shown in the paginated list because it
+      # does not match any involvement filter.
+      let!(:accepted_group_managed_request) do
+        create(:bs_request_with_submit_action,
+               source_package: create(:project_with_package).packages.first,
+               target_package: group_managed_project.packages.first).tap { |r| r.update_column(:state, 'accepted') }
+      end
+
+      before do
+        group.groups_users.create(user: user)
+        login user
+        Flipper.enable(:request_index, user)
+        get :counts, format: :turbo_stream
+      end
+
+      it 'does not count accepted requests that are only reachable via group maintainership' do
+        expect(assigns(:counts_grouped_by_state)['accepted']).to eq(1)
+      end
+    end
+  end
 end


### PR DESCRIPTION
The badge counter (1125) is calculated without applying the involvement filter. But when you click "accepted" and see the list, the system also applies an involvement filter by default (incoming, outgoing and review). This filter is more restrictive because it only includes requests where the user is a maintainer of the source or target project or package.

So the paginated list (757) is always smaller than the badge counter (1125) because the involvement filter is applied automatically, even if the user did not select it.

Assisted-by: Claude:claude-sonnet-4-6