### PR TITLE
Refactor the cmd router away

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -47,6 +47,7 @@ RSpec/MultipleExpectations:
   Exclude:
     - 'dist/t/spec/features/0010_authentication_spec.rb'
     - 'dist/t/spec/features/0020_interconnect_spec.rb'
+    - 'dist/t/spec/features/0030_project_spec.rb'
     - 'dist/t/spec/features/0040_package_spec.rb'
 
 # Offense count: 4

--- a/dist/t/spec/features/0030_project_spec.rb
+++ b/dist/t/spec/features/0030_project_spec.rb
@@ -19,38 +19,16 @@ RSpec.describe 'Project', type: :feature do
   end
 
   it 'is able to add repositories' do
-    # Standard REST API design: Trigger immediate fetch via 'cmd=refresh' query param
-    require 'net/http'
-    require 'uri'
-    uri = URI.parse("#{Capybara.app_host}/distributions?cmd=refresh")
-    http = Net::HTTP.new(uri.host, uri.port)
-    if uri.scheme == 'https'
-      http.use_ssl = true
-      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+    # Trigger refresh of distributions...
+    post '/distributions/refresh'
+    expect(response).to be_success
+    visit '/'
+    within('#left-navigation') do
+      click_link('Your Home Project')
     end
-    request = Net::HTTP::Post.new(uri.request_uri)
-    request.basic_auth('Admin', 'opensuse')
-    begin
-      response = http.request(request)
-      puts "Triggered distributions refresh: #{response.code} #{response.body}" # rubocop:disable RSpec/Output
-    rescue => e # rubocop:disable Style/RescueStandardError
-      puts "Failed to trigger distributions refresh: #{e}" # rubocop:disable RSpec/Output
-    end
-
-    Timeout.timeout(300) do
-      loop do
-        within('#left-navigation') do
-          click_link('Your Home Project')
-        end
-        click_link('Repositories')
-        click_link('Add from a Distribution')
-        break unless have_text('There are no distributions configured. Maybe you want to connect to one of the public OBS instances?')
-
-        break if have_text('Add Repositories to home:Admin')
-
-        sleep 10
-      end
-    end
+    click_link('Repositories')
+    click_link('Add from a Distribution')
+    expect(page).to have_text('Add Repositories to home:Admin')
     check('openSUSE Leap 15.5')
     visit current_path
     expect(page).to have_checked_field('openSUSE Leap 15.5')

--- a/src/api/.rubocop_todo.yml
+++ b/src/api/.rubocop_todo.yml
@@ -425,6 +425,7 @@ Naming/PredicateMethod:
   Exclude:
     - 'app/controllers/webui/package_controller.rb'
     - 'app/controllers/webui/request_controller.rb'
+    - 'app/jobs/fetch_remote_distributions_job.rb'
     - 'app/lib/suse/permission.rb'
     - 'app/models/comment.rb'
     - 'app/models/concerns/staging_project.rb'

--- a/src/api/app/controllers/distributions_controller.rb
+++ b/src/api/app/controllers/distributions_controller.rb
@@ -1,6 +1,6 @@
 class DistributionsController < ApplicationController
   before_action :require_admin, except: %i[index show include_remotes]
-  before_action :set_body_xml, except: %i[index show include_remotes]
+  before_action :set_body_xml, except: %i[index show include_remotes refresh]
 
   validate_action bulk_replace: { method: :put, request: :distributions }
   validate_action bulk_replace: { method: :post, request: :distributions }
@@ -33,14 +33,6 @@ class DistributionsController < ApplicationController
 
   # POST /distributions
   def create
-    # Standard REST API design: Support 'refresh' action modifier via query params
-    # to trigger the FetchRemoteDistributionsJob on-demand.
-    if params[:cmd] == 'refresh'
-      FetchRemoteDistributionsJob.perform_now
-      render_ok
-      return
-    end
-
     distribution = Distribution.new_from_xmlhash(@body_xml)
 
     if distribution.save
@@ -110,19 +102,18 @@ class DistributionsController < ApplicationController
     end
   end
 
-  private
-
-  def validate_xml_request(method = nil)
-    # Skip XML request schema validation for on-demand remote refresh triggers
-    return if params[:cmd] == 'refresh'
-
-    super
+  # POST /distributions/refresh
+  def refresh
+    if FetchRemoteDistributionsJob.perform_now
+      render_ok
+    else
+      render_error message: 'Failed to refresh distributions', errorcode: 'failed_distribution_refresh'
+    end
   end
 
-  def set_body_xml
-    # Skip XML parsing of empty request body for refresh command triggers
-    return if params[:cmd] == 'refresh'
+  private
 
+  def set_body_xml
     @body_xml = Xmlhash.parse(request.body.read)
   end
 end

--- a/src/api/app/jobs/fetch_remote_distributions_job.rb
+++ b/src/api/app/jobs/fetch_remote_distributions_job.rb
@@ -3,10 +3,10 @@ class FetchRemoteDistributionsJob < ApplicationJob
     Project.remote.each do |project|
       distributions_xml = Project::RemoteURL.load(project, '/distributions.xml')
 
-      # Retain cached distributions on transient connection or server errors instead of purging them
-      if distributions_xml.nil?
-        Rails.logger.warn "Connection error fetching remote distributions from #{project.name}. Retaining cached values."
-      elsif Xmlhash.parse(distributions_xml).blank?
+      # Project::RemoteURL returns nil (and reports to log/Airbrake) in case of errors, we are done if this happens...
+      return false if distributions_xml.nil?
+
+      if Xmlhash.parse(distributions_xml).blank?
         Distribution.remote.for_project(project.name).destroy_all
       else
         Suse::Validator.validate('distributions', distributions_xml)
@@ -14,6 +14,8 @@ class FetchRemoteDistributionsJob < ApplicationJob
         bulk_replace(project: project.name, distributions_xmlhash: distributions_xmlhash)
       end
     end
+
+    true
   end
 
   private

--- a/src/api/config/routes/api.rb
+++ b/src/api/config/routes/api.rb
@@ -167,10 +167,10 @@ match 'public/lastevents' => 'source#lastevents_public', via: %i[get post]
 post '/lastevents' => 'source#lastevents'
 
 ### /distributions
-
 resources :distributions, except: %i[new edit] do
   collection do
     get 'include_remotes'
+    post 'refresh'
     put 'bulk_replace' => :bulk_replace
     # This GET routes gives us a poor mans osc interface for bulk replacing...
     # Like: osc api -e /distributions/bulk_replace

--- a/src/api/public/apidocs/OBS-v2.10.50.yaml
+++ b/src/api/public/apidocs/OBS-v2.10.50.yaml
@@ -189,7 +189,7 @@ paths:
   /distributions:
     $ref: 'paths/distributions.yaml'
   /distributions?cmd=refresh:
-    $ref: 'paths/distributions_cmd_refresh.yaml'
+    $ref: 'paths/distributions_refresh.yaml'
   /distributions/include_remotes:
     $ref: 'paths/distributions_include_remotes.yaml'
   /distributions/{distribution_id}:

--- a/src/api/public/apidocs/paths/distributions_refresh.yaml
+++ b/src/api/public/apidocs/paths/distributions_refresh.yaml
@@ -1,27 +1,22 @@
 post:
-  summary: Trigger on-demand synchronization of remote distributions.
+  summary: Trigger synchronization of remote distributions.
   description: |
-    Trigger an on-demand synchronization of remote distributions from configured
-    remote registries (e.g. `build.opensuse.org`).
-
-    This operation executes the background job (`FetchRemoteDistributionsJob`) to
-    retrieve, update, and cache remote distributions.
-
+    Trigger synchronization of distributions from interconnect projects.
     This is only for admins.
   security:
     - basic_authentication: []
-  parameters:
-    - in: query
-      name: cmd
-      required: true
-      schema:
-        type: string
-        enum:
-          - refresh
-      description: Command to trigger remote distributions refresh.
   responses:
     '200':
       $ref: '../components/responses/succeeded.yaml'
+    '400':
+      description: Bad Request. Somehow failed to refresh distributions from the network.
+      content:
+        application/xml; charset=utf-8:
+          schema:
+            $ref: '../components/schemas/api_response.yaml'
+          example:
+            code: failed_distribution_refresh
+            summary: Failed to refresh distributions
     '401':
       $ref: '../components/responses/unauthorized.yaml'
     '403':

--- a/src/api/spec/controllers/distributions_controller_spec.rb
+++ b/src/api/spec/controllers/distributions_controller_spec.rb
@@ -67,27 +67,6 @@ RSpec.describe DistributionsController do
       it { expect { subject }.not_to change(Distribution, :count) }
       it { is_expected.to have_http_status(:bad_request) }
     end
-
-    # Ensure that calling POST with cmd=refresh bypasses normal XML creation
-    # and directly invokes the background fetch job.
-    context 'when cmd is refresh' do
-      subject { post :create, params: { cmd: 'refresh' }, format: :xml }
-
-      before do
-        allow(FetchRemoteDistributionsJob).to receive(:perform_now)
-      end
-
-      it { is_expected.to have_http_status(:ok) }
-
-      it 'triggers the remote distributions fetch job' do
-        subject
-        expect(FetchRemoteDistributionsJob).to have_received(:perform_now).once
-      end
-
-      it 'does not parse body as XML' do
-        expect { subject }.not_to raise_error
-      end
-    end
   end
 
   describe '#update' do
@@ -156,6 +135,31 @@ RSpec.describe DistributionsController do
 
       it { expect { subject }.not_to change(Distribution, :count) }
       it { is_expected.to have_http_status(:bad_request) }
+    end
+  end
+
+  describe '#refresh' do
+    subject { post :refresh, format: :xml }
+
+    before do
+      login admin
+    end
+
+    context  'when job succeeds' do
+      before do
+        allow(FetchRemoteDistributionsJob).to receive(:perform_now).and_return(true)
+      end
+
+      it { is_expected.to have_http_status(:ok) }
+    end
+
+    context  'when job fails' do
+      before do
+        allow(FetchRemoteDistributionsJob).to receive(:perform_now).and_return(false)
+      end
+
+      it { is_expected.to have_http_status(:bad_request) }
+      it { expect(subject.headers['X-Opensuse-Errorcode']).to eql('failed_distribution_refresh') }
     end
   end
 end


### PR DESCRIPTION
We already have a router, no need to invent another one via parameters...

Also:

- Only render an error if FetchRemoteDistributionsJob has gone wrong
- Rspec can do POST requests, no need for Net::HTTP

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/openSUSE/open-build-service/blob/master/CONTRIBUTING.md
-->
