### PR TITLE
Revert the token trigger project and package parameter checks

### DIFF
--- a/src/api/app/controllers/concerns/triggerable.rb
+++ b/src/api/app/controllers/concerns/triggerable.rb
@@ -2,8 +2,6 @@ module Triggerable
   def set_project
     # By default we operate on the package association
     @project = @token.package.try(:project)
-    validate_token_project
-
     # If the token has no package, let's find one from the parameters or the step intructions
     @project ||= Project.get_by_name(@project_name)
     # Remote projects are read-only, can't trigger something for them.
@@ -15,8 +13,6 @@ module Triggerable
     package_find_options = @token.package_find_options if package_find_options.blank?
     # By default we operate on the package association
     @package = @token.package
-    validate_token_package
-
     # If the token has no package, let's find one from the parameters
     if @package_name.present?
       @package ||= Package.get_by_project_and_name(@project.name,
@@ -51,13 +47,5 @@ module Triggerable
 
   def project_links_to_remote?
     @project.scmsync.present? || @project.links_to_remote?
-  end
-
-  def validate_token_project
-    raise Trigger::Errors::InvalidProject if @project && @project_name && (@project_name != @project.name)
-  end
-
-  def validate_token_package
-    raise Trigger::Errors::InvalidPackage if @package && @package_name && (@package_name != @package.name)
   end
 end

--- a/src/api/app/controllers/trigger/errors.rb
+++ b/src/api/app/controllers/trigger/errors.rb
@@ -12,14 +12,4 @@ module Trigger::Errors
   class MissingExtractor < APIError
     setup 'bad_request', 400, 'Extractor could not be created.'
   end
-
-  class InvalidProject < APIError
-    setup 'bad_request', 400, 'Token is setup with another project.'
-  end
-
-  class InvalidProjectName < APIError; end
-
-  class InvalidPackage < APIError
-    setup 'bad_request', 400, 'Token is setup with another package.'
-  end
 end

--- a/src/api/app/controllers/trigger_controller.rb
+++ b/src/api/app/controllers/trigger_controller.rb
@@ -83,7 +83,7 @@ class TriggerController < ApplicationController
   end
 
   def set_project_name
-    @project_name = params[:project]
+    @project_name = params[:project].to_s
   end
 
   def set_package_name

--- a/src/api/app/controllers/trigger_controller.rb
+++ b/src/api/app/controllers/trigger_controller.rb
@@ -83,10 +83,6 @@ class TriggerController < ApplicationController
   end
 
   def set_project_name
-    # Don't take random content when people just use a random webhook on our
-    # route, e.g. GitLab sending its own data with an unrelated project hash.
-    raise InvalidProjectName if params[:project].present? && !params[:project].is_a?(String)
-
     @project_name = params[:project]
   end
 

--- a/src/api/spec/controllers/concerns/triggerable_spec.rb
+++ b/src/api/spec/controllers/concerns/triggerable_spec.rb
@@ -82,29 +82,6 @@ RSpec.describe Triggerable do
     end
   end
 
-  describe 'validate_token_project' do
-    let(:package) { create(:package) }
-    let(:token) { Token::Rebuild.create(executor: user, package: package) }
-
-    before do
-      fake_controller_instance.instance_variable_set(:@project_name, 'i:dont:match')
-    end
-
-    it { expect { fake_controller_instance.set_project }.to raise_error(Trigger::Errors::InvalidProject) }
-  end
-
-  describe 'validate_token_package' do
-    let(:package) { create(:package) }
-    let(:token) { Token::Service.create(executor: user, package: package) }
-
-    before do
-      fake_controller_instance.instance_variable_set(:@project, package.project)
-      fake_controller_instance.instance_variable_set(:@package_name, 'i-dont-match')
-    end
-
-    it { expect { fake_controller_instance.set_package }.to raise_error(Trigger::Errors::InvalidPackage) }
-  end
-
   describe '#set_object_to_authorize' do
     let(:token) { Token::Service.create(executor: user) }
 

--- a/src/api/spec/controllers/trigger_controller_spec.rb
+++ b/src/api/spec/controllers/trigger_controller_spec.rb
@@ -71,12 +71,25 @@ RSpec.describe TriggerController do
       it { expect(subject).to have_http_status(:success) }
     end
 
-    context 'with an untrusted project parameter that is not a string' do
-      # e.g. a random webhook (like GitLab) sending its own payload with a
-      # project hash. The controller must not treat that as a project name.
-      subject { post :rebuild, params: { project: { unrelated: 'payload' }, format: :xml } }
+    context 'with token.package and a project parameter that is not a string' do
+      # An SCM posting its own payload to our route, e.g. GitLab, where "project"
+      # is a hash. The token knows what to rebuild, so the payload is ignored.
+      subject do
+        post :rebuild, params: { project: { id: 4762, name: 'Maintenance ToolKit', path_with_namespace: 'tools/maintenance-toolkit' },
+                                 format: :xml }
+      end
 
-      it { expect(subject).to have_http_status(:bad_request) }
+      before do
+        token.update!(package: package)
+        allow(Backend::Api::Sources::Package).to receive(:rebuild).with(project.name, package.name, {}).and_return("<status code=\"ok\" />\n")
+      end
+
+      it { expect(subject).to have_http_status(:success) }
+
+      it 'rebuilds the package of the token' do
+        subject
+        expect(Backend::Api::Sources::Package).to have_received(:rebuild).with(project.name, package.name, {})
+      end
     end
   end
 

--- a/src/api/spec/controllers/trigger_controller_spec.rb
+++ b/src/api/spec/controllers/trigger_controller_spec.rb
@@ -91,6 +91,18 @@ RSpec.describe TriggerController do
         expect(Backend::Api::Sources::Package).to have_received(:rebuild).with(project.name, package.name, {})
       end
     end
+
+    context 'without token.package and a project parameter that is not a string' do
+      # Same payload, but now there is no package on the token to fall back to,
+      # so we end up looking for a project named after the payload.
+      subject do
+        post :rebuild, params: { project: { id: 4762, name: 'Maintenance ToolKit', path_with_namespace: 'tools/maintenance-toolkit' },
+                                 format: :xml }
+      end
+
+      it { expect(subject).to have_http_status(:not_found) }
+      it { expect(Xmlhash.parse(subject.body)['code']).to eq('unknown_project') }
+    end
   end
 
   describe '#release', :vcr do


### PR DESCRIPTION
Reverts #17702 and #20055.

The trigger routes deliberately accept non-String parameters, because SCMs post their own payload to them: GitLab sends a `project` hash and GitHub an integer pull request number. That is why this controller skips `validate_params`.

#20055 rejects a `project` parameter that is not a String, and #17702 compares the `project` and `package` parameters against the ones the token is set up with. Either one is enough to make a GitLab webhook fail with a 400, even though the token already knows which package to operate on, so both go.

With both reverted the parameters are ignored again when the token is set up with a package: the payload is never read, and a token can still only ever operate on its own package.

Includes a spec for that case, which none of the reverted tests covered.