### PR TITLE
Translate scmsync links to SCM browse URLs

### DIFF
--- a/src/api/app/models/concerns/scmsync_url.rb
+++ b/src/api/app/models/concerns/scmsync_url.rb
@@ -1,0 +1,100 @@
+module ScmsyncUrl
+  extend ActiveSupport::Concern
+
+  COMMIT_SHA_PATTERN = /\A\h{40}\z/
+  SCM_PROVIDER_MATCHERS = {
+    github: /(^|\.)github(\.|$)/,
+    gitlab: /(^|\.)gitlab(\.|$)/,
+    gitea: /(^|\.)gitea(\.|$)|\Asrc\.opensuse\.org\z/
+  }.freeze
+
+  # OBS stores clone URLs and adds query params like `subdir` for SCM synced
+  # projects. Translate them into provider browse URLs for WebUI links.
+  def scmsync_url
+    return if scmsync.blank?
+
+    build_scmsync_url(Addressable::URI.parse(scmsync))
+  rescue Addressable::URI::InvalidURIError
+    scmsync
+  end
+
+  private
+
+  def build_scmsync_url(parsed_scmsync_url)
+    revision = parsed_scmsync_url.fragment
+    subdir = parsed_scmsync_url.query_values&.fetch('subdir', nil)&.delete_prefix('/')
+
+    normalize_scmsync_url!(parsed_scmsync_url)
+
+    return fallback_scmsync_url(parsed_scmsync_url, revision) if revision.blank?
+
+    translated_scmsync_url(parsed_scmsync_url, revision, subdir) || fallback_scmsync_url(parsed_scmsync_url, revision)
+  end
+
+  def normalize_scmsync_url!(parsed_scmsync_url)
+    parsed_scmsync_url.query = nil
+    parsed_scmsync_url.fragment = nil
+    parsed_scmsync_url.path = parsed_scmsync_url.path.chomp('/').delete_suffix('.git')
+  end
+
+  def translated_scmsync_url(parsed_scmsync_url, revision, subdir)
+    case scmsync_provider(parsed_scmsync_url)
+    when :github
+      github_scmsync_url(parsed_scmsync_url, revision, subdir)
+    when :gitlab
+      gitlab_scmsync_url(parsed_scmsync_url, revision, subdir)
+    when :gitea
+      gitea_scmsync_url(parsed_scmsync_url, revision, subdir)
+    end
+  end
+
+  def fallback_scmsync_url(parsed_scmsync_url, revision)
+    parsed_scmsync_url.fragment = revision
+    parsed_scmsync_url.to_s
+  end
+
+  def scmsync_provider(parsed_scmsync_url)
+    host = parsed_scmsync_url.host.to_s.downcase
+
+    provider = SCM_PROVIDER_MATCHERS.find { |_provider, matcher| host.match?(matcher) }
+    provider&.first
+  end
+
+  def github_scmsync_url(parsed_scmsync_url, revision, subdir)
+    parsed_scmsync_url.path = if subdir.present?
+                                "#{parsed_scmsync_url.path}/tree/#{revision}/#{subdir}"
+                              elsif commit_sha?(revision)
+                                "#{parsed_scmsync_url.path}/commit/#{revision}"
+                              else
+                                "#{parsed_scmsync_url.path}/tree/#{revision}"
+                              end
+    parsed_scmsync_url.to_s
+  end
+
+  def gitlab_scmsync_url(parsed_scmsync_url, revision, subdir)
+    parsed_scmsync_url.path = if subdir.present?
+                                "#{parsed_scmsync_url.path}/-/tree/#{revision}/#{subdir}"
+                              elsif commit_sha?(revision)
+                                "#{parsed_scmsync_url.path}/-/commit/#{revision}"
+                              else
+                                "#{parsed_scmsync_url.path}/-/tree/#{revision}"
+                              end
+    parsed_scmsync_url.to_s
+  end
+
+  def gitea_scmsync_url(parsed_scmsync_url, revision, subdir)
+    parsed_scmsync_url.path = if subdir.present?
+                                route = commit_sha?(revision) ? 'commit' : 'branch'
+                                "#{parsed_scmsync_url.path}/src/#{route}/#{revision}/#{subdir}"
+                              elsif commit_sha?(revision)
+                                "#{parsed_scmsync_url.path}/commit/#{revision}"
+                              else
+                                "#{parsed_scmsync_url.path}/src/branch/#{revision}"
+                              end
+    parsed_scmsync_url.to_s
+  end
+
+  def commit_sha?(revision)
+    revision.match?(COMMIT_SHA_PATTERN)
+  end
+end

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -13,6 +13,7 @@ class Package < ApplicationRecord
   include MultibuildPackage
   include PackageMediumContainer
   include ReportBugUrl
+  include ScmsyncUrl
 
   SPECIAL_NAMES = %w[_product _pattern _project _patchinfo].freeze
   has_many :relationships, dependent: :destroy, inverse_of: :package

--- a/src/api/app/models/project.rb
+++ b/src/api/app/models/project.rb
@@ -13,6 +13,7 @@ class Project < ApplicationRecord
   include ProjectDistribution
   include ProjectMaintenance
   include ReportBugUrl
+  include ScmsyncUrl
 
   TYPES = %w[standard maintenance maintenance_incident
              maintenance_release].freeze

--- a/src/api/app/views/webui/package/side_links/_show_scmsync.html.haml
+++ b/src/api/app/views/webui/package/side_links/_show_scmsync.html.haml
@@ -1,5 +1,5 @@
 %li
   %i.fas.fa-info-circle.text-info
   Developed at
-  = link_to package.scmsync do
+  = link_to package.scmsync_url do
     SCM

--- a/src/api/app/views/webui/project/_project_packages.html.haml
+++ b/src/api/app/views/webui/project/_project_packages.html.haml
@@ -9,7 +9,7 @@
 .card-body
   - if project.scmsync.present?
     %p
-    = link_to project.scmsync do
+    = link_to project.scmsync_url do
       This project is managed in SCM
   - elsif packages.present?
     - if Flipper.enabled?(:labels, User.session)

--- a/src/api/spec/models/concerns/scmsync_url_spec.rb
+++ b/src/api/spec/models/concerns/scmsync_url_spec.rb
@@ -1,0 +1,59 @@
+class TestScmsyncUrl
+  include ScmsyncUrl
+
+  attr_accessor :scmsync
+
+  def initialize(scmsync: nil)
+    @scmsync = scmsync
+  end
+end
+
+RSpec.describe ScmsyncUrl do
+  describe '#scmsync_url' do
+    subject(:scmsync_url) { record.scmsync_url }
+
+    let(:record) { TestScmsyncUrl.new(scmsync: scm_url) }
+    let(:commit_sha) { '1234567890abcdef1234567890abcdef12345678' }
+
+    context 'with a github branch' do
+      let(:scm_url) { 'https://github.com/example/repo.git#main' }
+
+      it { expect(scmsync_url).to eq('https://github.com/example/repo/tree/main') }
+    end
+
+    context 'with a github subdirectory' do
+      let(:scm_url) { 'https://github.com/example/repo.git?subdir=packages/test#main' }
+
+      it { expect(scmsync_url).to eq('https://github.com/example/repo/tree/main/packages/test') }
+    end
+
+    context 'with a gitlab commit' do
+      let(:scm_url) { "https://gitlab.com/example/repo.git##{commit_sha}" }
+
+      it { expect(scmsync_url).to eq("https://gitlab.com/example/repo/-/commit/#{commit_sha}") }
+    end
+
+    context 'with a gitea subdirectory' do
+      let(:scm_url) { "https://src.opensuse.org/home:autogits_obs_staging_bot/autogits:XObsPrj:PR:3.git?subdir=test-dir##{commit_sha}" }
+
+      it { expect(scmsync_url).to eq("https://src.opensuse.org/home:autogits_obs_staging_bot/autogits:XObsPrj:PR:3/src/commit/#{commit_sha}/test-dir") }
+    end
+
+    context 'with an unknown provider' do
+      let(:scm_url) { 'https://example.com/example/repo.git?subdir=test-dir#main' }
+
+      it { expect(scmsync_url).to eq('https://example.com/example/repo#main') }
+    end
+
+    context 'with an invalid URL' do
+      let(:scm_url) { 'not a valid url' }
+
+      it { expect(scmsync_url).to eq('not a valid url') }
+    end
+  end
+
+  describe 'including model classes' do
+    it { expect(Package.new).to respond_to(:scmsync_url) }
+    it { expect(Project.new).to respond_to(:scmsync_url) }
+  end
+end


### PR DESCRIPTION
## Description:

The WebUI currently links raw `scmsync` values directly. For SCM-synced projects and packages, that leaves OBS-specific query parameters like `subdir` in the `href` and does not translate revisions to provider browse URLs.

This adds a `scmsync_url` getter on `Project` and `Package` and uses it for the WebUI links. Known SCM providers are translated to their browse URLs for branches, commits, and subdirectories:

- GitHub
- GitLab
- Gitea / src.opensuse.org

Unknown providers fall back to the cleaned URL without OBS query parameters.

Closes #16595.

## Validation:

- `bundle exec rubocop app/models/concerns/scmsync_url.rb app/models/package.rb app/models/project.rb spec/models/concerns/scmsync_url_spec.rb`
- `bundle exec haml-lint app/views/webui/package/side_links/_show_scmsync.html.haml app/views/webui/project/_project_packages.html.haml`
- `bundle exec rspec spec/models/concerns/scmsync_url_spec.rb`