### PR TITLE
Introduce `Project#links_to_scmsync?` and use it in `Triggerable`

### DIFF
--- a/src/api/app/controllers/concerns/triggerable.rb
+++ b/src/api/app/controllers/concerns/triggerable.rb
@@ -46,6 +46,6 @@ module Triggerable
   end
 
   def project_links_to_remote?
-    @project.scmsync.present? || @project.links_to_remote?
+    @project.links_to_scmsync? || @project.links_to_remote?
   end
 end

--- a/src/api/app/models/concerns/project_links.rb
+++ b/src/api/app/models/concerns/project_links.rb
@@ -139,4 +139,8 @@ module ProjectLinks
   def links_to_remote?
     expand_all_projects(allow_remote_projects: true).any?(String)
   end
+
+  def links_to_scmsync?
+    expand_all_projects.any? { |project| project.scmsync.present? }
+  end
 end

--- a/src/api/spec/models/project_spec.rb
+++ b/src/api/spec/models/project_spec.rb
@@ -862,4 +862,38 @@ RSpec.describe Project, :vcr do
 
     it { expect(project.bs_requests).to contain_exactly(incoming_request, outgoing_request, request_with_review) }
   end
+
+  describe '#links_to_scmsync?' do
+    let(:scmsync_project) { create(:project, name: 'scmsync_project', scmsync: 'https://src.opensuse.org/pool/_ObsPrj.git') }
+
+    context 'when the project is managed through scmsync' do
+      it { expect(scmsync_project.links_to_scmsync?).to be(true) }
+    end
+
+    context 'when the project links to a project managed through scmsync' do
+      let(:linking_project) { create(:project, name: 'linking_scmsync_project', link_to: scmsync_project) }
+
+      it { expect(linking_project.links_to_scmsync?).to be(true) }
+    end
+
+    context 'when the project links to a project that links to one managed through scmsync' do
+      let(:middle_project) { create(:project, name: 'middle_project', link_to: scmsync_project) }
+      let(:linking_project) { create(:project, name: 'indirectly_linking_project', link_to: middle_project) }
+
+      it { expect(linking_project.links_to_scmsync?).to be(true) }
+    end
+
+    context 'when neither the project nor the ones it links to are managed through scmsync' do
+      let(:target_project) { create(:project, name: 'plain_target_project') }
+      let(:linking_project) { create(:project, name: 'plain_linking_project', link_to: target_project) }
+
+      it { expect(linking_project.links_to_scmsync?).to be(false) }
+    end
+
+    context 'when the project links to a remote project' do
+      let(:linking_project) { create(:project, name: 'remotely_linking_project', link_to: 'some:remote:project') }
+
+      it { expect(linking_project.links_to_scmsync?).to be(false) }
+    end
+  end
 end


### PR DESCRIPTION
`Triggerable#project_links_to_remote?` checks remote links through the whole chain of project links, but checks scmsync only on the project it was asked about. This adds `Project#links_to_scmsync?` next to `Project#links_to_remote?` and uses it, so both ask the same question.

**Nothing changes today**, because `Package.get_by_project_and_name` checks scmsync the same way and raises before this code runs. The commit message lists the cases.

It matters after PR 18563, which makes that model check transitive. From then on, for a project A that links to an scmsync project B, `@package` stays `nil` and `TriggerController` drops it with `.compact`. Nothing raises: `Token::Rebuild` rebuilds **every package in A** instead of one and still answers 200, `Token::Release` reports success without releasing, and the workflow steps stop reporting build status to the SCM.

So this is a prerequisite for PR 18563, like PR 20226 is on the web UI side. The same check in `Webui::WebuiController#set_package` needs the build log views to cope with a nil `@package` first, so it stays separate.

Related:
- #13176
- #18563
- #20226