### PR TITLE
Include the request number on the requests table (closes #20262)

### DIFF
--- a/src/api/app/assets/javascripts/webui/requests_table.js
+++ b/src/api/app/assets/javascripts/webui/requests_table.js
@@ -15,10 +15,10 @@ $(document).ready(function() {
     $(this).dataTable({
       order: [[0,'desc']],
       columnDefs: [
-        // We dont allow ordering by the request link.
-        // Columns: created, source, target, requester, type, priority, request link.
+        // We dont allow ordering by the request number or the request link.
+        // Columns: created, source, target, requester, type, priority, request number, request link.
         // First column has index 0.
-        { orderable: false, targets: [6], responsivePriority: 1 }
+        { orderable: false, targets: [6, 7], responsivePriority: 1 }
       ],
       paging: true,
       pagingType: 'full',

--- a/src/api/app/views/webui/shared/_requests_table.html.haml
+++ b/src/api/app/views/webui/shared/_requests_table.html.haml
@@ -8,5 +8,6 @@
       %th Requester
       %th Type
       %th Priority
+      %th #
       %th
   %tbody

--- a/src/api/app/views/webui/shared/bs_requests/index.json.erb
+++ b/src/api/app/views/webui/shared/bs_requests/index.json.erb
@@ -13,6 +13,7 @@
           "<%= escape_javascript(user_with_realname_and_icon(row.creator, short: true)) %>",
           "<%= escape_javascript(new_or_update_request(row)) %>",
           "<%= escape_javascript(row.priority) %>",
+          "<%= escape_javascript(link_to("##{row.number}", request_show_path(row.number), title: "Show request ##{row.number}")) %>",
           "<%= escape_javascript(link_to(
             '<span class="fa-stack half-font-size me-2">
                <i class="far fa-file fa-stack-2x"></i>


### PR DESCRIPTION
## What
Adds the request number as its own column in the "requests" table shown on project, package, user, and group pages (the shared `_requests_table.html.haml` partial / `bs_requests#index` JSON endpoint used by all four of those controllers).

## Why
Closes #20262. Package maintainers reviewing the Maintenance workflow (`osc mr`) currently have nothing in the table that identifies a request; they have to click "View" to learn the request number. This adds a "#" column with the request number, linked to the request, right before the existing "View" column.

## Changes
- `_requests_table.html.haml`: add a `#` header cell.
- `bs_requests/index.json.erb`: emit a new cell per row with `#<number>` linking to `request_show_path`.
- `requests_table.js`: the new column is non-orderable (like the existing "View" link), so it's added to the `orderable: false` targets alongside the shifted "View" column index (6 -> 7).

This only touches the shared partial/JSON view, so the change applies uniformly to the project, package, user ("My Involved Requests"), and group request tables, which all render through the same `webui/shared/bs_requests/index` view.

## Testing
I don't have a working OBS docker dev environment set up, so I wasn't able to run the RSpec/Capybara suite for this change. I did:
- Trace all four controllers (`Webui::Projects::BsRequestsController`, `Webui::Packages::BsRequestsController`, `Webui::Users::BsRequestsController`, `Webui::Groups::BsRequestsController`) to confirm they share the same `_requests_table.html.haml` partial and `bs_requests/index.json.erb` view, so one change covers all of them consistently.
- Checked the existing specs that touch this table (`a_bs_requests_data_table_controller.rb`'s shared examples, and `packages_spec.rb`'s Capybara test) — the new column is appended after the existing sortable columns (created/source/target/requester/type/priority stay at indices 0-5) and given no CSS class, so the existing hardcoded `order: {column: 5}` (priority) / `column: 2` (composite target) assertions and the `find('a', class: 'request_link')` Capybara lookup for the "View" link are unaffected.
- Syntax-checked the compiled ERB (Ruby `ERB.new(...).src` + `RubyVM::InstructionSequence.compile`) and the JS file (`node --check`); manually reviewed the one-line HAML addition.

Happy to run the full suite and fix anything it turns up if a maintainer can point me at a lighter-weight way to get the specs running, or I can try to get the docker compose setup working in a follow-up.