### PR TITLE
Fix #20066: Disable Anitya version checks for aggregate and link packages

### DIFF
--- a/src/api/app/jobs/sync_upstream_package_version_job.rb
+++ b/src/api/app/jobs/sync_upstream_package_version_job.rb
@@ -22,7 +22,7 @@ class SyncUpstreamPackageVersionJob < ApplicationJob
     PackageVersionUpstream.where(package_id: project.packages.ids).delete_all && return if distribution_name.blank?
 
     project.packages.each do |package|
-      next if package.anitya_ignore
+      next if skip_package?(package)
 
       create_upstream_package_versions(package_name: package.name, distribution_name: distribution_name, package_ids: [package.id])
     end
@@ -33,6 +33,7 @@ class SyncUpstreamPackageVersionJob < ApplicationJob
   def create_for_all_projects_with_anitya_distribtion_name
     package_and_distro_name_grouped_on_package_ids = Project.where.not(anitya_distribution_name: [nil, ''])
                                                             .joins(:packages).where(packages: { anitya_ignore: false })
+                                                            .where.not(packages: { id: PackageKind.where(kind: %w[link aggregate]).select(:package_id) })
                                                             .select('projects.anitya_distribution_name AS anitya_distribution_name',
                                                                     'packages.name AS package_name',
                                                                     'packages.id AS project_package_id',
@@ -80,5 +81,9 @@ class SyncUpstreamPackageVersionJob < ApplicationJob
     return if response.nil?
 
     response.dig('items', 0, 'stable_version')
+  end
+
+  def skip_package?(package)
+    package.anitya_ignore || package.link? || package.aggregate?
   end
 end

--- a/src/api/app/models/package.rb
+++ b/src/api/app/models/package.rb
@@ -516,6 +516,10 @@ class Package < ApplicationRecord
     of_kind?(:link)
   end
 
+  def aggregate?
+    of_kind?(:aggregate)
+  end
+
   def channel?
     of_kind?(:channel)
   end

--- a/src/api/db/data/20260905195209_remove_upstream_versions_for_aggregates_and_links.rb
+++ b/src/api/db/data/20260905195209_remove_upstream_versions_for_aggregates_and_links.rb
@@ -1,0 +1,12 @@
+class RemoveUpstreamVersionsForAggregatesAndLinks < ActiveRecord::Migration[7.0]
+  def up
+    # Delete all upstream versions for packages that are currently links or aggregates
+    PackageVersionUpstream.where(
+      package_id: PackageKind.where(kind: %w[link aggregate]).select(:package_id)
+    ).delete_all
+  end
+
+  def down
+    # Nothing to do for down migration
+  end
+end

--- a/src/api/spec/jobs/sync_upstream_package_version_job_spec.rb
+++ b/src/api/spec/jobs/sync_upstream_package_version_job_spec.rb
@@ -12,7 +12,12 @@ RSpec.describe SyncUpstreamPackageVersionJob, :vcr do
 
     context 'when the package is available upstream' do
       context 'providing a project name' do
+        let!(:link_package) { create(:package, project: project, name: 'link_pkg') }
+        let!(:aggregate_package) { create(:package, project: project, name: 'aggregate_pkg') }
+
         before do
+          create(:package_kind, package: link_package, kind: 'link')
+          create(:package_kind, package: aggregate_package, kind: 'aggregate')
           travel_to sync_time do
             described_class.perform_now(project_name: project.name)
           end
@@ -21,6 +26,7 @@ RSpec.describe SyncUpstreamPackageVersionJob, :vcr do
         it 'creates a package version upstream record for the projects packages' do
           expect(PackageVersionUpstream.count).to eq(1)
           expect(package.package_versions.first).to have_attributes(version: '2.12.2', type: 'PackageVersionUpstream')
+          expect(PackageVersionUpstream.where(package: [link_package, aggregate_package]).count).to eq(0)
         end
 
         it 'updates the anitya distribution synced at column on the project' do


### PR DESCRIPTION
Fixes #20066

The new Anitya version check feature is currently trying to fetch upstream versions for aggregate and link packages. Since these packages just pull sources from elsewhere and aren't standalone upstream projects, this leads to an incorrect/red status in the WebUI. 

As suggested in the issue, this PR explicitly disables the Anitya version sync for any package that is a `link` or `aggregate`. 

I've also included a quick data migration to sweep up any incorrectly synced upstream versions for these packages so that the bad frontend status clears up immediately upon deployment.
