### PR TITLE
Redirect instead of leaving `@package` `nil` for scmsync projects

### DIFF
--- a/src/api/app/controllers/webui/packages/build_log_controller.rb
+++ b/src/api/app/controllers/webui/packages/build_log_controller.rb
@@ -6,7 +6,7 @@ module Webui
 
       before_action :check_ajax, only: :update_build_log
       before_action :set_project
-      before_action :set_package
+      before_action :set_optional_package
       before_action :set_repository
       before_action :set_architecture
       before_action :set_object_to_authorize

--- a/src/api/app/controllers/webui/packages/trigger_controller.rb
+++ b/src/api/app/controllers/webui/packages/trigger_controller.rb
@@ -3,7 +3,7 @@ module Webui
     class TriggerController < WebuiController
       before_action :require_login
       before_action :set_project
-      before_action :set_package
+      before_action :set_optional_package
       before_action :set_object_to_authorize
 
       after_action :verify_authorized

--- a/src/api/app/controllers/webui/webui_controller.rb
+++ b/src/api/app/controllers/webui/webui_controller.rb
@@ -11,6 +11,7 @@ class Webui::WebuiController < ActionController::Base
   include FlipperFeature
   include Webui::RescueHandler
   include RescueAuthorizationHandler
+  include ScmsyncChecker
   include SetCurrentRequestDetails
   include Webui::ElisionsHelper
   include ActiveStorage::SetCurrent
@@ -92,6 +93,26 @@ class Webui::WebuiController < ActionController::Base
   end
 
   def set_package
+    resolve_package
+
+    return if @package || @package_name.blank?
+
+    return check_scmsync if @project.scmsync.present?
+
+    raise_package_not_found
+  end
+
+  # Leaves @package nil for packages that only exist in the backend, which is every package
+  # of an scmsync project. Any other missing package is still an error.
+  def set_optional_package
+    resolve_package
+
+    return if @package || @package_name.blank? || @project.scmsync.present?
+
+    raise_package_not_found
+  end
+
+  def resolve_package
     @package_name = params[:package] || params[:package_name]
 
     return if @package_name.blank?
@@ -102,9 +123,6 @@ class Webui::WebuiController < ActionController::Base
     rescue APIError
       raise_package_not_found
     end
-
-    # Packages of scmsync projects only exist in the backend, @package stays nil for those.
-    raise_package_not_found if @package.nil? && @project.scmsync.blank?
   end
 
   def raise_package_not_found

--- a/src/api/app/controllers/webui/webui_controller.rb
+++ b/src/api/app/controllers/webui/webui_controller.rb
@@ -100,8 +100,15 @@ class Webui::WebuiController < ActionController::Base
       @package = Package.get_by_project_and_name(@project.name, @package_name, follow_multibuild: true)
     # why it's not found is of no concern
     rescue APIError
-      raise Package::UnknownObjectError, "Package not found: #{@project.name}/#{@package_name}"
+      raise_package_not_found
     end
+
+    # Packages of scmsync projects only exist in the backend, @package stays nil for those.
+    raise_package_not_found if @package.nil? && @project.scmsync.blank?
+  end
+
+  def raise_package_not_found
+    raise Package::UnknownObjectError, "Package not found: #{@project.name}/#{@package_name}"
   end
 
   def set_repository

--- a/src/api/config/brakeman.ignore
+++ b/src/api/config/brakeman.ignore
@@ -276,6 +276,40 @@
       "note": ""
     },
     {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 2,
+      "fingerprint": "3e76aea56e760a87adae4e6ff7d00c935d6526aa7671125805821a6575ca9d10",
+      "check_name": "CrossSiteScripting",
+      "message": "Unescaped model attribute",
+      "file": "app/views/webui/package/_rpmlint_result.html.haml",
+      "line": 6,
+      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
+      "code": "::Haml::AttributeBuilder.build_data(true, \"'\", :project => ::Project.find_by(:name => (params[:project_name] or params[:project]).to_s).name, :package => @package.name)",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "Webui::PackageController",
+          "method": "rpmlint_result",
+          "line": 325,
+          "file": "app/controllers/webui/package_controller.rb",
+          "rendered": {
+            "name": "webui/package/_rpmlint_result",
+            "file": "app/views/webui/package/_rpmlint_result.html.haml"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "webui/package/_rpmlint_result"
+      },
+      "user_input": "::Project.find_by(:name => (params[:project_name] or params[:project]).to_s).name",
+      "confidence": "Weak",
+      "cwe_id": [
+        79
+      ],
+      "note": ""
+    },
+    {
       "warning_type": "SQL Injection",
       "warning_code": 0,
       "fingerprint": "45840f44547aeced1506343b80e3fe0ad1b6262ae3799e5086907ff71bddb03c",
@@ -367,6 +401,50 @@
     },
     {
       "warning_type": "Cross-Site Scripting",
+      "warning_code": 2,
+      "fingerprint": "61a4b7fc417f099ab89fb8ba318ebe9eed3ece18e3fb6d9525c947795e8aee35",
+      "check_name": "CrossSiteScripting",
+      "message": "Unescaped model attribute",
+      "file": "app/views/webui/shared/user_or_groups_roles/_index.html.haml",
+      "line": 15,
+      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
+      "code": "::Haml::AttributeBuilder.build_data(true, \"'\", \"project\" => ::Project.find_by(:name => (params[:project_name] or params[:project]).to_s).name, \"save-user\" => project_save_person_url, \"remove\" => project_remove_role_url, \"save-group\" => project_save_group_path, \"package\" => @package.name)",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "Webui::PackageController",
+          "method": "users",
+          "line": 159,
+          "file": "app/controllers/webui/package_controller.rb",
+          "rendered": {
+            "name": "webui/package/users",
+            "file": "app/views/webui/package/users.html.haml"
+          }
+        },
+        {
+          "type": "template",
+          "name": "webui/package/users",
+          "line": 6,
+          "file": "app/views/webui/package/users.html.haml",
+          "rendered": {
+            "name": "webui/shared/user_or_groups_roles/_index",
+            "file": "app/views/webui/shared/user_or_groups_roles/_index.html.haml"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "webui/shared/user_or_groups_roles/_index"
+      },
+      "user_input": "::Project.find_by(:name => (params[:project_name] or params[:project]).to_s).name",
+      "confidence": "Weak",
+      "cwe_id": [
+        79
+      ],
+      "note": ""
+    },
+    {
+      "warning_type": "Cross-Site Scripting",
       "warning_code": 4,
       "fingerprint": "62f93283e161bc75b900aad23f7f63f20ba56c3ecb3d38c24dbb900607e3bc26",
       "check_name": "LinkToHref",
@@ -403,50 +481,6 @@
         "template": "webui/staging/projects/_checks"
       },
       "user_input": "(Unresolved Model).new.url",
-      "confidence": "Weak",
-      "cwe_id": [
-        79
-      ],
-      "note": ""
-    },
-    {
-      "warning_type": "Cross-Site Scripting",
-      "warning_code": 2,
-      "fingerprint": "64ac8eb6c9c40c44b441d2e574dcfa260baf867223e58b5654167b5f551dabaa",
-      "check_name": "CrossSiteScripting",
-      "message": "Unescaped model attribute",
-      "file": "app/views/webui/shared/user_or_groups_roles/_index.html.haml",
-      "line": 15,
-      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
-      "code": "::Haml::AttributeBuilder.build_data(true, \"'\", \"project\" => ::Project.find_by(:name => (params[:project_name] or params[:project]).to_s).name, \"save-user\" => project_save_person_url, \"remove\" => project_remove_role_url, \"save-group\" => project_save_group_path, \"package\" => Package.get_by_project_and_name(::Project.find_by(:name => (params[:project_name] or params[:project]).to_s).name, (params[:package] or params[:package_name]), :follow_multibuild => true).name)",
-      "render_path": [
-        {
-          "type": "controller",
-          "class": "Webui::PackageController",
-          "method": "users",
-          "line": 159,
-          "file": "app/controllers/webui/package_controller.rb",
-          "rendered": {
-            "name": "webui/package/users",
-            "file": "app/views/webui/package/users.html.haml"
-          }
-        },
-        {
-          "type": "template",
-          "name": "webui/package/users",
-          "line": 6,
-          "file": "app/views/webui/package/users.html.haml",
-          "rendered": {
-            "name": "webui/shared/user_or_groups_roles/_index",
-            "file": "app/views/webui/shared/user_or_groups_roles/_index.html.haml"
-          }
-        }
-      ],
-      "location": {
-        "type": "template",
-        "template": "webui/shared/user_or_groups_roles/_index"
-      },
-      "user_input": "::Project.find_by(:name => (params[:project_name] or params[:project]).to_s).name",
       "confidence": "Weak",
       "cwe_id": [
         79
@@ -519,108 +553,6 @@
       "confidence": "Medium",
       "cwe_id": [
         89
-      ],
-      "note": ""
-    },
-    {
-      "warning_type": "Cross-Site Scripting",
-      "warning_code": 2,
-      "fingerprint": "c1b89d88e47a066ac25ba2a3d0e5b4a1d7040b9b51afae34affdb7d701dac1a6",
-      "check_name": "CrossSiteScripting",
-      "message": "Unescaped model attribute",
-      "file": "app/views/webui/package/_rpmlint_result.html.haml",
-      "line": 6,
-      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
-      "code": "::Haml::AttributeBuilder.build_data(true, \"'\", :project => ::Project.find_by(:name => (params[:project_name] or params[:project]).to_s).name, :package => Package.get_by_project_and_name(::Project.find_by(:name => (params[:project_name] or params[:project]).to_s).name, (params[:package] or params[:package_name]), :follow_multibuild => true).name)",
-      "render_path": [
-        {
-          "type": "controller",
-          "class": "Webui::PackageController",
-          "method": "rpmlint_result",
-          "line": 325,
-          "file": "app/controllers/webui/package_controller.rb",
-          "rendered": {
-            "name": "webui/package/_rpmlint_result",
-            "file": "app/views/webui/package/_rpmlint_result.html.haml"
-          }
-        }
-      ],
-      "location": {
-        "type": "template",
-        "template": "webui/package/_rpmlint_result"
-      },
-      "user_input": "::Project.find_by(:name => (params[:project_name] or params[:project]).to_s).name",
-      "confidence": "Weak",
-      "cwe_id": [
-        79
-      ],
-      "note": ""
-    },
-    {
-      "warning_type": "Cross-Site Scripting",
-      "warning_code": 2,
-      "fingerprint": "c3cdcdad958f89ab5351c660dc9718914496dfd942530bc617a20557d74a4012",
-      "check_name": "CrossSiteScripting",
-      "message": "Unescaped model attribute",
-      "file": "app/views/webui/package/rdiff.html.haml",
-      "line": 18,
-      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
-      "code": "::Haml::AttributeBuilder.build_data(true, \"'\", :package => Package.get_by_project_and_name(::Project.find_by(:name => (params[:project_name] or params[:project]).to_s).name, (params[:package] or params[:package_name]), :follow_multibuild => true))",
-      "render_path": [
-        {
-          "type": "controller",
-          "class": "Webui::PackageController",
-          "method": "rdiff",
-          "line": 230,
-          "file": "app/controllers/webui/package_controller.rb",
-          "rendered": {
-            "name": "webui/package/rdiff",
-            "file": "app/views/webui/package/rdiff.html.haml"
-          }
-        }
-      ],
-      "location": {
-        "type": "template",
-        "template": "webui/package/rdiff"
-      },
-      "user_input": "Package.get_by_project_and_name(::Project.find_by(:name => (params[:project_name] or params[:project]).to_s).name, (params[:package] or params[:package_name]), :follow_multibuild => true)",
-      "confidence": "Weak",
-      "cwe_id": [
-        79
-      ],
-      "note": ""
-    },
-    {
-      "warning_type": "Cross-Site Scripting",
-      "warning_code": 2,
-      "fingerprint": "c3cdcdad958f89ab5351c660dc9718914496dfd942530bc617a20557d74a4012",
-      "check_name": "CrossSiteScripting",
-      "message": "Unescaped model attribute",
-      "file": "app/views/webui/package/rdiff.html.haml",
-      "line": 20,
-      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
-      "code": "::Haml::AttributeBuilder.build_data(true, \"'\", :package => Package.get_by_project_and_name(::Project.find_by(:name => (params[:project_name] or params[:project]).to_s).name, (params[:package] or params[:package_name]), :follow_multibuild => true))",
-      "render_path": [
-        {
-          "type": "controller",
-          "class": "Webui::PackageController",
-          "method": "rdiff",
-          "line": 230,
-          "file": "app/controllers/webui/package_controller.rb",
-          "rendered": {
-            "name": "webui/package/rdiff",
-            "file": "app/views/webui/package/rdiff.html.haml"
-          }
-        }
-      ],
-      "location": {
-        "type": "template",
-        "template": "webui/package/rdiff"
-      },
-      "user_input": "Package.get_by_project_and_name(::Project.find_by(:name => (params[:project_name] or params[:project]).to_s).name, (params[:package] or params[:package_name]), :follow_multibuild => true)",
-      "confidence": "Weak",
-      "cwe_id": [
-        79
       ],
       "note": ""
     },
@@ -699,50 +631,6 @@
       "cwe_id": [
         565,
         502
-      ],
-      "note": ""
-    },
-    {
-      "warning_type": "Cross-Site Scripting",
-      "warning_code": 2,
-      "fingerprint": "faaef8211bbc25be8d5a10b458e757782cbe3665335e0ebac9b4f7a52a90de17",
-      "check_name": "CrossSiteScripting",
-      "message": "Unescaped model attribute",
-      "file": "app/views/webui/package/_revision_diff_detail.html.haml",
-      "line": 6,
-      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
-      "code": "::Haml::AttributeBuilder.build_data(true, \"'\", :package => Package.get_by_project_and_name(::Project.find_by(:name => (params[:project_name] or params[:project]).to_s).name, (params[:package] or params[:package_name]), :follow_multibuild => true))",
-      "render_path": [
-        {
-          "type": "controller",
-          "class": "Webui::PackageController",
-          "method": "rdiff",
-          "line": 230,
-          "file": "app/controllers/webui/package_controller.rb",
-          "rendered": {
-            "name": "webui/package/rdiff",
-            "file": "app/views/webui/package/rdiff.html.haml"
-          }
-        },
-        {
-          "type": "template",
-          "name": "webui/package/rdiff",
-          "line": 38,
-          "file": "app/views/webui/package/rdiff.html.haml",
-          "rendered": {
-            "name": "webui/package/_revision_diff_detail",
-            "file": "app/views/webui/package/_revision_diff_detail.html.haml"
-          }
-        }
-      ],
-      "location": {
-        "type": "template",
-        "template": "webui/package/_revision_diff_detail"
-      },
-      "user_input": "Package.get_by_project_and_name(::Project.find_by(:name => (params[:project_name] or params[:project]).to_s).name, (params[:package] or params[:package_name]), :follow_multibuild => true)",
-      "confidence": "Weak",
-      "cwe_id": [
-        79
       ],
       "note": ""
     }

--- a/src/api/config/brakeman.ignore
+++ b/src/api/config/brakeman.ignore
@@ -122,25 +122,6 @@
       "note": ""
     },
     {
-      "warning_type": "Unmaintained Dependency",
-      "warning_code": 122,
-      "fingerprint": "21ab0fe00fdd5899ffc405cff75aadb91b805ee996a614f7e27b08a287e9062d",
-      "check_name": "EOLRails",
-      "message": "Support for Rails 8.0.5.1 ends on 2026-10-07",
-      "file": "Gemfile.lock",
-      "line": 385,
-      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
-      "code": null,
-      "render_path": null,
-      "location": null,
-      "user_input": null,
-      "confidence": "Weak",
-      "cwe_id": [
-        1104
-      ],
-      "note": ""
-    },
-    {
       "warning_type": "SQL Injection",
       "warning_code": 0,
       "fingerprint": "23288c7e9dea90dd0d6a14268bf929de5b7651f16e9c2233776751400dda5d11",
@@ -178,7 +159,7 @@
           "type": "controller",
           "class": "Webui::UsersController",
           "method": "show",
-          "line": 37,
+          "line": 36,
           "file": "app/controllers/webui/users_controller.rb",
           "rendered": {
             "name": "webui/users/show",
@@ -443,7 +424,7 @@
           "type": "controller",
           "class": "Webui::PackageController",
           "method": "users",
-          "line": 165,
+          "line": 159,
           "file": "app/controllers/webui/package_controller.rb",
           "rendered": {
             "name": "webui/package/users",
@@ -556,7 +537,7 @@
           "type": "controller",
           "class": "Webui::PackageController",
           "method": "rpmlint_result",
-          "line": 331,
+          "line": 325,
           "file": "app/controllers/webui/package_controller.rb",
           "rendered": {
             "name": "webui/package/_rpmlint_result",
@@ -590,7 +571,7 @@
           "type": "controller",
           "class": "Webui::PackageController",
           "method": "rdiff",
-          "line": 236,
+          "line": 230,
           "file": "app/controllers/webui/package_controller.rb",
           "rendered": {
             "name": "webui/package/rdiff",
@@ -624,7 +605,7 @@
           "type": "controller",
           "class": "Webui::PackageController",
           "method": "rdiff",
-          "line": 236,
+          "line": 230,
           "file": "app/controllers/webui/package_controller.rb",
           "rendered": {
             "name": "webui/package/rdiff",
@@ -682,7 +663,7 @@
           "type": "controller",
           "class": "Webui::ProjectController",
           "method": "buildresult",
-          "line": 249,
+          "line": 241,
           "file": "app/controllers/webui/project_controller.rb",
           "rendered": {
             "name": "webui/project/_buildstatus",
@@ -736,7 +717,7 @@
           "type": "controller",
           "class": "Webui::PackageController",
           "method": "rdiff",
-          "line": 236,
+          "line": 230,
           "file": "app/controllers/webui/package_controller.rb",
           "rendered": {
             "name": "webui/package/rdiff",

--- a/src/api/spec/cassettes/Webui_PackageController/GET_show/with_a_package_missing_from_a_project_that_links_to_a_remote_project/does_not_assign_a_package.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/GET_show/with_a_package_missing_from_a_project_that_links_to_a_remote_project/does_not_assign_a_package.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/project_1/_meta?user=user_1
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_1">
+          <title>In a Dry Season</title>
+          <description/>
+          <link project="openSUSE.org:home:hans"/>
+        </project>
+    headers:
+      X-Frontend-Start:
+      - '1787679199'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '144'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_1">
+          <title>In a Dry Season</title>
+          <description></description>
+          <link project="openSUSE.org:home:hans"/>
+        </project>
+  recorded_at: Tue, 25 Aug 2026 17:33:19 GMT
+recorded_with: VCR 6.4.0

--- a/src/api/spec/cassettes/Webui_PackageController/GET_show/with_a_package_missing_from_a_project_that_links_to_a_remote_project/sets_a_flash_error.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/GET_show/with_a_package_missing_from_a_project_that_links_to_a_remote_project/sets_a_flash_error.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/project_2/_meta?user=user_2
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_2">
+          <title>The Wealth of Nations</title>
+          <description/>
+          <link project="openSUSE.org:home:hans"/>
+        </project>
+    headers:
+      X-Frontend-Start:
+      - '1787679200'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '150'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="project_2">
+          <title>The Wealth of Nations</title>
+          <description></description>
+          <link project="openSUSE.org:home:hans"/>
+        </project>
+  recorded_at: Tue, 25 Aug 2026 17:33:20 GMT
+recorded_with: VCR 6.4.0

--- a/src/api/spec/cassettes/Webui_PackageController/GET_show/with_a_package_that_does_not_exist/does_not_assign_a_package.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/GET_show/with_a_package_that_does_not_exist/does_not_assign_a_package.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      X-Frontend-Start:
+      - '1787679199'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '128'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer"/>
+        </project>
+  recorded_at: Tue, 25 Aug 2026 17:33:19 GMT
+recorded_with: VCR 6.4.0

--- a/src/api/spec/cassettes/Webui_PackageController/GET_show/with_a_package_that_does_not_exist/sets_a_flash_error.yml
+++ b/src/api/spec/cassettes/Webui_PackageController/GET_show/with_a_package_that_does_not_exist/sets_a_flash_error.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://backend:5352/source/home:tom/_meta?user=tom
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title/>
+          <description/>
+          <person userid="tom" role="maintainer"/>
+        </project>
+    headers:
+      X-Frontend-Start:
+      - '1787679199'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Length:
+      - '128'
+    body:
+      encoding: UTF-8
+      string: |
+        <project name="home:tom">
+          <title></title>
+          <description></description>
+          <person userid="tom" role="maintainer"/>
+        </project>
+  recorded_at: Tue, 25 Aug 2026 17:33:19 GMT
+recorded_with: VCR 6.4.0

--- a/src/api/spec/controllers/webui/package_controller_spec.rb
+++ b/src/api/spec/controllers/webui/package_controller_spec.rb
@@ -153,6 +153,37 @@ RSpec.describe Webui::PackageController, :vcr do
         it { expect(response).to redirect_to(package_show_path(project: user.home_project, package: package_with_revisions)) }
       end
     end
+
+    context 'with a package that does not exist' do
+      before do
+        get :show, params: { project: user.home_project, package: 'does_not_exist' }
+      end
+
+      it 'sets a flash error' do
+        expect(flash[:error]).to eq("Package not found: #{user.home_project.name}/does_not_exist")
+      end
+
+      it 'does not assign a package' do
+        expect(assigns(:package)).to be_nil
+      end
+    end
+
+    # Regression test
+    context 'with a package missing from a project that links to a remote project' do
+      let(:linking_project) { create(:project, link_to: 'openSUSE.org:home:hans') }
+
+      before do
+        get :show, params: { project: linking_project, package: 'does_not_exist' }
+      end
+
+      it 'sets a flash error' do
+        expect(flash[:error]).to eq("Package not found: #{linking_project.name}/does_not_exist")
+      end
+
+      it 'does not assign a package' do
+        expect(assigns(:package)).to be_nil
+      end
+    end
   end
 
   describe 'GET #revisions' do

--- a/src/api/spec/controllers/webui/package_controller_spec.rb
+++ b/src/api/spec/controllers/webui/package_controller_spec.rb
@@ -691,4 +691,21 @@ RSpec.describe Webui::PackageController, :vcr do
       it { expect(response.parsed_body).to eql([]) }
     end
   end
+
+  describe 'GET #rpmlint_result for a project managed through scmsync' do
+    let(:scmsync_project) { create(:project, name: 'scmsync_project', scmsync: 'https://src.opensuse.org/pool/_ObsPrj.git') }
+
+    before do
+      get :rpmlint_result, params: { project: scmsync_project, package: 'only_in_the_backend' }
+    end
+
+    it 'redirects to the project' do
+      expect(flash[:error]).to eq("The project #{scmsync_project.name} is configured through scmsync. This is not supported by the OBS frontend")
+      expect(response).to redirect_to(project_show_path(scmsync_project))
+    end
+
+    it 'does not assign a package' do
+      expect(assigns(:package)).to be_nil
+    end
+  end
 end

--- a/src/api/spec/controllers/webui/packages/build_log_controller_spec.rb
+++ b/src/api/spec/controllers/webui/packages/build_log_controller_spec.rb
@@ -33,5 +33,22 @@ RSpec.describe Webui::Packages::BuildLogController do
 
       it { expect(flash[:error]).to eq('Package not found: my_project/my_package') }
     end
+
+    context 'with a package of a project managed through scmsync' do
+      let(:project) { create(:project, name: 'my_project', scmsync: 'https://src.opensuse.org/pool/_ObsPrj.git') }
+
+      before do
+        allow(Package).to receive(:what_depends_on).and_return([])
+        allow(Backend::Api::BuildResults::Status).to receive(:build_result).and_return(build_result)
+        get :live_build_log, params: { project: project, package: 'only_in_the_backend', repository: repository, arch: 'x86_64', format: 'js' }
+      end
+
+      it { expect(response).to have_http_status(:ok) }
+
+      it 'does not assign a package but keeps its name' do
+        expect(assigns(:package)).to be_nil
+        expect(assigns(:package_name)).to eq('only_in_the_backend')
+      end
+    end
   end
 end

--- a/src/api/spec/controllers/webui/packages/trigger_controller_spec.rb
+++ b/src/api/spec/controllers/webui/packages/trigger_controller_spec.rb
@@ -53,4 +53,24 @@ RSpec.describe Webui::Packages::TriggerController, :vcr do
       it { expect(flash[:error]).to eq('Error while triggering abort build for my_project/my_package: no repository defined') }
     end
   end
+
+  describe 'POST #rebuild for a project managed through scmsync' do
+    let(:project) do
+      create(:project_with_repository, name: 'scmsync_project', scmsync: 'https://src.opensuse.org/pool/_ObsPrj.git', maintainer: user)
+    end
+
+    before do
+      allow(Backend::Api::Sources::Package).to receive(:rebuild)
+      post :rebuild, params: { project_name: project, package_name: 'only_in_the_backend' }
+    end
+
+    it 'triggers the rebuild with the package name' do
+      expect(Backend::Api::Sources::Package).to have_received(:rebuild).with(project.name, 'only_in_the_backend', anything)
+      expect(flash[:success]).to eq('Rebuild successfully triggered')
+    end
+
+    it 'does not assign a package' do
+      expect(assigns(:package)).to be_nil
+    end
+  end
 end

--- a/src/api/spec/controllers/webui/webui_controller_spec.rb
+++ b/src/api/spec/controllers/webui/webui_controller_spec.rb
@@ -94,6 +94,34 @@ RSpec.describe Webui::WebuiController do
       end
     end
 
+    context 'with a package that is missing from a project linking to a remote project' do
+      let(:project) { create(:project, link_to: 'openSUSE.org:home:hans') }
+
+      it 'redirects back' do
+        from project_show_path(project: project)
+        get :create, params: { project: project, package: 'invalid' }
+        expect(flash[:error]).to eq("Package not found: #{project.name}/invalid")
+        expect(response).to redirect_to project_show_url(project: project)
+      end
+
+      it 'does not assign a package' do
+        get :create, params: { project: project, package: 'invalid' }
+        expect(assigns(:package)).to be_nil
+      end
+    end
+
+    context 'with a package that is missing from a project managed through scmsync' do
+      let(:project) { create(:project, scmsync: 'https://src.opensuse.org/pool/_ObsPrj.git') }
+
+      it 'does not raise and leaves the package unassigned' do
+        get :create, params: { project: project, package: 'invalid' }
+
+        expect(response).to have_http_status(:success)
+        expect(assigns(:package)).to be_nil
+        expect(flash[:error]).to be_nil
+      end
+    end
+
     context 'with valid package parameter' do
       let(:package) { create(:package, project: project) }
 

--- a/src/api/spec/controllers/webui/webui_controller_spec.rb
+++ b/src/api/spec/controllers/webui/webui_controller_spec.rb
@@ -5,8 +5,9 @@ RSpec.describe Webui::WebuiController do
   controller do
     before_action :require_admin, only: :new
     before_action :require_login, only: :show
-    before_action :set_project, only: %i[edit create]
+    before_action :set_project, only: %i[edit create update]
     before_action :set_package, only: :create
+    before_action :set_optional_package, only: :update
 
     # RSpec anonymous controller only support RESTful routes
     # http://stackoverflow.com/questions/7027518/no-route-matches-rspecs-anonymous-controller
@@ -24,6 +25,10 @@ RSpec.describe Webui::WebuiController do
 
     def create
       render plain: 'anonymous controller - set_package'
+    end
+
+    def update
+      render plain: 'anonymous controller - set_optional_package'
     end
   end
 
@@ -113,12 +118,15 @@ RSpec.describe Webui::WebuiController do
     context 'with a package that is missing from a project managed through scmsync' do
       let(:project) { create(:project, scmsync: 'https://src.opensuse.org/pool/_ObsPrj.git') }
 
-      it 'does not raise and leaves the package unassigned' do
+      it 'redirects to the project' do
         get :create, params: { project: project, package: 'invalid' }
+        expect(flash[:error]).to eq("The project #{project.name} is configured through scmsync. This is not supported by the OBS frontend")
+        expect(response).to redirect_to project_show_path(project)
+      end
 
-        expect(response).to have_http_status(:success)
+      it 'does not assign a package' do
+        get :create, params: { project: project, package: 'invalid' }
         expect(assigns(:package)).to be_nil
-        expect(flash[:error]).to be_nil
       end
     end
 
@@ -127,6 +135,56 @@ RSpec.describe Webui::WebuiController do
 
       it 'sets the correct project' do
         get :create, params: { project: project, package: package }
+        expect(assigns(:package)).to eq(package)
+      end
+    end
+  end
+
+  describe 'set_optional_package before filter' do
+    let(:project) { create(:project, scmsync: 'https://src.opensuse.org/pool/_ObsPrj.git') }
+
+    context 'with a package that is missing from a project managed through scmsync' do
+      it 'renders the action' do
+        get :update, params: { id: 1, project: project, package: 'only_in_the_backend' }
+        expect(response).to have_http_status(:success)
+        expect(flash[:error]).to be_nil
+      end
+
+      it 'leaves the package unassigned but keeps its name' do
+        get :update, params: { id: 1, project: project, package: 'only_in_the_backend' }
+        expect(assigns(:package)).to be_nil
+        expect(assigns(:package_name)).to eq('only_in_the_backend')
+      end
+    end
+
+    context 'with a package that is missing from a project not managed through scmsync' do
+      let(:project) { create(:project) }
+
+      it 'still refuses to leave the package unassigned' do
+        from project_show_path(project: project)
+        get :update, params: { id: 1, project: project, package: 'invalid' }
+        expect(flash[:error]).to eq("Package not found: #{project.name}/invalid")
+        expect(response).to redirect_to project_show_url(project: project)
+      end
+    end
+
+    context 'with a package that is missing from a project linking to a remote project' do
+      let(:project) { create(:project, link_to: 'openSUSE.org:home:hans') }
+
+      it 'still refuses to leave the package unassigned' do
+        from project_show_path(project: project)
+        get :update, params: { id: 1, project: project, package: 'invalid' }
+        expect(flash[:error]).to eq("Package not found: #{project.name}/invalid")
+        expect(response).to redirect_to project_show_url(project: project)
+      end
+    end
+
+    context 'with valid package parameter' do
+      let(:project) { create(:project) }
+      let(:package) { create(:package, project: project) }
+
+      it 'sets the correct package' do
+        get :update, params: { id: 1, project: project, package: package }
         expect(assigns(:package)).to eq(package)
       end
     end


### PR DESCRIPTION
Depends on:
- #20226
- #20234

Fixes #20222

`Webui::WebuiController#set_package` could leave `@package` nil for packages of an scmsync project, and most of the nineteen controllers using that filter are not written for it. Details and the reasoning are in the commit message.

### How Issue 20222 Happens

`GNOME:Factory` is an scmsync project, so `libhandy` exists in the backend but has no row in the database. `package#rpmlint_result` runs `set_package` but not `check_scmsync`, so `@package` is nil, and the
tabs view asks for a `package_show_path` without a package. The link comes from the build results shown on a request page, which take package names from the backend, so it is reachable without ever loading
the package page — `package#show` redirects for scmsync projects and never gets the chance.

Same shape, same fix: `files` (every action but `show`), `attribute`, `packages/branches`, `packages/bs_requests` and the four `requests/*` controllers.

### What changes for a user

| Request | Before | After |
|---|---|---|
| Missing package, plain project | flash + redirect | unchanged |
| Missing package, project links to a remote project | flash + redirect | unchanged |
| Missing package, scmsync, controller calling `check_scmsync` | redirect | unchanged |
| Missing package, scmsync, controller not calling it | **500** | flash + redirect |
| Missing package, scmsync, build log | works, `@package` nil | unchanged |
| Missing package, scmsync, trigger actions | works, `@package` nil | unchanged |
| `package#show`, scmsync, package does not resolve | "Package sources for project X are received through scmsync", redirect back | "The project X is configured through scmsync…", redirect to the project |

The last row is the only user-visible message change. It replaces the inline check in `Webui::PackageController#show` with the wording every other scmsync redirect already uses. No test asserts the old wording.

`ScmsyncChecker` stays and is still needed: it redirects even when the package *does* resolve, which the new branch does not. It also stays non-transitive, so a project that merely links to an scmsync project keeps its own packages browsable.

### Tests

`Webui::Packages::BuildLogController` and `Webui::Packages::TriggerController` had no scmsync coverage at all before this. They do now, which is what should stop someone moving them back onto `set_package`.

### Not in this PR

- Nothing transitive. #18563 changes `Package.get_by_project_and_name` to look through project links; this guard will need the same change then.
- The RPM Lint page still cannot render without a `Package`. Making it work for scmsync packages means rewriting it around `package_name`, and it would then move to `set_optional_package`.
- `package/rpmlint_result(/:project)(/:package)` makes `:package` optional while `package_show` requires it, and the filter form on that page builds its URL without a project or a package. Separate bug, separate PR.
- The ten `include ScmsyncChecker` in subclasses are now redundant. Left alone to keep this diff to the fix.