### PR TITLE
Fix #20075: Gracefully handle expired GitLab tokens

### DIFF
--- a/src/api/app/models/workflow_run.rb
+++ b/src/api/app/models/workflow_run.rb
@@ -86,7 +86,9 @@ class WorkflowRun < ApplicationRecord
     # "Failed to report back to Gitea: Unauthorized request. Please check your credentials again."
     # "Failed to report back to Gitea: Request is forbidden."
 
-    return unless message.include?('Unauthorized request') || /Request (is )?forbidden/.match?(message)
+    return unless message.include?('Unauthorized request') ||
+                  /Request (is )?forbidden/.match?(message) ||
+                  /token is expired/i.match?(message)
 
     token.update(enabled: false, reason: "Authentication to #{scm_vendor.titleize} failed while reporting the build status. Check your tokens authorization setup!")
   end

--- a/src/api/app/services/scm_exception_handler.rb
+++ b/src/api/app/services/scm_exception_handler.rb
@@ -43,6 +43,12 @@ class SCMExceptionHandler
     log_to_workflow_run(exception, 'Gitea') if @workflow_run.present?
   end
 
+  rescue_from Gitlab::Error::Unauthorized do |exception|
+    raise exception unless exception.message.match?(/token is expired/i)
+
+    log_to_workflow_run(exception, 'GitLab') if @workflow_run.present?
+  end
+
   def initialize(event_payload, event_subscription_payload, scm_token, workflow_run = nil)
     @event_payload = event_payload.deep_symbolize_keys
     @event_subscription_payload = event_subscription_payload.deep_symbolize_keys

--- a/src/api/app/services/scm_exception_message.rb
+++ b/src/api/app/services/scm_exception_message.rb
@@ -106,6 +106,10 @@ class SCMExceptionMessage
     message = EXCEPTIONS_PER_SCM.fetch(scm, {})[exception.class]
     return exception.message if message.nil?
 
+    if exception.is_a?(Gitlab::Error::Unauthorized) && exception.message.match?(/token is expired/i)
+      return 'Token is expired. Please check your credentials again.'
+    end
+
     message
   end
 end

--- a/src/api/spec/services/gitlab_status_reporter_spec.rb
+++ b/src/api/spec/services/gitlab_status_reporter_spec.rb
@@ -98,5 +98,59 @@ RSpec.describe GitlabStatusReporter, type: :service do
         expect(gitlab_instance).to have_received(:update_commit_status).with('26_212_710', '123456789', state, status_options)
       end
     end
+
+    context 'when GitLab responds with 401 Unauthorized (token expired)' do
+      subject { scm_status_reporter.call }
+
+      let(:event_payload) { { project: 'home:user', package: 'pkg', repository: 'repo', arch: 'x86_64' } }
+      let(:event_subscription_payload) { { scm: 'gitlab', project_id: '123', commit_sha: 'abc' } }
+      let(:token) { 'EXPIRED' }
+      let(:event_type) { nil }
+      let(:state) { 'pending' }
+      let(:initial_report) { false }
+      let(:gitlab_instance) { instance_spy(Gitlab::Client) }
+      let(:exception) do
+        e = Gitlab::Error::Unauthorized.allocate
+        allow(e).to receive_messages(message: 'Token is expired', response_message: 'Token is expired')
+        e
+      end
+
+      before do
+        allow(Gitlab).to receive(:client).and_return(gitlab_instance)
+        allow(gitlab_instance).to receive(:update_commit_status).and_raise(exception)
+        allow(scm_status_reporter.instance_variable_get(:@workflow_run)).to receive(:save_scm_report_failure)
+      end
+
+      it 'handles the exception by marking workflow_run as failed without re-raising', :aggregate_failures do
+        expect { subject }.not_to raise_error
+        expect(scm_status_reporter.instance_variable_get(:@workflow_run)).to have_received(:save_scm_report_failure).with(/Token is expired/, anything)
+      end
+    end
+
+    context 'when GitLab responds with 401 Unauthorized (regular auth failure)' do
+      subject { scm_status_reporter.call }
+
+      let(:event_payload) { { project: 'home:user', package: 'pkg', repository: 'repo', arch: 'x86_64' } }
+      let(:event_subscription_payload) { { scm: 'gitlab', project_id: '123', commit_sha: 'abc' } }
+      let(:token) { 'INVALID' }
+      let(:event_type) { nil }
+      let(:state) { 'pending' }
+      let(:initial_report) { false }
+      let(:gitlab_instance) { instance_spy(Gitlab::Client) }
+      let(:exception) do
+        e = Gitlab::Error::Unauthorized.allocate
+        allow(e).to receive_messages(message: 'Unauthorized request.', response_message: 'Unauthorized request.')
+        e
+      end
+
+      before do
+        allow(Gitlab).to receive(:client).and_return(gitlab_instance)
+        allow(gitlab_instance).to receive(:update_commit_status).and_raise(exception)
+      end
+
+      it 're-raises the exception for the retry loop' do
+        expect { subject }.to raise_error(Gitlab::Error::Unauthorized, /Unauthorized request/)
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes:  #20075 

### Description

Currently, when a GitLab token expires, [ReportToSCMJob](cci:2://file:///home/akarsh/open-build-service/src/api/app/jobs/report_to_scm_job.rb:0:0-105:3) gets hit with a `401 Unauthorized` exception. Since this error is flagged as retryable, the job blindly retries 6 times, spanning almost 20 minutes, while spamming Errbit with noisy exceptions. Most importantly, the user is never told their token actually expired. 

This PR intercepts that specific expired token error so it fails gracefully.

**Changes:**
- **[scm_exception_handler.rb](cci:7://file:///home/akarsh/open-build-service/src/api/app/services/scm_exception_handler.rb:0:0-0:0)**: Added a rescue block for `Gitlab::Error::Unauthorized`. If the message says "token is expired", we catch it and route it to failure immediately instead of re-raising it for a retry.
- **[workflow_run.rb](cci:7://file:///home/akarsh/open-build-service/src/api/app/models/workflow_run.rb:0:0-0:0)**: Tweaked the circuit breaker in [update_as_failed](cci:1://file:///home/akarsh/open-build-service/src/api/app/models/workflow_run.rb:72:2-93:5) to recognize the "token is expired" message. This ensures the token gets disabled in the database, which automatically fires off a notification to the user so they know they need to re-authenticate.

**How to test:**
Trigger a workflow run using a disabled or expired GitLab token. The run should fail immediately (no retry loops) and the token should automatically be disabled with a reason explaining the auth failure.
