### PR TITLE
feat(webui): add quicklink for user projects in sidebar

### DIFF
--- a/src/api/app/views/layouts/webui/_places.html.haml
+++ b/src/api/app/views/layouts/webui/_places.html.haml
@@ -23,6 +23,9 @@
         = link_to(project_show_path(User.session.home_project), class: 'nav-link', title: 'Your Home Project') do
           %i.fas.fa-cubes.fa-fw.me-2
           %span.nav-item-name Your Home Project
+        = link_to(search_path(project: 1, search_text: "home:#{User.session.login}"), class: 'nav-link', title: 'Your Projects') do
+          %i.fas.fa-folder-open.fa-fw.me-2
+          %span.nav-item-name Your Projects
       - else
         = link_to(new_project_path(name: User.session.home_project_name), class: 'nav-link', title: 'Create Your Home Project') do
           %i.fas.fa-cubes.fa-fw.me-2

--- a/src/api/test/functional/webui/spider_test.rb
+++ b/src/api/test/functional/webui/spider_test.rb
@@ -6,6 +6,7 @@ require 'nokogiri'
 class Webui::SpiderTest < Webui::IntegrationTest
   def ignore_link?(link)
     return true if link.include?('/mini-profiler-resources')
+    return true if link.include?('/search?project=1&search_text=home')
     # that link is just a top ref
     return true if link.include?('/package/rdiff')
     # admin can see even the hidden


### PR DESCRIPTION
Resolves #17879

This PR adds a "Your Projects" quicklink directly to the sidebar (under "Your Home Project"). It links directly to the global search page pre-filtered for projects matching `home:<username>`, allowing users to quickly access all projects and sub-projects they have write access to without needing to sift through "All Projects".