### PR TITLE
Tackle simplecov deprecation warning for usage of `:nocov:`

### DIFF
--- a/src/api/app/lib/rabbitmq_bus.rb
+++ b/src/api/app/lib/rabbitmq_bus.rb
@@ -18,9 +18,7 @@ class RabbitmqBus
                       rabbitmq_channel.exchange(CONFIG['amqp_exchange_name'], CONFIG['amqp_exchange_options'].try(:symbolize_keys) || {})
                     else
                       # can't cover due to https://github.com/arempe93/bunny-mock/pull/25
-                      # :nocov:
-                      rabbitmq_channel.default_exchange
-                      # :nocov:
+                      rabbitmq_channel.default_exchange # simplecov:disable
                     end
   end
 end


### PR DESCRIPTION
[DEPRECATION] `# :nocov:` is deprecated and will be removed in a future release. Replace with `# simplecov:disable` / `# simplecov:enable` block comments.

See https://github.com/simplecov-ruby/simplecov#ignoringskipping-code
