### PR TITLE
Ignore non-String project parameters in the token trigger

### DIFF
--- a/src/api/app/controllers/trigger/errors.rb
+++ b/src/api/app/controllers/trigger/errors.rb
@@ -17,8 +17,6 @@ module Trigger::Errors
     setup 'bad_request', 400, 'Token is setup with another project.'
   end
 
-  class InvalidProjectName < APIError; end
-
   class InvalidPackage < APIError
     setup 'bad_request', 400, 'Token is setup with another package.'
   end

--- a/src/api/app/controllers/trigger_controller.rb
+++ b/src/api/app/controllers/trigger_controller.rb
@@ -64,9 +64,9 @@ class TriggerController < ApplicationController
     when 'Token::Workflow'
       raise InvalidToken, 'Invalid token found'
     when 'Token::Rebuild', 'Token::Release'
-      return if params[:project].present?
+      return if project_param.present?
     when 'Token::Service'
-      return if params[:project].present? && params[:package].present?
+      return if project_param.present? && params[:package].present?
     end
 
     return if @token.package.present?
@@ -83,14 +83,18 @@ class TriggerController < ApplicationController
   end
 
   def set_project_name
-    # Don't take random content when people just use a random webhook on our
-    # route, e.g. GitLab sending its own data with an unrelated project hash.
-    raise InvalidProjectName if params[:project].present? && !params[:project].is_a?(String)
-
-    @project_name = params[:project]
+    @project_name = project_param
   end
 
   def set_package_name
     @package_name = params[:package]
+  end
+
+  # SCMs post their own payload to our route: GitLab sends a "project" hash and
+  # GitHub an integer pull request number. Such a value is not a project name,
+  # so ignore it instead of taking it as one. This is the same reason why this
+  # controller skips the validate_params before_action.
+  def project_param
+    params[:project] if params[:project].is_a?(String)
   end
 end

--- a/src/api/spec/controllers/trigger_controller_spec.rb
+++ b/src/api/spec/controllers/trigger_controller_spec.rb
@@ -77,6 +77,28 @@ RSpec.describe TriggerController do
       subject { post :rebuild, params: { project: { unrelated: 'payload' }, format: :xml } }
 
       it { expect(subject).to have_http_status(:bad_request) }
+      it { expect(Xmlhash.parse(subject.body)['code']).to eq('missing_parameter') }
+    end
+
+    context 'with an untrusted project parameter that is not a string and a token with a package' do
+      # A GitLab webhook posts its own payload, where "project" is a hash. The
+      # token knows which package to rebuild, so the payload must be ignored.
+      subject do
+        post :rebuild, params: { project: { id: 4762, name: 'Maintenance ToolKit', path_with_namespace: 'tools/maintenance-toolkit' },
+                                 format: :xml }
+      end
+
+      before do
+        token.update!(package: package)
+        allow(Backend::Api::Sources::Package).to receive(:rebuild).with(project.name, package.name, {}).and_return("<status code=\"ok\" />\n")
+      end
+
+      it { expect(subject).to have_http_status(:success) }
+
+      it 'rebuilds the package of the token' do
+        subject
+        expect(Backend::Api::Sources::Package).to have_received(:rebuild).with(project.name, package.name, {})
+      end
     end
   end
 


### PR DESCRIPTION
Restores the behaviour of the original guard in #16545: a `project` parameter that is not a String is **ignored**, not rejected.

Ignoring the parameter (leaving `@project_name` nil) is what the original commit in #16545 did, and it is also the only thing that keeps `validate_token_project` from comparing the payload against the token's project name: that comparison, added in #17702, raises `InvalidProject` for the very same input, so reverting #20055 or coercing the value with `to_s` would not be enough.

Tokens that are not set up with a package still need a usable project, so `validate_parameters_by_token` now requires a String there and raises the regular `missing_parameter` error otherwise (400, as asked for in the review of #20055). `Trigger::Errors::InvalidProjectName` is removed, since nothing raises it anymore.

The guard lives in the shared before_actions, so `rebuild`, `release` and `runservice` are all covered.

Original change by Adrian Schröter, extracted from PR #16545.