### PR TITLE
Update brakeman to ignore Rails 8.0.5.1 EOL

### DIFF
--- a/src/api/config/brakeman.ignore
+++ b/src/api/config/brakeman.ignore
@@ -122,7 +122,25 @@
       "note": ""
     },
     {
-
+      "warning_type": "Unmaintained Dependency",
+      "warning_code": 122,
+      "fingerprint": "21ab0fe00fdd5899ffc405cff75aadb91b805ee996a614f7e27b08a287e9062d",
+      "check_name": "EOLRails",
+      "message": "Support for Rails 8.0.5.1 ends on 2026-10-07",
+      "file": "Gemfile.lock",
+      "line": 385,
+      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
+      "code": null,
+      "render_path": null,
+      "location": null,
+      "user_input": null,
+      "confidence": "Weak",
+      "cwe_id": [
+        1104
+      ],
+      "note": ""
+    },
+    {
       "warning_type": "SQL Injection",
       "warning_code": 0,
       "fingerprint": "23288c7e9dea90dd0d6a14268bf929de5b7651f16e9c2233776751400dda5d11",
@@ -425,7 +443,7 @@
           "type": "controller",
           "class": "Webui::PackageController",
           "method": "users",
-          "line": 163,
+          "line": 165,
           "file": "app/controllers/webui/package_controller.rb",
           "rendered": {
             "name": "webui/package/users",
@@ -538,7 +556,7 @@
           "type": "controller",
           "class": "Webui::PackageController",
           "method": "rpmlint_result",
-          "line": 329,
+          "line": 331,
           "file": "app/controllers/webui/package_controller.rb",
           "rendered": {
             "name": "webui/package/_rpmlint_result",
@@ -572,7 +590,7 @@
           "type": "controller",
           "class": "Webui::PackageController",
           "method": "rdiff",
-          "line": 234,
+          "line": 236,
           "file": "app/controllers/webui/package_controller.rb",
           "rendered": {
             "name": "webui/package/rdiff",
@@ -606,7 +624,7 @@
           "type": "controller",
           "class": "Webui::PackageController",
           "method": "rdiff",
-          "line": 234,
+          "line": 236,
           "file": "app/controllers/webui/package_controller.rb",
           "rendered": {
             "name": "webui/package/rdiff",
@@ -664,7 +682,7 @@
           "type": "controller",
           "class": "Webui::ProjectController",
           "method": "buildresult",
-          "line": 248,
+          "line": 249,
           "file": "app/controllers/webui/project_controller.rb",
           "rendered": {
             "name": "webui/project/_buildstatus",
@@ -680,52 +698,6 @@
       "confidence": "Weak",
       "cwe_id": [
         79
-      ],
-      "note": ""
-    },
-    {
-      "warning_type": "Command Injection",
-      "warning_code": 14,
-      "fingerprint": "d4c9f090e8151a6c740c333ce710b4a1d029f5ec139d489f11243609b3f1392b",
-      "check_name": "Execute",
-      "message": "Possible command injection",
-      "file": "lib/memory_debugger.rb",
-      "line": 43,
-      "link": "https://brakemanscanner.org/docs/warning_types/command_injection/",
-      "code": "`ps -orss= -p#{$PROCESS_ID}`",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "MemoryDebugger",
-        "method": "call"
-      },
-      "user_input": "$PROCESS_ID",
-      "confidence": "Medium",
-      "cwe_id": [
-        77
-      ],
-      "note": ""
-    },
-    {
-      "warning_type": "Command Injection",
-      "warning_code": 14,
-      "fingerprint": "d4c9f090e8151a6c740c333ce710b4a1d029f5ec139d489f11243609b3f1392b",
-      "check_name": "Execute",
-      "message": "Possible command injection",
-      "file": "lib/memory_debugger.rb",
-      "line": 51,
-      "link": "https://brakemanscanner.org/docs/warning_types/command_injection/",
-      "code": "`ps -orss= -p#{$PROCESS_ID}`",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "MemoryDebugger",
-        "method": "call"
-      },
-      "user_input": "$PROCESS_ID",
-      "confidence": "Medium",
-      "cwe_id": [
-        77
       ],
       "note": ""
     },
@@ -764,7 +736,7 @@
           "type": "controller",
           "class": "Webui::PackageController",
           "method": "rdiff",
-          "line": 234,
+          "line": 236,
           "file": "app/controllers/webui/package_controller.rb",
           "rendered": {
             "name": "webui/package/rdiff",


### PR DESCRIPTION
Update brakeman to ignore Rails 8.0.5.1 EOL

Achieved following https://github.com/openSUSE/open-build-service/wiki/Brakeman