### PR TITLE
Avoid writing a "0" into files

### DIFF
--- a/src/backend/BSUtil.pm
+++ b/src/backend/BSUtil.pm
@@ -87,7 +87,7 @@ sub writestr {
   open($f, '>', $fn) || die("$fn: $!\n");
   my $l = length($_[2]);
   if ($l) {
-    (syswrite($f, $_[2] || 0) == $l) || die("$fn write: $!\n");
+    ((syswrite($f, $_[2]) || 0) == $l) || die("$fn write: $!\n");
   }
   do_fdatasync(fileno($f)) if defined($fnf) && $fdatasync_before_rename;
   close($f) || die("$fn close: $!\n");


### PR DESCRIPTION
This was accidentally broken in commit e1cf7f81fc22ef9ee5b22d86c331e065d941e21f

Now the `|| 0` suppresses warnings again.
```
Use of uninitialized value in numeric eq (==) at BSUtil.pm line 90.
```