### PR TITLE
Revamp distro release repository selection UI/UX 

### DIFF
--- a/src/api/app/assets/javascripts/webui/autocomplete.js
+++ b/src/api/app/assets/javascripts/webui/autocomplete.js
@@ -42,6 +42,10 @@ $(document).ready(function() {
         if(data.length === 0) {
           dropdown.append(new Option('No repositories found'));
         } else {
+          // Without a placeholder the first repository is preselected, so picking it fires no change event
+          var placeholder = dropdown.data('placeholder');
+          if (placeholder) { dropdown.append(new Option(placeholder, '', true, true)); }
+
           $.each(data, function (_, val) {
             dropdown.append(new Option(val));
           });
@@ -75,43 +79,87 @@ $(document).ready(function() {
     packageInput.autocomplete('option', { source: source });
   });
 
-  $('.architecture-autocomplete').on('click', '.add-button', function(event) {
-    var parent          = $(this).closest('.architecture-autocomplete'),
-        projectName     = parent.find('.ui-autocomplete-input').val(),
-        dropdown        = parent.find('.repository-dropdown'),
-        repositoryName = dropdown.find(":selected").val(),
-        button          = event.target,
-        list            = parent.find('.item-list'),
-        itemTemplate    = document.querySelector('#item-list-template'),
-        checkboxTemplate= document.querySelector('#item-list-checkbox');
+  $('.architecture-autocomplete').on('change', '.repository-dropdown', function() {
+    var parent              = $(this).closest('.architecture-autocomplete'),
+        projectName         = parent.find('.ui-autocomplete-input').val(),
+        repositoryName      = $(this).val(),
+        list                = parent.find('.item-list'),
+        warning             = parent.find('.architecture-warning'),
+        existingRepositories= parent.data('existing-repositories') || [],
+        itemTemplate        = document.querySelector('#item-list-template'),
+        checkboxTemplate    = document.querySelector('#item-list-checkbox');
 
     if (projectName === '') return;
     if (repositoryName === '') return;
+    if (!("content" in document.createElement("template"))) return;
+
+    var repository = projectName + '/' + repositoryName;
+
+    // Adding the same repository twice would duplicate the architecture checkboxes
+    if (list.find('[data-repository="' + repository + '"]').length !== 0) return;
 
     $.ajax({
-      url: button.dataset.source,
+      url: parent.data('architectures-source'),
       data: { project: projectName, repository: repositoryName },
       success: function (data) {
-        if(data.length !== 0) {
-          if ("content" in document.createElement("template")) {
-            const item = document.importNode(itemTemplate.content, true);
-            let itemName = item.querySelector('.item-name');
-            itemName.innerText = projectName + '/' + repositoryName;
-            let checkboxList = item.querySelector('.item-checkboxes');
-            Object.entries(data).forEach(([id, name]) => {
-              const checkbox = document.importNode(checkboxTemplate.content, true);
-              let checkboxLabel = checkbox.querySelector('label');
-              checkboxLabel.setAttribute('for', checkboxLabel.getAttribute('for') + id);
-              checkboxLabel.innerText = name;
-              let checkboxInput = checkbox.querySelector('input');
-              checkboxInput.id = checkboxInput.id + id;
-              checkboxInput.value = id;
-              checkboxList.appendChild(checkbox);
-            });
-            list.append(item);
-          }
+        if (Object.keys(data).length === 0) {
+          warning.text('The repository ' + repository + ' has no architectures.').removeClass('d-none');
+          return;
         }
+
+        const item = document.importNode(itemTemplate.content, true);
+        item.querySelector('li').dataset.repository = repository;
+        if (existingRepositories.indexOf(repository) === -1) {
+          item.querySelector('li').classList.add('list-group-item-success');
+        }
+        let itemName = item.querySelector('.item-name');
+        itemName.innerText = repository;
+        let checkboxList = item.querySelector('.item-checkboxes');
+        Object.entries(data).forEach(([id, name]) => {
+          const checkbox = document.importNode(checkboxTemplate.content, true);
+          let checkboxLabel = checkbox.querySelector('label');
+          checkboxLabel.setAttribute('for', checkboxLabel.getAttribute('for') + id);
+          checkboxLabel.innerText = name;
+          let checkboxInput = checkbox.querySelector('input');
+          checkboxInput.id = checkboxInput.id + id;
+          checkboxInput.value = id;
+          checkboxList.appendChild(checkbox);
+        });
+        list.append(item);
+
+        warning.addClass('d-none');
+        parent.find('.collapse').collapse('hide');
       }
     });
+  });
+
+  $('.architecture-autocomplete').on('click', '.remove-repository', function(event) {
+    event.preventDefault();
+    $(this).closest('li').remove();
+  });
+
+  // A repository without any architecture selected is silently dropped on save, so warn instead of submitting
+  $('.architecture-autocomplete').closest('form').on('submit', function(event) {
+    var warning = $(this).find('.architecture-warning'),
+        invalid = false;
+
+    $(this).find('.item-list > li').each(function() {
+      var valid = $(this).find('input.form-check-input:checked').length !== 0;
+
+      $(this).toggleClass('text-danger', !valid);
+      if (!valid) invalid = true;
+    });
+
+    if (!invalid) {
+      warning.addClass('d-none');
+      return;
+    }
+
+    // Stop jquery_ujs from seeing this submit at all, otherwise it still disables the submit
+    // button (via a delegated document handler scheduled with setTimeout) even though we
+    // cancel the actual submission, leaving the button stuck disabled.
+    event.preventDefault();
+    event.stopPropagation();
+    warning.text('Please select at least one architecture for every repository.').removeClass('d-none');
   });
 });

--- a/src/api/app/views/webui/distro_releases/_form.html.haml
+++ b/src/api/app/views/webui/distro_releases/_form.html.haml
@@ -12,51 +12,51 @@
     = form.text_field :url, class: 'form-control'
 
   .d-flex.justify-content-between.align-items-center
-    %b Repositories:
-    %button.btn.btn-link.text-decoration-none{ type: 'button', data: { 'bs-target': "#search-collapse-distro-release-#{model.id}",
-                                                                        'bs-toggle': 'collapse' } }
-      .expander
-        %i.fa.fa-circle-plus
-        Add a repository
+    %h3.mb-3 Add Repositories
+  .repository-autocomplete.architecture-autocomplete.mb-3{ data: { 'architectures-source': autocomplete_architectures_path,
+                                                                   'existing-repositories': model.repositories.distinct
+                                                                   .map { |repository| "#{repository.project.name}/#{repository.name}" }.to_json } }
+    = render partial: 'webui/shared/search_box', locals: { html_id: "search-project-distro-release-#{model.id}",
+                                                            required: false,
+                                                            label: '<strong>Project:</strong>'.html_safe,
+                                                            data: { source: autocomplete_projects_path } }
 
-  .repository-autocomplete.architecture-autocomplete.mx-3
-    .collapse{ id: "search-collapse-distro-release-#{model.id}" }
-      = render partial: 'webui/shared/search_box', locals: { html_id: "search-project-distro-release-#{model.id}",
-                                                              required: false,
-                                                              label: '<strong>Project:</strong>'.html_safe,
-                                                              data: { source: autocomplete_projects_path } }
-
-      .mb-3
-        = label_tag :repositories do
-          %strong Repositories:
-        = select_tag 'target_repo', options_for_select(['']), html_id: "search-repository-distro-release-#{model.id}",
-                                                              disabled: true,
-                                                              class: 'repository-dropdown form-select',
-                                                              data: { source: autocomplete_repositories_path }
-      .mb-3
-        %button.btn.btn-secondary{ type: 'button', data: { 'bs-target': "#search-collapse-distro-release-#{model.id}",
-                                                            'bs-toggle': 'collapse' } } Cancel
-        %button.btn.btn-primary.add-button{ id: "search-submit-distro-release-#{model.id}", type: 'button',
-                                            data: { source: autocomplete_architectures_path } } Add Repository
-
+    .mb-3
+      = label_tag :repositories do
+        %strong Repositories:
+      = select_tag 'target_repo', options_for_select(['']), id: "search-repository-distro-release-#{model.id}",
+                                                            disabled: true,
+                                                            class: 'repository-dropdown form-select',
+                                                            data: { source: autocomplete_repositories_path,
+                                                                    placeholder: 'Select a repository' }
+    = hidden_field_tag 'distro_release[repository_architecture_ids][]', '', id: nil
     %ul.list-group.list-group-flush.item-list
       - model.repositories.distinct.each do |repository|
-        %li.list-group-item.d-flex.justify-content-between
-          #{repository.project.name}/#{repository.name}
+        %li.list-group-item.d-flex.justify-content-between.align-items-center{ "data-repository": "#{repository.project.name}/#{repository.name}" }
+          .d-flex.align-items-center
+            = link_to '#', class: 'remove-repository pe-2', title: 'Remove repository' do
+              %i.fas.fa-times-circle.text-danger
+              #{repository.project.name}/#{repository.name}
           %div
             = form.collection_checkboxes :repository_architecture_ids, repository.repository_architectures, :id, :architecture do |checkbox|
               = checkbox.checkbox class: 'form-check-input'
               = checkbox.label class: 'form-check-label'
+    .text-danger.architecture-warning.d-none.mt-2
 
   %div
+    = link_to('Cancel', vendor_distro_path(model.distro.vendor, model.distro), title: 'Cancel',
+              class: 'btn btn-outline-secondary px-4 me-3 mt-3 mt-sm-0')
     = form.submit 'Save', class: 'btn btn-success'
 
 %template#item-list-template
-  %li.list-group-item.d-flex.justify-content-between
-    %span.item-name
+  %li.list-group-item.d-flex.justify-content-between.align-items-center
+    .d-flex.align-items-center
+      = link_to '#', class: 'remove-repository pe-2', title: 'Remove repository' do
+        %i.fas.fa-times-circle.text-danger
+      %span.item-name
     .item-checkboxes
       %input{ type: 'hidden', name: 'distro_release[repository_architecture_ids][]' }
 %template#item-list-checkbox
   %input.form-check-input{ type: 'checkbox', name: 'distro_release[repository_architecture_ids][]',
-                           id: 'distro_release_repository_architecture_ids_' }
+                           id: 'distro_release_repository_architecture_ids_', checked: 'checked' }
   %label.form-check-label{ for: 'distro_release_repository_architecture_ids_' }


### PR DESCRIPTION
~~DO NOT MERGE: Depends on https://github.com/openSUSE/open-build-service/pull/20260 (first four commits are included in this PR)~~

* Remove second primary button from form
* Warn user if no architecture is selected for a repository
* Preselect architecture checkboxes for repository
* Allow to remove a repository from the distro release

<img width="1742" height="816" alt="Screenshot 2026-09-09 at 18-14-24 Distro Release snapshot123 - Open Build Service" src="https://github.com/user-attachments/assets/f5ac4524-9ac7-453e-9ed8-d1a75b11226f" />
<img width="1806" height="613" alt="Screenshot 2026-09-09 at 18-15-09 Distro Release snapshot123 - Open Build Service" src="https://github.com/user-attachments/assets/ff456542-1b17-4c0c-9bb2-902b197b9a85" />
<img width="1773" height="566" alt="Screenshot 2026-09-09 at 18-15-28 Distro Release snapshot123 - Open Build Service" src="https://github.com/user-attachments/assets/90f9193f-bf6d-458c-a686-02d9200550b4" />

