### PR TITLE
fix: handle Project authorization in Token::ServicePolicy

### DIFF
--- a/src/api/app/policies/token/service_policy.rb
+++ b/src/api/app/policies/token/service_policy.rb
@@ -1,7 +1,8 @@
 class Token::ServicePolicy < TokenPolicy
   def trigger?
     return false unless user.active?
+    return PackagePolicy.new(user, record.object_to_authorize).update? if record.object_to_authorize.is_a?(Package)
 
-    PackagePolicy.new(user, record.object_to_authorize).update?
+    ProjectPolicy.new(user, record.object_to_authorize).update? if record.object_to_authorize.is_a?(Project)
   end
 end


### PR DESCRIPTION
`Token::ServicePolicy#trigger?` delegated to `PackagePolicy`, which raises `ArgumentError` when `object_to_authorize` is a project instead of a package. This happens for packages in project-level scmsync projects, where `Triggerable#set_object_to_authorize` sets the project as the authorization target because no local package record exists.
`Token::RebuildPolicy` and `Token::ReleasePolicy` already handle this with `is_a?` type checks. This PR applies the same pattern to ServicePolicy.

AI Disclosure: AI assistance was used in finding and fixing this bug, as I'm not particularly fluent in ruby.