### PR TITLE
Fix trigger params validation

### DIFF
--- a/src/api/app/controllers/concerns/triggerable.rb
+++ b/src/api/app/controllers/concerns/triggerable.rb
@@ -4,11 +4,9 @@ module Triggerable
     @project = @token.package.try(:project)
     validate_token_project
 
-    # If the token has no package, let's find one from the parameters or the step intructions
-    @project ||= Project.get_by_name(@project_name)
-    # Remote projects are read-only, can't trigger something for them.
-    # See https://github.com/openSUSE/open-build-service/wiki/Links#project-links
-    raise Project::Errors::UnknownObjectError, "Sorry, triggering tokens for remote project \"#{@project_name}\" is not possible." unless @project.is_a?(Project)
+    # If the token has no package, let's find one from the parameters/step intructions
+    @project ||= Project.find_by(name: @project_name)
+    raise Project::Errors::UnknownObjectError, "Project not found: #{@project_name}" unless @project
   end
 
   def set_package(package_find_options: {})

--- a/src/api/app/controllers/trigger/errors.rb
+++ b/src/api/app/controllers/trigger/errors.rb
@@ -17,8 +17,6 @@ module Trigger::Errors
     setup 'bad_request', 400, 'Token is setup with another project.'
   end
 
-  class InvalidProjectName < APIError; end
-
   class InvalidPackage < APIError
     setup 'bad_request', 400, 'Token is setup with another package.'
   end

--- a/src/api/app/controllers/trigger_controller.rb
+++ b/src/api/app/controllers/trigger_controller.rb
@@ -83,14 +83,10 @@ class TriggerController < ApplicationController
   end
 
   def set_project_name
-    # Don't take random content when people just use a random webhook on our
-    # route, e.g. GitLab sending its own data with an unrelated project hash.
-    raise InvalidProjectName if params[:project].present? && !params[:project].is_a?(String)
-
-    @project_name = params[:project]
+    @project_name = params[:project].to_s
   end
 
   def set_package_name
-    @package_name = params[:package]
+    @package_name = params[:package].to_s
   end
 end


### PR DESCRIPTION
It does not matter what is inside params, as long as the Token has a project set we are going to use that. So only fail *after* we checked that.

Also simplifies this by just making a string out of `@project_name`/`@package_name` and just looking in the database instead of using Project.get_by_name that is also looking at the interconnect just to raise afterward...

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
