### PR TITLE
Prevent need of second click on repository dropdown after autocomplete selection

### DIFF
--- a/src/api/app/assets/javascripts/webui/autocomplete.js
+++ b/src/api/app/assets/javascripts/webui/autocomplete.js
@@ -16,7 +16,7 @@ function setupAutocomplete(selector) {
 }
 
 $(document).ready(function() {
-  $('.repository-autocomplete').on('autocompleteselect autocompletechange', function(event, ui) {
+  $('.repository-autocomplete').on('autocompleteselect', function(event, ui) {
     var projectName,
         dropdown        = $(this).find('.repository-dropdown'),
         repoNameElement = $(this).find('.repository-name');


### PR DESCRIPTION
Right now it requires two click's to open the repository dropdown after the project is selected from the autocomplete selection.

This is happens since:

1. The mouse click causes the autocomplete input to lose focus (blur).

2. jQuery UI fires autocompletechange.

3. The code immediately runs `dropdown.html('').prop('disabled', true)` before the click event on the dropdown finishes.

4. Because the dropdown is emptied and disabled mid-click, Bootstrap cancels the toggle behavior for that click.

5. After the AJAX request finishes, dropdown.prop('disabled', false) re-enables it—meaning the second click finally works.

It is enough to fire on `autocompleteselect`.

<img width="1133" height="672" alt="2026-09-10_16-40" src="https://github.com/user-attachments/assets/ac52e01c-b334-4ca8-a66c-34b3886f63a4" />

*Same here for distro release repository selection:*
<img width="1650" height="719" alt="image" src="https://github.com/user-attachments/assets/341e6117-baa8-4d0d-800b-08949bcf2d39" />

