### PR TITLE
Gitea feature parity error handling

### DIFF
--- a/src/api/app/lib/gitea_api/v1/client.rb
+++ b/src/api/app/lib/gitea_api/v1/client.rb
@@ -11,46 +11,64 @@ module GiteaAPI
       HTTP_INTERNAL_SERVER_ERROR_CODE = 500
       HTTP_BAD_GATEWAY_CODE = 502
       HTTP_SERVICE_UNAVAILABLE_CODE = 503
+      HTTP_CLIENT_ERROR_CODES = (400..499).freeze
       HTTP_SERVER_ERROR_CODES = (500..599).freeze
 
       class GiteaApiError < StandardError
       end
 
-      class BadRequestError < GiteaApiError
+      # The three classes below are only intermediate classes to categorize the errors below them, they are never raised
+      # themselves. Only leaf classes are raised.
+      class ClientError < GiteaApiError
       end
 
-      class UnauthorizedError < GiteaApiError
-      end
-
-      class ForbiddenError < GiteaApiError
-      end
-
-      class NotFoundError < GiteaApiError
-      end
-
-      class TooManyRequestsError < GiteaApiError
-      end
-
-      class InternalServerError < GiteaApiError
-      end
-
-      class BadGatewayError < GiteaApiError
-      end
-
-      class ServiceUnavailableError < GiteaApiError
-      end
-
-      # Any server error without a dedicated class
       class ServerError < GiteaApiError
       end
 
       class ConnectionError < GiteaApiError
       end
 
-      class SSLError < GiteaApiError
+      class BadRequestError < ClientError
       end
 
-      class ApiError < GiteaApiError
+      class UnauthorizedError < ClientError
+      end
+
+      class ForbiddenError < ClientError
+      end
+
+      class NotFoundError < ClientError
+      end
+
+      class TooManyRequestsError < ClientError
+      end
+
+      # Any client error without a dedicated class
+      class UnknownClientError < ClientError
+      end
+
+      class InternalServerError < ServerError
+      end
+
+      class BadGatewayError < ServerError
+      end
+
+      class ServiceUnavailableError < ServerError
+      end
+
+      # Any server error without a dedicated class
+      class UnknownServerError < ServerError
+      end
+
+      class ConnectionFailedError < ConnectionError
+      end
+
+      class TimeoutError < ConnectionError
+      end
+
+      # A failed TLS handshake is a permanent configuration problem, not a transient network
+      # glitch, so it stays out of the ConnectionError family.
+      class SSLError < GiteaApiError
       end
 
       ERROR_CLASSES = {
@@ -82,8 +100,10 @@ module GiteaAPI
           )
         rescue Faraday::SSLError => e
           raise SSLError, "Failed to report back to Gitea: #{e.message}"
-        rescue Faraday::ConnectionFailed, Faraday::TimeoutError => e
-          raise ConnectionError, "Failed to report back to Gitea: #{e.message}"
+        rescue Faraday::TimeoutError => e
+          raise TimeoutError, "Failed to report back to Gitea: #{e.message}"
+        rescue Faraday::ConnectionFailed => e
+          raise ConnectionFailedError, "Failed to report back to Gitea: #{e.message}"
         end
 
         return @response.body if request_successful?
@@ -107,7 +127,11 @@ module GiteaAPI
       end
 
       def error_class
-        ERROR_CLASSES[@response.status] || (HTTP_SERVER_ERROR_CODES.cover?(@response.status) ? ServerError : ApiError)
+        return ERROR_CLASSES[@response.status] if ERROR_CLASSES.key?(@response.status)
+        return UnknownClientError if HTTP_CLIENT_ERROR_CODES.cover?(@response.status)
+        return UnknownServerError if HTTP_SERVER_ERROR_CODES.cover?(@response.status)
+
+        GiteaApiError
       end
     end
   end

--- a/src/api/app/lib/gitea_api/v1/client.rb
+++ b/src/api/app/lib/gitea_api/v1/client.rb
@@ -7,6 +7,11 @@ module GiteaAPI
       HTTP_UNAUTHORIZED_CODE = 401
       HTTP_FORBIDDEN_CODE = 403
       HTTP_NOT_FOUND_CODE = 404
+      HTTP_TOO_MANY_REQUESTS_CODE = 429
+      HTTP_INTERNAL_SERVER_ERROR_CODE = 500
+      HTTP_BAD_GATEWAY_CODE = 502
+      HTTP_SERVICE_UNAVAILABLE_CODE = 503
+      HTTP_SERVER_ERROR_CODES = (500..599).freeze
 
       class GiteaApiError < StandardError
       end
@@ -23,11 +28,41 @@ module GiteaAPI
       class NotFoundError < GiteaApiError
       end
 
+      class TooManyRequestsError < GiteaApiError
+      end
+
+      class InternalServerError < GiteaApiError
+      end
+
+      class BadGatewayError < GiteaApiError
+      end
+
+      class ServiceUnavailableError < GiteaApiError
+      end
+
+      # Any server error without a dedicated class
+      class ServerError < GiteaApiError
+      end
+
       class ConnectionError < GiteaApiError
+      end
+
+      class SSLError < GiteaApiError
       end
 
       class ApiError < GiteaApiError
       end
+
+      ERROR_CLASSES = {
+        HTTP_BAD_REQUEST_CODE => BadRequestError,
+        HTTP_UNAUTHORIZED_CODE => UnauthorizedError,
+        HTTP_FORBIDDEN_CODE => ForbiddenError,
+        HTTP_NOT_FOUND_CODE => NotFoundError,
+        HTTP_TOO_MANY_REQUESTS_CODE => TooManyRequestsError,
+        HTTP_INTERNAL_SERVER_ERROR_CODE => InternalServerError,
+        HTTP_BAD_GATEWAY_CODE => BadGatewayError,
+        HTTP_SERVICE_UNAVAILABLE_CODE => ServiceUnavailableError
+      }.freeze
 
       def initialize(api_endpoint:, token:)
         @api_endpoint = "#{api_endpoint}/api/v1/"
@@ -45,7 +80,9 @@ module GiteaAPI
             { state: state, context: kwargs[:context], description: kwargs[:description],
               target_url: kwargs[:target_url] }
           )
-        rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Faraday::SSLError => e
+        rescue Faraday::SSLError => e
+          raise SSLError, "Failed to report back to Gitea: #{e.message}"
+        rescue Faraday::ConnectionFailed, Faraday::TimeoutError => e
           raise ConnectionError, "Failed to report back to Gitea: #{e.message}"
         end
 
@@ -70,18 +107,7 @@ module GiteaAPI
       end
 
       def error_class
-        case @response.status
-        when HTTP_BAD_REQUEST_CODE
-          BadRequestError
-        when HTTP_UNAUTHORIZED_CODE
-          UnauthorizedError
-        when HTTP_FORBIDDEN_CODE
-          ForbiddenError
-        when HTTP_NOT_FOUND_CODE
-          NotFoundError
-        else
-          ApiError
-        end
+        ERROR_CLASSES[@response.status] || (HTTP_SERVER_ERROR_CODES.cover?(@response.status) ? ServerError : ApiError)
       end
     end
   end

--- a/src/api/app/models/workflow_run.rb
+++ b/src/api/app/models/workflow_run.rb
@@ -83,6 +83,8 @@ class WorkflowRun < ApplicationRecord
     # "Failed to report back to GitLab: Request forbidden."
     # "Failed to report back to GitHub: Unauthorized request. Please check your credentials again."
     # "Failed to report back to GitHub: Request is forbidden."
+    # "Failed to report back to Gitea: Unauthorized request. Please check your credentials again."
+    # "Failed to report back to Gitea: Request is forbidden."
 
     return unless message.include?('Unauthorized request') || /Request (is )?forbidden/.match?(message)
 

--- a/src/api/app/services/scm_exception_handler.rb
+++ b/src/api/app/services/scm_exception_handler.rb
@@ -35,11 +35,13 @@ class SCMExceptionHandler
     log_to_workflow_run(exception, 'GitLab') if @workflow_run.present?
   end
 
-  rescue_from GiteaAPI::V1::Client::ConnectionError,
-              GiteaAPI::V1::Client::NotFoundError,
+  rescue_from GiteaAPI::V1::Client::ApiError,
               GiteaAPI::V1::Client::BadRequestError,
-              GiteaAPI::V1::Client::UnauthorizedError,
-              GiteaAPI::V1::Client::ForbiddenError do |exception|
+              GiteaAPI::V1::Client::ConnectionError,
+              GiteaAPI::V1::Client::ForbiddenError,
+              GiteaAPI::V1::Client::NotFoundError,
+              GiteaAPI::V1::Client::SSLError,
+              GiteaAPI::V1::Client::UnauthorizedError do |exception|
     log_to_workflow_run(exception, 'Gitea') if @workflow_run.present?
   end
 

--- a/src/api/app/services/scm_exception_handler.rb
+++ b/src/api/app/services/scm_exception_handler.rb
@@ -35,13 +35,11 @@ class SCMExceptionHandler
     log_to_workflow_run(exception, 'GitLab') if @workflow_run.present?
   end
 
-  rescue_from GiteaAPI::V1::Client::ApiError,
-              GiteaAPI::V1::Client::BadRequestError,
-              GiteaAPI::V1::Client::ConnectionError,
+  rescue_from GiteaAPI::V1::Client::BadRequestError,
               GiteaAPI::V1::Client::ForbiddenError,
               GiteaAPI::V1::Client::NotFoundError,
               GiteaAPI::V1::Client::SSLError,
-              GiteaAPI::V1::Client::UnauthorizedError do |exception|
+              GiteaAPI::V1::Client::UnknownClientError do |exception|
     log_to_workflow_run(exception, 'Gitea') if @workflow_run.present?
   end
 

--- a/src/api/app/services/scm_exception_message.rb
+++ b/src/api/app/services/scm_exception_message.rb
@@ -75,13 +75,38 @@ class SCMExceptionMessage
       'Bad request. Please modify your request and try again.'
   }.freeze
 
+  # Exceptions carrying the response body of the SCM (ApiError) or the underlying Faraday
+  # error (ConnectionError, SSLError) are left out on purpose: their own message is the
+  # only diagnostic we get, so we let it through untouched.
+  GITEA_EXCEPTIONS = {
+    GiteaAPI::V1::Client::BadGatewayError =>          # 502
+      'Bad gateway. Please try again later.',
+    GiteaAPI::V1::Client::BadRequestError =>          # 400
+      'Bad request. Please modify your request and try again.',
+    GiteaAPI::V1::Client::ForbiddenError =>           # 403
+      'Request is forbidden.',
+    GiteaAPI::V1::Client::InternalServerError =>      # 500
+      'Internal error. Please try again later.',
+    GiteaAPI::V1::Client::NotFoundError =>            # 404
+      'Content not found.',
+    GiteaAPI::V1::Client::ServerError =>              # 500..599
+      'Generic server error. Please try again later.',
+    GiteaAPI::V1::Client::ServiceUnavailableError =>  # 503
+      'Service is unavailable. Please try again later.',
+    GiteaAPI::V1::Client::TooManyRequestsError =>     # 429
+      'Maximum number of requests exceeded. Please try again later.',
+    GiteaAPI::V1::Client::UnauthorizedError =>        # 401
+      'Unauthorized request. Please check your credentials again.'
+  }.freeze
+
+  EXCEPTIONS_PER_SCM = {
+    'Gitea' => GITEA_EXCEPTIONS,
+    'GitHub' => GITHUB_EXCEPTIONS,
+    'GitLab' => GITLAB_EXCEPTIONS
+  }.freeze
+
   def self.for(exception:, scm:)
-    case scm
-    when 'GitHub'
-      message = GITHUB_EXCEPTIONS[exception.class]
-    when 'GitLab'
-      message = GITLAB_EXCEPTIONS[exception.class]
-    end
+    message = EXCEPTIONS_PER_SCM.fetch(scm, {})[exception.class]
     return exception.message if message.nil?
 
     message

--- a/src/api/app/services/scm_exception_message.rb
+++ b/src/api/app/services/scm_exception_message.rb
@@ -75,28 +75,25 @@ class SCMExceptionMessage
       'Bad request. Please modify your request and try again.'
   }.freeze
 
-  # Exceptions carrying the response body of the SCM (ApiError) or the underlying Faraday
-  # error (ConnectionError, SSLError) are left out on purpose: their own message is the
-  # only diagnostic we get, so we let it through untouched.
   GITEA_EXCEPTIONS = {
-    GiteaAPI::V1::Client::BadGatewayError =>          # 502
+    GiteaAPI::V1::Client::BadGatewayError =>
       'Bad gateway. Please try again later.',
-    GiteaAPI::V1::Client::BadRequestError =>          # 400
+    GiteaAPI::V1::Client::BadRequestError =>
       'Bad request. Please modify your request and try again.',
-    GiteaAPI::V1::Client::ForbiddenError =>           # 403
+    GiteaAPI::V1::Client::ForbiddenError =>
       'Request is forbidden.',
-    GiteaAPI::V1::Client::InternalServerError =>      # 500
+    GiteaAPI::V1::Client::InternalServerError =>
       'Internal error. Please try again later.',
-    GiteaAPI::V1::Client::NotFoundError =>            # 404
+    GiteaAPI::V1::Client::NotFoundError =>
       'Content not found.',
-    GiteaAPI::V1::Client::ServerError =>              # 500..599
-      'Generic server error. Please try again later.',
-    GiteaAPI::V1::Client::ServiceUnavailableError =>  # 503
+    GiteaAPI::V1::Client::ServiceUnavailableError =>
       'Service is unavailable. Please try again later.',
-    GiteaAPI::V1::Client::TooManyRequestsError =>     # 429
+    GiteaAPI::V1::Client::TooManyRequestsError =>
       'Maximum number of requests exceeded. Please try again later.',
-    GiteaAPI::V1::Client::UnauthorizedError =>        # 401
-      'Unauthorized request. Please check your credentials again.'
+    GiteaAPI::V1::Client::UnauthorizedError =>
+      'Unauthorized request. Please check your credentials again.',
+    GiteaAPI::V1::Client::UnknownServerError =>
+      'Generic server error. Please try again later.'
   }.freeze
 
   EXCEPTIONS_PER_SCM = {

--- a/src/api/spec/lib/gitea_api/v1/client_spec.rb
+++ b/src/api/spec/lib/gitea_api/v1/client_spec.rb
@@ -28,28 +28,11 @@ RSpec.describe GiteaAPI::V1::Client do
         allow(Faraday::Response).to receive_messages(status: status, body: { 'message' => 'upppsss something went wrong' })
       end
 
-      {
-        400 => GiteaAPI::V1::Client::BadRequestError,
-        401 => GiteaAPI::V1::Client::UnauthorizedError,
-        403 => GiteaAPI::V1::Client::ForbiddenError,
-        404 => GiteaAPI::V1::Client::NotFoundError,
-        429 => GiteaAPI::V1::Client::TooManyRequestsError,
-        500 => GiteaAPI::V1::Client::InternalServerError,
-        502 => GiteaAPI::V1::Client::BadGatewayError,
-        503 => GiteaAPI::V1::Client::ServiceUnavailableError,
-        # Server errors without a dedicated class
-        504 => GiteaAPI::V1::Client::ServerError,
-        599 => GiteaAPI::V1::Client::ServerError,
-        # Any other status falls back to the generic error
-        418 => GiteaAPI::V1::Client::ApiError,
-        451 => GiteaAPI::V1::Client::ApiError
-      }.each do |response_status, error_class|
-        context "when the response status is #{response_status}" do
-          let(:status) { response_status }
+      context 'when the response status is 400' do
+        let(:status) { 400 }
 
-          it "sends a post request and raises #{error_class}" do
-            expect { subject }.to raise_error(error_class, "HTTP Code: #{response_status}, response: upppsss something went wrong")
-          end
+        it "sends a post request and raises #{GiteaAPI::V1::Client::BadRequestError}" do
+          expect { subject }.to raise_error(GiteaAPI::V1::Client::BadRequestError, "HTTP Code: 400, response: upppsss something went wrong")
         end
       end
     end
@@ -65,24 +48,30 @@ RSpec.describe GiteaAPI::V1::Client do
       context 'because the connection failed' do
         let(:faraday_error) { Faraday::ConnectionFailed.new('connection refused') }
 
-        it 'raises a ConnectionError' do
-          expect { subject }.to raise_error(GiteaAPI::V1::Client::ConnectionError, 'Failed to report back to Gitea: connection refused')
+        it 'raises a ConnectionFailedError' do
+          expect { subject }.to raise_error(GiteaAPI::V1::Client::ConnectionFailedError, 'Failed to report back to Gitea: connection refused')
         end
       end
 
       context 'because the request timed out' do
         let(:faraday_error) { Faraday::TimeoutError.new('execution expired') }
 
-        it 'raises a ConnectionError' do
-          expect { subject }.to raise_error(GiteaAPI::V1::Client::ConnectionError, 'Failed to report back to Gitea: execution expired')
+        it 'raises a TimeoutError instead of a ConnectionFailedError' do
+          expect { subject }.to raise_error(GiteaAPI::V1::Client::TimeoutError, 'Failed to report back to Gitea: execution expired')
         end
       end
 
       context 'because the SSL handshake failed' do
         let(:faraday_error) { Faraday::SSLError.new('certificate verify failed') }
 
-        it 'raises an SSLError instead of a ConnectionError' do
+        it 'raises an SSLError' do
           expect { subject }.to raise_error(GiteaAPI::V1::Client::SSLError, 'Failed to report back to Gitea: certificate verify failed')
+        end
+
+        # A failed handshake is a permanent configuration problem, so it must stay outside the
+        # ConnectionError family, which ReportToSCMJob retries.
+        it 'is not part of the ConnectionError family' do
+          expect(GiteaAPI::V1::Client::SSLError.ancestors).not_to include(GiteaAPI::V1::Client::ConnectionError)
         end
       end
     end

--- a/src/api/spec/lib/gitea_api/v1/client_spec.rb
+++ b/src/api/spec/lib/gitea_api/v1/client_spec.rb
@@ -20,14 +20,70 @@ RSpec.describe GiteaAPI::V1::Client do
     end
 
     context 'when something goes wrong' do
+      subject { client.create_commit_status(owner: 'krauselukas', repo: 'hello_world', sha: 'abc123cdf', state: 'succeeded') }
+
       before do
         allow(Faraday::Connection).to receive(:new).and_return(faraday)
         allow(faraday).to receive(:post).and_return(Faraday::Response)
-        allow(Faraday::Response).to receive_messages(status: 400, body: { 'message' => 'upppsss something went wrong' })
+        allow(Faraday::Response).to receive_messages(status: status, body: { 'message' => 'upppsss something went wrong' })
       end
 
-      it 'sends a post request and returns the correct exception class' do
-        expect { client.create_commit_status(owner: 'krauselukas', repo: 'hello_world', sha: 'abc123cdf', state: 'succeeded') }.to raise_error(GiteaAPI::V1::Client::BadRequestError)
+      {
+        400 => GiteaAPI::V1::Client::BadRequestError,
+        401 => GiteaAPI::V1::Client::UnauthorizedError,
+        403 => GiteaAPI::V1::Client::ForbiddenError,
+        404 => GiteaAPI::V1::Client::NotFoundError,
+        429 => GiteaAPI::V1::Client::TooManyRequestsError,
+        500 => GiteaAPI::V1::Client::InternalServerError,
+        502 => GiteaAPI::V1::Client::BadGatewayError,
+        503 => GiteaAPI::V1::Client::ServiceUnavailableError,
+        # Server errors without a dedicated class
+        504 => GiteaAPI::V1::Client::ServerError,
+        599 => GiteaAPI::V1::Client::ServerError,
+        # Any other status falls back to the generic error
+        418 => GiteaAPI::V1::Client::ApiError,
+        451 => GiteaAPI::V1::Client::ApiError
+      }.each do |response_status, error_class|
+        context "when the response status is #{response_status}" do
+          let(:status) { response_status }
+
+          it "sends a post request and raises #{error_class}" do
+            expect { subject }.to raise_error(error_class, "HTTP Code: #{response_status}, response: upppsss something went wrong")
+          end
+        end
+      end
+    end
+
+    context 'when the request never reaches Gitea' do
+      subject { client.create_commit_status(owner: 'krauselukas', repo: 'hello_world', sha: 'abc123cdf', state: 'succeeded') }
+
+      before do
+        allow(Faraday::Connection).to receive(:new).and_return(faraday)
+        allow(faraday).to receive(:post).and_raise(faraday_error)
+      end
+
+      context 'because the connection failed' do
+        let(:faraday_error) { Faraday::ConnectionFailed.new('connection refused') }
+
+        it 'raises a ConnectionError' do
+          expect { subject }.to raise_error(GiteaAPI::V1::Client::ConnectionError, 'Failed to report back to Gitea: connection refused')
+        end
+      end
+
+      context 'because the request timed out' do
+        let(:faraday_error) { Faraday::TimeoutError.new('execution expired') }
+
+        it 'raises a ConnectionError' do
+          expect { subject }.to raise_error(GiteaAPI::V1::Client::ConnectionError, 'Failed to report back to Gitea: execution expired')
+        end
+      end
+
+      context 'because the SSL handshake failed' do
+        let(:faraday_error) { Faraday::SSLError.new('certificate verify failed') }
+
+        it 'raises an SSLError instead of a ConnectionError' do
+          expect { subject }.to raise_error(GiteaAPI::V1::Client::SSLError, 'Failed to report back to Gitea: certificate verify failed')
+        end
       end
     end
   end

--- a/src/api/spec/services/gitea_status_reporter_spec.rb
+++ b/src/api/spec/services/gitea_status_reporter_spec.rb
@@ -131,8 +131,8 @@ RSpec.describe GiteaStatusReporter, type: :service do
         end
       end
 
-      context 'with a generic ApiError' do
-        let(:exception) { GiteaAPI::V1::Client::ApiError.new('HTTP Code: 418, response: I am a teapot') }
+      context 'with a client error we have no dedicated class for' do
+        let(:exception) { GiteaAPI::V1::Client::UnknownClientError.new('HTTP Code: 418, response: I am a teapot') }
 
         it 'does not let the exception escape' do
           expect { subject }.not_to raise_error
@@ -141,6 +141,17 @@ RSpec.describe GiteaStatusReporter, type: :service do
         it 'keeps the answer of Gitea in the workflow run' do
           subject
           expect(workflow_run.reload.response_body).to eq('Failed to report back to Gitea: HTTP Code: 418, response: I am a teapot')
+        end
+      end
+
+      # These are transient, so they have to reach ReportToSCMJob for it to retry them.
+      context 'with an exception we want to retry' do
+        context "like #{GiteaAPI::V1::Client::BadGatewayError}" do
+          let(:exception) { GiteaAPI::V1::Client::BadGatewayError.new('something went wrong') }
+
+          it 'lets the exception escape' do
+            expect { subject }.to raise_error(GiteaAPI::V1::Client::BadGatewayError, 'something went wrong')
+          end
         end
       end
     end

--- a/src/api/spec/services/gitea_status_reporter_spec.rb
+++ b/src/api/spec/services/gitea_status_reporter_spec.rb
@@ -96,5 +96,53 @@ RSpec.describe GiteaStatusReporter, type: :service do
         expect(gitea_client).to have_received(:create_commit_status).with(owner: 'openSUSE', repo: 'repo123', sha: '123456789', state: state, **status_options)
       end
     end
+
+    context 'when Gitea answers with an error' do
+      subject { scm_status_reporter.call }
+
+      let(:event_payload) do
+        { project: 'home:danidoni', package: 'hello_world',
+          repository: 'openSUSE_Tumbleweed', arch: 'x86_64' }
+      end
+      let(:event_subscription_payload) do
+        { scm: 'gitea', target_repository_full_name: 'openSUSE/repo123', commit_sha: '123456789' }
+      end
+      let(:token) { 'XYCABC' }
+      let(:event_type) { nil }
+      let(:state) { 'pending' }
+      let(:initial_report) { false }
+      let(:gitea_client) { instance_spy(GiteaAPI::V1::Client) }
+
+      before do
+        allow(GiteaAPI::V1::Client).to receive(:new).and_return(gitea_client)
+        allow(gitea_client).to receive(:create_commit_status).and_raise(exception)
+      end
+
+      context 'with an exception SCMExceptionMessage knows about' do
+        let(:exception) { GiteaAPI::V1::Client::NotFoundError.new('HTTP Code: 404, response: the repository does not exist') }
+
+        it 'does not let the exception escape' do
+          expect { subject }.not_to raise_error
+        end
+
+        it 'stores the readable message in the workflow run' do
+          subject
+          expect(workflow_run.reload.response_body).to eq('Failed to report back to Gitea: Content not found.')
+        end
+      end
+
+      context 'with a generic ApiError' do
+        let(:exception) { GiteaAPI::V1::Client::ApiError.new('HTTP Code: 418, response: I am a teapot') }
+
+        it 'does not let the exception escape' do
+          expect { subject }.not_to raise_error
+        end
+
+        it 'keeps the answer of Gitea in the workflow run' do
+          subject
+          expect(workflow_run.reload.response_body).to eq('Failed to report back to Gitea: HTTP Code: 418, response: I am a teapot')
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Reach feature parity for Gitea compared to GitHub (Octokit) and GitLab, because they have a gem to handle API interactions, Gitea doesn't, it's a custom internal implemented library.


Assisted-by: Claude:claude-opus-5