### PR TITLE
[backend] BSRPC: use 64k chunks when sending chunked data

### DIFF
--- a/src/backend/BSRPC.pm
+++ b/src/backend/BSRPC.pm
@@ -473,8 +473,12 @@ sub rpc {
     if (!ref($data)) {
       # append body to request (chunk encoded if requested)
       if ($chunked) {
-	$data = sprintf("%X\r\n", length($data)).$data."\r\n" if $data ne '';
-	$data .= "0\r\n\r\n";
+	my $cdata = '';
+	while ($data ne '') {
+	  my $c = substr($data, 0, 65536, '');
+	  $cdata .= sprintf("%X\r\n", length($c)).$c."\r\n";
+	}
+	$data = "${cdata}0\r\n\r\n";
       }
       $req .= $data;
       undef $data;


### PR DESCRIPTION
We used one big chunk before, which may be rejected by some servers.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
