### PR TITLE
webui: preserve notification bar parameters across request tabs

### DIFF
--- a/src/api/app/helpers/webui/request_helper.rb
+++ b/src/api/app/helpers/webui/request_helper.rb
@@ -178,7 +178,7 @@ module Webui::RequestHelper
   end
 
   def next_prev_path(**opts)
-    parameters = { number: opts[:number], request_action_id: opts[:request_action_id], diff_to_superseded: opts[:diff_to_superseded] }
+    parameters = { number: opts[:number], request_action_id: opts[:request_action_id], diff_to_superseded: opts[:diff_to_superseded] }.merge(notification_context_params)
 
     case opts[:page_name]
     when 'request_build_results'

--- a/src/api/app/helpers/webui/request_helper.rb
+++ b/src/api/app/helpers/webui/request_helper.rb
@@ -178,7 +178,8 @@ module Webui::RequestHelper
   end
 
   def next_prev_path(**opts)
-    parameters = { number: opts[:number], request_action_id: opts[:request_action_id], diff_to_superseded: opts[:diff_to_superseded] }.merge(notification_context_params)
+    parameters = { number: opts[:number], request_action_id: opts[:request_action_id], diff_to_superseded: opts[:diff_to_superseded] }
+    parameters.merge!(notification_context_params) if respond_to?(:notification_context_params, true)
 
     case opts[:page_name]
     when 'request_build_results'

--- a/src/api/app/views/webui/request/_request_tabs.html.haml
+++ b/src/api/app/views/webui/request/_request_tabs.html.haml
@@ -1,21 +1,21 @@
 .border-bottom
   %ul.nav.scrollable-tabs.border-0#request-tabs
     %li.nav-item.scrollable-tab-link
-      = link_to('Conversation', request_show_path(bs_request.number),
+      = link_to('Conversation', request_show_path(bs_request.number, notification_context_params),
                 class: "nav-link text-nowrap #{active_tab == 'conversation' ? 'active' : ''}")
     - if action.tab_visibility.build
       %li.nav-item.scrollable-tab-link.active
-        = link_to('Build Results', request_build_results_path(bs_request.number),
+        = link_to('Build Results', request_build_results_path(bs_request.number, notification_context_params),
                   class: "nav-link text-nowrap #{active_tab == 'build_results' ? 'active' : ''}")
     %li.nav-item.scrollable-tab-link
-      = link_to(request_changes_path(bs_request.number, actions_count > 1 ? action : nil),
+      = link_to(request_changes_path(bs_request.number, actions_count > 1 ? action : nil, notification_context_params),
                 class: "nav-link text-nowrap #{active_tab == 'changes' ? 'active' : ''}") do
         Changes
         - if actions_count > 1
           %span.badge.text-bg-primary.align-text-top= actions_count
     - if action.tab_visibility.issues
       %li.nav-item.scrollable-tab-link
-        = link_to(request_mentioned_issues_path(bs_request.number, actions_count > 1 ? action : nil),
+        = link_to(request_mentioned_issues_path(bs_request.number, actions_count > 1 ? action : nil, notification_context_params),
                   class: "nav-link text-nowrap #{active_tab == 'mentioned_issues' ? 'active' : ''}") do
           Mentioned Issues
           - if actions_count == 1

--- a/src/api/spec/helpers/webui/request_helper_spec.rb
+++ b/src/api/spec/helpers/webui/request_helper_spec.rb
@@ -204,6 +204,12 @@ RSpec.describe Webui::RequestHelper do
     context 'when user is on build results page' do
       it { expect(next_prev_path(number: 10, request_action_id: 30, page_name: 'request_build_results')).to eq('/requests/10/actions/30/build_results') }
     end
+
+    context 'when notification context params are present' do
+      let(:notification_context_params) { { notification_id: 123 } }
+
+      it { expect(next_prev_path(number: 10, request_action_id: 30)).to eq('/request/show/10/request_action/30?notification_id=123') }
+    end
   end
 
   describe '#find_source_release_targets' do


### PR DESCRIPTION
Fixes #20252

### Description

When navigating to a request from the notifications page, the notification bar is displayed on top to allow navigating between notifications. However, clicking on any of the request tabs (Conversation, Build Results, Changes, Mentioned Issues) or switching actions previously dropped the notification context parameters, causing the top bar to disappear.

This PR passes `notification_context_params` to the tab links and merges them in `next_prev_path` when available, keeping the notification bar visible while navigating across tabs and actions.

### How to verify

1. Go to the notifications page (`/notifications`).
2. Click on a notification pointing to a request to open its show page.
3. Confirm that the notification bar is visible at the top.
4. Click through the different request tabs (Conversation, Build Results, Changes, Mentioned Issues).
5. Verify that the notification bar remains visible across all tabs.
