### PR TITLE
Deduplicate handle_notification calls

### DIFF
--- a/src/api/app/controllers/concerns/webui/notifications_handler.rb
+++ b/src/api/app/controllers/concerns/webui/notifications_handler.rb
@@ -2,21 +2,20 @@ module Webui::NotificationsHandler
   extend ActiveSupport::Concern
 
   included do
+    before_action :set_current_notification
     helper_method :notification_target_path_with_return_to, :notification_return_to_path, :notification_context_params
   end
 
-  def handle_notification
-    return unless User.session && params[:notification_id]
-
-    current_notification = Notification.find_by(id: params[:notification_id])
-
-    return unless current_notification
-    return unless NotificationPolicy.new(User.session, current_notification).update?
-
-    current_notification
-  end
-
   private
+
+  def set_current_notification
+    notification = Notification.find_by(id: params[:notification_id])
+
+    return unless notification
+    return unless NotificationPolicy.new(User.session, notification).update?
+
+    @current_notification = notification
+  end
 
   def notification_target_path_with_return_to(path)
     uri = URI.parse(path)

--- a/src/api/app/controllers/concerns/webui/notifications_handler.rb
+++ b/src/api/app/controllers/concerns/webui/notifications_handler.rb
@@ -8,8 +8,9 @@ module Webui::NotificationsHandler
   def handle_notification
     return unless User.session && params[:notification_id]
 
-    current_notification = Notification.find(params[:notification_id])
+    current_notification = Notification.find_by(id: params[:notification_id])
 
+    return unless current_notification
     return unless NotificationPolicy.new(User.session, current_notification).update?
 
     current_notification

--- a/src/api/app/controllers/webui/appeals_controller.rb
+++ b/src/api/app/controllers/webui/appeals_controller.rb
@@ -7,7 +7,6 @@ class Webui::AppealsController < Webui::WebuiController
     @appeal = Appeal.find(params[:id])
 
     authorize @appeal
-    @current_notification = handle_notification
   end
 
   def new

--- a/src/api/app/controllers/webui/groups_controller.rb
+++ b/src/api/app/controllers/webui/groups_controller.rb
@@ -11,9 +11,7 @@ class Webui::GroupsController < Webui::WebuiController
     @groups = Group.includes(:users).order(:title)
   end
 
-  def show
-    @current_notification = handle_notification
-  end
+  def show; end
 
   def new; end
 

--- a/src/api/app/controllers/webui/package_controller.rb
+++ b/src/api/app/controllers/webui/package_controller.rb
@@ -85,8 +85,6 @@ class Webui::PackageController < Webui::WebuiController
     @comments = @package.comments.includes(:user)
     @comment = Comment.new
 
-    @current_notification = handle_notification
-
     @services = @files.any? { |file| file['name'] == '_service' }
 
     respond_to do |format|
@@ -157,10 +155,6 @@ class Webui::PackageController < Webui::WebuiController
     @users = [@project.users, @package.users].flatten.uniq
     @groups = [@project.groups, @package.groups].flatten.uniq
     @roles = Role.local_roles
-    if User.session && params[:notification_id]
-      @current_notification = Notification.find(params[:notification_id])
-      authorize @current_notification, :update?, policy_class: NotificationPolicy
-    end
     @current_request_action = BsRequestAction.find(params[:request_action_id]) if User.session && params[:request_action_id]
   end
 

--- a/src/api/app/controllers/webui/packages/build_log_controller.rb
+++ b/src/api/app/controllers/webui/packages/build_log_controller.rb
@@ -12,7 +12,6 @@ module Webui
       before_action :set_object_to_authorize
 
       def live_build_log
-        @current_notification = handle_notification
         @offset = 0
         @status = get_status(@project, @package_name, @repository, @architecture)
         @what_depends_on = Package.what_depends_on(@project, @package_name, @repository, @architecture)

--- a/src/api/app/controllers/webui/project_controller.rb
+++ b/src/api/app/controllers/webui/project_controller.rb
@@ -60,7 +60,6 @@ class Webui::ProjectController < Webui::WebuiController
 
     @comments = @project.comments
     @comment = Comment.new
-    @current_notification = handle_notification
 
     respond_to do |format|
       format.html
@@ -185,10 +184,6 @@ class Webui::ProjectController < Webui::WebuiController
     @users = @project.users
     @groups = @project.groups
     @roles = Role.local_roles
-    if User.session && params[:notification_id]
-      @current_notification = Notification.find(params[:notification_id])
-      authorize @current_notification, :update?, policy_class: NotificationPolicy
-    end
     @current_request_action = BsRequestAction.find(params[:request_action_id]) if User.session && params[:request_action_id]
   end
 

--- a/src/api/app/controllers/webui/reports_controller.rb
+++ b/src/api/app/controllers/webui/reports_controller.rb
@@ -8,8 +8,6 @@ class Webui::ReportsController < Webui::WebuiController
 
   def show
     authorize @report
-
-    @current_notification = handle_notification
   end
 
   def create

--- a/src/api/app/controllers/webui/request_controller.rb
+++ b/src/api/app/controllers/webui/request_controller.rb
@@ -565,7 +565,6 @@ class Webui::RequestController < Webui::WebuiController
   end
 
   def prepare_request_header_data
-    @current_notification = handle_notification
     action_index = @actions.index(@action)
     if action_index
       @prev_action = @actions[action_index - 1] unless action_index.zero?

--- a/src/api/app/controllers/webui/users_controller.rb
+++ b/src/api/app/controllers/webui/users_controller.rb
@@ -33,7 +33,6 @@ class Webui::UsersController < Webui::WebuiController
     @activities_per_year = UserYearlyContribution.new(@displayed_user, @first_day).call
     @date = params[:date]
     @activities_per_day = UserDailyContribution.new(@displayed_user, @date).call
-    @current_notification = handle_notification
   end
 
   def new

--- a/src/api/app/controllers/webui/workflow_runs_controller.rb
+++ b/src/api/app/controllers/webui/workflow_runs_controller.rb
@@ -24,7 +24,6 @@ class Webui::WorkflowRunsController < Webui::WebuiController
     @workflow_run = WorkflowRun.find(params[:id])
     authorize @workflow_run, policy_class: WorkflowRunPolicy
 
-    @current_notification = handle_notification
     @token = @workflow_run.token
   end
 


### PR DESCRIPTION
Do not spread the notification check in every controller, do that from a `before_action` in the concern instead