### PR TITLE
Refactor workflow create target project

### DIFF
--- a/src/api/app/models/workflow/step.rb
+++ b/src/api/app/models/workflow/step.rb
@@ -79,6 +79,22 @@ class Workflow::Step
     raise AbstractMethodCalled
   end
 
+  # The name of the step as it's written in the workflow configuration file, e.g. 'branch_package'
+  def step_name
+    self.class.name.demodulize.underscore.delete_suffix('_step')
+  end
+
+  def create_target_project
+    return target_project if target_project.present?
+
+    project = Project.new(name: target_project_name, url: workflow_run.event_source_url)
+    Pundit.authorize(@token.executor, project, :create?)
+
+    project.relationships.build(user: @token.executor, role: Role.find_by_title('maintainer'))
+    project.store(comment: "SCM/CI integration, #{step_name} step")
+    project
+  end
+
   def validate_project_names_in_step_instructions
     %i[project source_project target_project].each do |key_name|
       next unless step_instructions[key_name]

--- a/src/api/app/models/workflow/step/branch_package_step.rb
+++ b/src/api/app/models/workflow/step/branch_package_step.rb
@@ -102,18 +102,6 @@ class Workflow::Step::BranchPackageStep < Workflow::Step
                                 user: @token.executor.login)
   end
 
-  def create_target_project
-    return if target_project.present?
-
-    project = Project.new(name: target_project_name, url: workflow_run.event_source_url)
-    Pundit.authorize(@token.executor, project, :create?)
-
-    project.relationships.build(user: @token.executor,
-                                role: Role.find_by_title('maintainer'))
-    project.commit_user = User.session
-    project.store(comment: 'SCM/CI integration, branch_package step')
-  end
-
   # FIXME: Just because the tar_scm service accepts different formats for the _branch_request file, we don't need to have code
   # to generate those different formats. We can just generate one format, should be the gitlab format because it provides more
   # flexibility regarding the URL.

--- a/src/api/app/models/workflow/step/branch_package_step.rb
+++ b/src/api/app/models/workflow/step/branch_package_step.rb
@@ -44,10 +44,6 @@ class Workflow::Step::BranchPackageStep < Workflow::Step
     step_instructions[:target_project]
   end
 
-  def target_project
-    Project.find_by(name: target_project_name)
-  end
-
   def skip_repositories?
     return false if step_instructions[:add_repositories].blank?
 

--- a/src/api/app/models/workflow/step/branch_package_step.rb
+++ b/src/api/app/models/workflow/step/branch_package_step.rb
@@ -111,7 +111,7 @@ class Workflow::Step::BranchPackageStep < Workflow::Step
     project.relationships.build(user: @token.executor,
                                 role: Role.find_by_title('maintainer'))
     project.commit_user = User.session
-    project.store(comment: 'SCI/CI integration, branch_package step')
+    project.store(comment: 'SCM/CI integration, branch_package step')
   end
 
   # FIXME: Just because the tar_scm service accepts different formats for the _branch_request file, we don't need to have code

--- a/src/api/app/models/workflow/step/link_package_step.rb
+++ b/src/api/app/models/workflow/step/link_package_step.rb
@@ -30,10 +30,6 @@ class Workflow::Step::LinkPackageStep < Workflow::Step
     step_instructions[:target_project]
   end
 
-  def target_project
-    Project.find_by(name: target_project_name)
-  end
-
   def create_target_package
     return if target_package.present?
 

--- a/src/api/app/models/workflow/step/link_package_step.rb
+++ b/src/api/app/models/workflow/step/link_package_step.rb
@@ -34,14 +34,7 @@ class Workflow::Step::LinkPackageStep < Workflow::Step
     return if target_package.present?
 
     check_source_access
-
-    if target_project.nil?
-      project = Project.new(name: target_project_name)
-      Pundit.authorize(@token.executor, project, :create?)
-
-      project.relationships.new(user: User.session, role: Role.find_by_title('maintainer'))
-      project.store(comment: 'SCM/CI integration, link_package step')
-    end
+    create_target_project
 
     package = target_project.packages.new(name: target_package_name)
     Pundit.authorize(@token.executor, package, :create?)

--- a/src/api/app/models/workflow/step/link_project.rb
+++ b/src/api/app/models/workflow/step/link_project.rb
@@ -33,7 +33,7 @@ class Workflow::Step::LinkProject < Workflow::Step
     project.relationships.build(user: @token.executor,
                                 role: Role.find_by_title('maintainer'))
     project.commit_user = User.session
-    project.store(comment: 'SCI/CI integration, link_project step')
+    project.store(comment: 'SCM/CI integration, link_project step')
     project
   end
 end

--- a/src/api/app/models/workflow/step/link_project.rb
+++ b/src/api/app/models/workflow/step/link_project.rb
@@ -1,14 +1,13 @@
 class Workflow::Step::LinkProject < Workflow::Step
-
   REQUIRED_KEYS = %i[target_project source_project].freeze
-  
+
   def call
     return unless valid?
 
     if Project.exists_by_name(target_project_name)
       Pundit.authorize(@token.executor, target_project, :update?)
     else
-      create_target_project 
+      create_target_project
     end
 
     case
@@ -24,16 +23,5 @@ class Workflow::Step::LinkProject < Workflow::Step
   # This is the project the packages are going to land into
   def target_project_base_name
     step_instructions[:target_project]
-  end
-  
-  def create_target_project
-    project = Project.new(name: target_project_name, url: workflow_run.event_source_url)
-    Pundit.authorize(@token.executor, project, :create?)
-
-    project.relationships.build(user: @token.executor,
-                                role: Role.find_by_title('maintainer'))
-    project.commit_user = User.session
-    project.store(comment: 'SCM/CI integration, link_project step')
-    project
   end
 end

--- a/src/api/spec/models/workflow/step_spec.rb
+++ b/src/api/spec/models/workflow/step_spec.rb
@@ -212,6 +212,84 @@ RSpec.describe Workflow::Step do
     end
   end
 
+  describe '#create_target_project' do
+    subject { step.send(:create_target_project) }
+
+    let(:user) { create(:confirmed_user, :with_home, login: 'Iggy') }
+    let(:token) { create(:workflow_token, executor: user) }
+    # The executor is allowed to create the target project because they maintain its parent project
+    let!(:parent_project) { create(:project, name: 'target_project', maintainer: user) }
+    let(:workflow_run) do
+      create(:workflow_run, scm_vendor: 'github', hook_event: 'pull_request', hook_action: 'opened',
+                            request_payload: file_fixture('request_payload_github_pull_request_opened.json').read)
+    end
+    let(:step_instructions) do
+      { source_project: 'source_project', source_package: 'source_package', target_project: parent_project.name }
+    end
+    let(:step) { step_class.new(step_instructions: step_instructions, token: token, workflow_run: workflow_run) }
+
+    before do
+      login(user)
+    end
+
+    # All the steps creating a target project share the implementation of the parent class,
+    # they only differ in the step name they put into the commit comment.
+    { Workflow::Step::LinkProject => 'link_project',
+      Workflow::Step::BranchPackageStep => 'branch_package',
+      Workflow::Step::LinkPackageStep => 'link_package' }.each do |klass, step_name|
+      context "in a #{step_name} step" do
+        let(:step_class) { klass }
+
+        context 'when the target project does not exist yet' do
+          it 'creates it' do
+            expect { subject }.to change(Project, :count).by(1)
+          end
+
+          it 'names it after the target project of the step instructions and the pull request' do
+            expect(subject.name).to eq('target_project:openSUSE:repo123:PR-1')
+          end
+
+          it 'sets its url to the url of the event source' do
+            expect(subject.url).to eq('http://github.com/something')
+          end
+
+          it 'makes the executor of the token a maintainer of it' do
+            expect(subject.maintainers).to eq([user])
+          end
+
+          context 'storing it' do
+            let(:new_project) { Project.new(name: step.target_project_name, url: workflow_run.event_source_url) }
+
+            before do
+              # Project.new is also called by the create? policy, so we only replace the one call we care about
+              allow(Project).to receive(:new).and_call_original
+              allow(Project).to receive(:new).with(name: new_project.name, url: new_project.url).and_return(new_project)
+              allow(new_project).to receive(:store).and_call_original
+
+              subject
+            end
+
+            it 'mentions the step in the commit comment' do
+              expect(new_project).to have_received(:store).with(comment: "SCM/CI integration, #{step_name} step")
+            end
+          end
+        end
+
+        context 'when the target project already exists' do
+          let!(:existing_target_project) { create(:project, name: step.target_project_name, maintainer: user) }
+
+          it 'returns it' do
+            expect(subject).to eq(existing_target_project)
+          end
+
+          it 'does not create another project' do
+            expect { subject }.not_to change(Project, :count)
+          end
+        end
+      end
+    end
+  end
+
   describe '#validate_project_names_in_step_instructions' do
     before do
       subject.valid?


### PR DESCRIPTION
Deduplicate `create_target_project` implementation of different workflow steps.

Assisted-by: Claude:claude-opus-5
