### PR TITLE
Distro Index UI Revamp

### DIFF
--- a/src/api/app/views/webui/distros/_distro.html.haml
+++ b/src/api/app/views/webui/distros/_distro.html.haml
@@ -1,7 +1,8 @@
 = render(CardComponent.new) do |component|
   %p.card-text
-    URL:
-    = link_to(distro.url, distro.url)
+    - if distro.url.present?
+      %i.fas.fa-link.text-info
+      = render partial: 'webui/shared/external_link', locals: { text: distro.url, url: distro.url }
   %p.card-text
     = truncate(distro.description, length: 100)
   - component.with_header do

--- a/src/api/app/views/webui/distros/_distro.html.haml
+++ b/src/api/app/views/webui/distros/_distro.html.haml
@@ -13,7 +13,7 @@
       = link_to '#', title: 'Delete Distro',
         data: { 'bs-toggle': 'modal', 'bs-target': '#delete-distro-modal', vendor_name: distro.vendor.name,
                 distro_name: distro.name, action: vendor_distro_path(distro.vendor, distro) } do
-        %i.fas.fa-trash-can.text-danger
+        %i.fas.fa-times-circle.text-danger
   - if policy(distro).edit?
     - component.with_action do
       = link_to(edit_vendor_distro_path(distro.vendor, distro), class: 'ps-2', title: 'Edit') do

--- a/src/api/app/views/webui/distros/_distro.html.haml
+++ b/src/api/app/views/webui/distros/_distro.html.haml
@@ -18,7 +18,3 @@
       = link_to(edit_vendor_distro_path(distro.vendor, distro), class: 'ps-2', title: 'Edit') do
         %i.fas.fa-edit
         %span.nav-item-name Edit
-  - if policy(DistroRelease.new(distro: distro)).create?
-    - component.with_action do
-      = render partial: 'webui/distro_releases/modal', locals: { model: DistroRelease.new(distro: distro), url: distro_releases_path(distro),
-                                                                 text: 'Add Release', icon: 'circle-plus' }

--- a/src/api/app/views/webui/distros/_distro.html.haml
+++ b/src/api/app/views/webui/distros/_distro.html.haml
@@ -13,12 +13,11 @@
         data: { 'bs-toggle': 'modal', 'bs-target': '#delete-distro-modal', vendor_name: distro.vendor.name,
                 distro_name: distro.name, action: vendor_distro_path(distro.vendor, distro) } do
         %i.fas.fa-trash-can.text-danger
-
   - if policy(distro).edit?
     - component.with_action do
-      = render partial: 'webui/distros/modal', locals: { model: distro, url: vendor_distro_path(distro.vendor, distro),
-                                                         text: 'Edit Distro', icon: 'edit' }
-
+      = link_to(edit_vendor_distro_path(distro.vendor, distro), class: 'ps-2', title: 'Edit') do
+        %i.fas.fa-edit
+        %span.nav-item-name Edit
   - if policy(DistroRelease.new(distro: distro)).create?
     - component.with_action do
       = render partial: 'webui/distro_releases/modal', locals: { model: DistroRelease.new(distro: distro), url: distro_releases_path(distro),

--- a/src/api/spec/features/webui/projects/vendor_spec.rb
+++ b/src/api/spec/features/webui/projects/vendor_spec.rb
@@ -51,22 +51,6 @@ RSpec.describe 'Vendors', :js, :vcr do
       end
     end
 
-    context 'editing a distro through its own modal' do
-      before do
-        find("button[data-bs-target='#distro-modal-#{distro.id}-modal']").click
-
-        within("#distro-modal-#{distro.id}-modal") do
-          fill_in('Name', with: 'Slowroll')
-          click_button('Save')
-        end
-      end
-
-      it 'updates the distro' do
-        expect(page).to have_text('Distro was successfully updated.')
-        expect(distro.reload.name).to eq('Slowroll')
-      end
-    end
-
     context 'deleting a distro through the shared delete modal' do
       before do
         find("a[data-action='#{vendor_distro_path(vendor, distro)}']").click


### PR DESCRIPTION
Couple of improvements for the Distro Index part of the Vendor show page:

* Collapse long distro descriptions
* Do not use modals to edit distros. Link to the edit distro path instead
* Remove the "Add release" modal/link from the index. This is part of the distro show page.
* Align how we show the distro url

<img width="1151" height="523" alt="image" src="https://github.com/user-attachments/assets/c7155743-7504-43b2-b22e-c1ffa47d2a61" />

