### PR TITLE
Fix #20223: Guard against nil @package in SourcePackageCommandController#set_package

### DIFF
--- a/src/api/app/controllers/source_package_command_controller.rb
+++ b/src/api/app/controllers/source_package_command_controller.rb
@@ -465,6 +465,7 @@ class SourcePackageCommandController < SourceController
                 remove_flag: { follow_project_links: false } }.freeze
 
     @package = Package.get_by_project_and_name(params[:project], params[:package], options[params[:cmd].to_sym])
+    raise Package::Errors::UnknownObjectError, "Package not found: #{params[:project]}/#{params[:package]}" unless @package
   end
 
   def require_valid_package_name


### PR DESCRIPTION
Fixes #20223

## What Changed

When a project uses `scmsync` but the command options do not enable `follow_project_scmsync_links` (e.g. `updatepatchinfo`), `Package.get_by_project_and_name` returns `nil` instead of raising an error. This `nil` then propagates to the `authorize @package` call, causing Pundit to crash with `unable to find policy NilClassPolicy for nil`.

## Fix

Added a nil guard after the `Package.get_by_project_and_name` call that raises `Package::Errors::UnknownObjectError` (HTTP 404) when `@package` is nil. This matches the same error handling pattern already used inside `get_by_project_and_name` itself (line 276 of `package.rb`).

## How to Verify

1. Have a project with `scmsync` configured (e.g. `editors:tree-sitter`)
2. Call `POST /source/editors:tree-sitter/tree-sitter-swift?cmd=updatepatchinfo`
3. **Before**: 500 error — `unable to find policy NilClassPolicy for nil`
4. **After**: Clean `404 unknown_package` response
