### PR TITLE
Add missing annotations

### DIFF
--- a/src/api/app/models/event_subscription.rb
+++ b/src/api/app/models/event_subscription.rb
@@ -120,7 +120,7 @@ end
 # Table name: event_subscriptions
 #
 #  id              :integer          not null, primary key
-#  channel         :integer          default("disabled"), not null
+#  channel         :integer          default(0), not null
 #  enabled         :boolean          default(FALSE)
 #  eventtype       :string(255)      not null
 #  receiver_role   :string(255)      not null

--- a/src/api/app/models/kiwi/description.rb
+++ b/src/api/app/models/kiwi/description.rb
@@ -25,7 +25,7 @@ end
 #  id               :integer          not null, primary key
 #  author           :string(255)
 #  contact          :string(255)
-#  description_type :integer          default("system")
+#  description_type :integer          default(0)
 #  specification    :string(255)
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null

--- a/src/api/app/models/report.rb
+++ b/src/api/app/models/report.rb
@@ -93,7 +93,7 @@ end
 # Table name: reports
 #
 #  id              :bigint           not null, primary key
-#  category        :integer          default("other")
+#  category        :integer          default(99)
 #  comments_count  :integer          default(0), not null, indexed
 #  reason          :text(65535)
 #  reportable_type :string(255)      indexed => [reportable_id]

--- a/src/api/app/models/scm_status_report.rb
+++ b/src/api/app/models/scm_status_report.rb
@@ -36,7 +36,7 @@ end
 #  id                 :integer          not null, primary key
 #  request_parameters :text(4294967295)
 #  response_body      :text(4294967295)
-#  status             :integer          default("success"), not null
+#  status             :integer          default(0), not null
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
 #  workflow_run_id    :integer

--- a/src/api/app/models/status_message.rb
+++ b/src/api/app/models/status_message.rb
@@ -50,7 +50,7 @@ end
 # Table name: status_messages
 #
 #  id                  :integer          not null, primary key
-#  communication_scope :integer          default("all_users")
+#  communication_scope :integer          default(0)
 #  message             :text(65535)
 #  severity            :integer
 #  created_at          :datetime         indexed

--- a/src/api/app/models/unregistered_user.rb
+++ b/src/api/app/models/unregistered_user.rb
@@ -61,7 +61,7 @@ end
 #  adminnote                     :text(65535)
 #  biography                     :string(255)      default("")
 #  censored                      :boolean          default(FALSE), not null, indexed
-#  color_theme                   :integer          default("system"), not null
+#  color_theme                   :integer          default(0), not null
 #  deprecated_password           :string(255)      indexed
 #  deprecated_password_hash_type :string(255)
 #  deprecated_password_salt      :string(255)

--- a/src/api/app/models/user.rb
+++ b/src/api/app/models/user.rb
@@ -881,7 +881,7 @@ end
 #  adminnote                     :text(65535)
 #  biography                     :string(255)      default("")
 #  censored                      :boolean          default(FALSE), not null, indexed
-#  color_theme                   :integer          default("system"), not null
+#  color_theme                   :integer          default(0), not null
 #  deprecated_password           :string(255)      indexed
 #  deprecated_password_hash_type :string(255)
 #  deprecated_password_salt      :string(255)

--- a/src/api/app/models/workflow_run.rb
+++ b/src/api/app/models/workflow_run.rb
@@ -244,7 +244,7 @@ end
 #  response_body               :text(65535)
 #  response_url                :string(255)
 #  scm_vendor                  :string(255)
-#  status                      :integer          default("running"), not null
+#  status                      :integer          default(0), not null
 #  workflow_configuration      :text(65535)
 #  workflow_configuration_path :string(255)
 #  workflow_configuration_url  :string(255)


### PR DESCRIPTION
Everytime we run `db:migrate` we get these missing annotations 
