### PR TITLE
Fix token invalid project name validation

### DIFF
--- a/src/api/app/controllers/trigger/errors.rb
+++ b/src/api/app/controllers/trigger/errors.rb
@@ -17,8 +17,6 @@ module Trigger::Errors
     setup 'bad_request', 400, 'Token is setup with another project.'
   end
 
-  class InvalidProjectName < APIError; end
-
   class InvalidPackage < APIError
     setup 'bad_request', 400, 'Token is setup with another package.'
   end

--- a/src/api/app/controllers/trigger_controller.rb
+++ b/src/api/app/controllers/trigger_controller.rb
@@ -91,6 +91,8 @@ class TriggerController < ApplicationController
   end
 
   def set_package_name
+    return if params[:package].blank? || @project_name.blank?
+
     @package_name = params[:package]
   end
 end

--- a/src/api/app/controllers/trigger_controller.rb
+++ b/src/api/app/controllers/trigger_controller.rb
@@ -83,16 +83,10 @@ class TriggerController < ApplicationController
   end
 
   def set_project_name
-    # Don't take random content when people just use a random webhook on our
-    # route, e.g. GitLab sending its own data with an unrelated project hash.
-    raise InvalidProjectName if params[:project].present? && !params[:project].is_a?(String)
-
     @project_name = params[:project]
   end
 
   def set_package_name
-    return if params[:package].blank? || @project_name.blank?
-
     @package_name = params[:package]
   end
 end

--- a/src/api/spec/controllers/trigger_controller_spec.rb
+++ b/src/api/spec/controllers/trigger_controller_spec.rb
@@ -70,14 +70,6 @@ RSpec.describe TriggerController do
 
       it { expect(subject).to have_http_status(:success) }
     end
-
-    context 'with an untrusted project parameter that is not a string' do
-      # e.g. a random webhook (like GitLab) sending its own payload with a
-      # project hash. The controller must not treat that as a project name.
-      subject { post :rebuild, params: { project: { unrelated: 'payload' }, format: :xml } }
-
-      it { expect(subject).to have_http_status(:bad_request) }
-    end
   end
 
   describe '#release', :vcr do


### PR DESCRIPTION
Reverts #20055 and the follow-up #20061.

When validating a project name on a token action, we should not error con receiving a hash.