### PR TITLE
Bug fix: creating a vendor, there is no vendors page

### DIFF
--- a/src/api/app/views/webui/vendors/new.html.haml
+++ b/src/api/app/views/webui/vendors/new.html.haml
@@ -11,4 +11,4 @@
     %br
 
     %div
-      = link_to "Back to vendors", project_vendors_path
+      = link_to "Back to project", project_show_path(@project)


### PR DESCRIPTION
Wrong link reaches 404 page, there is no vendors index page.