### PR TITLE
increase code resilience by checking against nil

### DIFF
--- a/src/api/app/views/webui/package/_file.html.haml
+++ b/src/api/app/views/webui/package/_file.html.haml
@@ -8,7 +8,10 @@
       - link_opts[:rev] = srcmd5
     = link_to_if(is_viewable, nbsp(file['name']), link_opts)
   %td.text-nowrap
-    %span.d-none= file['size'].rjust(10, '0')
+    - if file['size']
+      %span.d-none= file['size'].rjust(10, '0')
+    - else
+      %span.d-none= 0
     = human_readable_fsize(file['size'])
   %td.text-nowrap{ data: { order: "-#{file['mtime']}" } }
     = render TimeComponent.new(time: Time.zone.at(file['mtime'].to_i))


### PR DESCRIPTION
As described in https://github.com/openSUSE/open-build-service/issues/20249 we found a code path where a method is applied to a value without checking for nil: "file['size']-.rjust(...)" (code line 11 below) will make the OBS server return HTTP 500 if the file is not present in the server's file system (which is an error all by itself, but a different story - the issue was experienced in real life).

```
F, [2026-08-31T02:14:27.180593 #7328] FATAL -- : [98e96780-ac0c-4640-8a7e-b23ab076e454]
[98e96780-ac0c-4640-8a7e-b23ab076e454] ActionView::Template::Error (undefined method 'rjust' for nil):
[98e96780-ac0c-4640-8a7e-b23ab076e454]
Causes:
[98e96780-ac0c-4640-8a7e-b23ab076e454] NoMethodError (undefined method 'rjust' for nil)
[98e96780-ac0c-4640-8a7e-b23ab076e454]      8:       - link_opts[:rev] = srcmd5
[98e96780-ac0c-4640-8a7e-b23ab076e454]      9:     = link_to_if(is_viewable, nbsp(file['name']), link_opts)
[98e96780-ac0c-4640-8a7e-b23ab076e454]     10:   %td.text-nowrap
[98e96780-ac0c-4640-8a7e-b23ab076e454]     11:     %span.d-none= file['size'].rjust(10, '0')
[98e96780-ac0c-4640-8a7e-b23ab076e454]     12:     = human_readable_fsize(file['size'])
[98e96780-ac0c-4640-8a7e-b23ab076e454]     13:   %td.text-nowrap{ data: { order: "-#{file['mtime']}" } }
[98e96780-ac0c-4640-8a7e-b23ab076e454]     14:     = render TimeComponent.new(time: Time.zone.at(file['mtime'].to_i))
[98e96780-ac0c-4640-8a7e-b23ab076e454]
[98e96780-ac0c-4640-8a7e-b23ab076e454] app/views/webui/package/_file.html.haml:11
[98e96780-ac0c-4640-8a7e-b23ab076e454] app/views/webui/package/_files_view.html.haml:17
[98e96780-ac0c-4640-8a7e-b23ab076e454] app/views/webui/package/show.html.haml:83
[98e96780-ac0c-4640-8a7e-b23ab076e454] config/initializers/prefer_xml_over_html.rb:15:in 'PreferXmlOverHtml#call'
```

This MR makes the actual call depend on the value not being nil and setting a seemingly reasonable default value otherwise.

Resolves #20249