### PR TITLE
Fix #20225: Prevent encoding crash when writing YAML to Tempfile

### DIFF
--- a/src/api/app/services/workflows/yaml_downloader.rb
+++ b/src/api/app/services/workflows/yaml_downloader.rb
@@ -59,7 +59,7 @@ module Workflows
 
     def create_temp_file(content)
       tempfile = Tempfile.new([Time.zone.now.to_s, '.yaml'])
-      tempfile.write(content)
+      tempfile.write(content.force_encoding('UTF-8'))
       tempfile.rewind
       tempfile
     end

--- a/src/api/spec/services/workflows/yaml_downloader_spec.rb
+++ b/src/api/spec/services/workflows/yaml_downloader_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Workflows::YAMLDownloader, type: :service do
       end
 
       context 'gitlab' do
-        let(:gitlab_client) { instance_spy(Gitlab::Client, file_contents: true) }
+        let(:gitlab_client) { instance_spy(Gitlab::Client, file_contents: 'file contents') }
         let(:scm_vendor) { 'gitlab' }
         let(:hook_event) { 'Push Hook' }
 
@@ -102,7 +102,7 @@ RSpec.describe Workflows::YAMLDownloader, type: :service do
     end
 
     context 'given workflow_configuration_path' do
-      let(:gitlab_client) { instance_spy(Gitlab::Client, file_contents: true) }
+      let(:gitlab_client) { instance_spy(Gitlab::Client, file_contents: 'file contents') }
       let(:scm_vendor) { 'gitlab' }
       let(:hook_event) { 'Push Hook' }
 


### PR DESCRIPTION
Fixes: #20225 

### What this PR is about
This fixes a server crash in `trigger_workflow#create` caused by a `"\xE2" from ASCII-8BIT to UTF-8` conversion error when downloading GitHub workflow configurations.

### Why this change was made
When `Workflows::YAMLDownloader` downloads a workflow YAML file from GitHub, `Base64.decode64` returns the content as an `ASCII-8BIT` string. However, Rails configures `Tempfile` to expect `UTF-8` text. If the YAML file contains multi-byte characters (like an em-dash), Ruby attempts to transcode the binary string to UTF-8 during `write`, causing an `UndefinedConversionError`. 

By appending `.force_encoding('UTF-8')` before writing, we simply update the string's encoding label so Ruby safely writes the bytes exactly as they are without attempting a broken transcode.

### How to verify
1. Trigger a GitHub workflow sync using a repository where the YAML configuration file contains multi-byte characters (like an em-dash or smart quotes).
2. Verify that the background job successfully saves the file and proceeds, instead of crashing the action with an encoding error.