### PR TITLE
Tell people when no scm/ci workflow matched a filter or is ignored

### DIFF
--- a/src/api/app/controllers/trigger_workflow_controller.rb
+++ b/src/api/app/controllers/trigger_workflow_controller.rb
@@ -64,7 +64,10 @@ class TriggerWorkflowController < ApplicationController
       validation_errors = @token.call(@workflow_run)
 
       unless @workflow_run.status == 'fail' # The SCMStatusReporter might already set the status to 'fail', lets not overwrite it
-        if validation_errors.none?
+        if validation_errors.none? && !@token.any_filters_matched?
+          @workflow_run.update(status: 'success',
+                               response_body: render_ok(data: { info: 'No workflow filter matched received event or is set on the `ignore` filter section. No steps were triggered.' }))
+        elsif validation_errors.none?
           @workflow_run.update(status: 'success', response_body: render_ok)
         else
           @workflow_run.update_as_failed(render_error(status: 400, message: validation_errors.to_sentence))

--- a/src/api/app/controllers/trigger_workflow_controller.rb
+++ b/src/api/app/controllers/trigger_workflow_controller.rb
@@ -64,10 +64,12 @@ class TriggerWorkflowController < ApplicationController
       validation_errors = @token.call(@workflow_run)
 
       unless @workflow_run.status == 'fail' # The SCMStatusReporter might already set the status to 'fail', lets not overwrite it
-        if validation_errors.none?
-          @workflow_run.update(status: 'success', response_body: render_ok)
-        else
+        if validation_errors.any?
           @workflow_run.update_as_failed(render_error(status: 400, message: validation_errors.to_sentence))
+        elsif @token.workflows_without_matching_filters.any?
+          @workflow_run.update(status: 'success', response_body: render_ok(data: { info: workflows_without_matching_filters_message }))
+        else
+          @workflow_run.update(status: 'success', response_body: render_ok)
         end
       end
     # We always want to return 200 in the request. Because a lot of things in `Workflow`` can go wrong outside this request cycle.
@@ -81,5 +83,11 @@ class TriggerWorkflowController < ApplicationController
     rescue Pundit::NotAuthorizedError => e
       @workflow_run.update_as_failed(e.message)
     end
+  end
+
+  def workflows_without_matching_filters_message
+    workflow_names = @token.workflows_without_matching_filters
+    "No steps were triggered for the #{'workflow'.pluralize(workflow_names.size)} #{workflow_names.map { |name| "'#{name}'" }.to_sentence}: " \
+      'the received event matched no filter, or it is set in the `ignore` filter section.'
   end
 end

--- a/src/api/app/models/token/workflow.rb
+++ b/src/api/app/models/token/workflow.rb
@@ -48,12 +48,10 @@ class Token::Workflow < Token
 
     # Initial report with status set to pending
     ReportToSCMJob.perform_later(workflow_run: workflow_run, initial_report: true)
-    @workflows_without_matching_filters = []
     @workflows.each do |workflow|
       return workflow.errors.full_messages if workflow.invalid?(:call)
 
       workflow.call
-      @workflows_without_matching_filters << workflow.workflow_name unless workflow.filters_matched?
     end
     # Final status report
     ReportToSCMJob.perform_later(workflow_run: workflow_run, event_type: 'success', initial_report: true)
@@ -63,11 +61,10 @@ class Token::Workflow < Token
     raise Token::Errors::SCMTokenInvalid, "Your SCM token secret is not properly set in your OBS workflow token.\nCheck #{AUTHENTICATION_DOCUMENTATION_LINK}"
   end
 
-  # Names of the workflows which did not run because none of their filters matched the event.
-  # Only meaningful once #call has run past the point of evaluating each workflow's filters
-  # (i.e. not for ping events or requests that failed validation beforehand), where it stays empty.
   def workflows_without_matching_filters
-    @workflows_without_matching_filters || []
+    return [] unless @workflows
+
+    @workflows.reject(&:filters_matched?).map(&:workflow_name)
   end
 
   def owned_by?(some_user)

--- a/src/api/app/models/token/workflow.rb
+++ b/src/api/app/models/token/workflow.rb
@@ -48,10 +48,12 @@ class Token::Workflow < Token
 
     # Initial report with status set to pending
     ReportToSCMJob.perform_later(workflow_run: workflow_run, initial_report: true)
+    @workflows_without_matching_filters = []
     @workflows.each do |workflow|
       return workflow.errors.full_messages if workflow.invalid?(:call)
 
       workflow.call
+      @workflows_without_matching_filters << workflow.workflow_name unless workflow.filters_matched?
     end
     # Final status report
     ReportToSCMJob.perform_later(workflow_run: workflow_run, event_type: 'success', initial_report: true)
@@ -59,6 +61,13 @@ class Token::Workflow < Token
     validation_errors
   rescue Octokit::Unauthorized, Gitlab::Error::Unauthorized
     raise Token::Errors::SCMTokenInvalid, "Your SCM token secret is not properly set in your OBS workflow token.\nCheck #{AUTHENTICATION_DOCUMENTATION_LINK}"
+  end
+
+  # Names of the workflows which did not run because none of their filters matched the event.
+  # Only meaningful once #call has run past the point of evaluating each workflow's filters
+  # (i.e. not for ping events or requests that failed validation beforehand), where it stays empty.
+  def workflows_without_matching_filters
+    @workflows_without_matching_filters || []
   end
 
   def owned_by?(some_user)

--- a/src/api/app/models/token/workflow.rb
+++ b/src/api/app/models/token/workflow.rb
@@ -48,10 +48,12 @@ class Token::Workflow < Token
 
     # Initial report with status set to pending
     ReportToSCMJob.perform_later(workflow_run: workflow_run, initial_report: true)
+    @any_filters_matched = false
     @workflows.each do |workflow|
       return workflow.errors.full_messages if workflow.invalid?(:call)
 
       workflow.call
+      @any_filters_matched ||= workflow.filters_matched?
     end
     # Final status report
     ReportToSCMJob.perform_later(workflow_run: workflow_run, event_type: 'success', initial_report: true)
@@ -59,6 +61,12 @@ class Token::Workflow < Token
     validation_errors
   rescue Octokit::Unauthorized, Gitlab::Error::Unauthorized
     raise Token::Errors::SCMTokenInvalid, "Your SCM token secret is not properly set in your OBS workflow token.\nCheck #{AUTHENTICATION_DOCUMENTATION_LINK}"
+  end
+
+  # Only meaningful once #call has run past the point of evaluating each workflow's filters
+  # (i.e. not for ping events or requests that failed validation beforehand), where it stays nil.
+  def any_filters_matched?
+    @any_filters_matched != false
   end
 
   def owned_by?(some_user)

--- a/src/api/app/models/workflow.rb
+++ b/src/api/app/models/workflow.rb
@@ -15,6 +15,8 @@ class Workflow # rubocop:disable Metrics/ClassLength
   SUPPORTED_FILTERS = %i[branches event labels].freeze
 
   attr_accessor :workflow_instructions, :token, :workflow_run, :workflow_version_number, :workflow_name
+  attr_reader :filters_matched
+  alias filters_matched? filters_matched
 
   def initialize(attributes = {})
     run_callbacks(:initialize) do
@@ -32,18 +34,13 @@ class Workflow # rubocop:disable Metrics/ClassLength
 
   def call
     run_callbacks(:call) do
-      @filters_matched = filters_match?
-      return unless @filters_matched
+      return unless (@filters_matched = filters_match?)
 
       steps.each do |step|
         # ArtifactsCollector can only be called if the step.call doesn't return nil because of a validation error
         step.call && Workflows::ArtifactsCollector.new(step: step, workflow_run_id: workflow_run.id).call
       end
     end
-  end
-
-  def filters_matched?
-    @filters_matched
   end
 
   def event_supports_branches_filter?

--- a/src/api/app/models/workflow.rb
+++ b/src/api/app/models/workflow.rb
@@ -31,13 +31,18 @@ class Workflow # rubocop:disable Metrics/ClassLength
 
   def call
     run_callbacks(:call) do
-      return unless filters_match?
+      @filters_matched = filters_match?
+      return unless @filters_matched
 
       steps.each do |step|
         # ArtifactsCollector can only be called if the step.call doesn't return nil because of a validation error
         step.call && Workflows::ArtifactsCollector.new(step: step, workflow_run_id: workflow_run.id).call
       end
     end
+  end
+
+  def filters_matched?
+    @filters_matched
   end
 
   def event_supports_branches_filter?

--- a/src/api/app/models/workflow.rb
+++ b/src/api/app/models/workflow.rb
@@ -14,13 +14,14 @@ class Workflow # rubocop:disable Metrics/ClassLength
 
   SUPPORTED_FILTERS = %i[branches event labels].freeze
 
-  attr_accessor :workflow_instructions, :token, :workflow_run, :workflow_version_number
+  attr_accessor :workflow_instructions, :token, :workflow_run, :workflow_version_number, :workflow_name
 
   def initialize(attributes = {})
     run_callbacks(:initialize) do
       super
       @workflow_instructions = attributes[:workflow_instructions].deep_symbolize_keys
       @workflow_version_number = attributes[:workflow_version_number]
+      @workflow_name = attributes[:workflow_name]
     end
   end
 
@@ -31,13 +32,18 @@ class Workflow # rubocop:disable Metrics/ClassLength
 
   def call
     run_callbacks(:call) do
-      return unless filters_match?
+      @filters_matched = filters_match?
+      return unless @filters_matched
 
       steps.each do |step|
         # ArtifactsCollector can only be called if the step.call doesn't return nil because of a validation error
         step.call && Workflows::ArtifactsCollector.new(step: step, workflow_run_id: workflow_run.id).call
       end
     end
+  end
+
+  def filters_matched?
+    @filters_matched
   end
 
   def event_supports_branches_filter?

--- a/src/api/app/services/workflows/yaml_to_workflows_service.rb
+++ b/src/api/app/services/workflows/yaml_to_workflows_service.rb
@@ -31,9 +31,10 @@ module Workflows
 
       parsed_workflow_configuration = extract_and_set_workflow_version(parsed_workflow_configuration: parsed_workflow_configuration)
       parsed_workflow_configuration
-        .map do |_workflow_name, workflow_instructions|
+        .map do |workflow_name, workflow_instructions|
         Workflow.new(workflow_instructions: workflow_instructions, token: @token,
-                     workflow_run: @workflow_run, workflow_version_number: @workflow_version_number)
+                     workflow_run: @workflow_run, workflow_version_number: @workflow_version_number,
+                     workflow_name: workflow_name)
       end
     end
 

--- a/src/api/spec/controllers/trigger_workflow_controller_spec.rb
+++ b/src/api/spec/controllers/trigger_workflow_controller_spec.rb
@@ -229,6 +229,31 @@ RSpec.describe TriggerWorkflowController do
       it { expect(response.body).to include('Ok') }
     end
 
+    context 'no filters matched' do
+      let(:token_extractor_instance) { instance_double(TriggerControllerService::TokenExtractor) }
+      let(:token) { build_stubbed(:workflow_token, executor: build_stubbed(:confirmed_user)) }
+      let(:github_payload) { file_fixture('request_payload_github_pull_request_opened.json').read }
+
+      before do
+        allow(token).to receive(:call).and_return([])
+        allow(token).to receive(:any_filters_matched?).and_return(false)
+
+        allow(TriggerControllerService::TokenExtractor).to receive(:new).and_return(token_extractor_instance)
+        allow(token_extractor_instance).to receive(:call).and_return(token)
+
+        request.headers['ACCEPT'] = '*/*'
+        request.headers['CONTENT_TYPE'] = 'application/json'
+        request.headers['HTTP_X_GITHUB_EVENT'] = 'pull_request'
+
+        post :create, body: github_payload
+      end
+
+      it { expect(response).to have_http_status(:success) }
+      it { expect(WorkflowRun.count).to eq(1) }
+      it { expect(WorkflowRun.last.status).to eq('success') }
+      it { expect(response.body).to include('No workflow filter matched received event or is set on the `ignore` filter section. No steps were triggered.') }
+    end
+
     context 'the SCM is unsupported' do
       let(:token_extractor_instance) { instance_double(TriggerControllerService::TokenExtractor) }
       let(:token) { build_stubbed(:workflow_token, executor: build_stubbed(:confirmed_user)) }

--- a/src/api/spec/controllers/trigger_workflow_controller_spec.rb
+++ b/src/api/spec/controllers/trigger_workflow_controller_spec.rb
@@ -229,6 +229,63 @@ RSpec.describe TriggerWorkflowController do
       it { expect(response.body).to include('Ok') }
     end
 
+    context 'no filters matched' do
+      let(:token_extractor_instance) { instance_double(TriggerControllerService::TokenExtractor) }
+      let(:token) { build_stubbed(:workflow_token, executor: build_stubbed(:confirmed_user)) }
+      let(:github_payload) { file_fixture('request_payload_github_pull_request_opened.json').read }
+
+      before do
+        allow(token).to receive(:call).and_return([])
+        allow(token).to receive(:workflows_without_matching_filters).and_return(%w[test_workflow another_workflow])
+
+        allow(TriggerControllerService::TokenExtractor).to receive(:new).and_return(token_extractor_instance)
+        allow(token_extractor_instance).to receive(:call).and_return(token)
+
+        request.headers['ACCEPT'] = '*/*'
+        request.headers['CONTENT_TYPE'] = 'application/json'
+        request.headers['HTTP_X_GITHUB_EVENT'] = 'pull_request'
+
+        post :create, body: github_payload
+      end
+
+      it { expect(response).to have_http_status(:success) }
+      it { expect(WorkflowRun.count).to eq(1) }
+      it { expect(WorkflowRun.last.status).to eq('success') }
+
+      it 'names the workflows which filters did not match' do
+        expect(response.body).to include("No steps were triggered for the workflows 'test_workflow' and 'another_workflow': " \
+                                         'the received event matched no filter, or it is set in the `ignore` filter section.')
+      end
+    end
+
+    context 'only some filters matched' do
+      let(:token_extractor_instance) { instance_double(TriggerControllerService::TokenExtractor) }
+      let(:token) { build_stubbed(:workflow_token, executor: build_stubbed(:confirmed_user)) }
+      let(:github_payload) { file_fixture('request_payload_github_pull_request_opened.json').read }
+
+      before do
+        allow(token).to receive(:call).and_return([])
+        allow(token).to receive(:workflows_without_matching_filters).and_return(['test_workflow'])
+
+        allow(TriggerControllerService::TokenExtractor).to receive(:new).and_return(token_extractor_instance)
+        allow(token_extractor_instance).to receive(:call).and_return(token)
+
+        request.headers['ACCEPT'] = '*/*'
+        request.headers['CONTENT_TYPE'] = 'application/json'
+        request.headers['HTTP_X_GITHUB_EVENT'] = 'pull_request'
+
+        post :create, body: github_payload
+      end
+
+      it { expect(response).to have_http_status(:success) }
+      it { expect(WorkflowRun.last.status).to eq('success') }
+
+      it 'only names the workflow which filters did not match' do
+        expect(response.body).to include("No steps were triggered for the workflow 'test_workflow': " \
+                                         'the received event matched no filter, or it is set in the `ignore` filter section.')
+      end
+    end
+
     context 'the SCM is unsupported' do
       let(:token_extractor_instance) { instance_double(TriggerControllerService::TokenExtractor) }
       let(:token) { build_stubbed(:workflow_token, executor: build_stubbed(:confirmed_user)) }

--- a/src/api/spec/models/token/workflow_spec.rb
+++ b/src/api/spec/models/token/workflow_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe Token::Workflow do
       before do
         # Skipping call since it's tested in the Workflow model
         allow(workflow).to receive(:call).and_return(true)
+        allow(workflow).to receive(:filters_matched?).and_return(true)
 
         allow(Workflows::YAMLDownloader).to receive(:new).with(workflow_run, token: workflow_token).and_return(yaml_downloader)
         allow(yaml_downloader).to receive(:call).and_return(Resonad.Success(yaml_file))
@@ -61,6 +62,101 @@ RSpec.describe Token::Workflow do
       it 'sends the initial report twice' do
         subject
         expect(ReportToSCMJob).to have_received(:perform_later).twice
+      end
+
+      it 'reports that all workflow filters matched' do
+        subject
+        expect(workflow_token.workflows_without_matching_filters).to eq([])
+      end
+    end
+
+    context 'when none of the workflows filters match' do
+      subject { workflow_token.call(workflow_run) }
+
+      let(:workflow_run) do
+        create(:workflow_run, token: workflow_token, scm_vendor: scm_vendor, hook_event: hook_event,
+                              request_payload: request_payload, response_url: 'https://example.com')
+      end
+      let(:scm_vendor) { 'github' }
+      let(:hook_event) { 'pull_request' }
+      let(:request_payload) { file_fixture('request_payload_github_pull_request_opened.json').read }
+      let(:yaml_downloader) { Workflows::YAMLDownloader.new(workflow_run, token: workflow_token) }
+      let(:yaml_file) { file_fixture('workflows.yml') }
+      let(:yaml_to_workflows_service) { Workflows::YAMLToWorkflowsService.new(yaml_file: yaml_file, token: workflow_token, workflow_run: workflow_run) }
+      let(:workflow) do
+        Workflow.new(workflow_run: workflow_run, token: workflow_token, workflow_name: 'test_workflow',
+                     workflow_instructions: { steps: [{ branch_package: { source_project: 'home:Admin', source_package: 'ctris', target_project: 'dev:tools' } }] })
+      end
+      let(:workflows) { [workflow] }
+
+      before do
+        # Skipping call since it's tested in the Workflow model
+        allow(workflow).to receive(:call).and_return(nil)
+        allow(workflow).to receive(:filters_matched?).and_return(false)
+
+        allow(Workflows::YAMLDownloader).to receive(:new).with(workflow_run, token: workflow_token).and_return(yaml_downloader)
+        allow(yaml_downloader).to receive(:call).and_return(Resonad.Success(yaml_file))
+        allow(Workflows::YAMLToWorkflowsService).to receive(:new).with(yaml_file: yaml_file, token: workflow_token,
+                                                                       workflow_run: workflow_run).and_return(yaml_to_workflows_service)
+        allow(yaml_to_workflows_service).to receive(:call).and_return(workflows)
+        allow(ReportToSCMJob).to receive(:perform_later)
+      end
+
+      it 'still returns no validation errors' do
+        expect(subject).to eq([])
+      end
+
+      it 'reports the name of the workflow which filters did not match' do
+        subject
+        expect(workflow_token.workflows_without_matching_filters).to eq(['test_workflow'])
+      end
+    end
+
+    context 'when only some of the workflows filters match' do
+      subject { workflow_token.call(workflow_run) }
+
+      let(:workflow_run) do
+        create(:workflow_run, token: workflow_token, scm_vendor: scm_vendor, hook_event: hook_event,
+                              request_payload: request_payload, response_url: 'https://example.com')
+      end
+      let(:scm_vendor) { 'github' }
+      let(:hook_event) { 'pull_request' }
+      let(:request_payload) { file_fixture('request_payload_github_pull_request_opened.json').read }
+      let(:yaml_downloader) { Workflows::YAMLDownloader.new(workflow_run, token: workflow_token) }
+      let(:yaml_file) { file_fixture('workflows.yml') }
+      let(:yaml_to_workflows_service) { Workflows::YAMLToWorkflowsService.new(yaml_file: yaml_file, token: workflow_token, workflow_run: workflow_run) }
+      let(:matching_workflow) do
+        Workflow.new(workflow_run: workflow_run, token: workflow_token, workflow_name: 'matching_workflow',
+                     workflow_instructions: { steps: [{ branch_package: { source_project: 'home:Admin', source_package: 'ctris', target_project: 'dev:tools' } }] })
+      end
+      let(:non_matching_workflow) do
+        Workflow.new(workflow_run: workflow_run, token: workflow_token, workflow_name: 'non_matching_workflow',
+                     workflow_instructions: { steps: [{ branch_package: { source_project: 'home:Admin', source_package: 'ctris', target_project: 'dev:tools' } }] })
+      end
+      let(:workflows) { [matching_workflow, non_matching_workflow] }
+
+      before do
+        # Skipping call since it's tested in the Workflow model
+        allow(matching_workflow).to receive(:call).and_return(true)
+        allow(matching_workflow).to receive(:filters_matched?).and_return(true)
+        allow(non_matching_workflow).to receive(:call).and_return(nil)
+        allow(non_matching_workflow).to receive(:filters_matched?).and_return(false)
+
+        allow(Workflows::YAMLDownloader).to receive(:new).with(workflow_run, token: workflow_token).and_return(yaml_downloader)
+        allow(yaml_downloader).to receive(:call).and_return(Resonad.Success(yaml_file))
+        allow(Workflows::YAMLToWorkflowsService).to receive(:new).with(yaml_file: yaml_file, token: workflow_token,
+                                                                       workflow_run: workflow_run).and_return(yaml_to_workflows_service)
+        allow(yaml_to_workflows_service).to receive(:call).and_return(workflows)
+        allow(ReportToSCMJob).to receive(:perform_later)
+      end
+
+      it 'still returns no validation errors' do
+        expect(subject).to eq([])
+      end
+
+      it 'only reports the name of the workflow which filters did not match' do
+        subject
+        expect(workflow_token.workflows_without_matching_filters).to eq(['non_matching_workflow'])
       end
     end
 

--- a/src/api/spec/models/token/workflow_spec.rb
+++ b/src/api/spec/models/token/workflow_spec.rb
@@ -62,6 +62,53 @@ RSpec.describe Token::Workflow do
         subject
         expect(ReportToSCMJob).to have_received(:perform_later).twice
       end
+
+      it 'reports that filters matched' do
+        subject
+        expect(workflow_token.any_filters_matched?).to be true
+      end
+    end
+
+    context 'when none of the workflows filters match' do
+      subject { workflow_token.call(workflow_run) }
+
+      let(:workflow_run) do
+        create(:workflow_run, token: workflow_token, scm_vendor: scm_vendor, hook_event: hook_event,
+                              request_payload: request_payload, response_url: 'https://example.com')
+      end
+      let(:scm_vendor) { 'github' }
+      let(:hook_event) { 'pull_request' }
+      let(:request_payload) { file_fixture('request_payload_github_pull_request_opened.json').read }
+      let(:yaml_downloader) { Workflows::YAMLDownloader.new(workflow_run, token: workflow_token) }
+      let(:yaml_file) { file_fixture('workflows.yml') }
+      let(:yaml_to_workflows_service) { Workflows::YAMLToWorkflowsService.new(yaml_file: yaml_file, token: workflow_token, workflow_run: workflow_run) }
+      let(:workflow) do
+        Workflow.new(workflow_run: workflow_run, token: workflow_token,
+                     workflow_instructions: { steps: [{ branch_package: { source_project: 'home:Admin', source_package: 'ctris', target_project: 'dev:tools' } }] })
+      end
+      let(:workflows) { [workflow] }
+
+      before do
+        # Skipping call since it's tested in the Workflow model
+        allow(workflow).to receive(:call).and_return(nil)
+        allow(workflow).to receive(:filters_matched?).and_return(false)
+
+        allow(Workflows::YAMLDownloader).to receive(:new).with(workflow_run, token: workflow_token).and_return(yaml_downloader)
+        allow(yaml_downloader).to receive(:call).and_return(Resonad.Success(yaml_file))
+        allow(Workflows::YAMLToWorkflowsService).to receive(:new).with(yaml_file: yaml_file, token: workflow_token,
+                                                                       workflow_run: workflow_run).and_return(yaml_to_workflows_service)
+        allow(yaml_to_workflows_service).to receive(:call).and_return(workflows)
+        allow(ReportToSCMJob).to receive(:perform_later)
+      end
+
+      it 'still returns no validation errors' do
+        expect(subject).to eq([])
+      end
+
+      it 'reports that no filters matched' do
+        subject
+        expect(workflow_token.any_filters_matched?).to be false
+      end
     end
 
     context 'with validation errors' do

--- a/src/api/spec/models/workflow_spec.rb
+++ b/src/api/spec/models/workflow_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Workflow, :vcr do
 
       it 'does not run' do
         expect(subject.call).to be_nil
+        expect(subject.filters_matched?).to be false
       end
     end
 
@@ -27,6 +28,7 @@ RSpec.describe Workflow, :vcr do
 
       it 'does not run' do
         expect(subject.call).to be_nil
+        expect(subject.filters_matched?).to be false
       end
     end
 
@@ -36,6 +38,7 @@ RSpec.describe Workflow, :vcr do
 
       it 'does not run' do
         expect(subject.call).to be_nil
+        expect(subject.filters_matched?).to be false
       end
     end
 
@@ -45,6 +48,7 @@ RSpec.describe Workflow, :vcr do
 
       it 'does not run' do
         expect(subject.call).to be_nil
+        expect(subject.filters_matched?).to be false
       end
     end
 
@@ -54,6 +58,7 @@ RSpec.describe Workflow, :vcr do
 
       it 'does not run' do
         expect(subject.call).to be_nil
+        expect(subject.filters_matched?).to be false
       end
     end
 
@@ -63,6 +68,7 @@ RSpec.describe Workflow, :vcr do
 
       it 'does not run' do
         expect(subject.call).to be_nil
+        expect(subject.filters_matched?).to be false
       end
     end
 
@@ -72,6 +78,7 @@ RSpec.describe Workflow, :vcr do
 
       it 'does not run' do
         expect(subject.call).to be_nil
+        expect(subject.filters_matched?).to be false
       end
     end
 
@@ -122,6 +129,7 @@ RSpec.describe Workflow, :vcr do
         it 'the workflow runs' do
           subject.call
           expect(subject.steps.first).to have_received(:call)
+          expect(subject.filters_matched?).to be true
         end
       end
 
@@ -154,6 +162,7 @@ RSpec.describe Workflow, :vcr do
       it 'the workflow runs' do
         subject.call
         expect(subject.steps.first).to have_received(:call)
+        expect(subject.filters_matched?).to be true
       end
     end
 
@@ -172,6 +181,7 @@ RSpec.describe Workflow, :vcr do
       it 'the workflow does not run' do
         subject.call
         expect(subject.steps.first).not_to have_received(:call)
+        expect(subject.filters_matched?).to be false
       end
     end
 
@@ -198,6 +208,7 @@ RSpec.describe Workflow, :vcr do
       it 'the workflow does not run' do
         subject.call
         expect(subject.steps.first).not_to have_received(:call)
+        expect(subject.filters_matched?).to be false
       end
     end
 
@@ -216,6 +227,7 @@ RSpec.describe Workflow, :vcr do
       it 'the workflow runs' do
         subject.call
         expect(subject.steps.first).to have_received(:call)
+        expect(subject.filters_matched?).to be true
       end
 
       context 'the branches filter contains a number' do
@@ -228,6 +240,7 @@ RSpec.describe Workflow, :vcr do
         it 'the workflow runs' do
           subject.call
           expect(subject.steps.first).to have_received(:call)
+          expect(subject.filters_matched?).to be true
         end
       end
     end


### PR DESCRIPTION
Right now we simply return and do nothing when no workflow
filter matched the scm event.
Let's give a hint by updating the workflow_run and responding
to the SCM service with a message describing what happened.
