### PR TITLE
Publish EROFS and caibx artifacts

### DIFF
--- a/src/backend/bs_publish
+++ b/src/backend/bs_publish
@@ -1373,7 +1373,7 @@ sub createrepo_staticlinks {
         my $profile = $2 || "";
         $link = "$1$profile$4";
         $link = "$1-$2$profile$4" if $versioned;
-      } elsif (/^(.*?)(?:_(.*?))?(?:_(.*))?\.(manifest|metainfo.xml|efi|vmlinuz|initrd|tar|cpio|img|raw|verity|roothash|roothash\.p7s|usrhash|usrhash\.p7s)(\.(?:gz|bz2|xz|zst|zstd))?$/s) {
+      } elsif (/^(.*?)(?:_(.*?))?(?:_(.*))?\.(manifest|metainfo.xml|efi|vmlinuz|initrd|tar|cpio|img|raw|erofs|caibx|verity|roothash|roothash\.p7s|usrhash|usrhash\.p7s)(\.(?:gz|bz2|xz|zst|zstd))?$/s) {
         # mkosi appliance, format is 'name_version_architecture.extension' as defined in https://www.freedesktop.org/software/systemd/man/257/systemd.v.html
         # architecture and compression are optional
         next unless defined $2; # No version? Nothing to do
@@ -2633,7 +2633,7 @@ sub publish {
 	    BSPublisher::Helm::readhelminfo($r, "$1.helminfo");
 	    $p = $bin;
           };
-	} elsif ($bin =~ /\.(manifest|metainfo.xml|img|efi|vmlinuz|initrd|cpio|verity|roothash|roothash\.p7s|usrhash|usrhash\.p7s)(?:\.(?:gz|bz2|xz|zst|zstd))?(?:\.sha[0-9]*(?:\.asc)?)?$/) {
+	} elsif ($bin =~ /\.(manifest|metainfo.xml|img|efi|vmlinuz|initrd|cpio|erofs|caibx|verity|roothash|roothash\.p7s|usrhash|usrhash\.p7s)(?:\.(?:gz|bz2|xz|zst|zstd))?(?:\.sha[0-9]*(?:\.asc)?)?$/) {
 	  # split dm-verity/EFI artifacts from mkosi, or image manifest file
 	  $p = "$bin";
 	} elsif ($bin =~ /^SHA[0-9]*SUMS(?:\.gpg|\.asc)?$/) {


### PR DESCRIPTION
mkosi builds can emit EROFS filesystem images, but the publisher currently drops these artifacts because their suffixes are not recognized. .caibx images are helpful to allow delta downloads, so a user doesn't need to download the complete EROFS image again when trying to update an image-based system, but they are also dropped for the same reason.

This change will make OBS recognize .erofs and .caibx in the existing mkosi artifact lists so they can be published and handled by staticlinks.

I already build images with this setup successfully in OBS, but can't publish all my images currently:
https://build.opensuse.org/project/show/home:Tobi_Peter:proto

ChatGPT was used to find the correct list(s) to extend.

I didn't find tests checking that files with these suffixes are recognized, but I might have missed it. If there is one, please let me know and I can extend it :)